### PR TITLE
add smart intake improvements: conditional essentials, multi-choice, and bug fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -794,9 +794,17 @@ _Make the adaptive questionnaire smarter — extract more, ask less, validate an
 
 **Spot checks** (`make run` with real LLM):
 - [x] **Keyword extraction:** type `We're refactoring our legacy API built with Express and PostgreSQL, integrating Stripe for payments` → verify Q2 extracted as "Existing codebase", Q12 as "Stripe"
-- [ ] **Adaptive Q7:** answer Q6 with "5" → verify Q7 says "You said 5 engineers — what are their roles?"
-- [ ] **Adaptive Q13:** answer Q2 as "Existing codebase" → verify Q13 mentions "backward compatibility" in the hint
-- [ ] **Follow-up quality:** give a vague Q3 answer like "users" → verify follow-up asks about user personas (not generic "tell me more")
+- [ ] **Adaptive Q7:** answer Q6 with "5" → verify Q7 says "You said 5 engineers — what are their roles?" and renders as multi-choice (Backend, Frontend, Fullstack, DevOps/Infra, QA/Testing, Design, Data/ML)
+- [ ] **Adaptive Q12:** answer Q11 with a tech stack → verify Q12 is asked (conditional essential) with adaptive text mentioning the tech stack
+- [ ] **Adaptive Q13:** answer Q2 as "Existing codebase" → verify Q13 renders as multi-choice (Microservices, Monolith, Serverless, AWS, etc.) with hint about "backward compatibility"
+- [ ] **Conditional essentials — Q7 skipped when Q6 defaulted:** skip Q6 → verify Q7 is NOT asked (stays defaulted)
+- [ ] **Conditional essentials — all three fire:** provide description with team size, tech stack, and project type → verify Q7, Q12, Q13 all appear as gap questions in smart mode
+- [ ] **Multi-choice Q7:** verify Space toggles selections, Enter submits comma-joined answer (e.g. "Backend, Frontend")
+- [ ] **Multi-choice Q13:** verify same toggle/submit behavior for constraints
+- [ ] **Single-choice Q19 (CI/CD):** verify renders as Yes / No / Partial with arrow keys
+- [ ] **Single-choice Q25 (DoD):** verify renders as Yes — team has a standard DoD / No — use a recommended DoD
+- [ ] **Q30 (Onboarding):** verify PTO sub-loop still works — "Does anyone have planned leave?" Yes/No renders correctly, not overridden by static choices
+- [x] **Follow-up quality:** give a vague Q3 answer like "users" → verify follow-up asks about user personas (not generic "tell me more")
 - [ ] **Confidence breakdown:** at the intake summary, verify stats line shows `N direct | N extracted | N defaulted` (not the old `N answered | N defaults` format)
 - [ ] **Cross-validation — greenfield + URL:** answer Q2 as "Greenfield", then provide a repo URL at Q17 → verify summary shows "Heads up" warning about the contradiction
 - [ ] **Cross-validation — long timeline:** set Q8 = "2 weeks", Q10 = "15 sprints" → verify summary shows info warning about timeline spanning ~7 months

--- a/TODO.md
+++ b/TODO.md
@@ -763,45 +763,45 @@ _Tests:_
 33. `make test-fast` — 2207 pass, `make lint` — clean, `make snapshot-update` — 2 snapshots updated for formatter column change.
 
 
-
-#### Re-architect Greenfield projects for Harness Engineering (Include Github/Azure Devops push for the arhcitecture: https://github.com/nikomain/harness-engineering-boilerplate/tree/main)
-- [ ]
-
-
 #### Smart intake improvements - For Exisiting Repo Track
 _Make the adaptive questionnaire smarter — extract more, ask less, validate answers._
 
 **Smarter extraction:**
-- [ ] Relax extraction rules — infer Q2 (project type) from keywords like "refactor", "migrate", "legacy"
-- [ ] Extract integrations (Q12) from tech stack keywords (Stripe, Auth0, Firebase, etc.)
-- [ ] Extract architectural constraints (Q13) from infra signals (Kubernetes, microservices, AWS)
+- [x] Relax extraction rules — infer Q2 (project type) from keywords like "refactor", "migrate", "legacy"
+- [x] Extract integrations (Q12) from tech stack keywords (Stripe, Auth0, Firebase, etc.)
+- [x] Extract architectural constraints (Q13) from infra signals (Kubernetes, microservices, AWS)
 
 **Adaptive question text:**
-- [ ] Personalise Q7 (roles) based on Q6 team size — "You said 5 engineers; what are their roles?"
-- [ ] Personalise Q12 (integrations) with hints from Q11 tech stack
-- [ ] Reference Q2 answer in Q13 — greenfield vs existing has different constraint concerns
+- [x] Personalise Q7 (roles) based on Q6 team size — "You said 5 engineers; what are their roles?"
+- [x] Personalise Q12 (integrations) with hints from Q11 tech stack
+- [x] Reference Q2 answer in Q13 — greenfield vs existing has different constraint concerns
 
 **Cross-question validation:**
-- [ ] Detect contradictions — Q2="Greenfield" but Q17 has an existing repo URL
-- [ ] Flag unrealistic combos — Q8 sprint length × Q10 target sprints > 6 months → confirm scope
-- [ ] Sanity-check velocity (Q9) against team size (Q6) — flag if wildly off
+- [x] Detect contradictions — Q2="Greenfield" but Q17 has an existing repo URL
+- [x] Flag unrealistic combos — Q8 sprint length × Q10 target sprints > 6 months → confirm scope
+- [x] Sanity-check velocity (Q9) against team size (Q6) — flag if wildly off
 
 **Follow-up quality:**
-- [ ] Custom follow-up templates per question (not just generic "tell me more")
-- [ ] Q3 (problem): "Who experiences this problem? Give 2-3 user personas"
-- [ ] Q11 (tech stack): "What's the primary language and framework?"
-- [ ] Q21 (risks): "Which risk should be addressed earliest?"
+- [x] Custom follow-up templates per question (not just generic "tell me more")
+- [x] Q3 (problem): "Who experiences this problem? Give 2-3 user personas"
+- [x] Q11 (tech stack): "What's the primary language and framework?"
+- [x] Q21 (risks): "Which risk should be addressed earliest?"
 
 **Answer confidence signalling:**
-- [ ] Track answer source: `direct`, `extracted`, `defaulted`, `probed` per question
-- [ ] Show breakdown in intake summary: "12 direct, 3 extracted, 7 defaulted"
-- [ ] Pass confidence hints to downstream nodes — low-confidence areas → recommend spikes
+- [x] Track answer source: `direct`, `extracted`, `defaulted`, `probed` per question
+- [x] Show breakdown in intake summary: "12 direct, 3 extracted, 7 defaulted"
+- [x] Pass confidence hints to downstream nodes — low-confidence areas → recommend spikes
 
-#### Jira board & ticket format setup
-_Auto-configure a Jira project to match the agent's output format._
-- [ ] Project board with swimlanes (todo, in-progress, in-test, security-review, human-feedback, done)
-- [ ] User story ticket format (description, acceptance criteria, definition of done, test plan, prompt)
-- [ ] UI option to set up a new Jira project or analyse an existing project for compatibility
+**Spot checks** (`make run` with real LLM):
+- [x] **Keyword extraction:** type `We're refactoring our legacy API built with Express and PostgreSQL, integrating Stripe for payments` → verify Q2 extracted as "Existing codebase", Q12 as "Stripe"
+- [ ] **Adaptive Q7:** answer Q6 with "5" → verify Q7 says "You said 5 engineers — what are their roles?"
+- [ ] **Adaptive Q13:** answer Q2 as "Existing codebase" → verify Q13 mentions "backward compatibility" in the hint
+- [ ] **Follow-up quality:** give a vague Q3 answer like "users" → verify follow-up asks about user personas (not generic "tell me more")
+- [ ] **Confidence breakdown:** at the intake summary, verify stats line shows `N direct | N extracted | N defaulted` (not the old `N answered | N defaults` format)
+- [ ] **Cross-validation — greenfield + URL:** answer Q2 as "Greenfield", then provide a repo URL at Q17 → verify summary shows "Heads up" warning about the contradiction
+- [ ] **Cross-validation — long timeline:** set Q8 = "2 weeks", Q10 = "15 sprints" → verify summary shows info warning about timeline spanning ~7 months
+- [ ] **Cross-validation — clean:** answer Q2 = "Existing codebase", Q6 = "5", Q9 = "30" → verify NO spurious warnings appear
+- [ ] **Dry run smoke test:** `make run-dry` → TUI launches without errors, no crashes from new code paths
 
 
 #### "Create in Jira" option
@@ -823,545 +823,41 @@ _Push artifacts to Jira. Two modes: inline (during pipeline) and selective (post
 - [x] Cascade: Tasks stage creates Stories if not done; Sprints stage creates Stories if not done
 - [x] Tests for jira_sync module (unit + idempotency + error handling)
 - [x] Tests for new state fields and persistence round-trip
-- [ ] Manual test with real Jira: create stories → verify Epic + Stories with correct labels
-- [ ] Manual test: create tasks → verify Sub-tasks linked to Stories
-- [ ] Manual test: create sprints → verify Sprints created with stories assigned
-- [ ] Manual test: re-run same stage → verify idempotency (skips existing)
 
 
-### 13A½: OpenClaw Integration
 
-_Leverage [OpenClaw](https://openclaw.ai/) to expose the scrum agent beyond the terminal — multi-channel access, workflow automation, and always-on capabilities._
+### 13B: Packaging & Distribution (Homebrew)
 
-#### Skill: Scrum Planner (priority: high)
-- [ ] Package scrum-agent as an OpenClaw AgentSkill (`skills/scrum-planner/SKILL.md`)
-- [ ] Expose CLI in non-interactive mode for skill invocation
-- [ ] Enable sprint planning from Slack, Discord, WhatsApp, Teams via OpenClaw channels
-- [ ] Format agent output for chat-friendly rendering (markdown cards, summaries)
+_Ship the CLI as a Homebrew-installable app so anyone can `brew install scrum-agent` and go. This is a prerequisite for 13C (OpenClaw) — the skill needs an installable CLI to invoke._
 
-#### Webhook-Triggered Planning (priority: high)
-- [ ] Configure OpenClaw webhook endpoint to trigger planning on Jira epic creation
-- [ ] GitHub webhook: auto-generate project plan on new repo/milestone creation
-- [ ] Slack slash command (`/plan-sprint`) routed via OpenClaw webhook
+#### PyPI release (prerequisite for Homebrew)
+- [ ] Finalise `pyproject.toml` metadata (name, version, description, author, license, classifiers, URLs)
+- [ ] Add `[project.scripts]` entry point: `scrum-agent = "scrum_agent.cli:main"`
+- [ ] Build sdist + wheel with `uv build` / `python -m build`
+- [ ] Publish to PyPI (`twine upload` or GitHub Actions workflow)
+- [ ] Verify `pipx install scrum-agent` works end-to-end on a clean machine
 
-#### Conversational Intake via Chat (priority: high)
-- [ ] Wrap 30-question intake questionnaire as an OpenClaw conversational flow
-- [ ] Support async answering — users respond over hours/days in Slack/WhatsApp
-- [ ] Maintain questionnaire state across messages via OpenClaw session persistence
-- [ ] Trigger LLM pipeline once all questions answered, return plan inline
+#### Homebrew formula
+- [ ] Create Homebrew formula (`Formula/scrum-agent.rb`) — installs via `pip` into a virtualenv
+- [ ] Add formula to a personal tap (`homebrew-tap` repo): `brew tap omardin14/tap`
+- [ ] `brew install omardin14/tap/scrum-agent` installs the CLI + all dependencies
+- [ ] Post-install: prompt user to run `scrum-agent --setup` for API key configuration
+- [ ] Add `brew test` block — runs `scrum-agent --version` and `scrum-agent --help`
+- [ ] Automate formula version bumps via GitHub Actions on new PyPI release
 
-#### Lobster Workflow Pipeline (priority: medium)
-- [ ] Define `.lobster` workflow: intake → analysis → features → stories → tasks → sprints → Jira export
-- [ ] Map existing accept/edit/reject gates to Lobster approval checkpoints with resume tokens
-- [ ] Add crash-safe resume — pipeline restarts from last approved step
+#### Non-interactive / headless mode (prerequisite for OpenClaw skill)
+- [ ] Add `--non-interactive` flag — runs full pipeline with no TUI, auto-accepts all gates
+- [ ] Add `--output json` flag — structured JSON to stdout (epics, stories, tasks, sprints)
+- [ ] Accept project description and key params via CLI args (`--input`, `--team-size`, `--sprint-length`)
+- [ ] Combine with existing `--quick` mode for minimal-question headless runs
 
-#### Always-On Standup Bot (priority: medium)
-- [ ] OpenClaw cron job: daily standup at configurable time
-- [ ] Fetch active sprint from Jira (reuse `jira_read_board` / `jira_fetch_active_sprint` tools)
-- [ ] Generate standup summary (done yesterday, planned today, blockers)
-- [ ] Post to team Slack/Discord channel, collect responses
-
-#### Multi-Agent Scrum Team (priority: low — exploratory)
-- [ ] Scrum Master agent — runs full planning pipeline, facilitates ceremonies
-- [ ] Tech Lead agent — reviews stories for technical feasibility
-- [ ] QA agent — reviews acceptance criteria, suggests missing test scenarios
-- [ ] Product Owner agent — prioritises backlog, validates business alignment
-- [ ] Route different Slack channels to different agents via OpenClaw multi-agent routing
-
-#### HTML Report Delivery (priority: low)
-- [ ] Post sprint plan summary + HTML export to team channel after planning completes
-- [ ] Explore OpenClaw Canvas for interactive live view of generated plans
-
----
-
-### 13B: Production Infrastructure
-- [ ] Containerised deployment (Docker / Docker Compose)
-- [ ] Secret management (env vars → vault or cloud-native secrets)
-- [ ] Add token budget tracking per session
-- [ ] Add cost estimation before write operations ("This will create 14 tickets. Proceed?")
-- [ ] Implement model fallback chain (primary → backup → static response)
-- [ ] Add retry with exponential backoff for API failures
-- [ ] Add request timeout handling
-
-### 13C: Observability
-- [ ] LangSmith observability for production tracing
-- [ ] Error tracking and alerting (agent failures, API timeouts, LLM errors)
-- [ ] Token usage tracking per session
-- [ ] Health check endpoint
-
-### 13D: Packaging & Distribution
-- [ ] Package as installable CLI tool (`pip install scrum-agent` or `pipx`)
-- [ ] CI/CD pipeline for the project itself (lint, test, build, publish)
-- [ ] Comprehensive README with quick-start guide
-- [ ] Write deployment instructions (Docker, local, cloud)
+#### CI/CD pipeline
+- [ ] GitHub Actions workflow: lint → test → build → publish to PyPI on tagged releases
+- [ ] Auto-update Homebrew formula SHA and version on successful publish
 - [ ] `.env.example` review — ensure all options are documented
+
+#### Documentation
+- [ ] Comprehensive README with quick-start guide (`brew install` → first plan in 2 minutes)
 - [ ] Tag v1.0.0 release
 
-
-
-
 ---
-
-# Multi-Agent Transformation
-
-_Everything below Phase 13 transforms the shipped project planning CLI into a
-multi-agent platform with a web UI. The v1.0 planning agent becomes the
-**Project Planning Agent** — the first of many specialised agents that share a
-common state store and communicate via a central orchestrator. Each phase ships
-independently — users get value from each new agent as it lands._
-
-## Architecture
-
-```
-┌────────────────────────────────────────────────────────────────────┐
-│  Web Frontend (React / Next.js)                                    │
-│  Sprint board · Standup dashboard · Refinement voting · PR views   │
-└───────────────────────────┬────────────────────────────────────────┘
-                            │ WebSocket / REST
-┌───────────────────────────▼────────────────────────────────────────┐
-│  API + Orchestrator Layer (FastAPI)                                 │
-│  Auth · Team management · Event routing · Webhook receivers        │
-│  Agent dispatcher — routes tasks to the right specialised agent     │
-└──┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬───────────────┘
-   │      │      │      │      │      │      │      │
-   ▼      ▼      ▼      ▼      ▼      ▼      ▼      ▼
- Scrum  Daily  Sprint Review  Backlog  Code  QA   DevOps Security
- Master Standup Review  &     Refine-  Agent Agent Agent  Agent
- Agent  Agent  Agent   Retro  ment
-                       Agent  Agent
-└────────────────────────────────────────────────────────────────────┘
-  Shared: PostgreSQL · Vector Store (Chroma) · Jira/GitHub/Slack APIs
-```
-
----
-
-## Phase 14: Platform Foundation — Web App & Multi-Agent Infrastructure
-
-_Extract the core agent into a backend service, add auth, team management,
-and the orchestrator that routes work to specialised agents._
-
-### 14A: API Layer
-- [ ] Create FastAPI backend wrapping the existing agent core
-- [ ] RESTful endpoints: `/projects`, `/sessions`, `/agents/{name}/invoke`
-- [ ] WebSocket endpoint for real-time streaming (replaces REPL streaming)
-- [ ] Move session persistence from local SQLite to PostgreSQL
-- [ ] Auth: JWT-based authentication with team/role support
-- [ ] Team management: invite members, assign roles (Scrum Master, Dev, PO, QA)
-- [ ] API key management for external integrations (Jira, GitHub, Slack)
-
-### 14B: Agent Orchestrator
-- [ ] Central dispatcher that routes tasks to the correct specialised agent
-- [ ] Shared state store — agents read/write to a common project state (PostgreSQL + Redis)
-- [ ] Agent-to-agent messaging — structured handoffs (e.g. Code Agent → QA Agent)
-- [ ] Event bus for async triggers (webhook → event → agent invocation)
-- [ ] Agent registry — discover available agents, their capabilities, and health
-- [ ] Concurrency control — prevent two agents from modifying the same artifact simultaneously
-
-### 14C: Web Frontend
-- [ ] React/Next.js app with project dashboard
-- [ ] Sprint board view (kanban columns: To Do, In Progress, Review, Done)
-- [ ] Real-time updates via WebSocket (agent actions appear live)
-- [ ] Project setup wizard (replaces CLI questionnaire with a guided form)
-- [ ] Artifact viewers: epic/story/task detail panels with edit capability
-- [ ] Agent activity feed — shows what each agent is doing and has done
-- [ ] Notification system (in-app + email/Slack for important events)
-
-### 14D: CLI Preservation
-- [ ] Keep CLI as a first-class client (power users, local repo scanning, CI/CD scripting)
-- [ ] CLI talks to the API layer (same as web frontend)
-- [ ] `scrum-agent login` — authenticate against the API
-- [ ] `scrum-agent sync` — push local session to server, pull remote changes
-- [ ] Offline mode — full local functionality, sync when connected
-
----
-
-## Phase 15: Project Planning Agent (existing pipeline, enhanced)
-
-_The current single-agent pipeline becomes the Project Planning Agent — responsible
-for project setup, decomposition into epics/stories/tasks, and sprint planning.
-This phase also includes rebranding: rename "Scrum AI" labels, CLI name, and
-user-facing strings from scrum-master terminology to project planning terminology._
-
-### 15A: Rebrand to Project Planning Agent
-- [ ] Rename CLI entry point: `scrum-agent` → `planbot` (or chosen name)
-- [ ] Rename "Scrum AI" label in REPL to "Planning Agent" (AI_LABEL, AI_QUESTION_LABEL)
-- [ ] Rename package: `scrum_agent` → new package name (if desired, or keep internal name)
-- [ ] Update README, CLAUDE.md, and all user-facing docs
-- [ ] Update Docker image name and PyPI package name
-- [ ] Rename `SCRUM.md` convention to `PROJECT.md` (keep SCRUM.md as deprecated alias)
-
-### 15B: Enhanced Planning
-- [ ] Project board and ticket format setup (auto-configure Jira board, columns, workflows)
-- [ ] Dynamic capacity retrieval — pull team availability from Jira/calendar APIs
-- [ ] Sprint planning risk adviser — analyse constraints, dependencies, team history before planning
-- [ ] Story labels: "Code", "Documentation", "Infrastructure", "Testing" auto-tagged based on content
-- [ ] Testing plans included in stories — auto-generate test plan section in each story’s AC
-
-### 15C: Vector-Store RAG (Chroma)
-- [ ] Add `chromadb` + `langchain-chroma` dependencies
-- [ ] `VectorStore` wrapper: init, ingest, query, reset (persisted in project DB)
-- [ ] Codebase ingestion with language-aware chunking (`RecursiveCharacterTextSplitter`)
-- [ ] Document ingestion: scrum-docs, SCRUM.md, Confluence pages
-- [ ] Incremental re-indexing (only changed files)
-- [ ] `vector_search` tool for semantic search across codebase + docs
-- [ ] Hybrid retrieval: vector similarity + BM25 keyword matching
-- [ ] Wire retriever into epic_generator and story_writer nodes
-
----
-
-## Phase 16: Daily Standup Agent
-
-_Monitors team communication (Slack), collects standup updates, identifies
-blockers and patterns, and provides actionable insights to the Scrum Master._
-
-### 16A: Slack Integration
-- [ ] Slack bot: `/standup` command to submit daily updates
-- [ ] Parse standup format: What I did · What I’m doing · Blockers
-- [ ] Accept updates via DM or channel thread
-- [ ] Scheduled reminders for missing standups (configurable time)
-- [ ] Thread-based follow-up questions when updates are vague
-
-### 16B: Performance Insights
-- [ ] Track velocity trends per engineer and per team over sprints
-- [ ] Detect patterns: consistently blocked engineers, scope creep, uneven workload
-- [ ] Compare planned vs actual story points per sprint
-- [ ] Identify stories that have been "In Progress" too long
-- [ ] Weekly digest: team health summary with trends and recommendations
-
-### 16C: Recommendations Engine
-- [ ] Flag at-risk stories (no progress for N days, blocked, reassigned multiple times)
-- [ ] Suggest pair programming when an engineer is stuck on a complex story
-- [ ] Recommend workload rebalancing when capacity is uneven
-- [ ] Detect and flag anti-patterns: hero culture, knowledge silos, skipped ceremonies
-- [ ] Push recommendations to Slack channel or web dashboard
-
-### 16D: Testing
-- [ ] Mock Slack API tests for standup collection
-- [ ] Test pattern detection with synthetic sprint data
-- [ ] Test recommendation engine with edge cases (empty sprints, single-person teams)
-
----
-
-## Phase 17: Sprint Review Agent
-
-_Facilitates mid-sprint and end-of-sprint reviews. Analyses progress against
-the sprint goal and recommends scope adjustments._
-
-### 17A: Mid-Sprint Review
-- [ ] Triggered automatically at sprint midpoint (or on-demand via `/review`)
-- [ ] Pull current sprint state from Jira: completed, in-progress, not started
-- [ ] Calculate burndown trajectory — on track, ahead, or behind
-- [ ] Recommend scope changes: stories to pull in (ahead) or defer (behind)
-- [ ] Present recommendations to team via web UI or Slack with accept/reject buttons
-- [ ] Auto-update Jira when team approves scope changes
-
-### 17B: End-of-Sprint Review
-- [ ] Generate sprint report: planned vs delivered, velocity, carry-over stories
-- [ ] Summarise what was accomplished and how it delivers customer value
-- [ ] Compare actual vs estimated story points — identify estimation gaps
-- [ ] Risk analysis update — new risks discovered during the sprint
-- [ ] Draft stakeholder-ready report (formatted for governance/compliance if needed)
-- [ ] Archive sprint data for historical trend analysis
-
-### 17C: Retrospective Facilitation
-- [ ] Collect anonymous feedback (web form or Slack DM): went well, improve, action items
-- [ ] AI-powered theme clustering — group similar feedback automatically
-- [ ] Voting on action items (web UI with real-time vote counts)
-- [ ] Track action item follow-through across sprints (did we actually do it?)
-- [ ] Detect recurring themes that never get resolved — escalate
-
-### 17D: Testing
-- [ ] Test burndown calculation with various sprint scenarios
-- [ ] Test scope change recommendations (ahead/behind/on-track)
-- [ ] Test retrospective clustering with diverse feedback inputs
-
----
-
-## Phase 18: Backlog Refinement Agent
-
-_Facilitates collaborative backlog refinement sessions. Provides tools for
-story discussion, estimation voting, and acceptance criteria improvement._
-
-### 18A: Refinement Session Management
-- [ ] Create refinement sessions linked to a set of stories/epics
-- [ ] Present stories one-by-one with full context (description, AC, dependencies)
-- [ ] Real-time discussion thread per story (web UI + optional Slack bridge)
-- [ ] Time-box per story with configurable defaults (5 min discussion, 2 min voting)
-- [ ] Session summary: refined stories, updated estimates, unresolved questions
-
-### 18B: Estimation Voting (built-in web UI)
-- [ ] Custom voting UI in the web frontend — no third-party dependency
-- [ ] Each team member votes simultaneously (hidden until reveal)
-- [ ] Support Fibonacci (1,2,3,5,8,13) and T-shirt (XS,S,M,L,XL) scales
-- [ ] AI-suggested estimate based on historical data and story complexity
-- [ ] Highlight large variance in votes — trigger discussion before re-vote
-- [ ] Auto-update Jira story points after team consensus
-- [ ] Voting history tracked for estimation accuracy insights over time
-
-### 18C: Story Enhancement
-- [ ] AI-driven suggestions: missing AC, ambiguous requirements, implicit dependencies
-- [ ] "What about..." prompts — edge cases the team might not have considered
-- [ ] Acceptance criteria completeness check (happy path, error, edge, security)
-- [ ] Auto-detect stories that should be split (too large, multiple concerns)
-- [ ] Documentation generation for refined stories
-
-### 18D: Testing
-- [ ] Test voting mechanics (hidden votes, reveal, variance detection)
-- [ ] Test AI estimation against historical sprint data
-- [ ] Test story enhancement suggestions with various story types
-
----
-
-## Phase 19: Coding Agent Integration Hub
-
-_Rather than building a coding agent from scratch (competing with Copilot, Claude Code,
-Cursor, Devin, etc.), this phase makes the platform the **brain that tells coding agents
-what to do** and the **quality gate that reviews what they produce**. The platform owns
-the spec and the review — the coding agent is pluggable._
-
-### 19A: Story Spec Export (universal format)
-- [ ] Define a structured story spec format (markdown + frontmatter YAML) containing:
-  description, AC (Given/When/Then), test plan, related files, dependencies, architecture context
-- [ ] Export spec to clipboard / file / stdout for manual use with any tool
-- [ ] Include codebase context from vector store (relevant files, patterns, conventions)
-- [ ] Include architecture decisions from SCRUM.md / Confluence / scrum-docs
-- [ ] Spec quality score — warn if AC is vague, test plan is missing, or scope is unclear
-
-### 19B: GitHub / Azure DevOps Integration
-- [ ] Write story spec to GitHub Issue (with labels, assignee, milestone)
-- [ ] Write story spec to Azure DevOps Work Item
-- [ ] GitHub Copilot Workspace picks up Issues natively — zero extra integration
-- [ ] Link PRs back to stories automatically (branch naming convention + webhook)
-- [ ] Track story status from Issue/PR lifecycle (opened → in review → merged → done)
-
-### 19C: MCP Server (Claude Code / AI IDE integration)
-- [ ] Expose stories as an MCP tool server (`get_next_story`, `get_story_spec`, `mark_done`)
-- [ ] Claude Code, Windsurf, and other MCP-compatible tools can pull stories directly
-- [ ] Serve codebase context alongside the story (relevant files, test patterns)
-- [ ] Bi-directional: coding agent reports progress/blockers back via MCP
-- [ ] Auth: token-scoped access per developer
-
-### 19D: IDE Extensions
-- [ ] VS Code extension: sidebar showing assigned stories, one-click to load spec into editor
-- [ ] JetBrains plugin: same functionality for IntelliJ/WebStorm/PyCharm users
-- [ ] Story context injected into editor’s AI assistant (Copilot, Cursor, Cody, etc.)
-- [ ] "Start working" button: creates branch, loads spec, opens relevant files
-
-### 19E: CLI Integration
-- [ ] `planbot work [story-key]` — fetch story spec, create branch, output spec to terminal
-- [ ] Pipe-friendly: `planbot spec PROJ-123 | claude-code` or similar
-- [ ] `planbot done [story-key]` — mark story complete, trigger QA Agent review
-- [ ] Works offline with cached story specs from last sync
-
-### 19F: Webhook / API (bring-your-own-agent)
-- [ ] REST API: `GET /stories/{key}/spec` returns the full structured spec
-- [ ] Webhook: notify external systems when a story is ready for development
-- [ ] Support custom coding agents (Devin, SWE-Agent, OpenHands, internal tools)
-- [ ] Agent-agnostic callback: any tool can POST results (PR link, status, blockers)
-
-### 19G: Documentation Generation (post-merge)
-- [ ] Triggered after PR merge — auto-generate docs for completed stories
-- [ ] Update README sections affected by code changes
-- [ ] Generate changelog entries per story/sprint
-- [ ] Create/update Confluence pages for significant features
-- [ ] Label documentation stories as "Documentation" in Jira
-
-### 19H: Testing
-- [ ] Test spec export format with various story types (frontend, backend, infra)
-- [ ] Test GitHub Issue creation and PR-to-story linking
-- [ ] Test MCP server with mock client
-- [ ] Test webhook delivery and callback handling
-
----
-
-## Phase 20: QA Agent
-
-_AI-powered quality gate that reviews PRs against story specs. Outsources
-test execution to the project’s own CI pipeline and existing testing frameworks
-(pytest, Jest, Playwright, Cypress, etc.) — the agent provides the intelligence,
-not the infrastructure._
-
-### 20A: PR Review (your AI — unique value)
-- [ ] Triggered when a PR is opened or updated (via GitHub/AzDO webhook)
-- [ ] Validate against story AC — does the code actually implement what was specified?
-- [ ] AI diff analysis: logic errors, missing edge cases, code smell detection
-- [ ] Post structured review comments on the PR (by file, with severity levels)
-- [ ] Suggest improvements with code snippets, not just complaints
-
-### 20B: Test Plan Validation (your AI + external runners)
-- [ ] Read the test plan from the story’s AC (Given/When/Then scenarios)
-- [ ] Map test plan items to existing automated tests (or flag missing coverage)
-- [ ] Suggest additional test cases the developer may have missed
-- [ ] Integrate with CI: read test results from GitHub Actions / Azure Pipelines / Jenkins
-- [ ] Integrate with coverage tools: Codecov, Coveralls, SonarQube — read reports, don’t regenerate
-- [ ] Post coverage delta as PR comment ("Coverage: 84% → 87%, +3 new files covered")
-
-### 20C: Quality Gates (your orchestration + external signals)
-- [ ] Aggregate signals: CI status + coverage delta + AI review + security scan results
-- [ ] Quality score per PR (0-100 composite from all sources)
-- [ ] Block merge when critical issues found (configurable severity threshold)
-- [ ] Track quality trends over time per engineer and per module
-- [ ] Flag regressions: "This module’s coverage dropped from 85% to 72%"
-
-### 20D: Testing
-- [ ] Test PR analysis with synthetic diffs (clean code, buggy code, missing tests)
-- [ ] Test CI result ingestion from mock GitHub Actions / Azure Pipelines
-- [ ] Test quality scoring with various signal combinations
-
----
-
-## Phase 21: DevOps Agent
-
-_AI intelligence layer over existing DevOps tools. Monitors and diagnoses
-CI/CD pipelines, manages repo configuration, and orchestrates deployments —
-but delegates actual infrastructure to Terraform Cloud, ArgoCD, GitHub Actions,
-and other existing tools._
-
-### 21A: CI/CD Intelligence (your AI + existing pipelines)
-- [ ] Monitor pipeline runs via GitHub Actions / Azure Pipelines / Jenkins APIs
-- [ ] Diagnose failed builds — read logs, identify root cause, suggest fix
-- [ ] Detect flaky tests — track failure patterns, flag unreliable tests
-- [ ] Pipeline performance tracking — build time trends, bottleneck identification
-- [ ] Suggest pipeline optimisations (caching, parallelism, unnecessary steps)
-- [ ] Post diagnosis to PR or Slack when a build fails
-
-### 21B: Repository Management (your orchestration + GitHub/AzDO APIs)
-- [ ] Branch protection rules — configure/enforce per project policy via API
-- [ ] Auto-merge approved PRs that pass all checks (configurable policy)
-- [ ] Stale branch cleanup — identify and archive old feature branches
-- [ ] Release management — auto-tag, generate release notes, create GitHub releases
-- [ ] Integrate with existing CODEOWNERS and review requirements
-
-### 21C: Deployment Orchestration (your intelligence + external IaC)
-- [ ] Integrate with Terraform Cloud / Pulumi / ArgoCD — trigger deployments, read state
-- [ ] Deployment tracking — which commit is deployed where (read from CD tool APIs)
-- [ ] Rollback recommendations when post-deploy metrics degrade
-- [ ] Integrate with cloud cost tools (Infracost, AWS Cost Explorer) — alert on spend spikes
-- [ ] Preview environment management — trigger creation/teardown via existing IaC
-
-### 21D: Testing
-- [ ] Test pipeline diagnosis with synthetic build logs
-- [ ] Test branch management with mock GitHub API
-- [ ] Test deployment tracking with mock CD tool responses
-
----
-
-## Phase 22: Security Agent
-
-_AI orchestration layer that aggregates findings from best-in-class security
-scanners (Snyk, Semgrep, SonarQube, GitHub Advanced Security, Trivy) and
-provides unified, story-aware security intelligence. Doesn’t replace scanners —
-makes them smarter by correlating findings with your project context._
-
-### 22A: Code Security Review (your AI + external scanners)
-- [ ] Integrate with Semgrep / SonarQube / CodeQL — ingest scan results via API
-- [ ] AI enrichment: correlate findings with story context, assess real exploitability
-- [ ] Detect hardcoded secrets via GitLeaks / GitHub Secret Scanning integration
-- [ ] Reduce noise: suppress false positives, prioritise by actual risk to this project
-- [ ] Post unified security review on PRs (one comment thread, not five scanner bots)
-
-### 22B: Dependency Security (your orchestration + Snyk/Dependabot/OSV)
-- [ ] Integrate with Snyk / Dependabot / OSV.dev — pull vulnerability data via API
-- [ ] AI triage: assess impact on your codebase (is the vulnerable function actually used?)
-- [ ] Auto-raise PRs for critical dependency updates (via Dependabot or Renovate)
-- [ ] License compliance checking — flag incompatible licenses
-- [ ] Track vulnerability resolution time per team
-
-### 22C: Infrastructure Security (your AI + Trivy/Checkov/tfsec)
-- [ ] Integrate with Trivy / Checkov / tfsec — ingest IaC scan results
-- [ ] AI enrichment: prioritise findings by blast radius and business impact
-- [ ] Compliance mapping: link findings to GDPR, SOC2, PCI-DSS controls
-- [ ] Security posture dashboard — unified score from all integrated scanners
-- [ ] Trend tracking — is the security posture improving or degrading?
-
-### 22D: Testing
-- [ ] Test scanner result ingestion with mock API responses (Snyk, Semgrep, Trivy)
-- [ ] Test AI triage with intentionally vulnerable code + scanner output
-- [ ] Test false positive suppression accuracy
-
----
-
-## Phase 23: Product Discovery Agent
-
-_Analyses feature requests, customer feedback, and market signals to help
-the Product Owner make informed backlog prioritisation decisions._
-
-### 23A: Feature Request Analysis
-- [ ] Ingest feature requests from Jira, Slack, email, or web form
-- [ ] Compare against product strategy/goals — is this aligned?
-- [ ] Score by impact (users affected), effort (complexity estimate), and strategic fit
-- [ ] Cluster similar requests to identify demand patterns
-- [ ] Auto-suggest: accept (add to backlog), park (add to discovery), or archive
-
-### 23B: User Feedback Loop
-- [ ] Ingest customer feedback from support tickets, NPS surveys, app reviews
-- [ ] Sentiment analysis and theme extraction
-- [ ] Link feedback to existing stories/epics ("12 users mentioned this pain point")
-- [ ] Surface feedback during refinement sessions for relevant stories
-- [ ] Track feature adoption post-release — did users actually use it?
-
-### 23C: Testing
-- [ ] Test scoring model with diverse feature requests
-- [ ] Test clustering with overlapping and distinct requests
-- [ ] Test sentiment analysis with mixed feedback
-
----
-
-## Phase 24: Observability & Analytics Agent
-
-_Monitors all agent activity, tracks team performance metrics, and provides
-executive-level dashboards and reports._
-
-### 24A: Agent Observability
-- [ ] LangSmith integration for production tracing across all agents
-- [ ] Token usage tracking per agent, per session, per team
-- [ ] Cost attribution — which agents/features consume the most tokens
-- [ ] Agent performance metrics: latency, success rate, user satisfaction
-- [ ] Error tracking and alerting (agent failures, API timeouts, LLM errors)
-
-### 24B: Team Analytics Dashboard
-- [ ] Velocity trends (per team, per sprint, per engineer — anonymised option)
-- [ ] Sprint predictability score — how often does the team deliver what it planned?
-- [ ] Cycle time tracking — from story creation to deployment
-- [ ] Blocker frequency and resolution time
-- [ ] Cross-sprint comparison with configurable date ranges
-
-### 24C: Executive Reports
-- [ ] Auto-generated weekly/sprint/monthly reports
-- [ ] Progress against OKRs/milestones with RAG status
-- [ ] Resource utilisation and capacity planning insights
-- [ ] Risk register with AI-assessed likelihood and impact
-- [ ] Exportable to PDF, Confluence, or email
-
----
-
-## Phase 25: Platform Deployment & Infrastructure
-
-_Production infrastructure for the multi-agent platform._
-
-- [ ] Containerised deployment (Docker Compose for dev, Kubernetes for prod)
-- [ ] Secret management (HashiCorp Vault or cloud-native secrets manager)
-- [ ] PostgreSQL for persistent state (sessions, team data, sprint history)
-- [ ] Redis for real-time state and agent-to-agent messaging
-- [ ] Chroma (or Pinecone) for vector store in production
-- [ ] API rate limiting and request throttling
-- [ ] Horizontal scaling — multiple agent workers behind a queue
-- [ ] Health checks and readiness probes for each agent
-- [ ] Backup and disaster recovery for project data
-
----
-
-## Phase 26: Platform Production Readiness
-
-- [ ] Add token budget tracking per session
-- [ ] Add cost estimation before write operations ("This will create 14 tickets. Proceed?")
-- [ ] Implement model fallback chain (primary → backup → static response)
-- [ ] Add retry with exponential backoff for API failures
-- [ ] Add request timeout handling
-- [ ] LangSmith observability for production tracing
-- [ ] Comprehensive deployment documentation
-- [ ] Package as installable CLI tool (`pip install scrum-agent` or `pipx`)
-- [ ] CI/CD pipeline for the platform itself (lint, test, build, deploy)
-- [ ] Security audit of the platform (auth, data handling, API security)
-- [ ] Load testing — concurrent users, multiple agents, large projects
-- [ ] Tag v1.0.0 release

--- a/src/scrum_agent/agent/__init__.py
+++ b/src/scrum_agent/agent/__init__.py
@@ -18,8 +18,10 @@ from scrum_agent.agent.nodes import (
     task_decomposer,
 )
 from scrum_agent.agent.state import Discipline, ProjectAnalysis, PromptQualityRating, ScrumState
+from scrum_agent.prompts.intake import AnswerSource
 
 __all__ = [
+    "AnswerSource",
     "Discipline",
     "ProjectAnalysis",
     "PromptQualityRating",

--- a/src/scrum_agent/agent/nodes.py
+++ b/src/scrum_agent/agent/nodes.py
@@ -49,6 +49,7 @@ from scrum_agent.prompts.analyzer import get_analyzer_prompt
 from scrum_agent.prompts.feature_generator import get_feature_generator_prompt
 from scrum_agent.prompts.intake import (
     ADAPTIVE_QUESTION_TEMPLATES,
+    CONDITIONAL_ESSENTIALS,
     ESSENTIAL_QUESTIONS,
     FOLLOW_UP_TEMPLATES,
     INTAKE_QUESTIONS,
@@ -1118,9 +1119,14 @@ def _parse_date_dmy(text: str):
     if year < 100:
         year += 2000
     try:
-        return date(year, month, day)
+        parsed = date(year, month, day)
     except ValueError:
         return None
+    # Reject dates obviously in the past (> 6 months ago) — catches 2-digit year
+    # typos like "12/12/12" → 2012 which is clearly not a future leave date.
+    if (date.today() - parsed).days > 180:
+        return None
+    return parsed
 
 
 def _count_working_days(start_date, end_date) -> int:
@@ -2037,6 +2043,13 @@ def _prepare_bank_holiday_choices(questionnaire: QuestionnaireState) -> None:
 def _find_essential_gaps(questionnaire: QuestionnaireState, essential_set: frozenset[int]) -> list[int]:
     """Return sorted list of essential question numbers that are still unanswered.
 
+    # See README: "Project Intake Questionnaire" — conditional essentials
+    #
+    # In addition to the static essential set, CONDITIONAL_ESSENTIALS maps
+    # questions to their prerequisites. A conditional question becomes a gap
+    # when its prerequisite has a real (non-defaulted) answer — e.g., Q7
+    # (team roles) is only asked when Q6 (team size) was actually answered.
+
     Args:
         questionnaire: The current questionnaire state.
         essential_set: The set of essential question numbers to check.
@@ -2044,7 +2057,21 @@ def _find_essential_gaps(questionnaire: QuestionnaireState, essential_set: froze
     Returns:
         Sorted list of question numbers that have no answer recorded.
     """
-    return sorted(q for q in essential_set if q not in questionnaire.answers)
+    gaps = set(q for q in essential_set if q not in questionnaire.answers)
+
+    # Conditionals: promote to essential when prerequisite is answered (not defaulted).
+    # A conditional question becomes a gap when:
+    #   - it has no answer at all, OR it was auto-defaulted (worth re-asking)
+    #   - its prerequisite has a real (non-defaulted) answer
+    for q, prereq in CONDITIONAL_ESSENTIALS.items():
+        if (
+            (q not in questionnaire.answers or q in questionnaire.defaulted_questions)
+            and prereq in questionnaire.answers
+            and prereq not in questionnaire.defaulted_questions
+        ):
+            gaps.add(q)
+
+    return sorted(gaps)
 
 
 def _resolve_adaptive_text(q_num: int, questionnaire: QuestionnaireState) -> str:
@@ -2297,7 +2324,7 @@ def _validate_cross_questions(answers: dict[int, str]) -> list[ValidationWarning
     # Rule 1: Greenfield + repo URL
     q2 = answers.get(2, "")
     q17 = answers.get(17, "")
-    if q2 == "Greenfield" and q17 and "http" in q17.lower():
+    if q2.lower().strip() == "greenfield" and q17 and "http" in q17.lower():
         warnings.append(
             ValidationWarning(
                 question_nums=(2, 17),
@@ -2690,9 +2717,9 @@ def _show_summary_or_pto(questionnaire: QuestionnaireState, prefix: str = "") ->
         questionnaire._leave_input_stage = "ask"
         # Set awaiting_confirmation so the PTO handler runs in the confirmation gate
         questionnaire.awaiting_confirmation = True
-        # Keep current_question at TOTAL_QUESTIONS (not +1) so the TUI accordion
-        # can render — question TOTAL_QUESTIONS+1 has no accordion entry.
-        questionnaire.current_question = TOTAL_QUESTIONS
+        # Show PTO under Q28 (Holidays & leave) in the accordion — semantically
+        # PTO belongs with the leave/holidays section, not onboarding (Q30).
+        questionnaire.current_question = 28
         return {
             "questionnaire": questionnaire,
             "messages": [

--- a/src/scrum_agent/agent/nodes.py
+++ b/src/scrum_agent/agent/nodes.py
@@ -48,17 +48,27 @@ from scrum_agent.agent.state import (
 from scrum_agent.prompts.analyzer import get_analyzer_prompt
 from scrum_agent.prompts.feature_generator import get_feature_generator_prompt
 from scrum_agent.prompts.intake import (
+    ADAPTIVE_QUESTION_TEMPLATES,
+    ESSENTIAL_QUESTIONS,
+    FOLLOW_UP_TEMPLATES,
     INTAKE_QUESTIONS,
     PHASE_INTROS,
     PHASE_LABELS,
+    Q2_CONSTRAINT_HINTS,
+    Q2_INFERENCE_KEYWORDS,
     Q2_TO_Q15_MAP,
+    Q12_SERVICE_KEYWORDS,
+    Q13_INFRA_KEYWORDS,
     QUESTION_DEFAULTS,
     QUESTION_IMPROVEMENT_HINTS,
     QUESTION_METADATA,
+    QUESTION_SHORT_LABELS,
     QUICK_ESSENTIALS,
     QUICK_FALLBACK_DEFAULTS,
     SCRUM_MD_HINT,
     SMART_ESSENTIALS,
+    AnswerSource,
+    ValidationWarning,
     is_choice_question,
 )
 from scrum_agent.prompts.sprint_planner import get_sprint_planner_prompt
@@ -371,7 +381,10 @@ def _extract_answers_from_description(description: str) -> dict[int, str]:
         "mapping the question number (as a string key) to the extracted answer.\n\n"
         "STRICT RULES:\n"
         "- Only include questions where the user DIRECTLY stated the answer.\n"
-        "- Do NOT infer Q2 (project type) from verbs like 'refactor' or 'migrate'.\n"
+        "- Q2 (project type): INFER from strong signals like 'refactor', 'migrate', 'legacy' → Existing codebase; "
+        "'from scratch', 'new project', 'greenfield' → Greenfield.\n"
+        "- Q12 (integrations): EXTRACT named services (e.g. 'Stripe', 'Auth0', 'Firebase').\n"
+        "- Q13 (constraints): EXTRACT named infra (e.g. 'Kubernetes', 'AWS', 'microservices').\n"
         "- Do NOT infer Q11 (tech stack) from product/service names (e.g. 'Teleport', 'Kubernetes').\n"
         "- Do NOT infer Q4 (end-state) from vague goals like 'improve security'.\n"
         "- Do NOT extract Q3 (problem/users) unless the description names specific users or problems.\n"
@@ -421,6 +434,48 @@ def _extract_answers_from_description(description: str) -> dict[int, str]:
         # 26 questions as usual — the feature never breaks the existing flow.
         logger.debug("Failed to extract answers from description, falling back to full questionnaire", exc_info=True)
         return {}
+
+
+def _keyword_extract_fallback(description: str, extracted: dict[int, str]) -> dict[int, str]:
+    """Deterministic keyword-based extraction fallback after LLM extraction.
+
+    # See README: "Project Intake Questionnaire" — smart intake
+    #
+    # Scans the description for strong keyword signals for Q2 (project type),
+    # Q12 (integrations), and Q13 (architectural constraints). Only fills
+    # questions not already extracted by the LLM — LLM-extracted values
+    # always take priority.
+
+    Args:
+        description: The user's project description text.
+        extracted: The LLM-extracted answers dict (mutated in place with additions).
+
+    Returns:
+        The same extracted dict with any new keyword-based additions.
+    """
+    desc_lower = description.lower()
+
+    # Q2: project type from keywords
+    if 2 not in extracted:
+        for keyword, value in Q2_INFERENCE_KEYWORDS.items():
+            if keyword in desc_lower:
+                extracted[2] = value
+                break
+
+    # Q12: service/integration names
+    if 12 not in extracted:
+        found_services = [kw for kw in Q12_SERVICE_KEYWORDS if kw in desc_lower]
+        if found_services:
+            # Capitalize service names for readability
+            extracted[12] = ", ".join(s.capitalize() for s in sorted(found_services))
+
+    # Q13: infrastructure/architecture keywords
+    if 13 not in extracted:
+        found_infra = [kw for kw in Q13_INFRA_KEYWORDS if kw in desc_lower]
+        if found_infra:
+            extracted[13] = ", ".join(sorted(found_infra))
+
+    return extracted
 
 
 def _next_unskipped_question(current: int, skipped: set[int]) -> int | None:
@@ -568,6 +623,7 @@ def _batch_defaults_for_phase(questionnaire: QuestionnaireState) -> tuple[list[s
             default_val = meta.options[meta.default_index]
             questionnaire.answers[q_num] = default_val
             questionnaire.defaulted_questions.add(q_num)
+            questionnaire.answer_sources[q_num] = AnswerSource.DEFAULTED
             summary_lines.append(f"  Q{q_num}: {default_val}")
             count += 1
         elif q_num in QUESTION_DEFAULTS:
@@ -575,6 +631,7 @@ def _batch_defaults_for_phase(questionnaire: QuestionnaireState) -> tuple[list[s
             default_val = QUESTION_DEFAULTS[q_num]
             questionnaire.answers[q_num] = default_val
             questionnaire.defaulted_questions.add(q_num)
+            questionnaire.answer_sources[q_num] = AnswerSource.DEFAULTED
             summary_lines.append(f"  Q{q_num}: {default_val}")
             count += 1
         else:
@@ -1609,6 +1666,7 @@ def _auto_apply_extractions(questionnaire: QuestionnaireState, extracted: dict[i
     for q_num, answer in extracted.items():
         questionnaire.answers[q_num] = answer
         questionnaire.extracted_questions.add(q_num)
+        questionnaire.answer_sources[q_num] = AnswerSource.EXTRACTED
 
 
 def _auto_default_remaining(
@@ -1648,12 +1706,15 @@ def _auto_default_remaining(
         if meta and meta.default_index is not None:
             questionnaire.answers[q_num] = meta.options[meta.default_index]
             questionnaire.defaulted_questions.add(q_num)
+            questionnaire.answer_sources[q_num] = AnswerSource.DEFAULTED
         elif q_num in QUESTION_DEFAULTS:
             questionnaire.answers[q_num] = QUESTION_DEFAULTS[q_num]
             questionnaire.defaulted_questions.add(q_num)
+            questionnaire.answer_sources[q_num] = AnswerSource.DEFAULTED
         elif fallbacks and q_num in fallbacks:
             questionnaire.answers[q_num] = fallbacks[q_num]
             questionnaire.defaulted_questions.add(q_num)
+            questionnaire.answer_sources[q_num] = AnswerSource.DEFAULTED
 
 
 # Prompt shown immediately after Q2 is answered as "Existing codebase" or "Hybrid",
@@ -1701,6 +1762,7 @@ def _derive_q15_from_q2(questionnaire: QuestionnaireState) -> None:
     if derived:
         questionnaire.answers[15] = derived
         questionnaire.defaulted_questions.add(15)
+        questionnaire.answer_sources[15] = AnswerSource.DEFAULTED
 
 
 def _detect_bank_holidays_for_window(
@@ -1780,6 +1842,7 @@ def _derive_q27_from_locale(questionnaire: QuestionnaireState) -> None:
     questionnaire.answers[27] = "Fresh start (today)"
     questionnaire.extracted_questions.add(27)
     questionnaire.defaulted_questions.discard(27)
+    questionnaire.answer_sources[27] = AnswerSource.EXTRACTED
 
 
 def _resolve_sprint_start_date(questionnaire: QuestionnaireState) -> str:
@@ -1948,11 +2011,13 @@ def _prepare_bank_holiday_choices(questionnaire: QuestionnaireState) -> None:
         questionnaire.answers[28] = summary
         questionnaire.extracted_questions.add(28)
         questionnaire.defaulted_questions.discard(28)
+        questionnaire.answer_sources[28] = AnswerSource.EXTRACTED
         logger.debug("BANK_HOLIDAY: Q28 set to %r (extracted)", summary)
     else:
         questionnaire.answers[28] = "No bank holidays detected"
         questionnaire.extracted_questions.add(28)
         questionnaire.defaulted_questions.discard(28)
+        questionnaire.answer_sources[28] = AnswerSource.EXTRACTED
         logger.debug("BANK_HOLIDAY: Q28 set to 'No bank holidays detected'")
 
     # Populate choice menu for standard mode (Q28 is still interactive there)
@@ -1982,6 +2047,53 @@ def _find_essential_gaps(questionnaire: QuestionnaireState, essential_set: froze
     return sorted(q for q in essential_set if q not in questionnaire.answers)
 
 
+def _resolve_adaptive_text(q_num: int, questionnaire: QuestionnaireState) -> str:
+    """Return personalized question text if a template exists and dependencies are met.
+
+    # See README: "Project Intake Questionnaire" — adaptive question text
+    #
+    # Checks ADAPTIVE_QUESTION_TEMPLATES for q_num. If all referenced prior
+    # answers are available (and not defaulted), formats the template with
+    # those answers. Otherwise falls back to INTAKE_QUESTIONS[q_num].
+
+    Args:
+        q_num: The question number to resolve text for.
+        questionnaire: The current questionnaire state with answers.
+
+    Returns:
+        The personalized question text, or the original INTAKE_QUESTIONS text.
+    """
+    template = ADAPTIVE_QUESTION_TEMPLATES.get(q_num)
+    if not template:
+        return INTAKE_QUESTIONS[q_num]
+
+    try:
+        # Build format kwargs from prior answers
+        kwargs: dict[str, str] = {}
+        if "{q6}" in template:
+            q6 = questionnaire.answers.get(6)
+            if not q6 or 6 in questionnaire.defaulted_questions:
+                return INTAKE_QUESTIONS[q_num]
+            kwargs["q6"] = q6
+        if "{q11}" in template:
+            q11 = questionnaire.answers.get(11)
+            if not q11 or 11 in questionnaire.defaulted_questions:
+                return INTAKE_QUESTIONS[q_num]
+            kwargs["q11"] = q11
+        if "{q2}" in template:
+            q2 = questionnaire.answers.get(2)
+            if not q2 or 2 in questionnaire.defaulted_questions:
+                return INTAKE_QUESTIONS[q_num]
+            kwargs["q2"] = q2
+        if "{hint}" in template:
+            q2 = questionnaire.answers.get(2, "")
+            hint = Q2_CONSTRAINT_HINTS.get(q2, "microservices vs monolith, cloud provider")
+            kwargs["hint"] = hint
+        return template.format(**kwargs)
+    except (KeyError, ValueError):
+        return INTAKE_QUESTIONS[q_num]
+
+
 def _build_gap_prompt(gaps: list[int], questionnaire: QuestionnaireState) -> tuple[str, list[int]]:
     """Build the prompt text for the next essential gap to ask.
 
@@ -2001,7 +2113,7 @@ def _build_gap_prompt(gaps: list[int], questionnaire: QuestionnaireState) -> tup
 
     q_num = gaps[0]
 
-    prompt = INTAKE_QUESTIONS[q_num]
+    prompt = _resolve_adaptive_text(q_num, questionnaire)
     suggest = _build_suggestion_line(questionnaire, q_num)
     return (f"{prompt}{suggest}", [q_num])
 
@@ -2029,7 +2141,7 @@ def _build_skip_acknowledgment(question_num: int, *, during_probe: bool, default
     return f"Skipped Q{question_num} — I'll work without this information."
 
 
-def _check_vague_answer(question: str, answer: str) -> tuple[str, tuple[str, ...]] | None:
+def _check_vague_answer(question: str, answer: str, q_num: int = 0) -> tuple[str, tuple[str, ...]] | None:
     """Use the LLM to judge whether an intake answer is too vague.
 
     # See README: "Project Intake Questionnaire" — follow-up probing
@@ -2045,10 +2157,15 @@ def _check_vague_answer(question: str, answer: str) -> tuple[str, tuple[str, ...
     # Dynamic choices: when the answer is vague, the LLM also generates 2-4
     # contextual options for the follow-up so the user can pick a number
     # instead of composing a free-text answer from scratch.
+    #
+    # Custom follow-up templates (Step 4): when q_num has a FOLLOW_UP_TEMPLATES
+    # entry, the template is injected into the prompt as a hint. This produces
+    # more targeted follow-ups for key questions.
 
     Args:
         question: The intake question that was asked.
         answer: The user's response to the question.
+        q_num: The question number (used for custom follow-up templates).
 
     Returns:
         A (follow_up, choices) tuple if the answer is vague, where choices
@@ -2069,6 +2186,11 @@ def _check_vague_answer(question: str, answer: str) -> tuple[str, tuple[str, ...
     except ValueError:
         pass
 
+    # Build custom follow-up hint if available for this question
+    custom_hint = ""
+    if q_num and q_num in FOLLOW_UP_TEMPLATES:
+        custom_hint = f"\nIf vague, use this follow-up: '{FOLLOW_UP_TEMPLATES[q_num]}'\n"
+
     prompt = (
         "You are evaluating whether a user's answer to a project intake question "
         "is specific enough to be useful for Scrum planning.\n\n"
@@ -2080,6 +2202,7 @@ def _check_vague_answer(question: str, answer: str) -> tuple[str, tuple[str, ...
         "- Short answers can still be specific. 'React' is specific, 'something modern' is vague.\n"
         "- Only flag an answer as vague if it truly lacks actionable detail "
         "(e.g. 'stuff', 'not sure', 'the usual', 'some things').\n\n"
+        f"{custom_hint}"
         "If the answer is too vague or generic to be actionable, respond with JSON:\n"
         '{"vague": true, "follow_up": "A specific follow-up question to get more detail", '
         '"choices": ["Option A", "Option B", "Option C"]}\n\n'
@@ -2153,6 +2276,74 @@ def _parse_follow_up_choices(raw_choices: object) -> tuple[str, ...]:
     return tuple(cleaned[:4])
 
 
+def _validate_cross_questions(answers: dict[int, str]) -> list[ValidationWarning]:
+    """Run deterministic cross-question validation rules on completed answers.
+
+    # See README: "Project Intake Questionnaire" — cross-question validation
+    #
+    # Three rules (no LLM call):
+    # 1. Greenfield + repo URL → contradiction
+    # 2. Timeline > 6 months → advisory
+    # 3. Velocity / team_size outside 2-15 range → sanity check
+
+    Args:
+        answers: The questionnaire answers dict (q_num → answer string).
+
+    Returns:
+        A list of ValidationWarning instances (may be empty).
+    """
+    warnings: list[ValidationWarning] = []
+
+    # Rule 1: Greenfield + repo URL
+    q2 = answers.get(2, "")
+    q17 = answers.get(17, "")
+    if q2 == "Greenfield" and q17 and "http" in q17.lower():
+        warnings.append(
+            ValidationWarning(
+                question_nums=(2, 17),
+                message="Q2 says Greenfield but Q17 has a repo URL — did you mean Existing codebase?",
+            )
+        )
+
+    # Rule 2: Timeline > 6 months
+    q8 = answers.get(8, "")
+    q10 = answers.get(10, "")
+    sprint_weeks = _parse_first_int(q8) or 2
+    q10_nums = re.findall(r"\d+", q10)
+    if q10_nums:
+        target_sprints = int(q10_nums[-1])
+        total_weeks = sprint_weeks * target_sprints
+        if total_weeks > 26:
+            months = round(total_weeks / 4.3, 1)
+            warnings.append(
+                ValidationWarning(
+                    question_nums=(8, 10),
+                    message=f"Plan spans ~{months} months. Consider breaking into phases.",
+                    severity="info",
+                )
+            )
+
+    # Rule 3: Velocity sanity check
+    q6 = answers.get(6, "")
+    q9 = answers.get(9, "")
+    team_size = _parse_first_int(q6)
+    velocity = _parse_first_int(q9)
+    if team_size and team_size > 0 and velocity and velocity > 0:
+        ratio = velocity / team_size
+        if ratio < 2 or ratio > 15:
+            warnings.append(
+                ValidationWarning(
+                    question_nums=(6, 9),
+                    message=(
+                        f"Velocity of {velocity} with {team_size} engineers = "
+                        f"{ratio:.1f} pts/engineer. Typical range: 3-10."
+                    ),
+                )
+            )
+
+    return warnings
+
+
 def _build_intake_summary(questionnaire: QuestionnaireState) -> str:
     """Build a formatted markdown summary of all intake answers grouped by phase.
 
@@ -2187,22 +2378,44 @@ def _build_intake_summary(questionnaire: QuestionnaireState) -> str:
         sections.append("\n".join(lines))
 
     # Stats header — shows answer provenance at a glance
-    num_answered = len(
-        questionnaire.answers.keys() - questionnaire.extracted_questions - questionnaire.defaulted_questions
-    )
-    num_extracted = len(questionnaire.extracted_questions)
-    num_defaulted = len(questionnaire.defaulted_questions)
+    # Use answer_sources for the confidence breakdown when available,
+    # fall back to the legacy tracking sets for backward compatibility.
+    sources = questionnaire.answer_sources
+    if sources:
+        num_direct = sum(1 for v in sources.values() if v == AnswerSource.DIRECT)
+        num_extracted = sum(1 for v in sources.values() if v == AnswerSource.EXTRACTED)
+        num_defaulted = sum(1 for v in sources.values() if v == AnswerSource.DEFAULTED)
+        num_probed = sum(1 for v in sources.values() if v == AnswerSource.PROBED)
+    else:
+        num_direct = len(
+            questionnaire.answers.keys() - questionnaire.extracted_questions - questionnaire.defaulted_questions
+        )
+        num_extracted = len(questionnaire.extracted_questions)
+        num_defaulted = len(questionnaire.defaulted_questions)
+        num_probed = len(questionnaire.probed_questions)
     stats_parts: list[str] = []
-    if num_answered > 0:
-        stats_parts.append(f"{num_answered} answered")
+    if num_direct > 0:
+        stats_parts.append(f"{num_direct} direct")
     if num_extracted > 0:
         stats_parts.append(f"{num_extracted} extracted")
     if num_defaulted > 0:
-        stats_parts.append(f"{num_defaulted} defaults")
+        stats_parts.append(f"{num_defaulted} defaulted")
+    if num_probed > 0:
+        stats_parts.append(f"{num_probed} probed")
     stats_line = f"**{' | '.join(stats_parts)}**\n\n" if stats_parts else ""
 
+    # Cross-question validation — advisory warnings for contradictions/unrealistic combos
+    validation_warnings = _validate_cross_questions(questionnaire.answers)
+    warnings_block = ""
+    if validation_warnings:
+        warning_lines = ["**Heads up** — a few things worth double-checking:\n"]
+        for w in validation_warnings:
+            q_refs = ", ".join(f"Q{q}" for q in w.question_nums)
+            warning_lines.append(f"- {w.message} (edit {q_refs})")
+        warnings_block = "\n".join(warning_lines) + "\n\n"
+
     header = (
-        f"# Project Intake Summary\n\n{stats_line}"
+        f"# Project Intake Summary\n\n{stats_line}{warnings_block}"
         "Here's a summary of your answers. I'll use this to generate your Scrum plan.\n"
     )
     body = "\n---\n\n".join(sections)
@@ -2554,6 +2767,9 @@ def project_intake(state: ScrumState) -> dict:
                 description = first_msg.content
 
         extracted = _extract_answers_from_description(description)
+        # Deterministic keyword fallback — catches strong signals the LLM
+        # may have been too conservative to infer (Q2, Q12, Q13).
+        _keyword_extract_fallback(description, extracted)
 
         # ── SCRUM.md auto-population ─────────────────────────────────
         # Load SCRUM.md early so its content can pre-fill intake answers,
@@ -2593,6 +2809,7 @@ def project_intake(state: ScrumState) -> dict:
             if description.strip():
                 qs.answers[1] = description.strip()
                 qs.extracted_questions.add(1)
+                qs.answer_sources[1] = AnswerSource.EXTRACTED
 
             # Pick essential set based on mode (needed before extraction split)
             essential_set = QUICK_ESSENTIALS if intake_mode == "quick" else SMART_ESSENTIALS
@@ -2670,6 +2887,7 @@ def project_intake(state: ScrumState) -> dict:
                             )
                         qs.extracted_questions.add(9)
                         qs.defaulted_questions.discard(9)
+                        qs.answer_sources[9] = AnswerSource.EXTRACTED
                     else:
                         logger.debug(
                             "Jira velocity zero but org team size=%d stored",
@@ -2855,12 +3073,14 @@ def project_intake(state: ScrumState) -> dict:
                     questionnaire.answers[q_num] = last_msg.content
                     questionnaire.defaulted_questions.discard(q_num)
                     questionnaire.skipped_questions.discard(q_num)
+                    questionnaire.answer_sources[q_num] = AnswerSource.DIRECT
                 questionnaire._pending_merged_questions = []
             else:
                 # Single gap question
                 questionnaire.answers[current_q] = last_msg.content
                 questionnaire.defaulted_questions.discard(current_q)
                 questionnaire.skipped_questions.discard(current_q)
+                questionnaire.answer_sources[current_q] = AnswerSource.DIRECT
                 if current_q == 17:
                     _sync_platform_from_url(questionnaire)
                     platform = questionnaire.answers.get(16, "")
@@ -2890,10 +3110,11 @@ def project_intake(state: ScrumState) -> dict:
             # Skip for choice questions (selections are never vague).
             if not is_choice_question(current_q):
                 check_text = INTAKE_QUESTIONS[current_q]
-                vague_result = _check_vague_answer(check_text, last_msg.content)
+                vague_result = _check_vague_answer(check_text, last_msg.content, current_q)
                 if vague_result:
                     follow_up, choices = vague_result
                     questionnaire.probed_questions.add(current_q)
+                    questionnaire.answer_sources[current_q] = AnswerSource.PROBED
                     if choices:
                         questionnaire._follow_up_choices[current_q] = choices
                     return {
@@ -3403,7 +3624,7 @@ def project_intake(state: ScrumState) -> dict:
             return _show_summary_or_pto(questionnaire, prefix=f"{ack}\n\n")
 
         questionnaire.current_question = next_q
-        question = INTAKE_QUESTIONS[next_q]
+        question = _resolve_adaptive_text(next_q, questionnaire)
         new_phase = questionnaire.current_phase
         phase_label = PHASE_LABELS[new_phase]
         phase_intro = PHASE_INTROS.get(new_phase, "")
@@ -3436,6 +3657,7 @@ def project_intake(state: ScrumState) -> dict:
             default = QUESTION_DEFAULTS[current_q]
             questionnaire.answers[current_q] = default
             questionnaire.defaulted_questions.add(current_q)
+            questionnaire.answer_sources[current_q] = AnswerSource.DEFAULTED
             ack = _build_skip_acknowledgment(current_q, during_probe=False, default=default)
         else:
             # Essential question with no default — flag the gap
@@ -3449,7 +3671,7 @@ def project_intake(state: ScrumState) -> dict:
 
         prev_skip_phase = questionnaire.current_phase
         questionnaire.current_question = next_q
-        question = INTAKE_QUESTIONS[next_q]
+        question = _resolve_adaptive_text(next_q, questionnaire)
         new_skip_phase = questionnaire.current_phase
         phase_label = PHASE_LABELS[new_skip_phase]
         # Show phase intro when entering a new phase after a skip
@@ -3514,6 +3736,7 @@ def project_intake(state: ScrumState) -> dict:
     else:
         # First answer to this question — record it and check vagueness.
         questionnaire.answers[current_q] = last_msg.content
+        questionnaire.answer_sources[current_q] = AnswerSource.DIRECT
         if current_q == 17:
             _sync_platform_from_url(questionnaire)
             platform = questionnaire.answers.get(16, "")
@@ -3537,7 +3760,7 @@ def project_intake(state: ScrumState) -> dict:
         if is_choice_question(current_q):
             vague_result = None
         else:
-            vague_result = _check_vague_answer(INTAKE_QUESTIONS[current_q], last_msg.content)
+            vague_result = _check_vague_answer(INTAKE_QUESTIONS[current_q], last_msg.content, current_q)
         if vague_result:
             # Unpack follow-up question and dynamic choices from the LLM.
             # choices may be empty — the REPL gracefully degrades to open-ended.
@@ -3546,6 +3769,7 @@ def project_intake(state: ScrumState) -> dict:
             # The follow-up message has NO phase label or progress indicator
             # — it feels like a conversational clarification, not a new question.
             questionnaire.probed_questions.add(current_q)
+            questionnaire.answer_sources[current_q] = AnswerSource.PROBED
             # Store dynamic choices so the REPL can render a numbered menu.
             # Same lifecycle as probed_questions — cleared when follow-up is answered.
             if choices:
@@ -4122,6 +4346,20 @@ def compute_prompt_quality(qs: QuestionnaireState, *, has_user_context: bool = F
     if not has_user_context and len(suggestions) < _MAX_SUGGESTIONS:
         suggestions.append(SCRUM_MD_HINT)
 
+    # Low-confidence areas — essential questions that were defaulted.
+    # These are flagged as assumptions in ProjectAnalysis for downstream
+    # spike recommendations. Uses answer_sources when available.
+    low_confidence: list[str] = []
+    for q_num in sorted(ESSENTIAL_QUESTIONS):
+        is_defaulted = (
+            qs.answer_sources.get(q_num) == AnswerSource.DEFAULTED
+            if qs.answer_sources
+            else q_num in qs.defaulted_questions
+        )
+        if is_defaulted:
+            label = QUESTION_SHORT_LABELS.get(q_num, f"Q{q_num}")
+            low_confidence.append(label)
+
     return PromptQualityRating(
         score_pct=score_pct,
         grade=grade,
@@ -4131,6 +4369,7 @@ def compute_prompt_quality(qs: QuestionnaireState, *, has_user_context: bool = F
         skipped_count=skipped_count,
         probed_count=probed_count,
         suggestions=tuple(suggestions),
+        low_confidence_areas=tuple(low_confidence),
     )
 
 

--- a/src/scrum_agent/agent/state.py
+++ b/src/scrum_agent/agent/state.py
@@ -251,6 +251,7 @@ class PromptQualityRating:
     skipped_count: int
     probed_count: int
     suggestions: tuple[str, ...]
+    low_confidence_areas: tuple[str, ...] = ()  # QUESTION_SHORT_LABELS for defaulted essentials
 
 
 # See README: "Scrum Standards" — project analysis
@@ -412,6 +413,11 @@ class QuestionnaireState:
     # content (as opposed to the user's typed description). Used for provenance
     # markers in the intake preamble ("N from SCRUM.md").
     _scrum_md_questions: set[int] = field(default_factory=set)
+    # Unified answer provenance — maps question number to AnswerSource value.
+    # Populated alongside the existing tracking sets (extracted_questions,
+    # defaulted_questions, probed_questions) for backward compatibility.
+    # See README: "Project Intake Questionnaire" — answer confidence signalling
+    answer_sources: dict[int, str] = field(default_factory=dict)
 
     @property
     def current_phase(self) -> QuestionnairePhase:

--- a/src/scrum_agent/prompts/intake.py
+++ b/src/scrum_agent/prompts/intake.py
@@ -120,18 +120,18 @@ QUESTION_DEFAULTS: dict[int, str] = {
     16: "GitHub",
     17: "No repo URL provided",
     18: "Monorepo",
-    19: "No existing CI/CD pipeline",
+    19: "No",
     20: "No known technical debt identified",
     21: "No specific risks identified",
     22: "No known blockers or external dependencies",
     23: "No explicit exclusions",
     24: "Fibonacci points",
-    25: "Standard Scrum DoD (code reviewed, tests passing, deployed)",
+    25: "No — use a recommended DoD",
     26: "Markdown",
     27: "None",
     28: "No bank holidays detected",
     29: "10%",
-    30: "No engineers onboarding",
+    30: "None",
 }
 
 # ---------------------------------------------------------------------------
@@ -193,13 +193,14 @@ class QuestionMeta:
     # See README: "Project Intake Questionnaire" — selection menus
 
     Attributes:
-        question_type: "free_text" or "single_choice".
-        options: Tuple of option strings for single_choice questions.
-        default_index: Index into `options` for the default selection,
+        question_type: "free_text", "single_choice", or "multi_choice".
+        options: Tuple of option strings for choice questions.
+        default_index: Index into `options` for the default selection (single_choice),
             or None if no default (question is required / essential).
+            Ignored for multi_choice.
     """
 
-    question_type: str  # "free_text" | "single_choice"
+    question_type: str  # "free_text" | "single_choice" | "multi_choice"
     options: tuple[str, ...] = ()
     default_index: int | None = None
 
@@ -209,6 +210,10 @@ QUESTION_METADATA: dict[int, QuestionMeta] = {
         question_type="single_choice",
         options=("Greenfield", "Existing codebase", "Hybrid"),
         default_index=None,  # essential — no default
+    ),
+    7: QuestionMeta(
+        question_type="multi_choice",
+        options=("Backend", "Frontend", "Fullstack", "DevOps/Infra", "QA/Testing", "Design", "Data/ML"),
     ),
     8: QuestionMeta(
         question_type="single_choice",
@@ -226,6 +231,10 @@ QUESTION_METADATA: dict[int, QuestionMeta] = {
         ),
         default_index=4,  # No preference
     ),
+    13: QuestionMeta(
+        question_type="multi_choice",
+        options=("Microservices", "Monolith", "Serverless", "AWS", "GCP", "Azure", "On-premise", "Kubernetes/Docker"),
+    ),
     16: QuestionMeta(
         question_type="single_choice",
         options=("GitHub", "Azure DevOps", "GitLab", "Bitbucket", "Local"),
@@ -236,10 +245,20 @@ QUESTION_METADATA: dict[int, QuestionMeta] = {
         options=("Monorepo", "Multi-repo", "Microservices", "Monolith"),
         default_index=0,  # Monorepo
     ),
+    19: QuestionMeta(
+        question_type="single_choice",
+        options=("Yes", "No", "Partial/in progress"),
+        default_index=1,  # No
+    ),
     24: QuestionMeta(
         question_type="single_choice",
         options=("Fibonacci points", "T-shirt sizes", "No estimates"),
         default_index=0,  # Fibonacci points
+    ),
+    25: QuestionMeta(
+        question_type="single_choice",
+        options=("Yes — team has a standard DoD", "No — use a recommended DoD"),
+        default_index=1,  # No — use recommended
     ),
     26: QuestionMeta(
         question_type="single_choice",
@@ -260,6 +279,11 @@ QUESTION_METADATA: dict[int, QuestionMeta] = {
         question_type="single_choice",
         options=("0%", "5%", "10%", "15%", "20%"),
         default_index=2,  # 10%
+    ),
+    30: QuestionMeta(
+        question_type="single_choice",
+        options=("None", "1 engineer", "2 engineers", "3+ engineers"),
+        default_index=0,  # None
     ),
 }
 
@@ -290,6 +314,17 @@ ESSENTIAL_QUESTIONS: frozenset[int] = frozenset({1, 2, 3, 4, 6, 11, 15})
 # Q8 (sprint length) excluded — always defaults to "2 weeks" in smart mode.
 SMART_ESSENTIALS: frozenset[int] = frozenset({2, 3, 4, 6, 10, 11, 27})
 QUICK_ESSENTIALS: frozenset[int] = frozenset({6, 11})
+
+# Conditional essentials — questions that become essential when their
+# prerequisite has a real (non-defaulted) answer. This keeps smart mode
+# lean while still asking useful follow-ups when context is available.
+# See README: "Project Intake Questionnaire" — conditional essentials
+CONDITIONAL_ESSENTIALS: dict[int, int] = {
+    7: 6,  # ask team roles        when team size is answered
+    12: 11,  # ask integrations      when tech stack is answered
+    13: 2,  # ask constraints       when project type is answered
+    29: 6,  # ask unplanned leave % when team size is answered
+}
 
 # Deterministic mapping from Q2 (project type) → Q15 (existing codebase?).
 # Avoids an LLM call — Q15 is redundant when Q2 is answered.
@@ -578,13 +613,13 @@ class ValidationWarning:
 
 
 def is_choice_question(q_num: int) -> bool:
-    """Check whether a question number has single-choice metadata.
+    """Check whether a question number has choice metadata (single or multi).
 
     Args:
         q_num: The 1-based question number.
 
     Returns:
-        True if the question is a single-choice question with options.
+        True if the question is a single_choice or multi_choice question.
     """
     meta = QUESTION_METADATA.get(q_num)
-    return meta is not None and meta.question_type == "single_choice"
+    return meta is not None and meta.question_type in ("single_choice", "multi_choice")

--- a/src/scrum_agent/prompts/intake.py
+++ b/src/scrum_agent/prompts/intake.py
@@ -21,11 +21,32 @@
 """
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 # ---------------------------------------------------------------------------
 # All 30 intake questions, keyed by question number (1-based).
 # See README: "Project Intake Questionnaire" for rationale behind each phase.
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Answer provenance — tracks how each question was answered.
+# See README: "Project Intake Questionnaire" — answer confidence signalling
+#
+# Used by the intake summary to show a confidence breakdown and by
+# compute_prompt_quality() to identify low-confidence areas for downstream
+# spike recommendations.
+# ---------------------------------------------------------------------------
+
+
+class AnswerSource(StrEnum):
+    """How a questionnaire answer was obtained."""
+
+    DIRECT = "direct"
+    EXTRACTED = "extracted"
+    DEFAULTED = "defaulted"
+    PROBED = "probed"
+    SCRUM_MD = "scrum_md"
+
 
 INTAKE_QUESTIONS: dict[int, str] = {
     # Phase 1 — Project Context (Q1–Q5)
@@ -433,6 +454,127 @@ QUESTION_IMPROVEMENT_HINTS: dict[int, str] = {
 # was loaded. The SCRUM.md file lets users provide free-form project context
 # (URLs, design notes, tech decisions) that enriches the analysis.
 SCRUM_MD_HINT: str = "Add a SCRUM.md file to your project root with links, design notes, or tech decisions"
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Smarter Extraction — keyword maps for deterministic fallback
+# See README: "Project Intake Questionnaire" — smart intake
+#
+# After LLM extraction, a deterministic keyword scan catches signals the
+# LLM may have been too conservative to infer. Keywords are case-insensitive.
+# ---------------------------------------------------------------------------
+
+Q2_INFERENCE_KEYWORDS: dict[str, str] = {
+    "refactor": "Existing codebase",
+    "migrate": "Existing codebase",
+    "legacy": "Existing codebase",
+    "rewrite": "Existing codebase",
+    "from scratch": "Greenfield",
+    "new project": "Greenfield",
+    "startup": "Greenfield",
+    "greenfield": "Greenfield",
+}
+
+Q12_SERVICE_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "stripe",
+        "auth0",
+        "firebase",
+        "twilio",
+        "sendgrid",
+        "segment",
+        "launchdarkly",
+        "datadog",
+        "pagerduty",
+        "sentry",
+        "okta",
+        "plaid",
+        "algolia",
+        "cloudflare",
+        "vercel",
+    }
+)
+
+Q13_INFRA_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "kubernetes",
+        "k8s",
+        "microservices",
+        "serverless",
+        "lambda",
+        "aws",
+        "gcp",
+        "azure",
+        "docker",
+        "monolith",
+        "on-premise",
+        "terraform",
+        "cloudformation",
+        "ecs",
+        "eks",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Adaptive Question Text — templates that reference prior answers
+# See README: "Project Intake Questionnaire" — adaptive question text
+#
+# When a template's dependencies are available (and not defaulted), the
+# intake node renders the personalized version instead of the generic
+# INTAKE_QUESTIONS text. Fallback is always the original question.
+# ---------------------------------------------------------------------------
+
+ADAPTIVE_QUESTION_TEMPLATES: dict[int, str] = {
+    7: "You said {q6} engineers — what are their roles? (e.g., 2 backend, 1 frontend, 1 fullstack)",
+    12: "You mentioned {q11} as your tech stack. Are there any existing APIs, services, or third-party integrations?",
+    13: "Since this is a {q2} project, are there any architectural constraints? (e.g., {hint})",
+}
+
+Q2_CONSTRAINT_HINTS: dict[str, str] = {
+    "Greenfield": "microservices vs monolith, cloud provider, language choices",
+    "Existing codebase": "must preserve existing APIs, database migrations, backward compatibility",
+    "Hybrid": "which parts are new vs existing, integration boundaries",
+}
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Follow-up Quality — custom follow-up templates per question
+# See README: "Project Intake Questionnaire" — follow-up probing
+#
+# When _check_vague_answer detects a vague answer for one of these questions,
+# the custom template is injected into the LLM prompt as a hint. This produces
+# more targeted follow-ups than the generic "tell me more" approach.
+# ---------------------------------------------------------------------------
+
+FOLLOW_UP_TEMPLATES: dict[int, str] = {
+    3: "Who experiences this problem? Can you give 2-3 user personas?",
+    4: "What measurable outcome would tell you the project succeeded?",
+    7: "Can you break down the team by specialty? (e.g., 2 backend, 1 frontend, 1 DevOps)",
+    11: "What's the primary language and framework? And what database/storage?",
+    12: "Which integrations are critical vs nice-to-have?",
+    13: "Are these constraints firm (non-negotiable) or preferences?",
+    20: "Which area of tech debt is the highest risk?",
+    21: "Which risk should be addressed earliest? What's the worst-case impact?",
+}
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Cross-Question Validation — catch contradictions before analysis
+# See README: "Project Intake Questionnaire" — cross-question validation
+#
+# Deterministic rules (no LLM call) that flag contradictory or unrealistic
+# answer combinations. Warnings are advisory — the user can still confirm.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidationWarning:
+    """A warning about contradictory or unrealistic intake answers."""
+
+    question_nums: tuple[int, ...]
+    message: str
+    severity: str = "warning"  # "warning" | "info"
 
 
 def is_choice_question(q_num: int) -> bool:

--- a/src/scrum_agent/repl/_io.py
+++ b/src/scrum_agent/repl/_io.py
@@ -245,6 +245,18 @@ def _append_capacity_section(lines: list[str], graph_state: dict) -> None:
     team_size = graph_state.get("team_size", 0)
     velocity = graph_state.get("velocity_per_sprint", 0)
     net_velocity = graph_state.get("net_velocity_per_sprint", 0)
+
+    # Fallback: if analyzer hasn't run yet (export at intake review stage),
+    # compute capacity from the questionnaire directly — same as the intake
+    # summary does. This ensures early exports include PTO/capacity data.
+    if (not team_size or not velocity) and graph_state.get("questionnaire"):
+        from scrum_agent.agent.nodes import _extract_capacity_deductions, _extract_team_and_velocity
+
+        qs = graph_state["questionnaire"]
+        tv = _extract_team_and_velocity(qs)
+        team_size = team_size or tv.get("team_size", 0)
+        velocity = velocity or tv.get("velocity_per_sprint", 0)
+
     _log.debug(
         "CAPACITY_EXPORT: team_size=%s velocity=%s net_velocity=%s",
         team_size,
@@ -255,9 +267,23 @@ def _append_capacity_section(lines: list[str], graph_state: dict) -> None:
         _log.debug("CAPACITY_EXPORT: skipping — team_size or velocity is 0/missing")
         return
 
-    sprint_weeks = graph_state.get("sprint_length_weeks", 2)
+    sprint_weeks = graph_state.get("sprint_length_weeks", 0)
     analysis = graph_state.get("project_analysis")
     target_sprints = analysis.target_sprints if analysis else 0
+
+    # Fallback: derive sprint_weeks and target_sprints from questionnaire
+    if graph_state.get("questionnaire"):
+        from scrum_agent.agent.nodes import _parse_first_int
+
+        qs = graph_state["questionnaire"]
+        if not sprint_weeks:
+            sprint_weeks = _parse_first_int(qs.answers.get(8, "2 weeks")) or 2
+        if not target_sprints:
+            import re
+
+            q10 = qs.answers.get(10, "")
+            q10_nums = re.findall(r"\d+", q10)
+            target_sprints = int(q10_nums[-1]) if q10_nums else 0
     if not target_sprints:
         return
 
@@ -268,6 +294,17 @@ def _append_capacity_section(lines: list[str], graph_state: dict) -> None:
     ktlo = graph_state.get("capacity_ktlo_engineers", 0)
     discovery_pct = graph_state.get("capacity_discovery_pct", 5)
 
+    # Fallback: extract capacity deductions from questionnaire
+    if not any([bank_holidays, planned_leave, unplanned_pct, onboarding]) and graph_state.get("questionnaire"):
+        from scrum_agent.agent.nodes import _extract_capacity_deductions
+
+        qs = graph_state["questionnaire"]
+        cap = _extract_capacity_deductions(qs)
+        bank_holidays = bank_holidays or cap.get("capacity_bank_holiday_days", 0)
+        planned_leave = planned_leave or cap.get("capacity_planned_leave_days", 0)
+        unplanned_pct = unplanned_pct or cap.get("capacity_unplanned_leave_pct", 0)
+        onboarding = onboarding or cap.get("capacity_onboarding_engineer_sprints", 0)
+
     lines.append("## Capacity")
     lines.append("")
     lines.append(f"- **Team size:** {team_size} engineer(s)")
@@ -277,6 +314,8 @@ def _append_capacity_section(lines: list[str], graph_state: dict) -> None:
 
     deductions: list[str] = []
     leave_entries = graph_state.get("planned_leave_entries", [])
+    if not leave_entries and graph_state.get("questionnaire"):
+        leave_entries = list(graph_state["questionnaire"]._planned_leave_entries)
     if planned_leave > 0:
         if leave_entries:
             leave_detail = ", ".join(f"{e['person']} {e['working_days']}d" for e in leave_entries)

--- a/src/scrum_agent/ui/session/phases/_phases_intake.py
+++ b/src/scrum_agent/ui/session/phases/_phases_intake.py
@@ -218,11 +218,26 @@ def _phase_intake_questions(
                 progress = f"Q{cur_q} of {TOTAL_QUESTIONS}"
             suggestion = _get_active_suggestion(graph_state)
 
-            # Choice options for single-choice questions
+            # Choice options for single-choice questions.
+            # When an extracted suggestion matches one of the options, pre-select
+            # it instead of the static default — the user sees the arrow on the
+            # extracted answer and can just press Enter to confirm.
             if is_choice_question(cur_q) and cur_q not in qs.probed_questions:
                 meta = QUESTION_METADATA.get(cur_q)
                 if meta:
-                    choices = [(opt, i == meta.default_index) for i, opt in enumerate(meta.options)]
+                    # Determine which option to highlight: extracted suggestion > static default
+                    pre_select_idx = meta.default_index
+                    if suggestion:
+                        sugg_lower = suggestion.lower().strip()
+                        for i, opt in enumerate(meta.options):
+                            if opt.lower().strip() == sugg_lower:
+                                pre_select_idx = i
+                                break
+                    choices = [(opt, i == pre_select_idx) for i, opt in enumerate(meta.options)]
+                    # Clear the text suggestion — the pre-selected option IS the
+                    # suggestion now, so we don't need the two-step confirm flow.
+                    if suggestion and pre_select_idx is not None:
+                        suggestion = None
 
             # Dynamic choices — follow-up probes or node-generated options (e.g. Q27 sprint selection)
             follow_up_choices = qs._follow_up_choices.get(cur_q)
@@ -318,7 +333,7 @@ def _phase_intake_questions(
             "suggestion": suggestion,
             "progress": progress,
             "phase_label": phase_label,
-            "selected_choice": 0,
+            "selected_choice": next((i for i, (_, is_def) in enumerate(choices) if is_def), 0) if choices else 0,
         }
         if isinstance(qs, QuestionnaireState):
             screen_kwargs["questionnaire"] = qs
@@ -386,7 +401,13 @@ def _question_input_loop(
     # Cursor at start for prefilled suggestions (so user sees beginning of long text),
     # at end for editing existing answers (user typically appends).
     cursor_pos = 0 if prefill else len(input_value)
+    # Start on the pre-selected option (extracted suggestion or static default) if any
     selected_choice = 0
+    if choices:
+        for i, (_opt, is_default) in enumerate(choices):
+            if is_default:
+                selected_choice = i
+                break
     selected_choices: set[int] = set()  # for multi-select mode
     scroll_offset = 0
     use_accordion = questionnaire is not None

--- a/src/scrum_agent/ui/session/phases/_phases_intake.py
+++ b/src/scrum_agent/ui/session/phases/_phases_intake.py
@@ -182,11 +182,15 @@ def _phase_intake_questions(
     while True:
         qs = graph_state.get("questionnaire")
         if isinstance(qs, QuestionnaireState):
-            # Don't exit the intake loop while PTO sub-loop is active —
+            # Don't exit the intake loop while PTO sub-loop or editing is active —
             # _awaiting_leave_input means we're still collecting leave entries
-            # within the confirmation gate, and the user needs to answer PTO
-            # questions before seeing the review screen.
-            if (qs.completed or qs.awaiting_confirmation) and not qs._awaiting_leave_input:
+            # within the confirmation gate, and editing_question means the user
+            # is re-answering a question from the review screen.
+            if (
+                (qs.completed or qs.awaiting_confirmation)
+                and not qs._awaiting_leave_input
+                and qs.editing_question is None
+            ):
                 logger.info("Intake questions complete: completed=%s", qs.completed)
                 return graph_state
 
@@ -218,14 +222,31 @@ def _phase_intake_questions(
                 progress = f"Q{cur_q} of {TOTAL_QUESTIONS}"
             suggestion = _get_active_suggestion(graph_state)
 
-            # Choice options for single-choice questions.
+            # Choice options for single-choice and multi-choice questions.
             # When an extracted suggestion matches one of the options, pre-select
             # it instead of the static default — the user sees the arrow on the
             # extracted answer and can just press Enter to confirm.
-            if is_choice_question(cur_q) and cur_q not in qs.probed_questions:
+            is_multi_select = False
+            # Skip static choice rendering when PTO sub-loop is active — it
+            # sets current_question=30 but shows its own Yes/No prompt text.
+            in_pto_subloop = qs._awaiting_leave_input
+            if is_choice_question(cur_q) and cur_q not in qs.probed_questions and not in_pto_subloop:
                 meta = QUESTION_METADATA.get(cur_q)
-                if meta:
-                    # Determine which option to highlight: extracted suggestion > static default
+                if meta and meta.question_type == "multi_choice":
+                    # Multi-choice: pre-select options that match extracted/suggested values
+                    is_multi_select = True
+                    pre_selected: set[int] = set()
+                    if suggestion:
+                        # Suggestion may be comma-separated (e.g. "Backend, Frontend")
+                        sugg_parts = {s.strip().lower() for s in suggestion.split(",")}
+                        for i, opt in enumerate(meta.options):
+                            if opt.lower() in sugg_parts:
+                                pre_selected.add(i)
+                        if pre_selected:
+                            suggestion = None
+                    choices = [(opt, i in pre_selected) for i, opt in enumerate(meta.options)]
+                elif meta:
+                    # Single-choice: highlight extracted suggestion > static default
                     pre_select_idx = meta.default_index
                     if suggestion:
                         sugg_lower = suggestion.lower().strip()
@@ -240,9 +261,9 @@ def _phase_intake_questions(
                         suggestion = None
 
             # Dynamic choices — follow-up probes or node-generated options (e.g. Q27 sprint selection)
+            # Skip during PTO sub-loop — it uses its own prompt text, not Q28's bank holiday choices.
             follow_up_choices = qs._follow_up_choices.get(cur_q)
-            is_multi_select = False
-            if follow_up_choices:
+            if follow_up_choices and not in_pto_subloop:
                 choices = [(opt, False) for opt in follow_up_choices]
                 is_multi_select = True
 

--- a/tests/_node_helpers.py
+++ b/tests/_node_helpers.py
@@ -27,6 +27,7 @@ def make_completed_questionnaire() -> QuestionnaireState:
     qs = QuestionnaireState(completed=True, current_question=TOTAL_QUESTIONS + 1)
     for i in range(1, TOTAL_QUESTIONS + 1):
         qs.answers[i] = f"Answer for Q{i}"
+        qs.answer_sources[i] = "direct"
     return qs
 
 

--- a/tests/unit/nodes/test_intake.py
+++ b/tests/unit/nodes/test_intake.py
@@ -37,6 +37,7 @@ from scrum_agent.agent.state import (
     QuestionnaireState,
 )
 from scrum_agent.prompts.intake import (
+    CONDITIONAL_ESSENTIALS,
     INTAKE_QUESTIONS,
     PHASE_INTROS,
     PHASE_LABELS,
@@ -849,42 +850,42 @@ class TestFollowUpProbing:
         # Should contain the follow-up
         assert "What kind of users?" in content
 
-    def test_probing_on_last_question_then_completes(self, monkeypatch):
-        """Probing on the last free-text question (Q25), then answering follow-up → completes questionnaire.
+    def test_probing_on_last_free_text_question_then_completes(self, monkeypatch):
+        """Probing on the last free-text question (Q23), then answering follow-up → advances.
 
-        Note: Q26 is a choice question (skips vagueness check), so we test with Q25
-        which is the last free-text question before Q26 is auto-answered.
+        Note: Q24, Q25, Q26 are choice questions (skip vagueness check), so we test
+        with Q23 which is the last free-text question before the choices run.
         """
-        # First call: vague answer on Q25 → follow-up
+        # First call: vague answer on Q23 → follow-up
         monkeypatch.setattr(
             "scrum_agent.agent.nodes._check_vague_answer",
-            lambda q, a, n=0: ("What does your Definition of Done include?", ("Tests passing", "Code reviewed")),
+            lambda q, a, n=0: ("What specifically is out of scope?", ("Mobile app", "Analytics")),
         )
 
-        qs = QuestionnaireState(current_question=25)
-        qs.answers = {i: f"answer {i}" for i in range(1, 25)}
+        qs = QuestionnaireState(current_question=23)
+        qs.answers = {i: f"answer {i}" for i in range(1, 23)}
         state = {
-            "messages": [HumanMessage(content="Standard")],
+            "messages": [HumanMessage(content="Nothing specific")],
             "questionnaire": qs,
         }
 
         result1 = project_intake(state)
         assert result1["questionnaire"].completed is False
-        assert 25 in result1["questionnaire"].probed_questions
+        assert 23 in result1["questionnaire"].probed_questions
 
-        # Second call: follow-up answer on Q25 → should advance to Q26
+        # Second call: follow-up answer on Q23 → should advance to Q24
         monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
         state2 = {
-            "messages": [HumanMessage(content="Code reviewed, tests passing, deployed to staging")],
+            "messages": [HumanMessage(content="Mobile app and advanced analytics are out of scope")],
             "questionnaire": result1["questionnaire"],
         }
 
         result2 = project_intake(state2)
-        # Should advance to Q26 (not complete yet)
-        assert result2["questionnaire"].current_question == 26
+        # Should advance to Q24 (not complete yet)
+        assert result2["questionnaire"].current_question == 24
         # Combined answer should be stored
-        assert "Follow-up detail:" in result2["questionnaire"].answers[25]
+        assert "Follow-up detail:" in result2["questionnaire"].answers[23]
 
 
 # ── Skip intent detection tests ──────────────────────────────────────
@@ -1949,19 +1950,21 @@ class TestExtractCapacityDeductions:
 class TestQuestionMetadata:
     """Tests for QUESTION_METADATA structure and is_choice_question helper."""
 
-    def test_metadata_has_ten_entries(self):
-        """QUESTION_METADATA should define exactly 10 choice questions."""
-        assert len(QUESTION_METADATA) == 10
+    def test_metadata_has_fifteen_entries(self):
+        """QUESTION_METADATA should define exactly 15 choice questions."""
+        assert len(QUESTION_METADATA) == 15
 
     def test_all_entries_are_question_meta(self):
         """Every value in QUESTION_METADATA should be a QuestionMeta instance."""
         for q_num, meta in QUESTION_METADATA.items():
             assert isinstance(meta, QuestionMeta), f"Q{q_num} is not a QuestionMeta"
 
-    def test_all_entries_are_single_choice(self):
-        """Every entry should have question_type == 'single_choice'."""
+    def test_all_entries_are_valid_choice_type(self):
+        """Every entry should have question_type 'single_choice' or 'multi_choice'."""
         for q_num, meta in QUESTION_METADATA.items():
-            assert meta.question_type == "single_choice", f"Q{q_num} is not single_choice"
+            assert meta.question_type in ("single_choice", "multi_choice"), (
+                f"Q{q_num} has invalid type '{meta.question_type}'"
+            )
 
     def test_all_entries_have_options(self):
         """Every entry should have at least 2 options (except Q27/Q28 which are dynamic)."""
@@ -1971,8 +1974,8 @@ class TestQuestionMetadata:
             assert len(meta.options) >= 2, f"Q{q_num} has fewer than 2 options"
 
     def test_expected_question_numbers(self):
-        """The 10 choice questions should be Q2, Q8, Q10, Q16, Q18, Q24, Q26, Q27, Q28, Q29."""
-        assert set(QUESTION_METADATA.keys()) == {2, 8, 10, 16, 18, 24, 26, 27, 28, 29}
+        """The 15 choice questions."""
+        assert set(QUESTION_METADATA.keys()) == {2, 7, 8, 10, 13, 16, 18, 19, 24, 25, 26, 27, 28, 29, 30}
 
     def test_default_index_valid_or_none(self):
         """default_index must be None or a valid index into options."""
@@ -1994,12 +1997,12 @@ class TestQuestionMetadata:
         assert is_choice_question(1) is False
         assert is_choice_question(3) is False
         assert is_choice_question(11) is False
-        assert is_choice_question(25) is False
+        assert is_choice_question(20) is False
 
     def test_defaults_consistency(self):
-        """For choice Qs with a default_index, QUESTION_DEFAULTS should match the option text."""
+        """For single_choice Qs with a default_index, QUESTION_DEFAULTS should match the option text."""
         for q_num, meta in QUESTION_METADATA.items():
-            if meta.default_index is not None:
+            if meta.question_type == "single_choice" and meta.default_index is not None:
                 expected = meta.options[meta.default_index]
                 assert QUESTION_DEFAULTS[q_num] == expected, (
                     f"Q{q_num}: QUESTION_DEFAULTS[{q_num}]='{QUESTION_DEFAULTS[q_num]}' "
@@ -2400,9 +2403,9 @@ class TestFindEssentialGaps:
         qs.answers = {2: "Greenfield", 6: "3"}
         gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
         # SMART_ESSENTIALS = {2, 3, 4, 6, 10, 11, 27}; answered: 2, 6
-        # Q8 excluded — always defaults to "2 weeks" in smart mode
-        # → gaps: 3, 4, 10, 11, 27
-        assert gaps == [3, 4, 10, 11, 27]
+        # Conditional: Q6 answered → Q7, Q29 promoted; Q2 answered → Q13 promoted
+        # → gaps: 3, 4, 7, 10, 11, 13, 27, 29
+        assert gaps == [3, 4, 7, 10, 11, 13, 27, 29]
 
     def test_no_gaps_when_all_answered(self):
         qs = QuestionnaireState()
@@ -2411,10 +2414,14 @@ class TestFindEssentialGaps:
             3: "Problem",
             4: "Done state",
             6: "3",
+            7: "Backend, Frontend",
             8: "2 weeks",
             10: "5 sprints",
             11: "React",
+            12: "No integrations",
+            13: "AWS",
             27: "Fresh start (today)",
+            29: "10%",
         }
         gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
         assert gaps == []
@@ -3248,6 +3255,8 @@ class TestPTOSubLoop:
 
     def test_pto_start_date_before_window_rejected(self):
         """Start date before planning window should be rejected."""
+        from datetime import date, timedelta
+
         qs = self._make_qs_at_confirmation("standard")
         qs._awaiting_leave_input = True
         qs._leave_input_stage = "start"
@@ -3255,7 +3264,9 @@ class TestPTOSubLoop:
         # Q8=2 weeks, Q10=2 sprints → window is today + 4 weeks
         qs.answers[8] = "2 weeks"
         qs.answers[10] = "2 sprints"
-        state = {"messages": [HumanMessage(content="01/01/2020")], "questionnaire": qs}
+        # Use a date within 6 months but before the planning window (yesterday)
+        yesterday = (date.today() - timedelta(days=1)).strftime("%d/%m/%Y")
+        state = {"messages": [HumanMessage(content=yesterday)], "questionnaire": qs}
         result = project_intake(state)
         assert "before" in result["messages"][0].content.lower()
         assert result["questionnaire"]._leave_input_stage == "start"
@@ -3309,6 +3320,13 @@ class TestPTOSubLoop:
         assert _parse_date_dmy("06/04/26") == date(2026, 4, 6)
         assert _parse_date_dmy("06-04-2026") == date(2026, 4, 6)
         assert _parse_date_dmy("06-04-26") == date(2026, 4, 6)
+
+    def test_rejects_dates_far_in_past(self):
+        """Dates more than 6 months in the past should be rejected (catches 2-digit year typos)."""
+        from scrum_agent.agent.nodes import _parse_date_dmy
+
+        assert _parse_date_dmy("12/12/12") is None  # 2012 — clearly in the past
+        assert _parse_date_dmy("01/01/2020") is None
 
 
 # ── Smart Intake Improvements tests ─────────────────────────────────
@@ -3587,6 +3605,15 @@ class TestCrossQuestionValidation:
         assert "Greenfield" in warnings[0].message
         assert "repo URL" in warnings[0].message
 
+    def test_greenfield_case_insensitive(self):
+        """Greenfield check should be case-insensitive."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        for variant in ("greenfield", "GREENFIELD", "Greenfield", " greenfield "):
+            answers = {2: variant, 17: "https://github.com/org/repo"}
+            warnings = _validate_cross_questions(answers)
+            assert len(warnings) == 1, f"Failed for q2={variant!r}"
+
     def test_existing_codebase_with_repo_url_no_warning(self):
         """Existing codebase + repo URL should NOT produce a warning."""
         from scrum_agent.agent.nodes import _validate_cross_questions
@@ -3659,3 +3686,141 @@ class TestCrossQuestionValidation:
         summary = _build_intake_summary(qs)
         assert "Heads up" in summary
         assert "Greenfield" in summary
+
+
+class TestConditionalEssentials:
+    """Tests for CONDITIONAL_ESSENTIALS and their integration with _find_essential_gaps."""
+
+    def test_q7_promoted_when_q6_answered(self):
+        """Q7 (team roles) becomes a gap when Q6 (team size) has a real answer."""
+        qs = QuestionnaireState()
+        qs.answers = {6: "5"}
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 7 in gaps
+
+    def test_q7_not_promoted_when_q6_defaulted(self):
+        """Q7 stays defaulted when Q6 was itself defaulted — no point asking roles."""
+        qs = QuestionnaireState()
+        qs.answers = {6: "3"}
+        qs.defaulted_questions.add(6)
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 7 not in gaps
+
+    def test_q12_promoted_when_q11_answered(self):
+        """Q12 (integrations) becomes a gap when Q11 (tech stack) is answered."""
+        qs = QuestionnaireState()
+        qs.answers = {11: "React, FastAPI"}
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 12 in gaps
+
+    def test_q12_not_promoted_when_q11_defaulted(self):
+        qs = QuestionnaireState()
+        qs.answers = {11: "Not specified"}
+        qs.defaulted_questions.add(11)
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 12 not in gaps
+
+    def test_q13_promoted_when_q2_answered(self):
+        """Q13 (constraints) becomes a gap when Q2 (project type) is answered."""
+        qs = QuestionnaireState()
+        qs.answers = {2: "Greenfield"}
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 13 in gaps
+
+    def test_q13_not_promoted_when_q2_defaulted(self):
+        qs = QuestionnaireState()
+        qs.answers = {2: "Greenfield"}
+        qs.defaulted_questions.add(2)
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 13 not in gaps
+
+    def test_conditional_not_promoted_when_directly_answered(self):
+        """If Q7 has a direct (non-defaulted) answer, it should not appear as a gap."""
+        qs = QuestionnaireState()
+        qs.answers = {6: "5", 7: "Backend, Frontend"}
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 7 not in gaps
+
+    def test_conditional_promoted_when_defaulted_and_prereq_answered(self):
+        """Q7 defaulted by _auto_default_remaining should become a gap when Q6 is answered."""
+        qs = QuestionnaireState()
+        qs.answers = {6: "5", 7: "Roles not specified — assuming generalist/fullstack team"}
+        qs.defaulted_questions.add(7)
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 7 in gaps
+
+    def test_q29_promoted_when_q6_answered(self):
+        """Q29 (unplanned leave %) becomes a gap when Q6 (team size) is answered."""
+        qs = QuestionnaireState()
+        qs.answers = {6: "5"}
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 29 in gaps
+
+    def test_q29_not_promoted_when_q6_defaulted(self):
+        qs = QuestionnaireState()
+        qs.answers = {6: "3"}
+        qs.defaulted_questions.add(6)
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 29 not in gaps
+
+    def test_multiple_conditionals_promoted_together(self):
+        """All four conditionals can fire at once when prerequisites are met."""
+        qs = QuestionnaireState()
+        qs.answers = {2: "Existing codebase", 6: "4", 11: "Python, Django"}
+        gaps = _find_essential_gaps(qs, SMART_ESSENTIALS)
+        assert 7 in gaps
+        assert 12 in gaps
+        assert 13 in gaps
+        assert 29 in gaps
+
+    def test_conditional_essentials_mapping_is_complete(self):
+        """Verify the mapping covers Q7→Q6, Q12→Q11, Q13→Q2, Q29→Q6."""
+        assert CONDITIONAL_ESSENTIALS == {7: 6, 12: 11, 13: 2, 29: 6}
+
+
+class TestMultiChoiceMetadata:
+    """Tests for multi_choice question metadata and is_choice_question."""
+
+    def test_q7_is_multi_choice(self):
+        meta = QUESTION_METADATA[7]
+        assert meta.question_type == "multi_choice"
+        assert "Backend" in meta.options
+        assert "Frontend" in meta.options
+        assert "Fullstack" in meta.options
+
+    def test_q13_is_multi_choice(self):
+        meta = QUESTION_METADATA[13]
+        assert meta.question_type == "multi_choice"
+        assert "AWS" in meta.options
+        assert "Microservices" in meta.options
+
+    def test_q19_is_single_choice(self):
+        meta = QUESTION_METADATA[19]
+        assert meta.question_type == "single_choice"
+        assert meta.options == ("Yes", "No", "Partial/in progress")
+        assert meta.default_index == 1
+
+    def test_q25_is_single_choice(self):
+        meta = QUESTION_METADATA[25]
+        assert meta.question_type == "single_choice"
+        assert len(meta.options) == 2
+        assert meta.default_index == 1
+
+    def test_q30_is_single_choice(self):
+        meta = QUESTION_METADATA[30]
+        assert meta.question_type == "single_choice"
+        assert "None" in meta.options
+        assert meta.default_index == 0
+
+    def test_is_choice_question_includes_multi_choice(self):
+        """is_choice_question should return True for both single and multi choice."""
+        assert is_choice_question(7) is True  # multi_choice
+        assert is_choice_question(13) is True  # multi_choice
+        assert is_choice_question(2) is True  # single_choice
+        assert is_choice_question(1) is False  # free text
+
+    def test_multi_choice_has_no_default_index(self):
+        """Multi-choice questions don't use default_index — users toggle selections."""
+        for q_num, meta in QUESTION_METADATA.items():
+            if meta.question_type == "multi_choice":
+                assert meta.default_index is None, f"Q{q_num} multi_choice should have no default_index"

--- a/tests/unit/nodes/test_intake.py
+++ b/tests/unit/nodes/test_intake.py
@@ -61,7 +61,7 @@ class TestProjectIntake:
         patches it to always return None (accept the answer as-is), keeping
         existing test logic unchanged.
         """
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     def test_first_call_initializes_questionnaire(self):
         """No questionnaire in state → returns a new QuestionnaireState."""
@@ -342,7 +342,7 @@ class TestAdaptiveSkipIntegration:
     @pytest.fixture(autouse=True)
     def _disable_vague_check(self, monkeypatch):
         """Disable vague-answer checking so adaptive-skip tests don't hit the LLM."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     def _mock_extract(self, monkeypatch, extracted: dict[int, str]):
         """Monkeypatch _extract_answers_from_description to return the given dict."""
@@ -688,9 +688,10 @@ class TestFollowUpProbing:
 
     def test_vague_answer_triggers_follow_up(self, monkeypatch):
         """A vague answer should trigger a follow-up and NOT advance the question."""
+        choices = ("Task management", "E-commerce", "Social platform")
         monkeypatch.setattr(
             "scrum_agent.agent.nodes._check_vague_answer",
-            lambda q, a: ("Can you describe the main features?", ("Task management", "E-commerce", "Social platform")),
+            lambda q, a, n=0: ("Can you describe the main features?", choices),
         )
 
         qs = QuestionnaireState(current_question=1)
@@ -719,7 +720,7 @@ class TestFollowUpProbing:
         """A vague answer with no valid choices should NOT store _follow_up_choices."""
         monkeypatch.setattr(
             "scrum_agent.agent.nodes._check_vague_answer",
-            lambda q, a: ("Can you be more specific?", ()),
+            lambda q, a, n=0: ("Can you be more specific?", ()),
         )
 
         qs = QuestionnaireState(current_question=1)
@@ -735,7 +736,7 @@ class TestFollowUpProbing:
     def test_follow_up_response_combines_answers_and_advances(self, monkeypatch):
         """After a follow-up, the user's second answer is combined with the first and the question advances."""
         # Disable vague check for the second pass (already probed → combines)
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
         # Simulate: Q1 was probed, user is now responding to the follow-up
         qs = QuestionnaireState(current_question=1)
@@ -764,11 +765,11 @@ class TestFollowUpProbing:
         # _check_vague_answer would say "vague" — but it shouldn't be called
         # because the probed_questions check happens first.
         call_count = {"n": 0}
-        original_check = lambda q, a: None  # noqa: E731
+        original_check = lambda q, a, n=0: None  # noqa: E731
 
-        def tracking_check(q, a):
+        def tracking_check(q, a, n=0):
             call_count["n"] += 1
-            return original_check(q, a)
+            return original_check(q, a, n)
 
         monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", tracking_check)
 
@@ -788,7 +789,7 @@ class TestFollowUpProbing:
 
     def test_specific_answer_advances_without_probing(self, monkeypatch):
         """A specific answer should advance the question without triggering a follow-up."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
         qs = QuestionnaireState(current_question=1)
         state = {
@@ -806,7 +807,7 @@ class TestFollowUpProbing:
         """A probed-but-not-advanced question should not double-count progress."""
         monkeypatch.setattr(
             "scrum_agent.agent.nodes._check_vague_answer",
-            lambda q, a: ("Tell me more?", ()),
+            lambda q, a, n=0: ("Tell me more?", ()),
         )
 
         qs = QuestionnaireState(current_question=1)
@@ -830,7 +831,7 @@ class TestFollowUpProbing:
         """Follow-up messages should feel conversational — no phase header or progress indicator."""
         monkeypatch.setattr(
             "scrum_agent.agent.nodes._check_vague_answer",
-            lambda q, a: ("What kind of users?", ()),
+            lambda q, a, n=0: ("What kind of users?", ()),
         )
 
         qs = QuestionnaireState(current_question=1)
@@ -857,7 +858,7 @@ class TestFollowUpProbing:
         # First call: vague answer on Q25 → follow-up
         monkeypatch.setattr(
             "scrum_agent.agent.nodes._check_vague_answer",
-            lambda q, a: ("What does your Definition of Done include?", ("Tests passing", "Code reviewed")),
+            lambda q, a, n=0: ("What does your Definition of Done include?", ("Tests passing", "Code reviewed")),
         )
 
         qs = QuestionnaireState(current_question=25)
@@ -872,7 +873,7 @@ class TestFollowUpProbing:
         assert 25 in result1["questionnaire"].probed_questions
 
         # Second call: follow-up answer on Q25 → should advance to Q26
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
         state2 = {
             "messages": [HumanMessage(content="Code reviewed, tests passing, deployed to staging")],
@@ -1007,7 +1008,7 @@ class TestSkipHandling:
     @pytest.fixture(autouse=True)
     def _disable_vague_check(self, monkeypatch):
         """Disable vague-answer checking so skip tests don't hit the LLM."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     # ── Default storage & advancement ────────────────────────────────
 
@@ -1144,7 +1145,7 @@ class TestSkipHandling:
         """Skip should bypass the vague-answer check entirely."""
         check_called = {"n": 0}
 
-        def tracking_check(q, a):
+        def tracking_check(q, a, n=0):
             check_called["n"] += 1
             return None
 
@@ -1306,7 +1307,7 @@ class TestConfirmation:
     @pytest.fixture(autouse=True)
     def _disable_vague_check(self, monkeypatch):
         """Disable vague-answer checking so confirmation tests don't hit the LLM."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     def _make_awaiting_state(self) -> QuestionnaireState:
         """Build a QuestionnaireState in awaiting_confirmation mode."""
@@ -1530,7 +1531,7 @@ class TestEditFlow:
     @pytest.fixture(autouse=True)
     def _disable_vague_check(self, monkeypatch):
         """Disable vague-answer checking so edit tests don't hit the LLM."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     def _make_awaiting_state(self) -> QuestionnaireState:
         """Build a QuestionnaireState in awaiting_confirmation mode."""
@@ -1843,7 +1844,7 @@ class TestConfirmationVelocity:
     @pytest.fixture(autouse=True)
     def _disable_vague_check(self, monkeypatch):
         """Disable vague-answer checking so confirmation tests don't hit the LLM."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     def _make_awaiting_state(self, **answer_overrides) -> QuestionnaireState:
         """Build a QuestionnaireState in awaiting_confirmation mode."""
@@ -2088,7 +2089,7 @@ class TestDefaultsCommand:
 
     def test_defaults_command_in_intake_node(self, monkeypatch):
         """Typing 'defaults' during intake should apply defaults and advance past the phase."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
         qs = QuestionnaireState(current_question=8)
         qs.answers = {i: f"answer {i}" for i in range(1, 8)}
@@ -2105,7 +2106,7 @@ class TestDefaultsCommand:
 
     def test_defaults_on_last_phase_shows_summary(self, monkeypatch):
         """Typing 'defaults' on the last phase should show the intake summary."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
         qs = QuestionnaireState(current_question=27)
         qs.answers = {i: f"answer {i}" for i in range(1, 27)}
@@ -2129,7 +2130,7 @@ class TestVaguenessSkipForChoiceQuestions:
         """A choice question answer should NOT trigger _check_vague_answer."""
         vague_called = False
 
-        def fake_vague(q, a):
+        def fake_vague(q, a, n=0):
             nonlocal vague_called
             vague_called = True
             return "This is vague!"
@@ -2151,7 +2152,7 @@ class TestVaguenessSkipForChoiceQuestions:
         """A free-text question should still trigger _check_vague_answer."""
         vague_called = False
 
-        def fake_vague(q, a):
+        def fake_vague(q, a, n=0):
             nonlocal vague_called
             vague_called = True
             return None  # Accept the answer
@@ -2270,7 +2271,7 @@ class TestQ2RepoUrlFollowUp:
 
     @pytest.fixture(autouse=True)
     def _disable_vague_check(self, monkeypatch):
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     def _make_state(self, current_q, answers):
         qs = QuestionnaireState(current_question=current_q)
@@ -2496,7 +2497,7 @@ class TestSmartIntakeMode:
     @pytest.fixture(autouse=True)
     def _disable_vague_check(self, monkeypatch):
         """Disable vague-answer checking so smart mode tests don't hit the LLM."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     @pytest.fixture(autouse=True)
     def _no_scrum_md(self, monkeypatch):
@@ -2681,7 +2682,7 @@ class TestSmartIntakeMode:
         # Override the autouse fixture for this test — we need vague detection active.
         monkeypatch.setattr(
             "scrum_agent.agent.nodes._check_vague_answer",
-            lambda q, a: ("Can you be more specific?", ("Option A", "Option B")),
+            lambda q, a, n=0: ("Can you be more specific?", ("Option A", "Option B")),
         )
         qs = QuestionnaireState(intake_mode="smart", current_question=6)
         qs.answers = {1: "A todo app", 2: "Greenfield", 3: "Problem", 4: "Done"}
@@ -2734,7 +2735,7 @@ class TestSmartIntakeMode:
         """Smart mode: choice question answers should NOT trigger vague checking."""
         tracking = {"called": False}
 
-        def tracking_check(q, a):
+        def tracking_check(q, a, n=0):
             tracking["called"] = True
             return ("follow-up?", ("A", "B"))
 
@@ -2761,7 +2762,7 @@ class TestSmartIntakeMode:
         """Smart mode: a vague Q3 answer should trigger follow-up probing."""
         tracking = {"called": False, "question_text": None}
 
-        def tracking_check(q, a):
+        def tracking_check(q, a, n=0):
             tracking["called"] = True
             tracking["question_text"] = q
             return ("Can you be more specific?", ("Option A", "Option B"))
@@ -2792,7 +2793,7 @@ class TestSmartIntakeMode:
 
     def test_q3_non_vague_advances_to_q4(self, monkeypatch):
         """Smart mode: a detailed Q3 answer advances to Q4 as the next gap."""
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
         qs = QuestionnaireState(intake_mode="smart", current_question=3)
         qs.answers = {1: "A todo app", 2: "Greenfield", 6: "3 engineers", 11: "Python, React"}
         qs.extracted_questions = {1, 2}
@@ -2897,7 +2898,7 @@ class TestIntakeSummaryProvenance:
         qs.defaulted_questions = {5, 7, 8}
         summary = _build_intake_summary(qs)
         assert "2 extracted" in summary
-        assert "3 defaults" in summary
+        assert "3 defaulted" in summary
 
     def test_answers_block_extracted_marker(self):
         """_build_answers_block should show extracted marker for extracted questions."""
@@ -2918,7 +2919,7 @@ class TestScrumMdAutoPopulation:
 
     @pytest.fixture(autouse=True)
     def _disable_vague_check(self, monkeypatch):
-        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a: None)
+        monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     def test_scrum_md_extractions_fill_gaps(self, monkeypatch):
         """SCRUM.md extractions fill questions not covered by the user's description."""
@@ -3308,3 +3309,353 @@ class TestPTOSubLoop:
         assert _parse_date_dmy("06/04/26") == date(2026, 4, 6)
         assert _parse_date_dmy("06-04-2026") == date(2026, 4, 6)
         assert _parse_date_dmy("06-04-26") == date(2026, 4, 6)
+
+
+# ── Smart Intake Improvements tests ─────────────────────────────────
+
+
+class TestAnswerSources:
+    """Tests for answer_sources tracking (Step 1: Answer Confidence Signalling)."""
+
+    def test_direct_answer_sets_source(self):
+        """A direct user answer should set answer_sources to 'direct'."""
+        qs = QuestionnaireState(current_question=1)
+        state = {
+            "messages": [HumanMessage(content="A todo app for tracking tasks")],
+            "questionnaire": qs,
+        }
+        # Disable vague check and extraction
+        from unittest.mock import patch
+
+        with patch("scrum_agent.agent.nodes._check_vague_answer", return_value=None):
+            result = project_intake(state)
+        assert result["questionnaire"].answer_sources.get(1) == "direct"
+
+    def test_extracted_answer_sets_source(self):
+        """Auto-applied extractions should set answer_sources to 'extracted'."""
+        from scrum_agent.agent.nodes import _auto_apply_extractions
+
+        qs = QuestionnaireState()
+        _auto_apply_extractions(qs, {6: "5 engineers", 11: "Python, FastAPI"})
+        assert qs.answer_sources[6] == "extracted"
+        assert qs.answer_sources[11] == "extracted"
+
+    def test_defaulted_answer_sets_source(self):
+        """Defaulted answers should set answer_sources to 'defaulted'."""
+        from scrum_agent.agent.nodes import _auto_default_remaining
+
+        qs = QuestionnaireState()
+        qs.answers[1] = "A project"
+        _auto_default_remaining(qs, frozenset({1, 2, 3, 4, 6, 11}))
+        # Q5 has a default ("No hard deadlines") and is not essential
+        assert qs.answer_sources.get(5) == "defaulted"
+
+    def test_batch_defaults_sets_source(self):
+        """_batch_defaults_for_phase should set answer_sources to 'defaulted'."""
+        qs = QuestionnaireState(current_question=6)
+        summary_lines, count = _batch_defaults_for_phase(qs)
+        # Q8 has a default (2 weeks)
+        assert qs.answer_sources.get(8) == "defaulted"
+
+    def test_summary_shows_confidence_breakdown(self):
+        """_build_intake_summary should show 'direct | extracted | defaulted' breakdown."""
+        qs = QuestionnaireState()
+        qs.answers = {i: f"Answer {i}" for i in range(1, TOTAL_QUESTIONS + 1)}
+        qs.answer_sources = {i: "direct" for i in range(1, TOTAL_QUESTIONS + 1)}
+        qs.answer_sources[1] = "extracted"
+        qs.answer_sources[2] = "extracted"
+        qs.answer_sources[5] = "defaulted"
+        qs.extracted_questions = {1, 2}
+        qs.defaulted_questions = {5}
+        summary = _build_intake_summary(qs)
+        assert "2 extracted" in summary
+        assert "1 defaulted" in summary
+        assert "direct" in summary
+
+    def test_low_confidence_areas_in_prompt_quality(self):
+        """compute_prompt_quality should populate low_confidence_areas for defaulted essentials."""
+        from scrum_agent.agent.nodes import compute_prompt_quality
+
+        qs = QuestionnaireState()
+        qs.answers = {i: f"Answer {i}" for i in range(1, TOTAL_QUESTIONS + 1)}
+        # Default Q2 (essential) and Q6 (essential)
+        qs.defaulted_questions = {2, 6}
+        qs.answer_sources = {i: "direct" for i in range(1, TOTAL_QUESTIONS + 1)}
+        qs.answer_sources[2] = "defaulted"
+        qs.answer_sources[6] = "defaulted"
+        rating = compute_prompt_quality(qs)
+        assert "Project type" in rating.low_confidence_areas
+        assert "Team size" in rating.low_confidence_areas
+
+    def test_no_low_confidence_when_all_direct(self):
+        """No low_confidence_areas when all essentials are direct."""
+        from scrum_agent.agent.nodes import compute_prompt_quality
+
+        qs = QuestionnaireState()
+        qs.answers = {i: f"Answer {i}" for i in range(1, TOTAL_QUESTIONS + 1)}
+        qs.answer_sources = {i: "direct" for i in range(1, TOTAL_QUESTIONS + 1)}
+        rating = compute_prompt_quality(qs)
+        assert rating.low_confidence_areas == ()
+
+
+class TestKeywordExtraction:
+    """Tests for _keyword_extract_fallback (Step 2: Smarter Extraction)."""
+
+    def test_refactor_infers_existing_codebase(self):
+        """'refactor' keyword should infer Q2 as 'Existing codebase'."""
+        from scrum_agent.agent.nodes import _keyword_extract_fallback
+
+        extracted: dict[int, str] = {}
+        _keyword_extract_fallback("We're refactoring our legacy API", extracted)
+        assert extracted[2] == "Existing codebase"
+
+    def test_greenfield_keyword_infers_greenfield(self):
+        """'from scratch' keyword should infer Q2 as 'Greenfield'."""
+        from scrum_agent.agent.nodes import _keyword_extract_fallback
+
+        extracted: dict[int, str] = {}
+        _keyword_extract_fallback("Building a new project from scratch", extracted)
+        assert extracted[2] == "Greenfield"
+
+    def test_llm_extracted_q2_takes_priority(self):
+        """LLM-extracted Q2 should not be overwritten by keyword fallback."""
+        from scrum_agent.agent.nodes import _keyword_extract_fallback
+
+        extracted: dict[int, str] = {2: "Hybrid"}
+        _keyword_extract_fallback("We're refactoring our legacy API", extracted)
+        assert extracted[2] == "Hybrid"  # LLM value preserved
+
+    def test_stripe_extracts_q12(self):
+        """'stripe' keyword should extract Q12 integration."""
+        from scrum_agent.agent.nodes import _keyword_extract_fallback
+
+        extracted: dict[int, str] = {}
+        _keyword_extract_fallback("integrating Stripe for payments and Sentry for monitoring", extracted)
+        assert "Sentry" in extracted[12]
+        assert "Stripe" in extracted[12]
+
+    def test_kubernetes_extracts_q13(self):
+        """'kubernetes' keyword should extract Q13 constraint."""
+        from scrum_agent.agent.nodes import _keyword_extract_fallback
+
+        extracted: dict[int, str] = {}
+        _keyword_extract_fallback("deployed on kubernetes with docker containers", extracted)
+        assert "docker" in extracted[13]
+        assert "kubernetes" in extracted[13]
+
+    def test_no_keywords_no_extraction(self):
+        """Description without any keywords should not add Q2/Q12/Q13."""
+        from scrum_agent.agent.nodes import _keyword_extract_fallback
+
+        extracted: dict[int, str] = {}
+        _keyword_extract_fallback("A simple web application", extracted)
+        assert 2 not in extracted
+        assert 12 not in extracted
+        assert 13 not in extracted
+
+    def test_case_insensitive(self):
+        """Keywords should match case-insensitively."""
+        from scrum_agent.agent.nodes import _keyword_extract_fallback
+
+        extracted: dict[int, str] = {}
+        _keyword_extract_fallback("Running on AWS with Docker", extracted)
+        assert 13 in extracted
+
+
+class TestAdaptiveQuestionText:
+    """Tests for _resolve_adaptive_text (Step 3: Adaptive Question Text)."""
+
+    def test_q7_personalized_with_team_size(self):
+        """Q7 should reference Q6 team size when available."""
+        from scrum_agent.agent.nodes import _resolve_adaptive_text
+
+        qs = QuestionnaireState()
+        qs.answers[6] = "5"
+        text = _resolve_adaptive_text(7, qs)
+        assert "5 engineers" in text
+
+    def test_q12_personalized_with_tech_stack(self):
+        """Q12 should reference Q11 tech stack when available."""
+        from scrum_agent.agent.nodes import _resolve_adaptive_text
+
+        qs = QuestionnaireState()
+        qs.answers[11] = "Python, FastAPI, PostgreSQL"
+        text = _resolve_adaptive_text(12, qs)
+        assert "Python, FastAPI, PostgreSQL" in text
+
+    def test_q13_personalized_with_project_type(self):
+        """Q13 should reference Q2 project type and show appropriate hints."""
+        from scrum_agent.agent.nodes import _resolve_adaptive_text
+
+        qs = QuestionnaireState()
+        qs.answers[2] = "Existing codebase"
+        text = _resolve_adaptive_text(13, qs)
+        assert "Existing codebase" in text
+        assert "backward compatibility" in text
+
+    def test_fallback_when_dependency_missing(self):
+        """Should return default question text when dependency is missing."""
+        from scrum_agent.agent.nodes import _resolve_adaptive_text
+
+        qs = QuestionnaireState()
+        # Q6 not answered — Q7 should fall back to default
+        text = _resolve_adaptive_text(7, qs)
+        assert text == INTAKE_QUESTIONS[7]
+
+    def test_fallback_when_dependency_defaulted(self):
+        """Should return default question text when dependency was defaulted."""
+        from scrum_agent.agent.nodes import _resolve_adaptive_text
+
+        qs = QuestionnaireState()
+        qs.answers[6] = "Roles not specified"
+        qs.defaulted_questions.add(6)
+        text = _resolve_adaptive_text(7, qs)
+        assert text == INTAKE_QUESTIONS[7]
+
+    def test_no_template_returns_default(self):
+        """Questions without templates should return INTAKE_QUESTIONS text."""
+        from scrum_agent.agent.nodes import _resolve_adaptive_text
+
+        qs = QuestionnaireState()
+        text = _resolve_adaptive_text(1, qs)
+        assert text == INTAKE_QUESTIONS[1]
+
+    def test_gap_prompt_uses_adaptive_text(self):
+        """_build_gap_prompt should use adaptive text when available."""
+        qs = QuestionnaireState()
+        qs.answers[6] = "3"
+        prompt, q_nums = _build_gap_prompt([7], qs)
+        assert "3 engineers" in prompt
+
+
+class TestFollowUpTemplates:
+    """Tests for custom follow-up templates (Step 4: Follow-up Quality)."""
+
+    def test_custom_template_injected_for_known_question(self, monkeypatch):
+        """When q_num has a FOLLOW_UP_TEMPLATES entry, it should appear in the LLM prompt."""
+        fake_response = AIMessage(content='{"vague": true, "follow_up": "Who are the users?", "choices": ["A", "B"]}')
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = fake_response
+
+        def capturing_llm(**kwargs):
+            return mock_llm
+
+        monkeypatch.setattr("scrum_agent.agent.nodes.get_llm", capturing_llm)
+
+        result = _check_vague_answer("What problem?", "stuff", q_num=3)
+        assert result is not None
+        # The prompt sent to the LLM should contain the custom template hint
+        call_args = mock_llm.invoke.call_args[0][0]
+        prompt_text = call_args[0].content
+        assert "Who experiences this problem?" in prompt_text
+
+    def test_no_template_for_unknown_question(self, monkeypatch):
+        """Questions without a FOLLOW_UP_TEMPLATES entry should NOT get a custom hint."""
+        fake_response = AIMessage(content='{"vague": true, "follow_up": "Tell me more", "choices": ["A", "B"]}')
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = fake_response
+        monkeypatch.setattr("scrum_agent.agent.nodes.get_llm", lambda **kwargs: mock_llm)
+
+        _check_vague_answer("What is the project?", "stuff", q_num=1)
+        call_args = mock_llm.invoke.call_args[0][0]
+        prompt_text = call_args[0].content
+        assert "If vague, use this follow-up:" not in prompt_text
+
+    def test_q_num_zero_no_template(self, monkeypatch):
+        """q_num=0 (default) should not inject any custom template."""
+        fake_response = AIMessage(content='{"vague": false}')
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = fake_response
+        monkeypatch.setattr("scrum_agent.agent.nodes.get_llm", lambda **kwargs: mock_llm)
+
+        _check_vague_answer("Question?", "answer")
+        call_args = mock_llm.invoke.call_args[0][0]
+        prompt_text = call_args[0].content
+        assert "If vague, use this follow-up:" not in prompt_text
+
+
+class TestCrossQuestionValidation:
+    """Tests for _validate_cross_questions (Step 5: Cross-Question Validation)."""
+
+    def test_greenfield_with_repo_url_warns(self):
+        """Greenfield + repo URL should produce a warning."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        answers = {2: "Greenfield", 17: "https://github.com/org/repo"}
+        warnings = _validate_cross_questions(answers)
+        assert len(warnings) == 1
+        assert "Greenfield" in warnings[0].message
+        assert "repo URL" in warnings[0].message
+
+    def test_existing_codebase_with_repo_url_no_warning(self):
+        """Existing codebase + repo URL should NOT produce a warning."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        answers = {2: "Existing codebase", 17: "https://github.com/org/repo"}
+        warnings = _validate_cross_questions(answers)
+        assert all("Greenfield" not in w.message for w in warnings)
+
+    def test_long_timeline_warns(self):
+        """Sprint weeks × sprint count > 26 weeks should produce an info warning."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        answers = {8: "2 weeks", 10: "15 sprints"}
+        warnings = _validate_cross_questions(answers)
+        assert any("months" in w.message for w in warnings)
+
+    def test_short_timeline_no_warning(self):
+        """Sprint weeks × sprint count ≤ 26 weeks should NOT warn."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        answers = {8: "2 weeks", 10: "5 sprints"}
+        warnings = _validate_cross_questions(answers)
+        assert not any("months" in w.message for w in warnings)
+
+    def test_velocity_sanity_warns_too_high(self):
+        """Velocity/team_size > 15 should produce a warning."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        answers = {6: "2 engineers", 9: "50 points"}
+        warnings = _validate_cross_questions(answers)
+        assert any("pts/engineer" in w.message for w in warnings)
+
+    def test_velocity_sanity_warns_too_low(self):
+        """Velocity/team_size < 2 should produce a warning."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        answers = {6: "10 engineers", 9: "5 points"}
+        warnings = _validate_cross_questions(answers)
+        assert any("pts/engineer" in w.message for w in warnings)
+
+    def test_normal_velocity_no_warning(self):
+        """Velocity/team_size in 2-15 range should NOT warn."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        answers = {6: "5 engineers", 9: "30 points"}
+        warnings = _validate_cross_questions(answers)
+        assert not any("pts/engineer" in w.message for w in warnings)
+
+    def test_clean_answers_no_warnings(self):
+        """A complete, consistent answer set should produce no warnings."""
+        from scrum_agent.agent.nodes import _validate_cross_questions
+
+        answers = {
+            2: "Existing codebase",
+            6: "5 engineers",
+            8: "2 weeks",
+            9: "30 points",
+            10: "5 sprints",
+            17: "https://github.com/org/repo",
+        }
+        warnings = _validate_cross_questions(answers)
+        assert warnings == []
+
+    def test_warnings_appear_in_summary(self):
+        """Validation warnings should appear in the intake summary."""
+        qs = QuestionnaireState()
+        qs.answers = {i: f"Answer {i}" for i in range(1, TOTAL_QUESTIONS + 1)}
+        qs.answers[2] = "Greenfield"
+        qs.answers[17] = "https://github.com/org/repo"
+        summary = _build_intake_summary(qs)
+        assert "Heads up" in summary
+        assert "Greenfield" in summary


### PR DESCRIPTION
## Summary
- **Smart intake improvements (commit 1):** AnswerSource enum for tracking answer provenance, keyword-based extraction fallback (Q2/Q12/Q13), adaptive question templates that reference prior answers, custom follow-up templates per question, cross-question validation warnings, confidence breakdown in intake summary
- **Conditional essentials (commit 2):** Q7/Q12/Q13/Q29 are only asked when their prerequisite has a real answer (Q6→Q7, Q11→Q12, Q2→Q13, Q6→Q29) — keeps smart mode lean while asking useful follow-ups
- **Multi-choice questions:** Q7 (team roles) and Q13 (arch constraints) render as Space-to-toggle multi-select pickers
- **New single-choice questions:** Q19 (CI/CD), Q25 (DoD), Q30 (Onboarding) with predefined options
- **Bug fixes:** edit mode input blocked during confirmation, PTO sub-loop rendering under wrong question, greenfield validation case-sensitive, date parser accepting 2-digit year typos, markdown export missing capacity data at intake stage, conditional essentials silently defaulted before gap-finding

## Test plan
- [x] `make test` — 2232 passed (unit + integration), 7 skipped
- [x] `make lint` — clean
- [ ] Spot check: smart mode with conditional essentials firing (Q7/Q12/Q13/Q29)
- [ ] Spot check: multi-choice Q7 and Q13 toggle/submit
- [ ] Spot check: edit mode — can type in all questions after editing
- [ ] Spot check: PTO sub-loop shows under Q28, not Q30
- [ ] Spot check: greenfield + repo URL cross-validation warning
- [ ] Spot check: early export includes capacity/PTO data

🤖 Generated with [Claude Code](https://claude.com/claude-code)