### PR TITLE
fix publish workflow: use uv sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,13 +23,13 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv pip install -e ".[dev]"
+        run: uv sync --extra dev
 
       - name: Lint
-        run: uv run ruff check src/ tests/
+        run: make lint
 
       - name: Test
-        run: uv run pytest tests/unit/ tests/integration/ tests/contract/ --tb=short
+        run: make test
 
   publish:
     name: Build & Publish to PyPI


### PR DESCRIPTION
## Summary

- Fix `publish.yml` test job — use `uv sync --extra dev` instead of `uv pip install -e ".[dev]"` (matches `ci.yml` pattern)
- The `uv pip install` approach fails because it requires a pre-existing venv; `uv sync` creates one automatically

## Test plan

- [x] Matches the working pattern from `ci.yml`
- [ ] Re-tag `v1.0.0` after merge to trigger the fixed workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)