### PR TITLE
bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "1.0.0"
+version = "1.1.0"
 description = "A terminal-based AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/__init__.py
+++ b/src/scrum_agent/__init__.py
@@ -64,4 +64,4 @@ _ls_logger = logging.getLogger("langsmith")
 _ls_logger.addHandler(_ls_handler)
 _ls_logger.propagate = False  # stop records reaching the root StreamHandler
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1750,7 +1750,7 @@ wheels = [
 
 [[package]]
 name = "scrum-agent"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary
- Bump version from 1.0.0 to 1.1.0 in `pyproject.toml` and `__init__.py`

## What's in v1.1.0
- AWS Bedrock as 4th LLM provider (IAM credentials, no API key)
- Auto-detect AWS region and profile from `~/.aws/config`
- Deploy on AWS Lightsail (OpenClaw) guide in README
- Phase 14 (OpenClaw x Slack) roadmap in TODO.md

## After merge
Tag `v1.1.0` to trigger the publish workflow (PyPI + GitHub Release + Homebrew tap update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)