### PR TITLE
feat: opt-in anonymous telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,132 @@
+# Telemetry — What We Collect
+
+scrum-agent includes **opt-in anonymous telemetry** to help us improve planning quality. It is **disabled by default** and must be explicitly enabled.
+
+## Enabling / Disabling
+
+```bash
+# Enable
+export SCRUM_AGENT_TELEMETRY=true
+
+# Disable (default)
+export SCRUM_AGENT_TELEMETRY=false
+# or simply don't set the variable
+```
+
+## What We Collect
+
+When telemetry is enabled, the following **anonymized, structural data** is sent after each completed session:
+
+### Session Metadata
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `event_id` | `a3f91b2c-...` | Unique event ID (random UUID, not tied to user) |
+| `timestamp` | `2026-03-23T12:00:00Z` | When the session completed |
+| `agent_version` | `1.0.0` | Which version of scrum-agent |
+| `platform` | `Darwin` | OS (macOS/Linux/Windows) |
+| `python_version` | `3.12.1` | Python version |
+| `llm_provider` | `anthropic` | Which LLM provider was used |
+
+### Project Patterns (no names or descriptions)
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `project.type` | `greenfield` | Project type classification |
+| `project.tech_stack` | `["Next.js", "FastAPI"]` | Technologies chosen |
+| `project.integrations` | `["Stripe", "Auth0"]` | Third-party integrations |
+| `project.sprint_length_weeks` | `2` | Sprint duration |
+| `project.target_sprints` | `4` | Planned sprint count |
+| `project.goal_count` | `3` | Number of goals (not the goals themselves) |
+| `project.constraint_count` | `2` | Number of constraints |
+| `project.risk_count` | `1` | Number of risks |
+| `project.skip_features` | `false` | Whether features were skipped (small project) |
+| `project.prompt_quality_grade` | `A` | Questionnaire completeness grade |
+
+### Intake Patterns
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `intake.questions_answered` | `22` | How many questions were answered |
+| `intake.total_questions` | `30` | Total available questions |
+| `intake.mode` | `smart` | Intake mode used |
+| `intake.team_size` | `5` | Team size (for velocity calibration) |
+
+### Artifact Counts
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `counts.features` | `4` | Number of features generated |
+| `counts.stories` | `16` | Number of user stories |
+| `counts.tasks` | `42` | Number of tasks |
+| `counts.sprints` | `3` | Number of sprints |
+| `counts.total_story_points` | `58` | Total story points |
+
+### Distributions (for better estimation models)
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `point_distribution` | `{"1": 2, "2": 5, "3": 4, "5": 3, "8": 2}` | Story point spread |
+| `discipline_distribution` | `{"FRONTEND": 6, "BACKEND": 8, "FULLSTACK": 2}` | Discipline breakdown |
+
+### Structural Patterns (shapes, not content)
+
+**Features** — per feature:
+- Priority level (critical/high/medium/low)
+- Title length and description length (character counts, not actual text)
+
+**Stories** — per story:
+- Story points (Fibonacci value)
+- Priority level
+- Discipline (frontend/backend/fullstack/etc.)
+- Number of acceptance criteria
+- Feature it belongs to
+- Number of applicable Definition of Done items
+
+**Tasks** — per task:
+- Label (code/documentation/infrastructure/testing)
+- Whether it has a test plan
+- Whether it has an AI prompt
+- Which story it belongs to
+
+**Sprints** — per sprint:
+- Capacity points
+- Number of stories assigned
+- Total points allocated
+
+### Human Feedback Signal
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `review_decisions` | `{"features": "accept", "stories": "edit"}` | Accept/edit/reject at each stage |
+
+## What We Do NOT Collect
+
+- **No project names or descriptions**
+- **No actual text content** (goals, stories, tasks, acceptance criteria)
+- **No source code**
+- **No API keys or credentials**
+- **No user names, emails, or IP addresses**
+- **No file paths or repository URLs**
+- **No Jira/GitHub/Confluence data**
+
+## How It Works
+
+1. On session completion, the telemetry module builds an anonymized payload
+2. The payload is POST'd to our collection endpoint with a 3-second timeout
+3. If the request fails for any reason, it fails silently — **never blocks or crashes the app**
+4. Data is stored in an S3 bucket partitioned by date
+5. We periodically analyse aggregate patterns to improve prompt quality, estimation accuracy, and decomposition strategies
+
+## Data Retention
+
+- Raw telemetry is stored indefinitely for trend analysis
+- Data is never sold or shared with third parties
+- Data is used exclusively to improve scrum-agent
+
+## Custom Endpoint
+
+If you want to collect telemetry for your own analysis:
+
+```bash
+export SCRUM_AGENT_TELEMETRY=true
+export SCRUM_AGENT_TELEMETRY_URL=https://your-endpoint.example.com/collect
+```
+
+## Questions?
+
+Open an issue at [github.com/omardin14/scrum-planning-ai-agent](https://github.com/omardin14/scrum-planning-ai-agent/issues).

--- a/src/scrum_agent/repl/_io.py
+++ b/src/scrum_agent/repl/_io.py
@@ -530,3 +530,7 @@ def _export_checkpoint(console: Console, graph_state: dict, stage: str = "comple
     md_path = _export_plan_markdown(graph_state)
     console.print(f"[success]HTML report  → {html_path}[/success]")
     console.print(f"[success]Markdown     → {md_path}[/success]")
+
+    # Send anonymous telemetry if opted in (never blocks or errors)
+    from scrum_agent.telemetry import send_telemetry
+    send_telemetry(graph_state)

--- a/src/scrum_agent/telemetry.py
+++ b/src/scrum_agent/telemetry.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 TELEMETRY_ENABLED = os.getenv("SCRUM_AGENT_TELEMETRY", "").lower() in ("true", "1", "yes")
 TELEMETRY_ENDPOINT = os.getenv(
     "SCRUM_AGENT_TELEMETRY_URL",
-    "https://telemetry.scrum-agent.dev/collect",  # placeholder — replace with real endpoint
+    "https://ykauzind6vf3vtlvwz5kru7ajq0cpgyd.lambda-url.eu-west-1.on.aws/",
 )
 
 

--- a/src/scrum_agent/telemetry.py
+++ b/src/scrum_agent/telemetry.py
@@ -1,0 +1,258 @@
+"""Opt-in anonymous telemetry for improving planning quality.
+
+Collects anonymized, structural data from completed sessions and uploads
+to S3 for later analysis. NO code, NO project names, NO PII — only
+patterns (tech stacks, story counts, point distributions, accept/edit rates).
+
+Disabled by default. Enable via:
+  SCRUM_AGENT_TELEMETRY=true
+
+# See README: "Architecture" — telemetry layer (opt-in)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import platform
+import uuid
+from dataclasses import asdict
+from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+TELEMETRY_ENABLED = os.getenv("SCRUM_AGENT_TELEMETRY", "").lower() in ("true", "1", "yes")
+TELEMETRY_ENDPOINT = os.getenv(
+    "SCRUM_AGENT_TELEMETRY_URL",
+    "https://telemetry.scrum-agent.dev/collect",  # placeholder — replace with real endpoint
+)
+
+
+def is_enabled() -> bool:
+    """Check if telemetry is opted in."""
+    return TELEMETRY_ENABLED
+
+
+# ---------------------------------------------------------------------------
+# Anonymization helpers
+# ---------------------------------------------------------------------------
+
+
+def _hash(value: str) -> str:
+    """One-way hash for anonymization. Same input → same hash (for grouping)."""
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+def _anonymize_text(text: str | None) -> str | None:
+    """Replace actual text with length indicator. Preserves structure, removes content."""
+    if not text:
+        return None
+    return f"[{len(text)} chars]"
+
+
+# ---------------------------------------------------------------------------
+# Payload builder
+# ---------------------------------------------------------------------------
+
+
+def build_telemetry_payload(graph_state: dict) -> dict | None:
+    """Build an anonymized telemetry payload from a completed session.
+
+    Returns None if there's nothing useful to send (e.g. session was abandoned).
+    """
+    from scrum_agent import __version__
+    from scrum_agent.agent.state import (
+        Feature,
+        ProjectAnalysis,
+        QuestionnaireState,
+        Sprint,
+        Task,
+        UserStory,
+    )
+
+    analysis: ProjectAnalysis | None = graph_state.get("analysis")
+    features: list[Feature] = graph_state.get("features", [])
+    stories: list[UserStory] = graph_state.get("stories", [])
+    tasks: list[Task] = graph_state.get("tasks", [])
+    sprints: list[Sprint] = graph_state.get("sprints", [])
+    questionnaire: QuestionnaireState | None = graph_state.get("questionnaire")
+
+    # Nothing to report if no analysis was generated
+    if not analysis:
+        return None
+
+    # --- Anonymized project metadata ---
+    project = {
+        "type": analysis.project_type,
+        "tech_stack": list(analysis.tech_stack),
+        "integrations": list(analysis.integrations),
+        "sprint_length_weeks": analysis.sprint_length_weeks,
+        "target_sprints": analysis.target_sprints,
+        "goal_count": len(analysis.goals),
+        "constraint_count": len(analysis.constraints),
+        "risk_count": len(analysis.risks),
+        "out_of_scope_count": len(analysis.out_of_scope),
+        "skip_features": analysis.skip_features,
+    }
+
+    # Prompt quality if available
+    if analysis.prompt_quality:
+        project["prompt_quality_grade"] = analysis.prompt_quality.grade
+        project["prompt_quality_score"] = analysis.prompt_quality.score
+
+    # --- Questionnaire patterns ---
+    intake = {}
+    if questionnaire:
+        q = asdict(questionnaire) if hasattr(questionnaire, "__dataclass_fields__") else questionnaire
+        # Only capture which questions were answered vs skipped/defaulted
+        answered = sum(1 for v in q.get("answers", {}).values() if v and v.strip())
+        intake = {
+            "questions_answered": answered,
+            "total_questions": len(q.get("answers", {})),
+            "mode": q.get("mode", "unknown"),
+        }
+        # Team size (useful for velocity calibration, not PII)
+        team_size = q.get("answers", {}).get("team_size")
+        if team_size:
+            intake["team_size"] = team_size
+
+    # --- Feature patterns ---
+    feature_data = [
+        {
+            "priority": f.priority.value if hasattr(f.priority, "value") else str(f.priority),
+            "title_length": len(f.title),
+            "description_length": len(f.description),
+        }
+        for f in features
+    ]
+
+    # --- Story patterns ---
+    story_data = [
+        {
+            "story_points": s.story_points.value if hasattr(s.story_points, "value") else s.story_points,
+            "priority": s.priority.value if hasattr(s.priority, "value") else str(s.priority),
+            "discipline": s.discipline.value if hasattr(s.discipline, "value") else str(s.discipline),
+            "ac_count": len(s.acceptance_criteria),
+            "feature_id": s.feature_id,
+            "dod_count": sum(1 for d in s.dod_applicable if d) if s.dod_applicable else 0,
+        }
+        for s in stories
+    ]
+
+    # --- Task patterns ---
+    task_data = [
+        {
+            "label": t.label.value if hasattr(t.label, "value") else str(t.label),
+            "story_id": t.story_id,
+            "has_test_plan": bool(t.test_plan and t.test_plan.strip()),
+            "has_ai_prompt": bool(t.ai_prompt and t.ai_prompt.strip()),
+        }
+        for t in tasks
+    ]
+
+    # --- Sprint patterns ---
+    sprint_data = [
+        {
+            "capacity_points": sp.capacity_points,
+            "story_count": len(sp.story_ids),
+            "total_points": sum(
+                s.story_points.value if hasattr(s.story_points, "value") else 0
+                for s in stories
+                if s.id in sp.story_ids
+            ),
+        }
+        for sp in sprints
+    ]
+
+    # --- Review decisions (accept/edit/reject rates) ---
+    review_decisions = graph_state.get("review_decisions", {})
+
+    # --- Aggregate stats ---
+    total_points = sum(
+        s.story_points.value if hasattr(s.story_points, "value") else 0
+        for s in stories
+    )
+
+    point_distribution = {}
+    for s in stories:
+        pts = s.story_points.value if hasattr(s.story_points, "value") else str(s.story_points)
+        point_distribution[str(pts)] = point_distribution.get(str(pts), 0) + 1
+
+    discipline_distribution = {}
+    for s in stories:
+        disc = s.discipline.value if hasattr(s.discipline, "value") else str(s.discipline)
+        discipline_distribution[disc] = discipline_distribution.get(disc, 0) + 1
+
+    return {
+        "event_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(UTC).isoformat(),
+        "agent_version": __version__,
+        "platform": platform.system(),
+        "python_version": platform.python_version(),
+        "llm_provider": os.getenv("LLM_PROVIDER", "anthropic"),
+
+        # Anonymized project
+        "project": project,
+        "intake": intake,
+
+        # Artifact counts
+        "counts": {
+            "features": len(features),
+            "stories": len(stories),
+            "tasks": len(tasks),
+            "sprints": len(sprints),
+            "total_story_points": total_points,
+        },
+
+        # Distributions (for training better estimation)
+        "point_distribution": point_distribution,
+        "discipline_distribution": discipline_distribution,
+
+        # Structural patterns (no content, just shapes)
+        "features": feature_data,
+        "stories": story_data,
+        "tasks": task_data,
+        "sprints": sprint_data,
+
+        # Human feedback signal
+        "review_decisions": review_decisions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Upload
+# ---------------------------------------------------------------------------
+
+
+def send_telemetry(graph_state: dict) -> None:
+    """Build and send telemetry payload. Fails silently — never blocks the user."""
+    if not is_enabled():
+        return
+
+    try:
+        payload = build_telemetry_payload(graph_state)
+        if not payload:
+            return
+
+        import urllib.request
+
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            TELEMETRY_ENDPOINT,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        # Fire and forget — 3 second timeout, swallow all errors
+        urllib.request.urlopen(req, timeout=3)
+        logger.info("Telemetry sent: %s", payload["event_id"])
+    except Exception:
+        # Never let telemetry crash the app
+        logger.debug("Telemetry send failed (this is fine)", exc_info=True)


### PR DESCRIPTION
## Summary
- New `telemetry.py` module — opt-in anonymous data collection (disabled by default)
- Collects anonymized structural patterns: tech stacks, story point distributions, accept/edit/reject rates
- NO code, NO project names, NO PII
- Lambda endpoint + S3 storage (no credentials in the app)
- `TELEMETRY.md` documents exactly what's collected

## How to enable
```bash
export SCRUM_AGENT_TELEMETRY=true
```

## Test plan
- [x] Unit tests pass (1792 passed)
- [x] Lambda endpoint tested with curl
- [x] Telemetry fires on `_export_checkpoint` (covers TUI + REPL + headless)
- [x] Fails silently on network error (3s timeout)