### PR TITLE
add OpenClaw scrum-planner skill

### DIFF
--- a/skills/scrum-planner/references/output-and-review.md
+++ b/skills/scrum-planner/references/output-and-review.md
@@ -55,18 +55,18 @@ Show one feature at a time if there are many.
 
 ### After All Phases Accepted
 
+**Immediately and automatically create the Slack Canvas** — do not ask, do not offer options first. Go straight to the Final Plan Output section below and run the canvas script.
+
+After the canvas is created, post this summary in thread:
+
 > 📋 *{project.name}* — {N} epics · {N} stories · {N} tasks · {N} sprints
 >
-> 🚀 *Sprint plan finalized!*
+> 🚀 *Sprint plan finalized! See the Canvas above ☝️*
 > • *Team:* {team_size} engineers · {sprint_length}-week sprints
 > • *Velocity:* {velocity} pts/sprint
 > • *Total effort:* {total_points} story points
 >
-> What's next?
-> 1. Show full plan as a single document
-> 2. Export as Markdown
-> 3. Drill into any story or feature
-> 4. 🎯 Push to Jira
+> 🎯 Want me to push this to Jira?
 
 ### Jira Push
 
@@ -78,10 +78,30 @@ Check if configured: `grep -q "JIRA_BASE_URL" ~/.scrum-agent/.env 2>/dev/null`
 
 Try Canvas first, fall back to threaded messages.
 
-### Canvas (preferred)
-If `canvases:write` scope is available, create a Canvas with: header, project summary, features & stories, task breakdown, sprint plan, diagnostics.
+> ⚠️ **IMPORTANT:** Never use the OpenClaw `canvas` tool — it requires a paired device and will not work here.
+> Always use the Python script below to create a **Slack Canvas** via the Slack API.
 
-Post summary in thread: `📋 *Sprint plan ready* — see the Canvas above ☝️`
+### Canvas (preferred)
+Use the canvas script to create the Slack Canvas — do not use the OpenClaw canvas tool, do not attempt direct API calls yourself.
+
+1. Write the final plan to a temp file:
+```bash
+cat > /tmp/scrum_plan_canvas.md << 'EOF'
+{full markdown plan}
+EOF
+```
+
+2. Run the canvas script with the channel ID from the current conversation:
+```bash
+python3 ~/.openclaw/workspace/skills/scrum-planner/scripts/canvas.py \
+  create-channel-canvas \
+  --channel {CHANNEL_ID} \
+  --content @/tmp/scrum_plan_canvas.md
+```
+
+The script tries `canvases.create` + `canvases.access.set` and handles all Slack API details. It reads the bot token from `~/.openclaw/openclaw.json` automatically.
+
+Post summary in thread after canvas is created: `📋 *Sprint plan ready* — see the Canvas above ☝️`
 
 Diagnostics commands:
 ```bash

--- a/skills/scrum-planner/scripts/canvas.py
+++ b/skills/scrum-planner/scripts/canvas.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+canvas.py — Slack Canvas operations for the scrum-planner skill.
+
+Creates or updates a channel canvas with the sprint plan content.
+Reads the bot token from ~/.openclaw/openclaw.json at runtime.
+
+Usage:
+    python canvas.py create-channel-canvas --channel C1234567 --content @/tmp/plan.md
+    python canvas.py update --canvas-id F1234567 --content @/tmp/plan.md
+    python canvas.py get-channel-canvas --channel C1234567
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+
+def get_bot_token() -> str:
+    config_path = Path.home() / ".openclaw" / "openclaw.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config not found at {config_path}")
+    config = json.loads(config_path.read_text())
+    token = config.get("channels", {}).get("slack", {}).get("botToken", "")
+    if not token:
+        raise ValueError("No Slack bot token found in openclaw.json")
+    return token
+
+
+def slack_api(method: str, payload: dict, token: str) -> dict:
+    url = f"https://slack.com/api/{method}"
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"HTTP {e.code}: {e.read().decode()}") from e
+    if not result.get("ok"):
+        raise RuntimeError(f"Slack API error ({method}): {result.get('error', 'unknown')} — {json.dumps(result)}")
+    return result
+
+
+def format_canvas_markdown(raw: str) -> str:
+    """
+    Post-process the plan markdown so it renders well in Slack Canvas.
+
+    Slack Canvas supports a subset of markdown:
+    - # H1, ## H2, ### H3 headings
+    - **bold**, *italic*
+    - - bullet lists (unordered)
+    - 1. numbered lists
+    - `inline code`
+    - ``` code blocks
+    - --- horizontal rules
+    - > blockquotes
+    - [text](url) links
+
+    What it does NOT support well:
+    - Markdown tables (render as raw text)
+    - • bullet character (use - instead)
+    - → arrow character (use - or numbered list)
+    - Emoji shortcodes like :white_check_mark: (use actual emoji ✅)
+    - HTML tags
+    """
+    import re
+
+    lines = raw.split("\n")
+    out = []
+
+    for line in lines:
+        # Slack Canvas only supports H1/H2/H3 — downgrade deeper headings
+        line = re.sub(r"^####\s+", "### ", line)
+        line = re.sub(r"^#####\s+", "### ", line)
+        line = re.sub(r"^######\s+", "### ", line)
+
+        # Convert bullet • to -
+        line = re.sub(r"^(\s*)•\s+", r"\1- ", line)
+
+        # Convert → task arrows to indented bullets
+        line = re.sub(r"^(\s*)→\s+", r"\1- ", line)
+
+        # Convert emoji shortcodes to actual emoji
+        emoji_map = {
+            ":white_check_mark:": "✅",
+            ":x:": "❌",
+            ":warning:": "⚠️",
+            ":rocket:": "🚀",
+            ":clipboard:": "📋",
+            ":gear:": "⚙️",
+            ":hammer:": "🔨",
+            ":bug:": "🐛",
+            ":lock:": "🔒",
+            ":chart_with_upwards_trend:": "📈",
+            ":books:": "📚",
+            ":pencil:": "✏️",
+            ":mag:": "🔍",
+            ":link:": "🔗",
+        }
+        for code, emoji in emoji_map.items():
+            line = line.replace(code, emoji)
+
+        out.append(line)
+
+    result = "\n".join(out)
+
+    # Ensure section breaks have proper spacing around ---
+    result = re.sub(r"\n---\n", "\n\n---\n\n", result)
+
+    # Ensure headings have a blank line before them (Canvas renders better)
+    result = re.sub(r"\n(#{1,3} )", r"\n\n\1", result)
+
+    return result.strip()
+
+
+def create_channel_canvas(channel_id: str, content: str, token: str) -> dict:
+    """Create a canvas and share it to the channel."""
+    formatted = format_canvas_markdown(content)
+
+    # Extract title from first H1 line
+    title = "Sprint Plan"
+    for line in formatted.splitlines():
+        if line.startswith("# "):
+            title = line[2:].strip()
+            break
+
+    # canvases.create produces better rendering than conversations.canvases.create
+    result = slack_api("canvases.create", {
+        "title": title,
+        "document_content": {"type": "markdown", "markdown": formatted},
+    }, token)
+
+    canvas_id = result.get("canvas_id")
+    if canvas_id:
+        slack_api("canvases.access.set", {
+            "canvas_id": canvas_id,
+            "access_level": "write",
+            "channel_ids": [channel_id],
+        }, token)
+
+    return result
+
+
+def update_canvas(canvas_id: str, content: str, token: str) -> dict:
+    """Update an existing canvas with new content."""
+    formatted = format_canvas_markdown(content)
+    result = slack_api("canvases.edit", {
+        "canvas_id": canvas_id,
+        "changes": [
+            {
+                "operation": "replace",
+                "document_content": {
+                    "type": "markdown",
+                    "markdown": formatted,
+                }
+            }
+        ]
+    }, token)
+    return result
+
+
+def get_channel_canvas(channel_id: str, token: str) -> dict | None:
+    """Get the canvas attached to a channel, or None if none exists."""
+    try:
+        result = slack_api("conversations.info", {
+            "channel": channel_id,
+            "include_num_members": False,
+        }, token)
+        canvas = result.get("channel", {}).get("properties", {}).get("canvas", {})
+        return canvas if canvas.get("file_id") else None
+    except RuntimeError:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Slack Canvas operations")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_create = sub.add_parser("create-channel-canvas")
+    p_create.add_argument("--channel", required=True)
+    p_create.add_argument("--content", required=True, help="Markdown string or @filepath")
+
+    p_update = sub.add_parser("update")
+    p_update.add_argument("--canvas-id", required=True)
+    p_update.add_argument("--content", required=True, help="Markdown string or @filepath")
+
+    p_get = sub.add_parser("get-channel-canvas")
+    p_get.add_argument("--channel", required=True)
+
+    args = parser.parse_args()
+    token = get_bot_token()
+
+    def resolve(raw: str) -> str:
+        return Path(raw[1:]).read_text() if raw.startswith("@") else raw
+
+    if args.command == "create-channel-canvas":
+        result = create_channel_canvas(args.channel, resolve(args.content), token)
+        print(json.dumps(result, indent=2))
+    elif args.command == "update":
+        result = update_canvas(args.canvas_id, resolve(args.content), token)
+        print(json.dumps(result, indent=2))
+    elif args.command == "get-channel-canvas":
+        canvas = get_channel_canvas(args.channel, token)
+        print(json.dumps(canvas or {"ok": False, "error": "no_canvas"}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/scrum-planner/scripts/canvas_push.py
+++ b/skills/scrum-planner/scripts/canvas_push.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+canvas_push.py — Watch /workspace/scrum_plan.md and push to Slack canvas on change.
+
+Run as a background process. When the plan file changes, automatically creates
+or updates the canvas in #scrum-planner.
+
+Usage:
+    python3 canvas_push.py [--channel CHANNEL_ID] [--workspace /path/to/workspace]
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+
+CHANNEL_ID = os.environ.get("SCRUM_CHANNEL_ID", "C0AMR19S057")
+# Support both host path and container mount path
+_WS_CANDIDATES = [
+    Path(os.environ.get("OPENCLAW_WORKSPACE", "")),
+    Path("/workspace"),
+    Path("/home/ubuntu/.openclaw/workspace"),
+]
+WORKSPACE = next((p for p in _WS_CANDIDATES if p.exists() and p != Path("")), Path("/workspace"))
+PLAN_FILE = WORKSPACE / "scrum_plan.md"
+STATE_FILE = WORKSPACE / ".canvas_state.json"
+POLL_INTERVAL = 3  # seconds
+
+
+def get_bot_token() -> str:
+    # Try multiple locations — container runs as root, host as ubuntu
+    candidates = [
+        Path("/home/ubuntu/.openclaw/openclaw.json"),
+        Path.home() / ".openclaw" / "openclaw.json",
+    ]
+    for p in candidates:
+        if p.exists():
+            return json.loads(p.read_text())["channels"]["slack"]["botToken"]
+    raise FileNotFoundError(f"Config not found in: {candidates}")
+
+
+def slack_api(method: str, payload: dict, token: str) -> dict:
+    import ssl
+    url = f"https://slack.com/api/{method}"
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(),
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    )
+    ca = os.environ.get("SSL_CERT_FILE") or os.environ.get("CURL_CA_BUNDLE")
+    ctx = ssl.create_default_context(cafile=ca) if ca and Path(ca).exists() else ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=ctx) as r:
+            result = json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return {"ok": False, "error": f"HTTP {e.code}", "body": e.read().decode()}
+    return result
+
+
+def format_canvas(raw: str) -> str:
+    lines = raw.split("\n")
+    out = []
+    for line in lines:
+        line = re.sub(r"^#{4,}\s+", "### ", line)
+        line = re.sub(r"^(\s*)•\s+", r"\1- ", line)
+        line = re.sub(r"^(\s*)→\s+", r"\1- ", line)
+        out.append(line)
+    result = "\n".join(out)
+    result = re.sub(r"\n---\n", "\n\n---\n\n", result)
+    result = re.sub(r"\n(#{1,3} )", r"\n\n\1", result)
+    return result.strip()
+
+
+def extract_title(content: str) -> str:
+    for line in content.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return "Sprint Plan"
+
+
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def save_state(state: dict) -> None:
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def push_to_canvas(content: str, token: str, existing_canvas_id: str | None) -> str | None:
+    """Create or update the channel canvas. Returns canvas_id on success."""
+    formatted = format_canvas(content)
+    title = extract_title(content)
+
+    # Try to update existing canvas first
+    if existing_canvas_id:
+        r = slack_api("canvases.edit", {
+            "canvas_id": existing_canvas_id,
+            "changes": [{"operation": "replace", "document_content": {"type": "markdown", "markdown": formatted}}]
+        }, token)
+        if r.get("ok"):
+            print(f"[canvas_push] Updated canvas {existing_canvas_id}")
+            return existing_canvas_id
+        print(f"[canvas_push] Update failed ({r.get('error')}) — creating new")
+
+    # conversations.canvases.create attaches to the channel canvas tab (visible in sidebar)
+    r = slack_api("conversations.canvases.create", {
+        "channel_id": CHANNEL_ID,
+        "document_content": {"type": "markdown", "markdown": formatted},
+    }, token)
+
+    if r.get("ok"):
+        # conversations.canvases.create doesn't return a canvas_id directly
+        # fetch it from conversations.info
+        r2 = slack_api("conversations.info", {"channel": CHANNEL_ID, "include_num_members": False}, token)
+        canvas_id = r2.get("channel", {}).get("properties", {}).get("canvas", {}).get("file_id")
+        if canvas_id:
+            print(f"[canvas_push] Created channel canvas {canvas_id}: {title}")
+            return canvas_id
+        # fallback — no id but creation succeeded
+        print(f"[canvas_push] Created channel canvas (id unknown): {title}")
+        return "channel-canvas"
+
+    # Last resort: standalone canvas shared to channel
+    print(f"[canvas_push] conversations.canvases.create failed ({r.get('error')}), trying standalone")
+    r3 = slack_api("canvases.create", {
+        "title": title,
+        "document_content": {"type": "markdown", "markdown": formatted},
+    }, token)
+    canvas_id = r3.get("canvas_id")
+    if canvas_id:
+        slack_api("canvases.access.set", {
+            "canvas_id": canvas_id, "access_level": "write", "channel_ids": [CHANNEL_ID]
+        }, token)
+        print(f"[canvas_push] Created standalone canvas {canvas_id}: {title}")
+    else:
+        print(f"[canvas_push] All canvas methods failed: {r3.get('error')}")
+    return canvas_id
+
+
+def run_once():
+    """Check if plan file changed since last push and push if so."""
+    state = load_state()
+    if not PLAN_FILE.exists():
+        print(f"[canvas_push] No plan file at {PLAN_FILE}")
+        return
+
+    mtime = PLAN_FILE.stat().st_mtime
+    last_mtime = state.get("last_mtime", 0)
+
+    if mtime <= last_mtime:
+        print(f"[canvas_push] No change since last push")
+        return
+
+    content = PLAN_FILE.read_text().strip()
+    if not content:
+        print(f"[canvas_push] Plan file is empty")
+        return
+
+    print(f"[canvas_push] Pushing to canvas...")
+    token = get_bot_token()
+    canvas_id = push_to_canvas(content, token, state.get("canvas_id"))
+    if canvas_id:
+        state["canvas_id"] = canvas_id
+        state["last_mtime"] = mtime
+        state["last_push"] = time.time()
+        save_state(state)
+        print(f"[canvas_push] Done — canvas_id={canvas_id}")
+
+
+def run_watch():
+    print(f"[canvas_push] Watching {PLAN_FILE} → #{CHANNEL_ID}")
+    last_mtime = None
+    state = load_state()
+
+    while True:
+        try:
+            if PLAN_FILE.exists():
+                mtime = PLAN_FILE.stat().st_mtime
+                if mtime != last_mtime:
+                    last_mtime = mtime
+                    content = PLAN_FILE.read_text().strip()
+                    if content:
+                        print(f"[canvas_push] Change detected, pushing to canvas...")
+                        token = get_bot_token()
+                        canvas_id = push_to_canvas(content, token, state.get("canvas_id"))
+                        if canvas_id:
+                            state["canvas_id"] = canvas_id
+                            state["last_push"] = time.time()
+                            save_state(state)
+        except Exception as e:
+            print(f"[canvas_push] Error: {e}")
+
+        time.sleep(POLL_INTERVAL)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--once", action="store_true", help="Check once and exit (don't watch)")
+    args = parser.parse_args()
+
+    if args.once:
+        run_once()
+    else:
+        run_watch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds the `scrum-planner` OpenClaw skill under `skills/scrum-planner/`
- Includes conversational intake flow (SKILL.md), installation docs (README.md), CLI invocation & SCRUM.md generation reference, phase-by-phase review reference, and Slack Canvas scripts
- Moved from the `skills-update` staging folder into the permanent `skills/scrum-planner/` location

## Files added
- `skills/scrum-planner/SKILL.md` — core skill (intake questions, confirmation gate, formatting rules)
- `skills/scrum-planner/README.md` — installation & usage docs
- `skills/scrum-planner/references/cli-and-generation.md` — SCRUM.md template, keyword rules, CLI invocation
- `skills/scrum-planner/references/output-and-review.md` — phase-by-phase review flow, Canvas output, error handling
- `skills/scrum-planner/scripts/canvas.py` — Slack Canvas create/update operations
- `skills/scrum-planner/scripts/canvas_push.py` — file watcher that auto-pushes plan changes to Slack Canvas

## Test plan
- [ ] Verify skill files are correctly placed under `skills/scrum-planner/`
- [ ] Verify `scrum-agent --install-skill` copies files to the OpenClaw skills directory
- [ ] Test Canvas script locally: `python3 skills/scrum-planner/scripts/canvas.py --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)