### PR TITLE
Offline voice input + graceful API errors + Homebrew deprecation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,15 @@ JIRA_PROJECT_KEY=MYPROJ
 # Space key is the short identifier visible in your Confluence space URL
 CONFLUENCE_SPACE_KEY=MYSPACE
 
+# Voice input (optional — double-tap Space in any text field to dictate)
+# Transcription runs locally & offline via faster-whisper (works with ANY LLM
+# provider, no API key). Install with: uv sync --extra voice  (+ PortAudio:
+# `brew install portaudio` / `apt install portaudio19-dev`).
+# VOICE_MODEL is the local Whisper model size, not a cloud model name.
+# Options: tiny, base (default), small, medium, large-v3 (+ .en variants).
+# Larger = more accurate but slower and a bigger one-time download.
+VOICE_MODEL=base
+
 # Session management
 # Auto-prune sessions older than N days (default 30, set to 0 to disable)
 SESSION_PRUNE_DAYS=30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,15 +63,7 @@ jobs:
         with:
           generate_release_notes: true
 
-  update-homebrew:
-    name: Notify Homebrew Tap
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          repository: omardin14/homebrew-tap
-          event-type: update-formula
-          client-payload: '{"version": "${{ github.ref_name }}"}'
+  # Note: no Homebrew tap update. scrum-agent can't be packaged for Homebrew
+  # (the sqlite-vec dependency ships no sdist), so the tap formula is disabled
+  # and steers users to `uv tool install` / `pipx install`. Distribution is
+  # PyPI-only via the `publish` job above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,7 @@ Version is defined in two places that **must be kept in sync**:
 
 The `__version__` is imported by `cli.py` for the `--version` flag. Package entry point: `scrum-agent = "scrum_agent.cli:main"`.
 
-Releasing: bump version in both files and merge to main. The `publish.yml` workflow triggers on `v*` tag push → PyPI → GitHub Release → Homebrew tap update.
+Releasing: bump version in both files and merge to main. The `publish.yml` workflow triggers on `v*` tag push → PyPI → GitHub Release. Distribution is PyPI-only (via `uv tool install` / `pipx install`); Homebrew is not supported because a required dependency (`sqlite-vec`) ships no sdist, so the `omardin14/homebrew-tap` formula is permanently disabled.
 
 ## CI/CD
 
@@ -412,12 +412,12 @@ Workflows in `.github/workflows/`:
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `ci.yml` | Every push | Lint + test |
-| `publish.yml` | Tag push `v*` | test → build → PyPI publish (OIDC) → GitHub Release → Homebrew tap update |
+| `publish.yml` | Tag push `v*` | test → build → PyPI publish (OIDC) → GitHub Release |
 | `smoke.yml` | Weekly cron | Live API smoke tests |
 | `claude.yml` | PR | Claude Code review |
 | `claude-code-review.yml` | PR | Claude Code review (alternate) |
 
-The `publish.yml` dispatches a `repository_dispatch` event to `omardin14/homebrew-tap` to auto-update the formula SHA256 and version on each release.
+There is no Homebrew tap auto-update: the `omardin14/homebrew-tap` formula is disabled (see Version Management) and `publish.yml` no longer dispatches to it.
 
 ## OpenClaw Skill
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Built with LangGraph](https://img.shields.io/badge/Built%20with-LangGraph-00CED1?style=for-the-badge)](https://langchain-ai.github.io/langgraph/)
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/omardin14/scrum-planning-ai-agent/ci.yml?style=for-the-badge&label=Tests&logo=github)](https://github.com/omardin14/scrum-planning-ai-agent/actions)
-[![Homebrew](https://img.shields.io/badge/Homebrew-Available-orange?style=for-the-badge&logo=homebrew&logoColor=white)](https://github.com/omardin14/homebrew-tap)
+[![PyPI](https://img.shields.io/pypi/v/scrum-agent?style=for-the-badge&logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/scrum-agent/)
 
 </div>
 
@@ -30,21 +30,34 @@
 
 ## 🚀 Quick Start
 
-### Homebrew (macOS)
+### Recommended: uv or pipx
+
+The most reliable way to install — pulls the full dependency tree from PyPI and isolates it in its own environment:
 
 ```bash
-brew tap omardin14/tap && brew install scrum-agent
-scrum-agent --setup   # configure your API key
-scrum-agent           # launch the interactive TUI
+uv tool install scrum-agent     # or: pipx install scrum-agent
+scrum-agent --setup             # configure your API key
+scrum-agent                     # launch the interactive TUI
 ```
 
-### pipx
+Optional extras (voice input, extra LLM providers) can be requested at install time:
 
 ```bash
-pipx install scrum-agent
-scrum-agent --setup
-scrum-agent
+uv tool install "scrum-agent[voice]"           # 🎤 dictate answers (double-tap Space) — offline, works with any LLM
+uv tool install "scrum-agent[all-providers]"   # OpenAI, Google, and Bedrock providers
+pipx install "scrum-agent[voice]"              # equivalent with pipx
 ```
+
+> **Voice input** transcribes on-device with [faster-whisper](https://github.com/SYSTRAN/faster-whisper)
+> — **no API key**, works with every LLM provider (Anthropic, Bedrock, …). It needs the PortAudio native
+> library (`brew install portaudio` on macOS, `sudo apt install portaudio19-dev` on Debian/Ubuntu) and
+> downloads a small Whisper model on first use (~140 MB for the default `base`; set `VOICE_MODEL` to
+> `tiny`/`small`/`medium`/`large-v3` to trade size for accuracy).
+
+> **Homebrew is not supported.** A required dependency (`sqlite-vec`) ships no
+> source distribution, which Homebrew's source-build model can't handle, so
+> `brew install scrum-agent` is intentionally disabled. Use `uv tool install`
+> or `pipx install` above instead.
 
 ### From source
 
@@ -344,7 +357,7 @@ You should see:
 1. **Smart extraction** — the skill detects project, tech stack, team size, integrations from your message
 2. **Follow-up questions** — only asks what's missing (project type, definition of done, target sprints)
 3. **Confirmation summary** — your answers + defaults, with option to override
-4. **TUI recommendation** — for complex projects (3+ features, 5+ engineers), the skill suggests installing the full TUI via `brew install scrum-agent` or `pipx install scrum-agent` for interactive editing, sprint visualisation, and capacity planning. This is informational only — generation always proceeds.
+4. **TUI recommendation** — for complex projects (3+ features, 5+ engineers), the skill suggests installing the full TUI via `uv tool install scrum-agent` or `pipx install scrum-agent` for interactive editing, sprint visualisation, and capacity planning. This is informational only — generation always proceeds.
 5. **Background generation** — progress updates as each phase completes (~3-5 minutes)
 6. **Phase-by-phase review** — features, stories, tasks, sprint plan — each with accept/edit/regenerate
 

--- a/TODO.md
+++ b/TODO.md
@@ -1142,3 +1142,25 @@ _Bring Azure DevOps to full feature parity with Jira — read board/velocity, cr
 - [ ] Feed accuracy data back into team profile (tighten calibration over time)
 - [ ] Show retro report: "Your plan estimated 45pts across 3 sprints; actuals were 52pts across 4 sprints"
 - [ ] Track improvement over time: "Plan accuracy improved from 62% to 78% over 3 projects"
+
+## Phase 18: Voice Input
+- [x] `voice.py` — mic recording (sounddevice) + **local, offline** faster-whisper transcription (no API key, works with any LLM provider), lazy-imported optional `voice` extra
+- [x] Model cache + `is_model_loaded()`/`backend_label()`; `VOICE_MODEL` = local model size (default `base`)
+- [x] Settings page "Voice Input" row showing dictation availability + backend
+- [x] Discoverability: always-on hint on text-entry screens (shows how to enable when not installed), welcome/mode-select footer tip, and setup-wizard completion tip
+- [x] Inline recording UX: pulsing red border + animated status line on the *same* screen (no full-screen popup); transcription runs in a background thread with a spinner; snappier stop-key poll (0.06s)
+- [x] Trigger changed from Ctrl+R → **double-tap Space** (modifier-free, Mac-friendly; `DoubleTapSpace` detector, ~300ms window, first space kept as separator); wired into description, intake question, and editor loops
+- [x] Verified end-to-end: `say`-generated audio → correct transcript, no key
+- [x] `get_voice_model()` config + `VOICE_MODEL` env var, `is_voice_available()` graceful degradation
+- [x] Ctrl+R keybinding in `_input.py` → `"voice"` key
+- [x] Shared `_voice_input.py` overlay (record → transcribe popup) reused by all text-entry loops
+- [x] Wired into project description, intake free-text answers, and artifact editor
+- [x] Discoverability hints (shown only when voice available)
+- [x] Unit tests `tests/unit/test_voice.py`
+
+## Phase 19: Graceful API Error Handling (TUI)
+- [x] Strengthen `_classify_api_error` (ui/session/_utils.py) — Jira/Azure/GitHub/OpenAI/generic via duck-typing, bounded length, never dumps raw `str(exc)`
+- [x] Add `_extract_status_code` helper (status_code/response/HTTP-in-message)
+- [x] Route all raw error surfaces through it: team analysis (both flows), epic export (Jira+AzDO), Jira/AzDO sync-all
+- [x] Top-level cli.py catch-all shows a friendly one-line message + log pointer instead of silent blank
+- [x] Unit tests `tests/unit/test_ui_error_classification.py` (16 cases incl. the real 401 dump)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ openai = ["langchain-openai"]
 google = ["langchain-google-genai"]
 pdf = ["pymupdf"]
 bedrock = ["langchain-aws", "boto3"]
+# Voice input — record mic audio (sounddevice/PortAudio) and transcribe locally
+# and offline with faster-whisper. Lazy-imported in voice.py; needs no API key
+# (works with any LLM provider) but the PortAudio native lib (e.g.
+# `brew install portaudio` on macOS) and a one-time Whisper model download.
+voice = ["sounddevice", "faster-whisper"]
 all-providers = ["langchain-openai", "langchain-google-genai", "langchain-aws", "boto3"]
 dev = [
     "pytest",

--- a/src/scrum_agent/cli.py
+++ b/src/scrum_agent/cli.py
@@ -1145,17 +1145,26 @@ def main(argv: list[str] | None = None) -> None:
 
         atexit.register(_terminal_cleanup)
         enable_mouse_tracking()
+        _tui_error: Exception | None = None
         try:
             mode_result = select_mode(console, dry_run=args.dry_run)
         except KeyboardInterrupt:
             mode_result = None
-        except Exception:
+        except Exception as _exc:
             logging.getLogger(__name__).exception("Unhandled exception in TUI")
+            _tui_error = _exc
             mode_result = None
         finally:
             disable_mouse_tracking()
             if console.is_alt_screen:
                 console.set_alt_screen(False)
+        # Surface a friendly, one-line message (never a raw traceback) now that
+        # the terminal is restored. See _classify_api_error for the mapping.
+        if _tui_error is not None:
+            from scrum_agent.ui.session._utils import _classify_api_error
+
+            console.print(f"[red]{_classify_api_error(_tui_error)}[/red]")
+            console.print("[dim]See ~/.scrum-agent/logs/tui/scrum-agent.log for details.[/dim]")
         if mode_result is None:
             return
         # mode_result is non-None only for offline import (questionnaire path)

--- a/src/scrum_agent/config.py
+++ b/src/scrum_agent/config.py
@@ -212,6 +212,18 @@ def get_google_api_key() -> str | None:
     return os.getenv("GOOGLE_API_KEY") or None
 
 
+def get_voice_model() -> str:
+    """Return the local Whisper model size for voice input.
+
+    Transcription runs on-device via faster-whisper, so this is a model *size*,
+    not a cloud model name. Override with the VOICE_MODEL env var. Valid values:
+    ``tiny``, ``base`` (default), ``small``, ``medium``, ``large-v3`` (and the
+    English-only ``.en`` variants). Larger = more accurate but slower and a
+    bigger one-time download.
+    """
+    return os.getenv("VOICE_MODEL") or "base"
+
+
 def get_session_prune_days() -> int:
     """Return the number of days after which old sessions are pruned.
 

--- a/src/scrum_agent/setup_wizard.py
+++ b/src/scrum_agent/setup_wizard.py
@@ -254,5 +254,18 @@ def run_setup_wizard(console: Console) -> bool:
     os.environ.update({k: v for k, v in merged.items() if v})
 
     console.print(f"\n[green]Setup complete! Config saved to {config_file}[/green]")
+
+    # Onboarding tip: voice input is optional and off by default. Mention it so
+    # new users discover they can dictate answers instead of typing.
+    from scrum_agent.voice import is_voice_available
+
+    if is_voice_available():
+        console.print("[dim]🎤 Voice input is ready — double-tap Space in any text field to dictate.[/dim]")
+    else:
+        console.print(
+            "[dim]🎤 Tip: enable voice input to dictate answers — "
+            "run [/dim][cyan]uv sync --extra voice[/cyan][dim] (works offline, any LLM provider).[/dim]"
+        )
+
     logger.info("Setup wizard completed successfully")
     return True

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -1091,6 +1091,7 @@ def _collect_settings_data() -> dict:
         "AZURE_DEVOPS_TOKEN",
         "AZURE_DEVOPS_TEAM",
         "GITHUB_TOKEN",
+        "VOICE_MODEL",
         "AWS_REGION",
         "AWS_PROFILE",
         "LOG_LEVEL",
@@ -1939,7 +1940,9 @@ def select_mode(
                                     _ta_profile_box[0] = _result[0]
                                     _ta_examples_box[0] = _result[1]
                             except Exception as exc:
-                                _ta_error_box[0] = str(exc)
+                                from scrum_agent.ui.session._utils import _classify_api_error
+
+                                _ta_error_box[0] = _classify_api_error(exc)
                             finally:
                                 _ta_done.set()
 
@@ -2561,7 +2564,10 @@ def select_mode(
                                         _sync_thread.join()
 
                                         if _sync_result_box[1] is not None:
-                                            path = f"{_tracker_label} sync failed: {_sync_result_box[1]}"
+                                            from scrum_agent.ui.session._utils import _classify_api_error
+
+                                            _sync_err = _classify_api_error(_sync_result_box[1])
+                                            path = f"{_tracker_label} sync failed: {_sync_err}"
                                         elif _sync_result_box[0] is not None:
                                             sr = _sync_result_box[0]
                                             new_gs = _sync_state_box[0]
@@ -3133,7 +3139,9 @@ def select_mode(
                                 _ta_profile_box[0] = _result[0]
                                 _ta_examples_box[0] = _result[1]
                         except Exception as exc:
-                            _ta_error_box[0] = str(exc)
+                            from scrum_agent.ui.session._utils import _classify_api_error
+
+                            _ta_error_box[0] = _classify_api_error(exc)
                         finally:
                             _ta_done.set()
 

--- a/src/scrum_agent/ui/mode_select/screens/_screens.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens.py
@@ -222,14 +222,29 @@ def _build_mode_screen(
             body.append(Text(""))
             body_h += 1
 
+    # Bottom-pinned discoverability tip for voice input — so users learn the
+    # feature exists from the very first screen, not only inside a session.
+    from scrum_agent.voice import is_voice_available
+
+    _voice_ok, _ = is_voice_available()
+    tip_text = (
+        "\U0001f3a4  Tip: double-tap Space in any text field to dictate"
+        if _voice_ok
+        else "\U0001f3a4  Voice input supported — enable with: uv sync --extra voice"
+    )
+    tip = Text(tip_text, style="dim", justify="center")
+
+    # Reserve the last row for the tip; centre the mode rows in the space above.
     inner_h = height - 4
-    mid_top = max(0, (inner_h - body_h) // 2)
-    mid_bot = max(0, inner_h - body_h - mid_top)
+    body_area = max(0, inner_h - 1)
+    mid_top = max(0, (body_area - body_h) // 2)
+    mid_bot = max(0, body_area - body_h - mid_top)
 
     content = Group(
         *[Text("") for _ in range(mid_top)],
         *body,
         *[Text("") for _ in range(mid_bot)],
+        tip,
     )
 
     return Panel(

--- a/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
@@ -3414,6 +3414,19 @@ def _build_settings_screen(
     _heading("GitHub")
     _row("Token", config_data.get("GITHUB_TOKEN", ""), masked=True)
 
+    # ── Voice Input ───────────────────────────────────────────────
+    # Local, offline dictation (double-tap Space in any text field) — works with every
+    # LLM provider, no API key. See README: "Voice Input".
+    _heading("Voice Input")
+    from scrum_agent.voice import backend_label, is_voice_available
+
+    _voice_ok, _voice_reason = is_voice_available()
+    if _voice_ok:
+        _row("Dictation", f"available — {backend_label()}", value_style=theme.good)
+    else:
+        _row("Dictation", f"unavailable — {_voice_reason}", value_style=theme.warn)
+    _row("Model Size", config_data.get("VOICE_MODEL", "") or "base (default)")
+
     # ── AWS Bedrock ───────────────────────────────────────────────
     aws_region = config_data.get("AWS_REGION", "")
     aws_profile = config_data.get("AWS_PROFILE", "")

--- a/src/scrum_agent/ui/session/_utils.py
+++ b/src/scrum_agent/ui/session/_utils.py
@@ -141,12 +141,43 @@ def _render_to_lines(console: Console, renderable, width: int) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _classify_api_error(err: Exception) -> str:
-    """Return a user-friendly error message for common API errors.
+def _extract_status_code(err: Exception) -> int | None:
+    """Best-effort extraction of an HTTP status code from any exception.
 
-    Used by TUI error handlers to show actionable feedback instead of
-    silently returning to the project select screen.
+    Works across SDKs without importing them: checks common attributes
+    (``status_code``, ``status``), a nested ``response`` object, and finally
+    parses an ``HTTP <code>`` token from the message (e.g. JIRAError's text).
     """
+    for attr in ("status_code", "status"):
+        val = getattr(err, attr, None)
+        if isinstance(val, int) and not isinstance(val, bool):
+            return val
+    resp = getattr(err, "response", None)
+    if resp is not None:
+        for attr in ("status_code", "status"):
+            val = getattr(resp, attr, None)
+            if isinstance(val, int) and not isinstance(val, bool):
+                return val
+    match = re.search(r"\bHTTP[\s:]+(\d{3})\b", str(err))
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _classify_api_error(err: Exception) -> str:
+    """Return a short, user-friendly message for any API/integration error.
+
+    Used by TUI error handlers so users see actionable, one-line feedback
+    instead of a raw exception dump. This is the single place that turns SDK
+    exceptions (Anthropic, Jira, Azure DevOps, GitHub, OpenAI, …) into human
+    text — call it everywhere an external-service error can reach the screen,
+    never render ``str(exc)`` directly (a JIRAError, for example, stringifies to
+    its entire HTTP response including every header).
+
+    Optional-dependency SDKs are matched by class/module name + status code
+    rather than isinstance, so this module never has to import them.
+    """
+    # Anthropic — the default provider, always installed.
     if isinstance(err, anthropic.AuthenticationError):
         return "Authentication failed — check your ANTHROPIC_API_KEY in .env (may be missing, expired, or invalid)."
     if isinstance(err, anthropic.RateLimitError):
@@ -155,11 +186,57 @@ def _classify_api_error(err: Exception) -> str:
         return "Network error — check your internet connection and try again."
     if isinstance(err, anthropic.APIStatusError):
         msg = getattr(err, "message", str(err))
-        # Detect billing/credit errors from the message body
         if "credit balance" in msg.lower() or "billing" in msg.lower():
             return "Insufficient API credits — visit Plans & Billing at console.anthropic.com to add credits."
         return f"API error (status {err.status_code}): {msg}"
-    return f"Unexpected error: {err}"
+
+    name = type(err).__name__
+    module = (type(err).__module__ or "").lower()
+    status = _extract_status_code(err)
+    is_auth = status in (401, 403)
+
+    # Jira (jira.exceptions.JIRAError) — its str() is a full HTTP dump, so we
+    # build the message from the status code and never fall through to str(err).
+    if "jira" in module or name == "JIRAError":
+        if is_auth:
+            return (
+                "Jira authentication failed — check your Jira URL, email, and API token "
+                "(Settings ▸ Issue Tracking, or JIRA_* in .env)."
+            )
+        if status == 404:
+            return "Jira project or board not found — check your JIRA_PROJECT_KEY."
+        return f"Jira request failed{f' (HTTP {status})' if status else ''} — check your Jira configuration."
+
+    # Azure DevOps (azure.devops.exceptions.*) — often lacks a status code.
+    if "azure" in module or "azuredevops" in name.lower():
+        if is_auth:
+            return (
+                "Azure DevOps authentication failed — check your personal access token and organisation URL "
+                "(Settings ▸ Issue Tracking, or AZURE_DEVOPS_* in .env)."
+            )
+        return "Azure DevOps request failed — check your Azure DevOps configuration."
+
+    # GitHub (github.GithubException / BadCredentialsException).
+    if "github" in module or name in ("GithubException", "BadCredentialsException"):
+        if is_auth:
+            return "GitHub authentication failed — check your GITHUB_TOKEN."
+        return f"GitHub request failed{f' (HTTP {status})' if status else ''} — check your GitHub configuration."
+
+    # Any other SDK, matched purely by status code (OpenAI, Google, requests…).
+    if is_auth:
+        return "Authentication failed — check the API key/token for this service in Settings."
+    if status == 429:
+        return "Rate limited — too many requests. Wait a moment and try again."
+    if "connection" in name.lower() or "timeout" in name.lower():
+        return "Network error — check your internet connection and try again."
+
+    # Fallback — bound the length and keep only the first line so a stray dump
+    # (headers, HTML body) can never flood or break the TUI layout.
+    text = str(err).strip()
+    first_line = text.splitlines()[0] if text else name
+    if len(first_line) > 200:
+        first_line = first_line[:197] + "…"
+    return f"Unexpected error: {first_line}"
 
 
 # ---------------------------------------------------------------------------

--- a/src/scrum_agent/ui/session/editor/_editor_core.py
+++ b/src/scrum_agent/ui/session/editor/_editor_core.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Callable
 
 import rich.box
@@ -306,6 +307,11 @@ def edit_buffer_loop(
     """
     scroll_offset = 0
 
+    # Voice input: double-tap Space to dictate at the cursor (see DoubleTapSpace).
+    from scrum_agent.ui.shared._voice_input import DoubleTapSpace
+
+    _dts = DoubleTapSpace()
+
     w, h = console.size
     panel, scroll_offset = render_fn(buffer, cursor_row, cursor_col, scroll_offset, w, h)
     live.update(panel)
@@ -425,8 +431,21 @@ def edit_buffer_loop(
             min_col = editable_start_fn(buffer[cursor_row])
             if min_col is not None and cursor_col >= min_col:
                 line = buffer[cursor_row]
-                buffer[cursor_row] = line[:cursor_col] + key + line[cursor_col:]
-                cursor_col += 1
+                prev_space = cursor_col > min_col and line[cursor_col - 1] == " "
+                if key == " " and _dts.is_double(prev_space, time.monotonic()):
+                    # Double-tap Space → dictate at the cursor (first space stays
+                    # as a separator), collapsing any newlines like a paste.
+                    from scrum_agent.ui.shared._voice_input import record_voice_input
+
+                    spoken = record_voice_input(live, console, _key)
+                    if spoken:
+                        spoken = spoken.replace("\n", " ")
+                        cur = buffer[cursor_row]
+                        buffer[cursor_row] = cur[:cursor_col] + spoken + cur[cursor_col:]
+                        cursor_col += len(spoken)
+                else:
+                    buffer[cursor_row] = line[:cursor_col] + key + line[cursor_col:]
+                    cursor_col += 1
 
         elif key == "":
             pass

--- a/src/scrum_agent/ui/session/phases/_phases.py
+++ b/src/scrum_agent/ui/session/phases/_phases.py
@@ -391,7 +391,9 @@ def _handle_tracker_sync(
                     _issue = _j.create_issue(fields=_fields)
                     _ep_result_box[0] = _issue.key
                 except Exception as exc:
-                    _ep_result_box[1] = str(exc)
+                    from scrum_agent.ui.session._utils import _classify_api_error
+
+                    _ep_result_box[1] = _classify_api_error(exc)
             else:
                 try:
                     from azure.devops.v7_0.work_item_tracking.models import JsonPatchOperation
@@ -407,7 +409,9 @@ def _handle_tracker_sync(
                     _wi = _wit.create_work_item(_ops, get_azure_devops_project(), "Epic")
                     _ep_result_box[0] = str(_wi.id)
                 except Exception as exc:
-                    _ep_result_box[1] = str(exc)
+                    from scrum_agent.ui.session._utils import _classify_api_error
+
+                    _ep_result_box[1] = _classify_api_error(exc)
             _ep_done.set()
 
         _ep_thread = threading.Thread(target=_create_epic, daemon=True)

--- a/src/scrum_agent/ui/session/phases/_phases_intake.py
+++ b/src/scrum_agent/ui/session/phases/_phases_intake.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 
 from langchain_core.messages import AIMessage, HumanMessage
 from rich.console import Console
@@ -20,7 +21,11 @@ from scrum_agent.repl._questionnaire import (
 from scrum_agent.repl._ui import _predict_next_node
 from scrum_agent.ui.session._utils import _invoke_with_animation
 from scrum_agent.ui.session.screens._accordion import _build_accordion_question_screen
-from scrum_agent.ui.session.screens._screens_input import _build_description_screen, _build_question_screen
+from scrum_agent.ui.session.screens._screens_input import (
+    _build_description_screen,
+    _build_question_screen,
+    _voice_hint,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +63,35 @@ def _phase_description_input(
 
     w, h = console.size
     live.update(_build_description_screen(input_lines, cursor_row, cursor_col, width=w, height=h))
+
+    # Voice input: double-tap Space to dictate (see DoubleTapSpace for why).
+    from scrum_agent.ui.shared._voice_input import DoubleTapSpace, record_voice_input, voice_indicator
+
+    _dts = DoubleTapSpace()
+
+    def _voice_render(status, tick):
+        _bw, _bh = console.size
+        _border, _line = voice_indicator(status, tick)
+        return _build_description_screen(
+            input_lines, cursor_row, cursor_col, width=_bw, height=_bh,
+            border_override=_border, status_line=_line,
+        )
+
+    def _run_voice() -> None:
+        nonlocal cursor_row, cursor_col
+        spoken = record_voice_input(live, console, _key, render_status=_voice_render)
+        if not spoken:
+            return
+        voice_lines = spoken.split("\n")
+        line = input_lines[cursor_row]
+        tail = line[cursor_col:]
+        input_lines[cursor_row] = line[:cursor_col] + voice_lines[0]
+        cursor_col += len(voice_lines[0])
+        for vl in voice_lines[1:]:
+            cursor_row += 1
+            input_lines.insert(cursor_row, vl)
+            cursor_col = len(vl)
+        input_lines[cursor_row] += tail
 
     while True:
         key = _key()
@@ -150,8 +184,13 @@ def _phase_description_input(
                     input_lines[cursor_row] += line[cursor_col - len(paste_lines[-1]) :]
         elif isinstance(key, str) and len(key) == 1 and key.isprintable():
             line = input_lines[cursor_row]
-            input_lines[cursor_row] = line[:cursor_col] + key + line[cursor_col:]
-            cursor_col += 1
+            if key == " " and _dts.is_double(cursor_col > 0 and line[cursor_col - 1] == " ", time.monotonic()):
+                # Double-tap Space → dictate; the first space stays as a separator
+                # and the second one is swallowed by the gesture (not inserted).
+                _run_voice()
+            else:
+                input_lines[cursor_row] = line[:cursor_col] + key + line[cursor_col:]
+                cursor_col += 1
         elif key == "":
             pass  # timeout, no input
         else:
@@ -459,7 +498,9 @@ def _question_input_loop(
                 height=h,
                 cursor_pos=cursor_pos,
                 edit_hint=(
-                    "Space toggle \u00b7 Enter submit" if multi_select else "Enter/Ctrl+S submit \u00b7 Esc cancel"
+                    "Space toggle \u00b7 Enter submit"
+                    if multi_select
+                    else ("Enter/Ctrl+S submit \u00b7 Esc cancel" + ("" if choices else _voice_hint()))
                 ),
             )
         return _build_question_screen(
@@ -476,6 +517,37 @@ def _question_input_loop(
         )
 
     live.update(_render())
+
+    # Voice input: double-tap Space to dictate (free-text questions only).
+    from scrum_agent.ui.shared._voice_input import DoubleTapSpace, record_voice_input, voice_indicator
+
+    _dts = DoubleTapSpace()
+
+    def _voice_render(status, tick):
+        _bw, _bh = console.size
+        _border, _line = voice_indicator(status, tick)
+        if use_accordion:
+            return _build_accordion_question_screen(
+                question_text, input_value, questionnaire,
+                choices=choices, suggestion=suggestion, progress=progress,
+                phase_label=phase_label, selected_choice=selected_choice,
+                selected_choices=selected_choices if multi_select else None,
+                scroll_offset=scroll_offset, width=_bw, height=_bh, cursor_pos=cursor_pos,
+                border_override=_border, edit_hint=_line,
+            )
+        return _build_question_screen(
+            question_text, input_value, choices=choices, suggestion=suggestion,
+            progress=progress, phase_label=phase_label, preamble_lines=preamble_lines,
+            selected_choice=selected_choice, width=_bw, height=_bh,
+            border_override=_border, status_line=_line,
+        )
+
+    def _run_voice() -> None:
+        nonlocal input_value, cursor_pos
+        spoken = record_voice_input(live, console, _key, render_status=_voice_render)
+        if spoken:
+            input_value = input_value[:cursor_pos] + spoken + input_value[cursor_pos:]
+            cursor_pos += len(spoken)
 
     while True:
         key = _key()
@@ -536,8 +608,12 @@ def _question_input_loop(
             input_value = input_value[:cursor_pos] + pasted + input_value[cursor_pos:]
             cursor_pos += len(pasted)
         elif isinstance(key, str) and len(key) == 1 and key.isprintable():
-            input_value = input_value[:cursor_pos] + key + input_value[cursor_pos:]
-            cursor_pos += 1
+            if key == " " and _dts.is_double(cursor_pos > 0 and input_value[cursor_pos - 1] == " ", time.monotonic()):
+                # Double-tap Space → dictate; the first space stays as a separator.
+                _run_voice()
+            else:
+                input_value = input_value[:cursor_pos] + key + input_value[cursor_pos:]
+                cursor_pos += 1
         elif key == "":
             pass
         else:

--- a/src/scrum_agent/ui/session/phases/_phases_intake.py
+++ b/src/scrum_agent/ui/session/phases/_phases_intake.py
@@ -73,8 +73,13 @@ def _phase_description_input(
         _bw, _bh = console.size
         _border, _line = voice_indicator(status, tick)
         return _build_description_screen(
-            input_lines, cursor_row, cursor_col, width=_bw, height=_bh,
-            border_override=_border, status_line=_line,
+            input_lines,
+            cursor_row,
+            cursor_col,
+            width=_bw,
+            height=_bh,
+            border_override=_border,
+            status_line=_line,
         )
 
     def _run_voice() -> None:
@@ -528,18 +533,35 @@ def _question_input_loop(
         _border, _line = voice_indicator(status, tick)
         if use_accordion:
             return _build_accordion_question_screen(
-                question_text, input_value, questionnaire,
-                choices=choices, suggestion=suggestion, progress=progress,
-                phase_label=phase_label, selected_choice=selected_choice,
+                question_text,
+                input_value,
+                questionnaire,
+                choices=choices,
+                suggestion=suggestion,
+                progress=progress,
+                phase_label=phase_label,
+                selected_choice=selected_choice,
                 selected_choices=selected_choices if multi_select else None,
-                scroll_offset=scroll_offset, width=_bw, height=_bh, cursor_pos=cursor_pos,
-                border_override=_border, edit_hint=_line,
+                scroll_offset=scroll_offset,
+                width=_bw,
+                height=_bh,
+                cursor_pos=cursor_pos,
+                border_override=_border,
+                edit_hint=_line,
             )
         return _build_question_screen(
-            question_text, input_value, choices=choices, suggestion=suggestion,
-            progress=progress, phase_label=phase_label, preamble_lines=preamble_lines,
-            selected_choice=selected_choice, width=_bw, height=_bh,
-            border_override=_border, status_line=_line,
+            question_text,
+            input_value,
+            choices=choices,
+            suggestion=suggestion,
+            progress=progress,
+            phase_label=phase_label,
+            preamble_lines=preamble_lines,
+            selected_choice=selected_choice,
+            width=_bw,
+            height=_bh,
+            border_override=_border,
+            status_line=_line,
         )
 
     def _run_voice() -> None:

--- a/src/scrum_agent/ui/session/screens/_screens_input.py
+++ b/src/scrum_agent/ui/session/screens/_screens_input.py
@@ -22,6 +22,22 @@ _PAD = PAD
 _INPUT_BOX_W_MAX = 74
 
 
+def _voice_hint() -> str:
+    """Return a discoverability suffix for voice input on text-entry screens.
+
+    Always advertises the feature so users know it exists. When the voice extra
+    is installed it prompts to speak; otherwise it shows how to enable it —
+    hiding it entirely (the old behaviour) meant the feature was invisible to
+    anyone who hadn't already set it up.
+    """
+    from scrum_agent.voice import is_voice_available
+
+    available, _reason = is_voice_available()
+    if available:
+        return " · \U0001f3a4 double-tap Space to speak"
+    return " · \U0001f3a4 dictate: uv sync --extra voice"
+
+
 # ---------------------------------------------------------------------------
 # Shared header — "Planning" ASCII title pinned at top of every screen
 # ---------------------------------------------------------------------------
@@ -48,12 +64,15 @@ def _build_description_screen(
     width: int = 80,
     height: int = 24,
     border_override: str = "",
+    status_line: str = "",
 ) -> Panel:
     """Build the multi-line project description input screen.
 
     Shows the Planning title, a "Tell me about your project" subtitle,
     and a multi-line text box. Enter on an empty line submits.
     border_override: if set, overrides the input box border colour (for green pulse).
+    status_line: if set, replaces the submit hint with this text (e.g. the
+        inline voice-recording indicator) so the user stays on this screen.
     """
     title = _planning_title()
     sub = Text(_PAD + "Tell me about your project", style="dim", justify="left")
@@ -119,11 +138,14 @@ def _build_description_screen(
         width=box_w,
     )
 
-    submit_hint = Text(
-        _PAD + "Enter submit \u00b7 \u2303N new line \u00b7 Esc go back \u00b7 \u2325+drag select text",
-        style="dim",
-        justify="left",
-    )
+    if status_line:
+        submit_hint = Text(_PAD + status_line, style="bold white", justify="left")
+    else:
+        submit_hint = Text(
+            _PAD + "Enter submit \u00b7 \u2303N new line \u00b7 Esc go back" + _voice_hint(),
+            style="dim",
+            justify="left",
+        )
 
     # Wrap the example to fit within the box width
     example_lines = _wrap_text(example_text, box_w - 4)
@@ -208,6 +230,7 @@ def _build_question_screen(
     width: int = 80,
     height: int = 24,
     border_override: str = "",
+    status_line: str = "",
 ) -> Panel:
     """Build a single intake question screen.
 
@@ -285,9 +308,13 @@ def _build_question_screen(
             body_h += 1
         body.append(Text(""))
         body_h += 1
-        hint = Text(_PAD + "Enter/Ctrl+S submit \u00b7 Esc cancel", style="dim", justify="left")
+        hint = Text(_PAD + "Enter/Ctrl+S submit \u00b7 Esc cancel" + _voice_hint(), style="dim", justify="left")
     else:
-        hint = Text(_PAD + "Enter/Ctrl+S submit \u00b7 Esc cancel", style="dim", justify="left")
+        hint = Text(_PAD + "Enter/Ctrl+S submit \u00b7 Esc cancel" + _voice_hint(), style="dim", justify="left")
+
+    # Inline voice-recording indicator replaces the hint so the user stays here.
+    if status_line:
+        hint = Text(_PAD + status_line, style="bold white", justify="left")
 
     if input_value:
         display = input_value + "\u2588"

--- a/src/scrum_agent/ui/shared/_voice_input.py
+++ b/src/scrum_agent/ui/shared/_voice_input.py
@@ -1,0 +1,198 @@
+"""Voice-input overlay for the TUI text-entry loops.
+
+# See README: "TUI system" — shared component used by every text entry point
+# (project description, intake answers, artifact editor). It drives the
+# record → transcribe flow.
+
+Design: the caller passes a ``render_status(status, tick)`` callback that
+re-renders *its own* screen with a recording/transcribing indicator, so the user
+stays on the same screen (a pulsing input-box border + a status line) instead of
+being taken to a full-screen popup. Recording stops on the next keypress (Esc
+cancels); transcription then runs in a background thread so the animated
+indicator keeps ticking instead of freezing.
+
+Callers that don't pass ``render_status`` fall back to a centred popup.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+from rich.align import Align
+from rich.console import Console, Group
+from rich.live import Live
+from rich.text import Text
+
+from scrum_agent.ui.shared._components import build_popup
+
+logger = logging.getLogger(__name__)
+
+_REC_BORDER = "rgb(80,200,100)"
+_WORK_BORDER = "rgb(110,140,220)"
+_ERR_BORDER = "rgb(220,80,80)"
+
+_SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+# Voice input is triggered by a quick double-tap of the space bar — chosen over a
+# Ctrl/Cmd chord because macOS terminals never receive Cmd (so Ctrl was the only
+# option and read as ambiguous), and terminals can't detect key-release, ruling
+# out true press-and-hold. Space is modifier-free and identical on every keyboard.
+_DOUBLE_TAP_SECONDS = 0.30
+
+
+class DoubleTapSpace:
+    """Detects a rapid double-tap of the space bar in a text-entry loop.
+
+    Call :meth:`is_double` on every Space keypress. It returns True when this
+    press completes a double-tap within the time window *and* the character
+    before the cursor is the space just inserted by the previous tap — in which
+    case the caller should delete that space and start recording. Otherwise it
+    returns False and the caller inserts the space normally.
+    """
+
+    def __init__(self, threshold: float = _DOUBLE_TAP_SECONDS) -> None:
+        self._threshold = threshold
+        self._last = 0.0
+
+    def is_double(self, prev_char_is_space: bool, now: float) -> bool:
+        if prev_char_is_space and 0.0 < (now - self._last) <= self._threshold:
+            self._last = 0.0  # reset so a third tap doesn't immediately retrigger
+            return True
+        self._last = now
+        return False
+
+
+def voice_indicator(status: str, tick: float) -> tuple[str, str]:
+    """Return ``(border_style, status_line)`` for an inline recording indicator.
+
+    Callers use ``border_style`` for their input-box border and render
+    ``status_line`` in place of the usual submit hint. ``tick`` drives the
+    animation (pulsing dot while recording, spinner while transcribing).
+    """
+    if status == "recording":
+        # Triangle-wave pulse (0..1) without importing math — brightens the red.
+        p = abs((tick * 1.5 % 1.0) - 0.5) * 2
+        r = 200 + int(55 * p)
+        gb = 70 + int(40 * p)
+        dot = "●" if int(tick * 3) % 2 == 0 else "○"
+        return f"rgb({r},{gb},{gb})", f"{dot} Recording…  press any key to stop  ·  Esc cancels"
+    if status == "transcribing":
+        spin = _SPINNER[int(tick * 12) % len(_SPINNER)]
+        return _WORK_BORDER, f"{spin} Transcribing your speech…"
+    return "", ""
+
+
+def _center(console: Console, message: str, border_style: str) -> Group:
+    """Fallback overlay: a popup centred over a full screen."""
+    _w, h = console.size
+    popup = build_popup(message, width=52, border_style=border_style)
+    top_pad = max(0, (h - 5) // 2)
+    return Group(*[Text("") for _ in range(top_pad)], Align.center(popup))
+
+
+def record_voice_input(live: Live, console: Console, _key, render_status=None) -> str | None:
+    """Record from the mic and return the transcribed text, or None.
+
+    ``render_status(status, tick)`` — optional callback returning a renderable
+    for status in {"recording", "transcribing"}; when omitted, a centred popup
+    is used. Records until any key is pressed (Esc cancels), transcribes in a
+    background thread while animating, and returns the transcript. Returns None
+    on cancel, no speech, or error (errors are logged and shown briefly).
+    """
+    from scrum_agent.voice import Recorder, is_model_loaded, is_voice_available, transcribe
+
+    def _paint(status: str, tick: float) -> None:
+        if render_status is not None:
+            live.update(render_status(status, tick))
+        elif status == "recording":
+            live.update(_center(console, "\U0001f3a4  Recording…  press any key to stop", _REC_BORDER))
+        else:
+            msg = "⏳  Transcribing…" if is_model_loaded() else "⏳  Preparing speech model (first run downloads it)…"
+            live.update(_center(console, msg, _WORK_BORDER))
+
+    available, reason = is_voice_available()
+    if not available:
+        logger.info("Voice input unavailable: %s", reason)
+        _flash(live, console, _key, reason, _ERR_BORDER)
+        return None
+
+    logger.info("Voice input: starting recording")
+    try:
+        recorder = Recorder()
+    except Exception:
+        logger.warning("Failed to start microphone", exc_info=True)
+        _flash(live, console, _key, "Could not access microphone", _ERR_BORDER)
+        return None
+
+    # ── Recording: animate until any key is pressed ───────────────────────
+    cancelled = False
+    tick = 0.0
+    _paint("recording", tick)
+    try:
+        while True:
+            try:
+                key = _key(timeout=0.06)
+            except TypeError:
+                key = _key()  # key reader without timeout support
+            if key == "":
+                tick += 0.06
+                _paint("recording", tick)
+                continue
+            cancelled = key == "esc"
+            break
+    except KeyboardInterrupt:
+        cancelled = True
+
+    wav_bytes = recorder.stop()
+    if cancelled:
+        logger.info("Voice input: cancelled by user")
+        return None
+    if not wav_bytes:
+        logger.info("Voice input: no audio captured")
+        return None
+
+    # ── Transcription: run in a thread so the indicator keeps animating ──
+    result: list = [None]
+    error: list = [None]
+    done = threading.Event()
+
+    def _worker() -> None:
+        try:
+            result[0] = transcribe(wav_bytes)
+        except Exception as exc:  # noqa: BLE001 - surfaced to the user below
+            error[0] = exc
+        finally:
+            done.set()
+
+    threading.Thread(target=_worker, daemon=True).start()
+    while not done.is_set():
+        _paint("transcribing", tick)
+        time.sleep(0.08)
+        tick += 0.08
+
+    if error[0] is not None:
+        logger.warning("Transcription failed", exc_info=error[0])
+        _flash(live, console, _key, "Transcription failed — see logs (try: uv sync --extra voice)", _ERR_BORDER)
+        return None
+
+    text = result[0] or ""
+    if not text:
+        logger.info("Voice input: empty transcript")
+        return None
+
+    logger.info("Voice input: inserted %d chars", len(text))
+    return text
+
+
+def _flash(live: Live, console: Console, _key, message: str, border_style: str) -> None:
+    """Show a message popup and wait for a keypress to dismiss it."""
+    live.update(_center(console, message, border_style))
+    try:
+        try:
+            _key(timeout=3.0)
+        except TypeError:
+            _key()
+    except KeyboardInterrupt:
+        pass

--- a/src/scrum_agent/voice.py
+++ b/src/scrum_agent/voice.py
@@ -1,0 +1,195 @@
+"""Voice input — record from the microphone and transcribe locally (offline).
+
+This module lets users *speak* their answers instead of typing them. It is used
+by the TUI text-entry loops (project description, intake question answers, and
+the artifact editor) which trigger recording on Ctrl+R.
+
+# See README: "Voice Input" — voice is an optional, provider-agnostic helper.
+# It does NOT go through the LangGraph agent or the get_llm() provider factory.
+
+Design notes / architectural decisions:
+- **Local, provider-agnostic transcription.** Speech-to-text runs on-device via
+  `faster-whisper` (a CTranslate2 Whisper implementation). This works no matter
+  which LLM_PROVIDER (Anthropic/Bedrock/OpenAI/Google) drives the planning
+  agent, and needs **no API key** — Anthropic and Bedrock have no speech-to-text
+  endpoint, so a cloud STT would have forced an OpenAI key on everyone.
+- **Lazy imports.** Both heavy dependencies (`sounddevice` for mic capture and
+  `faster_whisper` for transcription) are imported *inside* functions, mirroring
+  the optional-provider pattern in `agent/llm.py`. Importing this module never
+  fails; the deps are only needed when voice is actually used. Install with:
+  ``uv sync --extra voice`` (also needs the PortAudio native lib, e.g.
+  ``brew install portaudio`` on macOS).
+- **Cheap availability probe.** :func:`is_voice_available` uses
+  ``importlib.util.find_spec`` so a per-render hint check never triggers the
+  heavy ``faster_whisper`` / ``ctranslate2`` import; real mic/model failures are
+  handled gracefully at record/transcribe time.
+- **Model cache.** The Whisper model is loaded once per size and reused — the
+  first transcription downloads the model (~75 MB "tiny" … ~460 MB "small");
+  subsequent ones are fast.
+- **WAV assembled with the stdlib.** Recorded int16 frames are written with the
+  standard-library ``wave`` module and decoded back to a float32 array for the
+  model, so we never depend on ffmpeg or PyAV's decode path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import logging
+import wave
+
+from scrum_agent.config import get_voice_model
+
+logger = logging.getLogger(__name__)
+
+# Whisper models expect 16 kHz mono audio; recording at the target rate avoids a
+# resampling step before transcription.
+SAMPLE_RATE = 16000
+CHANNELS = 1
+_SAMPLE_WIDTH_BYTES = 2  # int16
+
+# Loaded WhisperModel instances keyed by size (e.g. "base"). Populated lazily on
+# first transcription so the (potentially large) model download happens once.
+_MODEL_CACHE: dict = {}
+
+
+def _installed(module_name: str) -> bool:
+    """Return True if a module is importable, without importing it.
+
+    Uses find_spec so this stays cheap enough to call on every screen render.
+    Treats a sys.modules entry of None (used in tests to simulate absence) and
+    any lookup error as "not installed".
+    """
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def is_voice_available() -> tuple[bool, str]:
+    """Return (available, reason) describing whether voice input can be used.
+
+    Voice needs the optional audio + transcription packages installed. No API
+    key is required — transcription is fully local. ``reason`` is empty when
+    available, otherwise a short human-readable explanation for the UI.
+    """
+    if not _installed("sounddevice"):
+        return False, "Install voice extra: uv sync --extra voice (needs PortAudio)"
+    if not _installed("faster_whisper"):
+        return False, "Install voice extra: uv sync --extra voice"
+    return True, ""
+
+
+def is_model_loaded() -> bool:
+    """Return True if the model for the configured size is already in memory.
+
+    Lets the UI show a "downloading model" message on the first transcription
+    instead of a bare "transcribing" that could hang for a while.
+    """
+    return get_voice_model() in _MODEL_CACHE
+
+
+def backend_label() -> str:
+    """Short human-readable description of the transcription backend (for Settings)."""
+    return f"local Whisper ({get_voice_model()})"
+
+
+class Recorder:
+    """Records microphone audio into memory until :meth:`stop` is called.
+
+    Uses a ``sounddevice.InputStream`` with a callback that appends each audio
+    block to a list — this lets the caller stop recording on an arbitrary event
+    (e.g. a keypress) rather than committing to a fixed duration up front.
+    """
+
+    def __init__(self, samplerate: int = SAMPLE_RATE, channels: int = CHANNELS) -> None:
+        import numpy as np  # noqa: F401 - imported to fail fast if numpy is absent
+        import sounddevice as sd
+
+        self.samplerate = samplerate
+        self.channels = channels
+        self._frames: list = []
+        self._stream = sd.InputStream(
+            samplerate=samplerate,
+            channels=channels,
+            dtype="int16",
+            callback=self._callback,
+        )
+        self._stream.start()
+        logger.info("Voice recording started: %d Hz, %d ch", samplerate, channels)
+
+    def _callback(self, indata, frames, time_info, status) -> None:
+        if status:  # pragma: no cover - hardware-dependent (overflows etc.)
+            logger.debug("Audio input status: %s", status)
+        # Copy — sounddevice reuses the underlying buffer across callbacks.
+        self._frames.append(indata.copy())
+
+    def stop(self) -> bytes:
+        """Stop the stream and return the recording as WAV-encoded bytes.
+
+        Returns empty bytes if nothing was captured (e.g. immediate stop).
+        """
+        import numpy as np
+
+        try:
+            self._stream.stop()
+            self._stream.close()
+        except Exception:  # pragma: no cover - defensive; stream already closed
+            logger.warning("Error closing audio stream", exc_info=True)
+
+        if not self._frames:
+            logger.info("Voice recording stopped: no audio captured")
+            return b""
+
+        data = np.concatenate(self._frames, axis=0)
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wav:
+            wav.setnchannels(self.channels)
+            wav.setsampwidth(_SAMPLE_WIDTH_BYTES)
+            wav.setframerate(self.samplerate)
+            wav.writeframes(data.tobytes())
+        wav_bytes = buf.getvalue()
+        logger.info("Voice recording stopped: %d bytes WAV", len(wav_bytes))
+        return wav_bytes
+
+
+def _get_model():
+    """Return a cached faster-whisper model for the configured size.
+
+    The first call for a given size loads (and, if missing, downloads) the
+    model. device="cpu"/compute_type="int8" is the broadly-compatible default.
+    """
+    size = get_voice_model()
+    model = _MODEL_CACHE.get(size)
+    if model is None:
+        from faster_whisper import WhisperModel
+
+        logger.info("Loading local Whisper model: size=%s (first run may download it)", size)
+        model = WhisperModel(size, device="cpu", compute_type="int8")
+        _MODEL_CACHE[size] = model
+    return model
+
+
+def transcribe(wav_bytes: bytes) -> str:
+    """Transcribe WAV audio to text locally via faster-whisper.
+
+    Returns the transcript (stripped), or an empty string if there is no audio.
+    Raises on model-load/transcription errors so the caller can surface them.
+    """
+    if not wav_bytes:
+        return ""
+
+    import numpy as np
+
+    # Decode the WAV int16 PCM back to the float32 mono array the model expects,
+    # avoiding any ffmpeg/PyAV decode dependency.
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
+        frames = wav.readframes(wav.getnframes())
+    samples = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+
+    model = _get_model()
+    logger.info("Transcribing %d samples with local Whisper", len(samples))
+    segments, _info = model.transcribe(samples, beam_size=5)
+    text = " ".join(segment.text.strip() for segment in segments).strip()
+    logger.info("Transcription complete: %d chars", len(text))
+    return text

--- a/tests/unit/nodes/test_intake.py
+++ b/tests/unit/nodes/test_intake.py
@@ -3200,11 +3200,18 @@ class TestPTOSubLoop:
 
     def test_pto_valid_start_asks_for_end(self):
         """Valid start date should ask for end date."""
+        from datetime import date, timedelta
+
         qs = self._make_qs_at_confirmation("standard")
         qs._awaiting_leave_input = True
         qs._leave_input_stage = "start"
         qs._leave_input_buffer = {"person": "Alice"}
-        state = {"messages": [HumanMessage(content="06/04/2026")], "questionnaire": qs}
+        # Q8=2 weeks, Q10=2 sprints → window is today + 4 weeks; pick a date inside it.
+        # Computed relative to today so the test doesn't rot once the date passes.
+        qs.answers[8] = "2 weeks"
+        qs.answers[10] = "2 sprints"
+        start = (date.today() + timedelta(days=7)).strftime("%d/%m/%Y")
+        state = {"messages": [HumanMessage(content=start)], "questionnaire": qs}
         result = project_intake(state)
         assert "end date" in result["messages"][0].content.lower()
         assert result["questionnaire"]._leave_input_stage == "end"

--- a/tests/unit/test_ui_error_classification.py
+++ b/tests/unit/test_ui_error_classification.py
@@ -1,0 +1,115 @@
+"""Unit tests for TUI API-error classification.
+
+`_classify_api_error` is the single place that turns SDK exceptions into short,
+user-friendly messages so the TUI never dumps a raw exception (a JIRAError, for
+example, stringifies to its entire HTTP response including every header). These
+tests cover each provider branch and the length-bounding fallback.
+"""
+
+from __future__ import annotations
+
+from scrum_agent.ui.session._utils import _classify_api_error, _extract_status_code
+
+
+def _make_error(name: str, module: str, *, status=None, text=""):
+    """Build a fake SDK exception with a given class name, module, and status."""
+    ns: dict = {}
+    if status is not None:
+        ns["status_code"] = status
+
+    def __str__(self):  # noqa: N807
+        return text or name
+
+    ns["__str__"] = __str__
+    cls = type(name, (Exception,), ns)
+    cls.__module__ = module
+    return cls()
+
+
+# The real 401 dump from the bug report — full HTTP response with every header.
+_JIRA_401_DUMP = (
+    "JiraError HTTP 401 url: https://youlend.atlassian.net/rest/agile/1.0/board?projectKeyOrId=PSOT\n"
+    "\ttext: Client must be authenticated to access this resource.\n"
+    "\tresponse headers = {'Content-Type': 'text/html', 'Www-Authenticate': 'OAuth realm=...', ...}\n"
+    "\tresponse text = Client must be authenticated to access this resource."
+)
+
+
+class TestExtractStatusCode:
+    def test_from_status_code_attr(self):
+        assert _extract_status_code(_make_error("JIRAError", "jira.exceptions", status=401)) == 401
+
+    def test_from_response_object(self):
+        err = Exception()
+        err.response = type("R", (), {"status_code": 403})()
+        assert _extract_status_code(err) == 403
+
+    def test_parsed_from_message(self):
+        assert _extract_status_code(Exception("Something HTTP 429 happened")) == 429
+
+    def test_none_when_absent(self):
+        assert _extract_status_code(Exception("plain error")) is None
+
+    def test_bool_is_not_a_status(self):
+        err = Exception()
+        err.status_code = True  # must not be treated as int status 1
+        assert _extract_status_code(err) is None
+
+
+class TestJira:
+    def test_401_is_friendly_and_hides_dump(self):
+        msg = _classify_api_error(_make_error("JIRAError", "jira.exceptions", status=401, text=_JIRA_401_DUMP))
+        assert "Jira authentication failed" in msg
+        # The giant HTTP dump must never leak into the UI message.
+        assert "Www-Authenticate" not in msg
+        assert "response headers" not in msg
+        assert len(msg) < 200
+
+    def test_404_project_not_found(self):
+        msg = _classify_api_error(_make_error("JIRAError", "jira.exceptions", status=404))
+        assert "not found" in msg.lower()
+
+    def test_other_status(self):
+        msg = _classify_api_error(_make_error("JIRAError", "jira.exceptions", status=500))
+        assert "Jira request failed" in msg
+        assert "500" in msg
+
+
+class TestAzureDevOps:
+    def test_auth_failure(self):
+        msg = _classify_api_error(_make_error("AzureDevOpsServiceError", "azure.devops.exceptions", status=401))
+        assert "Azure DevOps authentication failed" in msg
+
+    def test_no_status_code(self):
+        msg = _classify_api_error(_make_error("AzureDevOpsServiceError", "azure.devops.exceptions"))
+        assert "Azure DevOps request failed" in msg
+
+
+class TestGitHub:
+    def test_bad_credentials(self):
+        msg = _classify_api_error(_make_error("BadCredentialsException", "github.GithubException", status=401))
+        assert "GitHub authentication failed" in msg
+
+
+class TestGenericAndFallback:
+    def test_generic_401(self):
+        msg = _classify_api_error(_make_error("SomeSDKError", "acme.sdk", status=401))
+        assert "Authentication failed" in msg
+
+    def test_generic_429(self):
+        msg = _classify_api_error(_make_error("SomeSDKError", "acme.sdk", status=429))
+        assert "Rate limited" in msg
+
+    def test_connection_error(self):
+        # builtin ConnectionError has no status code → matched by name.
+        assert "Network error" in _classify_api_error(ConnectionError("refused"))
+
+    def test_fallback_truncates_and_takes_first_line(self):
+        long = "x" * 500 + "\nsecond line should be dropped"
+        msg = _classify_api_error(Exception(long))
+        assert msg.startswith("Unexpected error:")
+        assert "second line" not in msg
+        assert len(msg) <= 220  # bounded (prefix + 200 + ellipsis)
+
+    def test_short_fallback_passthrough(self):
+        assert _classify_api_error(ValueError("boom")) == "Unexpected error: boom"

--- a/tests/unit/test_voice.py
+++ b/tests/unit/test_voice.py
@@ -1,0 +1,399 @@
+"""Unit tests for voice input — mic recording, local Whisper transcription, overlay.
+
+The audio/transcription packages (sounddevice, numpy, faster-whisper) are
+optional and not installed in the test environment, so these tests inject fake
+modules into sys.modules to exercise the lazy-import code paths. Transcription
+runs locally (no API key), so there is nothing OpenAI-specific to mock.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import io
+import sys
+import types
+import wave
+
+import pytest
+
+from scrum_agent import voice
+from scrum_agent.config import get_voice_model
+
+# ---------------------------------------------------------------------------
+# Fakes for the optional dependencies
+# ---------------------------------------------------------------------------
+
+
+class _FakeNdarray:
+    """Minimal stand-in for a numpy array covering the ops voice.py uses."""
+
+    def __init__(self, data: bytes = b"", n: int = 0) -> None:
+        self._data = data
+        self._n = n
+
+    def copy(self) -> _FakeNdarray:
+        return self
+
+    def astype(self, _dtype) -> _FakeNdarray:
+        return self
+
+    def __truediv__(self, _other) -> _FakeNdarray:
+        return self
+
+    def __len__(self) -> int:
+        return self._n
+
+    def tobytes(self) -> bytes:
+        return self._data
+
+
+def _fake_numpy() -> types.ModuleType:
+    mod = types.ModuleType("numpy")
+    mod.int16 = "int16"
+    mod.float32 = "float32"
+    mod.concatenate = lambda frames, axis=0: _FakeNdarray(b"".join(f.tobytes() for f in frames))
+    mod.frombuffer = lambda buf, dtype=None: _FakeNdarray(bytes(buf), n=len(bytes(buf)) // 2)
+    return mod
+
+
+class _FakeInputStream:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.started = False
+        self.closed = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fake_sounddevice() -> types.ModuleType:
+    mod = types.ModuleType("sounddevice")
+    mod.InputStream = _FakeInputStream
+    return mod
+
+
+def _fake_faster_whisper(captured: dict, text_segments=("  hello ", "world  ")) -> types.ModuleType:
+    mod = types.ModuleType("faster_whisper")
+
+    class _Segment:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class WhisperModel:
+        def __init__(self, size, device=None, compute_type=None) -> None:
+            captured["size"] = size
+            captured["device"] = device
+            captured["compute_type"] = compute_type
+
+        def transcribe(self, samples, beam_size=None):
+            captured["beam_size"] = beam_size
+            captured["n_samples"] = len(samples)
+            return ([_Segment(t) for t in text_segments], object())
+
+    mod.WhisperModel = WhisperModel
+    return mod
+
+
+def _with_spec(mod: types.ModuleType) -> types.ModuleType:
+    """Attach a ModuleSpec so importlib.util.find_spec treats it as installed."""
+    mod.__spec__ = importlib.machinery.ModuleSpec(mod.__name__, loader=None)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_cache():
+    voice._MODEL_CACHE.clear()
+    yield
+    voice._MODEL_CACHE.clear()
+
+
+@pytest.fixture
+def _inject(monkeypatch):
+    """Inject fake optional modules; returns a helper to toggle presence."""
+
+    def install(*, numpy=True, sounddevice=True, faster_whisper_captured=None, segments=("  hello ", "world  ")):
+        if numpy:
+            monkeypatch.setitem(sys.modules, "numpy", _fake_numpy())
+        if sounddevice:
+            monkeypatch.setitem(sys.modules, "sounddevice", _with_spec(_fake_sounddevice()))
+        else:
+            monkeypatch.setitem(sys.modules, "sounddevice", None)
+        if faster_whisper_captured is not None:
+            monkeypatch.setitem(
+                sys.modules, "faster_whisper", _with_spec(_fake_faster_whisper(faster_whisper_captured, segments))
+            )
+
+    return install
+
+
+def _wav_bytes(pcm: bytes = b"\x01\x00\x02\x00") -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(pcm)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# get_voice_model / backend_label
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceModel:
+    def test_default_is_base(self, monkeypatch):
+        monkeypatch.delenv("VOICE_MODEL", raising=False)
+        assert get_voice_model() == "base"
+
+    def test_override(self, monkeypatch):
+        monkeypatch.setenv("VOICE_MODEL", "small")
+        assert get_voice_model() == "small"
+
+    def test_backend_label(self, monkeypatch):
+        monkeypatch.setenv("VOICE_MODEL", "tiny")
+        assert voice.backend_label() == "local Whisper (tiny)"
+
+
+# ---------------------------------------------------------------------------
+# is_voice_available — no API key required (fully local)
+# ---------------------------------------------------------------------------
+
+
+class TestIsVoiceAvailable:
+    def test_missing_sounddevice(self, _inject):
+        _inject(sounddevice=False, faster_whisper_captured={})
+        available, reason = voice.is_voice_available()
+        assert available is False
+        assert "voice" in reason.lower()
+
+    def test_missing_faster_whisper(self, monkeypatch, _inject):
+        _inject(faster_whisper_captured=None)  # sounddevice present, faster_whisper absent
+        monkeypatch.setitem(sys.modules, "faster_whisper", None)
+        available, reason = voice.is_voice_available()
+        assert available is False
+
+    def test_available_without_api_key(self, monkeypatch, _inject):
+        # Explicitly ensure no OpenAI key is needed anymore.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _inject(faster_whisper_captured={})
+        available, reason = voice.is_voice_available()
+        assert available is True
+        assert reason == ""
+
+
+# ---------------------------------------------------------------------------
+# Recorder
+# ---------------------------------------------------------------------------
+
+
+class TestRecorder:
+    def test_records_and_returns_valid_wav(self, _inject):
+        _inject()
+        rec = voice.Recorder()
+        assert rec._stream.started is True
+        rec._callback(_FakeNdarray(b"\x01\x00"), 1, None, None)
+        rec._callback(_FakeNdarray(b"\x02\x00"), 1, None, None)
+        wav_bytes = rec.stop()
+        assert rec._stream.closed is True
+        with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+            assert wf.getnchannels() == voice.CHANNELS
+            assert wf.getframerate() == voice.SAMPLE_RATE
+            assert wf.readframes(wf.getnframes()) == b"\x01\x00\x02\x00"
+
+    def test_no_audio_returns_empty(self, _inject):
+        _inject()
+        assert voice.Recorder().stop() == b""
+
+
+# ---------------------------------------------------------------------------
+# transcribe / model cache
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribe:
+    def test_empty_bytes_short_circuits(self):
+        assert voice.transcribe(b"") == ""
+
+    def test_transcribes_locally(self, monkeypatch, _inject):
+        monkeypatch.setenv("VOICE_MODEL", "base")
+        captured: dict = {}
+        _inject(faster_whisper_captured=captured)
+        assert voice.is_model_loaded() is False
+        result = voice.transcribe(_wav_bytes())
+        assert result == "hello world"
+        assert captured["size"] == "base"
+        assert captured["device"] == "cpu"
+        # Model is cached after first use.
+        assert voice.is_model_loaded() is True
+
+    def test_model_reused_across_calls(self, monkeypatch, _inject):
+        monkeypatch.setenv("VOICE_MODEL", "base")
+        captured: dict = {}
+        _inject(faster_whisper_captured=captured)
+        voice.transcribe(_wav_bytes())
+        first_model = voice._MODEL_CACHE["base"]
+        voice.transcribe(_wav_bytes())
+        assert voice._MODEL_CACHE["base"] is first_model  # not reloaded
+
+
+# ---------------------------------------------------------------------------
+# record_voice_input (TUI overlay)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLive:
+    def __init__(self):
+        self.frames = []
+
+    def update(self, renderable):
+        self.frames.append(renderable)
+
+
+def _console():
+    from rich.console import Console
+
+    return Console(file=io.StringIO(), width=80)
+
+
+class _KeySequence:
+    def __init__(self, keys):
+        self._keys = list(keys)
+
+    def __call__(self, timeout=None):
+        return self._keys.pop(0) if self._keys else ""
+
+
+class TestDoubleTapSpace:
+    def _d(self, threshold=0.30):
+        from scrum_agent.ui.shared._voice_input import DoubleTapSpace
+
+        return DoubleTapSpace(threshold=threshold)
+
+    def test_first_space_is_not_double(self):
+        assert self._d().is_double(prev_char_is_space=False, now=1.0) is False
+
+    def test_quick_second_space_triggers(self):
+        d = self._d()
+        d.is_double(prev_char_is_space=False, now=1.0)  # first tap inserts a space
+        assert d.is_double(prev_char_is_space=True, now=1.1) is True
+
+    def test_slow_second_space_does_not_trigger(self):
+        d = self._d(threshold=0.30)
+        d.is_double(prev_char_is_space=False, now=1.0)
+        assert d.is_double(prev_char_is_space=True, now=1.6) is False
+
+    def test_requires_prev_char_to_be_space(self):
+        # Cursor moved between taps → char before cursor isn't the inserted space.
+        d = self._d()
+        d.is_double(prev_char_is_space=False, now=1.0)
+        assert d.is_double(prev_char_is_space=False, now=1.1) is False
+
+    def test_no_immediate_retrigger_after_double(self):
+        d = self._d()
+        d.is_double(prev_char_is_space=False, now=1.0)
+        assert d.is_double(prev_char_is_space=True, now=1.1) is True
+        assert d.is_double(prev_char_is_space=True, now=1.15) is False
+
+
+class TestDoubleTapInDescriptionLoop:
+    """End-to-end wiring: double-tap Space in the description loop dictates."""
+
+    def test_double_tap_space_triggers_dictation(self, monkeypatch):
+        from scrum_agent.ui.session.phases import _phases_intake
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+
+        class _Rec:
+            def stop(self):
+                return b"AUDIO"
+
+        monkeypatch.setattr(voice, "Recorder", _Rec)
+        monkeypatch.setattr(voice, "transcribe", lambda wav: "four developers")
+
+        # Type "Hi", a space, then a second quick space (double-tap) → records;
+        # "z" stops recording; transcript inserts; Enter submits.
+        keys = iter(["H", "i", " ", " ", "z", "enter"])
+
+        def _key(timeout=None):
+            return next(keys, "")
+
+        result = _phases_intake._phase_description_input(_FakeLive(), _console(), _key)
+        assert result is not None
+        desc = result[0]
+        assert "four developers" in desc
+        # The first space is kept as a separator; the gesture's 2nd space is not.
+        assert desc.strip() == "Hi four developers"
+
+
+class TestVoiceIndicator:
+    def test_recording_has_red_border_and_stop_hint(self):
+        from scrum_agent.ui.shared._voice_input import voice_indicator
+
+        border, line = voice_indicator("recording", 0.0)
+        assert border.startswith("rgb(")
+        assert "Recording" in line
+        assert "any key to stop" in line
+
+    def test_transcribing_has_spinner(self):
+        from scrum_agent.ui.shared._voice_input import voice_indicator
+
+        border, line = voice_indicator("transcribing", 0.5)
+        assert "Transcribing" in line
+        assert border  # non-empty style
+
+    def test_unknown_status_is_empty(self):
+        from scrum_agent.ui.shared._voice_input import voice_indicator
+
+        assert voice_indicator("idle", 0.0) == ("", "")
+
+    def test_recording_animates_with_tick(self):
+        from scrum_agent.ui.shared._voice_input import voice_indicator
+
+        # Different ticks should vary the pulsing dot/border (animation).
+        frames = {voice_indicator("recording", t) for t in (0.0, 0.2, 0.4, 0.6)}
+        assert len(frames) > 1
+
+
+class TestRecordVoiceInput:
+    def _patch_voice(self, monkeypatch, *, available=(True, ""), transcript="hello", frames_have_audio=True):
+        from scrum_agent.ui.shared import _voice_input
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: available)
+
+        class _Rec:
+            def stop(self):
+                return b"AUDIO" if frames_have_audio else b""
+
+        monkeypatch.setattr(voice, "Recorder", _Rec)
+        monkeypatch.setattr(voice, "transcribe", lambda wav: transcript)
+        return _voice_input
+
+    def test_returns_transcript(self, monkeypatch):
+        mod = self._patch_voice(monkeypatch, transcript="build a todo app")
+        live = _FakeLive()
+        result = mod.record_voice_input(live, _console(), _KeySequence(["", "enter"]))
+        assert result == "build a todo app"
+        assert live.frames
+
+    def test_esc_cancels(self, monkeypatch):
+        mod = self._patch_voice(monkeypatch, transcript="ignored")
+        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["esc"])) is None
+
+    def test_unavailable_returns_none(self, monkeypatch):
+        mod = self._patch_voice(monkeypatch, available=(False, "Install voice extra: uv sync --extra voice"))
+        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["x"])) is None
+
+    def test_no_audio_returns_none(self, monkeypatch):
+        mod = self._patch_voice(monkeypatch, frames_have_audio=False)
+        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["", "enter"])) is None
+
+    def test_empty_transcript_returns_none(self, monkeypatch):
+        mod = self._patch_voice(monkeypatch, transcript="")
+        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["enter"])) is None

--- a/uv.lock
+++ b/uv.lock
@@ -71,6 +71,32 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "18.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a4/570a5a35c8638aba01e739925846c35fdd6b0756a15526766d0a4dd3b7df/av-18.0.0.tar.gz", hash = "sha256:4ef7e72c3d3a872584a1215173b16e0226811037f40dcdbf75992631098df1ba", size = 4340222, upload-time = "2026-07-02T06:37:58.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/4a/9e3463df030e063d757fa12f0f39be6541b45b06b5bad48c2ce361b924bf/av-18.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:149289d40e732a6e49c9530bc245b49d9964cfd1c8c9e06778703b7d5bba6b25", size = 22499354, upload-time = "2026-07-02T06:36:58.751Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b3/2576a44b4f39c7462ced4c17fec04c756f7b0f3c5cb940d124173e417d6a/av-18.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:35274c20d2ad3b4774fe632bcef2e34af79858ddf899352339cc3babbc13a484", size = 18175248, upload-time = "2026-07-02T06:37:01.741Z" },
+    { url = "https://files.pythonhosted.org/packages/84/74/6732f17b96dc23fd23b876b2805435855abdc8a3b397142be4e581165de8/av-18.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4d683b7747a0ba9222b8a5f81e41db5f796e7f64473454ec4fe2548e083c2fa0", size = 33387843, upload-time = "2026-07-02T06:37:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/7708c43fed7ae28b4a1bad060b4221e3334cd827cec24f7165902a6ac1f4/av-18.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ae56b40b6f8b067a8ad2dac664fbfbabac7f7a55b9a7bb031eb99289252bc017", size = 35536910, upload-time = "2026-07-02T06:37:08.806Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/94/eba99691d184f6a395a242d54dc370e2fd2265e95bbc98e2963a0fdbdd6c/av-18.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:ea2e8ebbce521f21b55df9400e00d721623c9020ef158f5a188a96130be0743f", size = 38984619, upload-time = "2026-07-02T06:37:11.861Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/0d7aee07fe16aa9ffdf96043c14bed5485a52c0dea4259de87aa306ecab4/av-18.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef96dabb3e50dac249913145dff5424b302b257fd95dcb64be3c7b7a8aef16d1", size = 34451176, upload-time = "2026-07-02T06:37:15.154Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/810da80b12680d4c4fe235bd1b4003289be9213ac7f114b77b8ecf0e3b3e/av-18.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0f65518a184613e41536f29e8758c8e3d8293e46bf5bef108f04f925bbfa3f44", size = 36619869, upload-time = "2026-07-02T06:37:18.495Z" },
+    { url = "https://files.pythonhosted.org/packages/11/85/0f121ff43dc5a70696676c98a8f1674e2fa787614c2abaacb15fa1a9bc99/av-18.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629", size = 27556236, upload-time = "2026-07-02T06:37:21.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f6/2509754d4d2356abc6fc0ea3d57c12ade29bac23a1fb7fc215a53ca518fb/av-18.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:adac2b3833b6cb9bd6cb52664a522b94db453615b3675b1dbb26e13fe1c80da6", size = 20221133, upload-time = "2026-07-02T06:37:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/25/4ee23a7f1609adf9b2f140c7a8ffade64a1449d89ab431d922a809eebf19/av-18.0.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:88dd8e35e9242662b409a6a05fd24a6775d949eb05da0ba31cab4f250eacbab5", size = 22740741, upload-time = "2026-07-02T06:37:26.659Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f0/b9f8363d07aa4521913e483f6a30c7c164973ef01de62769bf9b97049cd8/av-18.0.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f8f454349c402e2c8d6fa80b54eb2a3f86c00f414d2b399f01ae6dab075c6fd8", size = 18384189, upload-time = "2026-07-02T06:37:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e5/69397019aed280a72a43e97a252dee4295df1a9e608848452e5300ec4dab/av-18.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:88ce194c2201c6a6d40336adee8a5ddde46ed743eacb500e3ae9368d1c6d889e", size = 36749881, upload-time = "2026-07-02T06:37:33.096Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3a/1614d74f0d676ea6745eb59553c9ad01ca25db523cba808d522e838f4f5b/av-18.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:aa15e567a018cc94a26b0ab45da676dee70c4146ace6e92e47d30cc9689cbfbe", size = 38645927, upload-time = "2026-07-02T06:37:37.086Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3c/5f54710d69b0ea93634134f92b49c7a2a7fd27da5486a8a7e6251ac1cfb4/av-18.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:613153e48cefc91700746dde0ad0282d4677b194cba22cc771de14c78411cf8b", size = 40454783, upload-time = "2026-07-02T06:37:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/26/92/8293e6a267e0591b543abd96ae01e7e8ed228509bdb4e4644a8a8395d90f/av-18.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:30404f53ca1ea7f350ac86ff22a2c04f903014758e9b33f398c5a62de34bd84f", size = 37573117, upload-time = "2026-07-02T06:37:44.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0c/38ed7601277ae57dfe857d040be4762530fd728efff45c2fb8f035fef96a/av-18.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6882a48f7aec2863c96cddee3256ff2da98f7fb6cbed83cee9d7e70a8f186a6b", size = 39669026, upload-time = "2026-07-02T06:37:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/0636ca04d5d89d01c49bd366d2b660cc85d1f8117c476b2be62eb0c70855/av-18.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:55a646e9afce9fdc5de5224205a8a12c7ed1ba9803145dcc876c40bfc03a109b", size = 28448336, upload-time = "2026-07-02T06:37:52.477Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/1e24450ea981c44ed328691496fd2774dfa9fa3c3b00fd07f72fd5614abe/av-18.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:96f594ff506a09475e5549359352332049a25d37a08f00b4623f7f6e92e45b9c", size = 21377289, upload-time = "2026-07-02T06:37:55.935Z" },
+]
+
+[[package]]
 name = "azure-core"
 version = "1.38.2"
 source = { registry = "https://pypi.org/simple" }
@@ -298,6 +324,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -366,6 +404,43 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/c4/0e450796f90e54f3325697fc67db4f4ecd397aef96d7b3924e26fb8bd04b/ctranslate2-4.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c2db633a06e3b34bbfb72fd26eee58053d9df1f9c1610ac4df3a6a1e25af7d7", size = 1270559, upload-time = "2026-07-03T12:39:01.154Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/54/7b6db16470d0788fb8ab43a99e3e18ba9d41a9b50b7fef7dec353eafbe20/ctranslate2-4.8.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:079976cbce3a68de04bf9948d08c96beb86df44e5cd2974e4187bc9c9bb388f3", size = 11928069, upload-time = "2026-07-03T12:39:02.6Z" },
+    { url = "https://files.pythonhosted.org/packages/37/66/8fee1366631d224bf26b34db9063a0c88ce358d58331c2393689b0ea27ff/ctranslate2-4.8.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74bae0a8dc9f98c5a6100bf1c17a91782b384ea53b83e2606030ebf9f25318fe", size = 16707971, upload-time = "2026-07-03T12:39:05.09Z" },
+    { url = "https://files.pythonhosted.org/packages/30/84/f610e90bb419707632b9b668476b9fd4cdb090c9b53c119ce017699b58ca/ctranslate2-4.8.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0a584c17f21779eb9035bcbc1ec280998f90b36725b70a5ff911f33e343199a", size = 39351971, upload-time = "2026-07-03T12:39:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6c/7230ecbdd23ab867715e1b6ffe99211c39c11cae8ec2d6c3ec9208c38ee2/ctranslate2-4.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:82982f07a7d615d2248d17d6ec4c43cd50e534b094aa27cda62125a5e3a6e3fc", size = 19219248, upload-time = "2026-07-03T12:39:11.329Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/09/9a50eeab00db68aeac08f6ab7f98b5c36abd26b89cbd707ea39e70656500/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9de0dddd91ae68da0a7323441e90708d14b31d31cd443004dda0e1198b5bf11e", size = 1270522, upload-time = "2026-07-03T12:39:13.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/6c41c4d3ae539ec76b1943c362184677befd7c1d5290d2ec361182cdb1e0/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:82e0e6eb7d4301fd79a714495c8faf34242e09542cef04c9e9794c3fe90014a1", size = 11930367, upload-time = "2026-07-03T12:39:14.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d4/03428106134a0a58922461074f8942f92c5ed0bb3a8d018677ad64a9c476/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5ca144b93035b9f53e6d67b7cdf5802c3fffca9aa0247940eecbd4592c68ce2f", size = 16882768, upload-time = "2026-07-03T12:39:17.425Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c9/976a565398a03fb2973cbe5edd5ca03c4332d86b634799e0ee562420d3bc/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dacc408f716ebc73b3b3c6ddd937700e776c4c68b6d9c81862990150ff0f6af6", size = 39529060, upload-time = "2026-07-03T12:39:20.468Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/82/0a5f7f2b03b4e10aacb3146715724e1b96bb993cc7d199be28c9825aa120/ctranslate2-4.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:49f96e861b57301f0b76a082109bde2cac8204a6b4fedc870883008271e82251", size = 19220789, upload-time = "2026-07-03T12:39:23.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a7/3101c3a0785253a8ef386f39744ad19c28c75b7f227e7c232aee7a5c416a/ctranslate2-4.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba628835e6ad4ad399261ab6cb51bf152de563e6b122a9e8eb0c61e69f925931", size = 1270478, upload-time = "2026-07-03T12:39:25.401Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b9/e50c7558e96a054d6b1e6a6c5e729dda4a4f05584e065f2902aa5f1bc4c8/ctranslate2-4.8.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:85ef15ce0b2172ec471975b8a30d5c5bc71e7cffcd163ad6c07ea32f1943d940", size = 11930241, upload-time = "2026-07-03T12:39:26.927Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2f/ea7a19c6d7e949b731fb034664633184bbfc7882846d107f4d790693fb76/ctranslate2-4.8.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0030670278a73cae09dff9bca72cdd248af61f9367257f18db9b3b94fbb3a50d", size = 16883512, upload-time = "2026-07-03T12:39:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4a/21f325a9d0925d8ad24b04249adf29bf9909442967603634f7f6d4acbb79/ctranslate2-4.8.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4242a7f8e285f922525f4cffd5b1fb43cbacc61d0611cf54832e9c447d030840", size = 39529085, upload-time = "2026-07-03T12:39:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e7/37da1a7500b57496a5269318c4f57962ea0c26dcac06b85222d7831acf00/ctranslate2-4.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:d52499f05a60a791aeadee28d609efa130142f376d1ea76b2b1c593bb01f8827", size = 19220784, upload-time = "2026-07-03T12:39:35.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/66/39111224e418400d97fd79fbc9e72329c51f91a3e7a9c9a1a182e4f88022/ctranslate2-4.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b4c3246aa4a7f309109a841ca743a72cc4abad4f93c0bf7da691023323215621", size = 1271321, upload-time = "2026-07-03T12:39:37.907Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/89/13f827fae226eea51315729c00111f716813d7736ebb827fecb8f361fe0d/ctranslate2-4.8.1-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:c989f747789e8619cbc2e06443b3674c31bc71bad0369652485bd894b627360a", size = 11930735, upload-time = "2026-07-03T12:39:39.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/94/4b73f9bbaba29df4227cc65114f11d83fe6d696ef3705cb1ade79eb118fd/ctranslate2-4.8.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90eb0bd67b6bb183712cc3fd14bf01ec4f622cd625c5b33cc6c56be7d1c9c34", size = 16872460, upload-time = "2026-07-03T12:39:42.272Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d0/9816494d5ff0745bdf9abe5af04e57a103a416444e604cbe83a6eb0aed7b/ctranslate2-4.8.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e3e3aef4670a6c8dcea367401675f82b49b02c18f5837221bcd7cca90b1707a8", size = 39494736, upload-time = "2026-07-03T12:39:45.733Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/dc/22a2c874ca8bb6caa7018dfefdff92dddd487db31cf169891c4c6d408091/ctranslate2-4.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:a2dcce0a57beee984a691d9daa8fc3fd389f5b6cada2644c34571011833bd5b1", size = 19477164, upload-time = "2026-07-03T12:39:48.952Z" },
+    { url = "https://files.pythonhosted.org/packages/77/39/7b8d47bf49748ba73182742683eef74b46608beb879765d9d4efc46bc345/ctranslate2-4.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a28c5889585cd17ee3649dfd46d9002ddf50204173f8bff476b9f76d6585795", size = 1293935, upload-time = "2026-07-03T12:39:50.924Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/20/434e30c752c433eaef5deccd4de54775bc1f205a6fe6c9e756b737018209/ctranslate2-4.8.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:911a5cdef8a405c1804330613a1865f616eb9c092a0e932ee4648128eb20b627", size = 11951789, upload-time = "2026-07-03T12:39:52.886Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f2/d716426220b462bbb5bb354b9c6c8d9a41285f067203c860cc79f9f19917/ctranslate2-4.8.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84723cae6f802551bbf2438e5e4810722631a2183b89a82c31df26566b54821d", size = 16860414, upload-time = "2026-07-03T12:39:55.54Z" },
+    { url = "https://files.pythonhosted.org/packages/69/11/cdab0e7e2ad4e547f15ab227c09207569f1272abae05816900ecebb0797a/ctranslate2-4.8.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1910752ec541980644191fa3b407bc61dee00e88070b0aed29b4cef75010b3ea", size = 39465200, upload-time = "2026-07-03T12:39:59.017Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/03/126e963fc3237a416f3085b8a663ebd8ab449ed6c37195b4e0b49597ba0c/ctranslate2-4.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dc9f1abef55579cc02cdc74b3a55df38491ec56d177d6e6039609d61d09ed30e", size = 19499597, upload-time = "2026-07-03T12:40:01.68Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -414,6 +489,22 @@ wheels = [
 ]
 
 [[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.24.3"
 source = { registry = "https://pypi.org/simple" }
@@ -429,6 +520,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
 ]
 
 [[package]]
@@ -481,6 +589,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "holidays"
 version = "0.92"
 source = { registry = "https://pypi.org/simple" }
@@ -518,6 +658,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/8f/999e4dda11c6187c78f090eac00895a47e11a0049308f07579bcb7aa3aa2/huggingface_hub-1.23.0.tar.gz", hash = "sha256:c04997fb8bbdace1e57b7703d30ed7678af51f70d00d241819ff411b92ae9a88", size = 919163, upload-time = "2026-07-09T14:49:32.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/ce/13b2ba57838b8db1e6bd033c1b21ce0b9f6153b87d4e4939f77074e41eb0/huggingface_hub-1.23.0-py3-none-any.whl", hash = "sha256:b1d604788f5adc7f0eb246e03e0ec19011ca06e38400218c347dccc3dffa64a2", size = 770336, upload-time = "2026-07-09T14:49:30.597Z" },
 ]
 
 [[package]]
@@ -1004,6 +1164,43 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1f/a2117aa3f144fce88774efa37440d0ca72d0c9144854dfc0961f2b04c6fc/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2eb083321af8a236a84c7c140a7f4cecbfa2a987a18c07c78db471c20cd390ef", size = 16419330, upload-time = "2026-06-15T22:42:37.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cd/74bb804170ceb622fda9111df31a07b3024f7491472256d3a90b5391a4d2/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4f7b0e90d2d212e2c2deaa6c8291616183ab815d3ec558ea12d3ac8b26d36f4", size = 18636930, upload-time = "2026-06-15T22:43:01.584Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8f/5b8e2b85e81735696887175dbaf6409f215683f5ca9d4928fbb038211d32/onnxruntime-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:ff050e4f6bf7f12918fa14dcb047c0b02e295f35e86d42532552be4b3d54e977", size = 13356110, upload-time = "2026-06-15T22:43:32.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/4f568de678126b6a371a93862f015a82138359decd97fcac61fc84b5b774/onnxruntime-1.27.0-cp311-cp311-win_arm64.whl", hash = "sha256:75fbc1e1fb43a39a856c8209c544cca7817b5de7ac16b15b1bdf55d1cc67b9df", size = 13098635, upload-time = "2026-06-15T22:43:19.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/dd3a524ed93a820dff1af902d0412957ab12499953333e9daa01af5bc480/onnxruntime-1.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a14c2ce45312def86b77aea651f46565e45960cf5f0721bfdff449165086ab76", size = 18433506, upload-time = "2026-06-15T22:43:47.026Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/c3b6b17745a1997d784dadc9bd88d713d2e6721139a5a0e885b28cfb79b1/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fddce0539a4898c7bef35b052ffd37935b2190e35488eab99ce91887743ea1", size = 16438140, upload-time = "2026-06-15T22:42:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/26/81/24dd9b31b0fb912ee19ca53ac1c9764bfd79d58a2ccef564eb693be831a5/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c65a7438632d55dfbc8a02ee60bd6cf7dd9d1ba05a43d4b851452f32338e194", size = 18658316, upload-time = "2026-06-15T22:43:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/88/8ec9db1a4d126bb8b758992beb40d1249df171917d75f44a327eb5f20dda/onnxruntime-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:20c321cf187ba496e648acf6b4cf90b4d398b0d17c2a77fdaeba365b908cc1c1", size = 13358769, upload-time = "2026-06-15T22:43:34.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9f/fdad359dfcba7e7cd8815569b304a596531d4efa77a75d77f8b4981891a2/onnxruntime-1.27.0-cp312-cp312-win_arm64.whl", hash = "sha256:d0d1f68868e2ef30ef70998ba9bbbc5c305e9b17041e3936751c1b8aa6aade06", size = 13104440, upload-time = "2026-06-15T22:43:22.893Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/2b/54208fd03ad410480bc17edf4869376362da8bbf46fe186ddf4cb5cc20fe/onnxruntime-1.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:b3e5b58b8c89c2b20e086e890aa9527377e5c240dc3ecc1640d18e07705eeb1c", size = 18432958, upload-time = "2026-06-15T22:42:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/24fc51fcbb126da6d032372314e47b55c3faad58f2aa78c0e199ccd20b9c/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b3d87eb560ff6a772240506f3c78d6d27c63cafedd5c775672e1194f968cfd", size = 16438180, upload-time = "2026-06-15T22:42:43.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/19/14929c3c2fe0b79b41cce24463062bf3afa4cdd3c19dccf00319caa92bff/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6872443f236a554921cda6f318c900e2d0c226792cf3534d00e5057c6926e5d2", size = 18658445, upload-time = "2026-06-15T22:43:08.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/76/59ed932b0244acd7bbbd6449480053a6d958ea66357f022f932872e19287/onnxruntime-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:760021bca514d64a811837820d351a08a41741f16f8b4c26450da708fecf14e6", size = 13357856, upload-time = "2026-06-15T22:43:37.315Z" },
+    { url = "https://files.pythonhosted.org/packages/79/51/d1ec60ec7b1e2ae2d7340ba52b8a13529140039cd4407ba8dddbbc046582/onnxruntime-1.27.0-cp313-cp313-win_arm64.whl", hash = "sha256:2fdfa9df40a0ded0028ce6f9cd863264237f3970559dea2b81456e9ac4622b94", size = 13104412, upload-time = "2026-06-15T22:43:27.457Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/e6bb1c6445c94f708c38cd8fbb7bf0264108c33498b9445c93e60fe6d329/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54c0c4e9202c36c4ecdb1f3443f5dfbfd5ee3b54d1362c4b4c6134110e74fb32", size = 16443331, upload-time = "2026-06-15T22:42:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/b18b31e806eabc41077810199fbbb36fbc2d5f19912416e5ccfbf73053d1/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b215aa662c8f983f7d6dedafe65a9be72c26e5338e0fe98b3e0422c32c85428", size = 18670967, upload-time = "2026-06-15T22:43:10.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/37/48ab79c39b58a7c9f6f5aac1fa0ff2b993eb2643393d6ed9e839ddb6f347/onnxruntime-1.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0874edc171f470fc4dd2bbb60bc0989612ed1a8b89b365cda016630a93227f13", size = 18433941, upload-time = "2026-06-15T22:42:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/24/d535ca8a09dbf697f853377c8dc0820dbcaae5f334316b400b953afbcba8/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b51c014cf1a4fcd93c29a97eac8071fa27710dae05a4d0380bb60a66d60a62c", size = 16439970, upload-time = "2026-06-15T22:42:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b1/ea9ee80c0bdaa4efb13f29f8c236f3740f6655e8c092a2d119515a5a652c/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:445fb702ea5241ba813a3ce2febe2e9408a64f6ad2eb610924322c536165f7cd", size = 18659240, upload-time = "2026-06-15T22:43:13.165Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f2/1404507d76a21940e8bf46f414e3d1abd94dc888cb89a30f4a540275846f/onnxruntime-1.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:49e416be0d717338b6d041b99911b716d70c397d277056450724f93bdded3fc2", size = 13685306, upload-time = "2026-06-15T22:43:40.416Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/ca5cf012ccccb806c70e94aadfebca5606acc62b33eb88cec13352d0778f/onnxruntime-1.27.0-cp314-cp314-win_arm64.whl", hash = "sha256:856032937dd3bc7a7c141909c8d7ae4fde3e3f59bddf061ae627b9a051bda95c", size = 13456280, upload-time = "2026-06-15T22:43:29.693Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7b/dca330a8397e9d816c976d7aed4e24a4a2d279bb1e551e3d0221d1389b1d/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6197a02e3f620c4dc13cff51b80672409fc1ffab3aa2593911b19fd322ff48b", size = 16443274, upload-time = "2026-06-15T22:42:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/2bac21f722aa45d876d4a51f26bd0ef30e704068a3cd5021a5a7cd784271/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:370d211e1ceeac4cd5f45301655463ac59e27cdc74d9f7aeb2d19ff4b7a76715", size = 18670781, upload-time = "2026-06-15T22:43:17.151Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1191,6 +1388,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -1794,6 +2006,10 @@ openai = [
 pdf = [
     { name = "pymupdf" },
 ]
+voice = [
+    { name = "faster-whisper" },
+    { name = "sounddevice" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1806,6 +2022,7 @@ requires-dist = [
     { name = "azure-devops" },
     { name = "boto3", marker = "extra == 'all-providers'" },
     { name = "boto3", marker = "extra == 'bedrock'" },
+    { name = "faster-whisper", marker = "extra == 'voice'" },
     { name = "holidays" },
     { name = "jira" },
     { name = "langchain" },
@@ -1828,11 +2045,21 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "sounddevice", marker = "extra == 'voice'" },
 ]
-provides-extras = ["openai", "google", "pdf", "bedrock", "all-providers", "dev"]
+provides-extras = ["openai", "google", "pdf", "bedrock", "voice", "all-providers", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "syrupy", specifier = ">=5.1.0" }]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
 
 [[package]]
 name = "six"
@@ -1850,6 +2077,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sounddevice"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
 ]
 
 [[package]]
@@ -1946,6 +2189,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
     { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
     { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Three related improvements from a voice-input session. Reviewable as three commits.

## 🎤 Voice input (offline, double-tap Space)
Speak answers instead of typing them, in the project-description, intake-question, and artifact-editor fields.
- **Local & offline** via `faster-whisper` (new `voice` extra) — **no API key**, works with any LLM provider. Claude/Bedrock have no speech-to-text endpoint, so a cloud STT would have forced an OpenAI key on everyone. Model auto-downloads on first use; `VOICE_MODEL` picks the size (default `base`).
- **Trigger: double-tap Space** — modifier-free and unambiguous on macOS (Cmd never reaches a terminal; hold-to-talk is impossible without key-release events). First space is kept as a separator.
- **Inline recording UX** on the same screen: pulsing red border + animated status line; transcription runs in a background thread with a spinner.
- **Discoverable**: always-on hint (shows how to enable when not installed), welcome-screen tip, setup-wizard tip, and a Settings row.
- Install: `uv tool install "scrum-agent[voice]"` + `brew install portaudio`.

## 🛟 Graceful API errors in the TUI
A Jira 401 (or any integration failure) used to hit the screen as raw `str(exc)` — for a `JIRAError` that's the whole HTTP response incl. every header, which overflowed the box and looked like a crash.
- `_classify_api_error` now maps Jira/Azure DevOps/GitHub/OpenAI/generic exceptions to short, actionable one-liners, with a length-bounded fallback.
- Routed through every raw error surface (team analysis, epic export, sync-all) + a friendly top-level catch-all in `cli.py`.

## 🍺 Homebrew deprecation
`scrum-agent` can't be packaged for Homebrew — `sqlite-vec` (via `langgraph-checkpoint-sqlite`) ships only wheels, no sdist, which Homebrew's source-build model can't resolve.
- Removed the dead tap-dispatch from `publish.yml`; distribution is PyPI-only (`uv tool install` / `pipx install`).
- The tap formula is disabled with a pointer to uv/pipx (in the separate `omardin14/homebrew-tap` repo, already pushed).

## Verification
- New tests: `test_voice.py` (26 — detector, indicator, recorder, transcription, end-to-end double-tap wiring) and `test_ui_error_classification.py` (16, incl. the real 401 dump).
- Real end-to-end voice check: `say`-generated audio → correct transcript, no key.
- Full unit suite: **2179 pass**; lint clean. The one failure (`TestPTOSubLoop::test_pto_valid_start_asks_for_end`) is pre-existing and date-dependent, unrelated to this branch.

## Notes for the reviewer
- Not driven live in the interactive TUI (no mic/headless), so animation timing + the 300 ms double-tap window are verified by tests, not by watching. Both are one-line tweaks if the feel is off.
- The artifact editor uses the (now-animated) popup fallback for the recording overlay rather than a fully inline indicator — its render function is opaque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)