### PR TITLE
Automate PyPI releases on version bump (+ cut v1.4.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,69 +1,86 @@
 name: Publish to PyPI
 
+# Auto-release on version bump. On every push to main, publish to PyPI *iff* the
+# version in pyproject.toml has no matching git tag yet. So releasing is just:
+# bump `version` in pyproject.toml and merge to main — CI publishes, tags, and
+# cuts a GitHub Release. Normal merges (version unchanged) are a cheap no-op.
+#
+# The workflow filename MUST stay "publish.yml" to keep PyPI's OIDC trusted-
+# publisher configuration valid.
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
+  workflow_dispatch: {} # allow a manual re-run from the Actions tab
 
 permissions:
-  contents: write   # GitHub Release
-  id-token: write   # PyPI trusted publishing (OIDC)
+  contents: read
 
 jobs:
+  check:
+    name: Check for version bump
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.v.outputs.should_release }}
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need full history + tags to check for an existing release
+      - id: v
+        run: |
+          VERSION=$(grep -m1 -E '^version = ' pyproject.toml | sed -E 's/^version = "([^"]+)".*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::v$VERSION is already released — nothing to publish."
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::New version v$VERSION detected — building and publishing."
+          fi
+
   test:
     name: Lint & Test
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Install dependencies
-        run: uv sync --extra dev
-
-      - name: Lint
-        run: make lint
-
-      - name: Test
-        run: make test
+      - uses: astral-sh/setup-uv@v4
+      - run: uv python install 3.12
+      - run: uv sync --extra dev
+      - run: make lint
+      - run: make test
 
   publish:
     name: Build & Publish to PyPI
-    needs: test
+    needs: [check, test]
+    if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      id-token: write # PyPI trusted publishing (OIDC)
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Build
-        run: uv build
-
+      - uses: astral-sh/setup-uv@v4
+      - run: uv python install 3.12
+      - run: uv build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true # idempotent: re-runs won't fail if already published
 
   release:
-    name: GitHub Release
-    needs: publish
+    name: Tag & GitHub Release
+    needs: [check, publish]
+    if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the tag + GitHub Release
     steps:
       - uses: actions/checkout@v4
-
-      - name: Create GitHub Release
+      - name: Create tag and GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ needs.check.outputs.version }}
+          name: v${{ needs.check.outputs.version }}
           generate_release_notes: true
-
-  # Note: no Homebrew tap update. scrum-agent can't be packaged for Homebrew
-  # (the sqlite-vec dependency ships no sdist), so the tap formula is disabled
-  # and steers users to `uv tool install` / `pipx install`. Distribution is
-  # PyPI-only via the `publish` job above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,13 +397,11 @@ The `_dict_to_*()` functions in `sessions.py` use `.get()` for optional fields s
 
 ## Version Management
 
-Version is defined in two places that **must be kept in sync**:
-- `src/scrum_agent/__init__.py`: `__version__ = "1.2.0"`
-- `pyproject.toml`: `version = "1.2.0"`
+Version is **single-sourced in `pyproject.toml`** (`version = "…"`). `src/scrum_agent/__init__.py` reads it at runtime from the installed package metadata (`importlib.metadata.version("scrum-agent")`, with a `0.0.0+dev` fallback for uninstalled source trees). `__version__` is imported by `cli.py` for the `--version` flag. Package entry point: `scrum-agent = "scrum_agent.cli:main"`.
 
-The `__version__` is imported by `cli.py` for the `--version` flag. Package entry point: `scrum-agent = "scrum_agent.cli:main"`.
+**Releasing is automatic on a version bump.** To ship a release: bump `version` in `pyproject.toml` (semver) and merge to `main`. On that push, `publish.yml` detects there's no `v<version>` tag yet and runs test → build → PyPI publish (OIDC) → creates the `v<version>` tag + GitHub Release. Merges that don't change the version are a no-op. Never tag manually — the workflow owns tagging.
 
-Releasing: bump version in both files and merge to main. The `publish.yml` workflow triggers on `v*` tag push → PyPI → GitHub Release. Distribution is PyPI-only (via `uv tool install` / `pipx install`); Homebrew is not supported because a required dependency (`sqlite-vec`) ships no sdist, so the `omardin14/homebrew-tap` formula is permanently disabled.
+Distribution is PyPI-only (via `uv tool install` / `pipx install`); Homebrew is not supported because a required dependency (`sqlite-vec`) ships no sdist, so the `omardin14/homebrew-tap` formula is permanently disabled.
 
 ## CI/CD
 
@@ -412,7 +410,7 @@ Workflows in `.github/workflows/`:
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `ci.yml` | Every push | Lint + test |
-| `publish.yml` | Tag push `v*` | test → build → PyPI publish (OIDC) → GitHub Release |
+| `publish.yml` | Push to `main` | if `pyproject.toml` version has no tag yet: test → build → PyPI publish (OIDC) → tag + GitHub Release (else no-op) |
 | `smoke.yml` | Weekly cron | Live API smoke tests |
 | `claude.yml` | PR | Claude Code review |
 | `claude-code-review.yml` | PR | Claude Code review (alternate) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "1.3.0"
+version = "1.4.0"
 description = "A terminal-based AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/__init__.py
+++ b/src/scrum_agent/__init__.py
@@ -2,6 +2,8 @@
 
 import logging
 import warnings
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 # Suppress LangChain's Pydantic V1 compatibility warning on Python 3.14+.
 # langchain-core internally imports pydantic.v1 shims which don't work on
@@ -64,4 +66,9 @@ _ls_logger = logging.getLogger("langsmith")
 _ls_logger.addHandler(_ls_handler)
 _ls_logger.propagate = False  # stop records reaching the root StreamHandler
 
-__version__ = "1.3.0"
+# Single source of truth: the version lives only in pyproject.toml and is read
+# here from the installed package metadata. Bump pyproject.toml to release.
+try:
+    __version__ = _pkg_version("scrum-agent")
+except PackageNotFoundError:  # running from a raw source tree without an install
+    __version__ = "0.0.0+dev"

--- a/uv.lock
+++ b/uv.lock
@@ -1962,7 +1962,7 @@ wheels = [
 
 [[package]]
 name = "scrum-agent"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
Makes releasing a **single action** and ships **v1.4.0** (the voice input + graceful-error work from #21).

## ⚠️ Merging this publishes v1.4.0 to PyPI
Because it both adds the auto-release workflow *and* bumps the version, merging to `main` will trigger the new `publish.yml`, which will build and **publish `scrum-agent` 1.4.0 to PyPI** and cut a `v1.4.0` GitHub Release. That's intended — just merge deliberately.

## What changes
- **Single-source the version.** It now lives only in `pyproject.toml`; `__init__.py` reads it from installed package metadata (`importlib.metadata`, with a `0.0.0+dev` fallback). No more hand-syncing two files.
- **Auto-publish on version bump.** `publish.yml` now triggers on push to `main`: a cheap `check` job compares the `pyproject.toml` version against existing tags and only proceeds when it's new — then test → build → PyPI (OIDC) → tag + GitHub Release. Normal merges (version unchanged) are a no-op.
- Kept the workflow **filename** (`publish.yml`) and `environment: pypi` so PyPI's OIDC trusted-publisher config stays valid; added `skip-existing: true` (idempotent re-runs) and least-privilege per-job permissions.
- Bumped version `1.3.0 → 1.4.0`; updated CLAUDE.md release/CI docs.

## The new release process (going forward)
> Bump `version` in `pyproject.toml`, merge to `main`. Done — CI publishes and tags automatically. Never tag by hand.

## Verification
- Workflow YAML parses; version-extraction returns `1.4.0`; tag-check logic confirmed (`v1.4.0` absent → releases, `v1.3.0` present → would skip).
- `__version__` resolves to `1.4.0` from metadata after `uv sync`; `--version` CLI tests pass; lint clean.

## After merge — test the real install
```bash
brew install portaudio
uv tool install "scrum-agent[voice]"
scrum-agent   # double-tap Space in the description field to dictate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)