### PR TITLE
docs: correct PortAudio guidance (bundled on macOS/Windows)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,8 +61,8 @@ CONFLUENCE_SPACE_KEY=MYSPACE
 
 # Voice input (optional — double-tap Space in any text field to dictate)
 # Transcription runs locally & offline via faster-whisper (works with ANY LLM
-# provider, no API key). Install with: uv sync --extra voice  (+ PortAudio:
-# `brew install portaudio` / `apt install portaudio19-dev`).
+# provider, no API key). Install with: uv sync --extra voice
+# (self-contained on macOS/Windows; Linux also needs: apt install libportaudio2).
 # VOICE_MODEL is the local Whisper model size, not a cloud model name.
 # Options: tiny, base (default), small, medium, large-v3 (+ .en variants).
 # Larger = more accurate but slower and a bigger one-time download.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ pipx install "scrum-agent[voice]"              # equivalent with pipx
 ```
 
 > **Voice input** transcribes on-device with [faster-whisper](https://github.com/SYSTRAN/faster-whisper)
-> — **no API key**, works with every LLM provider (Anthropic, Bedrock, …). It needs the PortAudio native
-> library (`brew install portaudio` on macOS, `sudo apt install portaudio19-dev` on Debian/Ubuntu) and
-> downloads a small Whisper model on first use (~140 MB for the default `base`; set `VOICE_MODEL` to
-> `tiny`/`small`/`medium`/`large-v3` to trade size for accuracy).
+> — **no API key**, works with every LLM provider (Anthropic, Bedrock, …). On **macOS/Windows** the
+> `[voice]` extra is fully self-contained (the `sounddevice` wheel bundles PortAudio). On **Linux**, also
+> install the system library: `sudo apt install libportaudio2`. A small Whisper model downloads on first
+> use (~140 MB for the default `base`; set `VOICE_MODEL` to `tiny`/`small`/`medium`/`large-v3` to trade
+> size for accuracy).
 
 > **Homebrew is not supported.** A required dependency (`sqlite-vec`) ships no
 > source distribution, which Homebrew's source-build model can't handle, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,11 @@ openai = ["langchain-openai"]
 google = ["langchain-google-genai"]
 pdf = ["pymupdf"]
 bedrock = ["langchain-aws", "boto3"]
-# Voice input — record mic audio (sounddevice/PortAudio) and transcribe locally
-# and offline with faster-whisper. Lazy-imported in voice.py; needs no API key
-# (works with any LLM provider) but the PortAudio native lib (e.g.
-# `brew install portaudio` on macOS) and a one-time Whisper model download.
+# Voice input — record mic audio (sounddevice) and transcribe locally and
+# offline with faster-whisper. Lazy-imported in voice.py; needs no API key
+# (works with any LLM provider). The sounddevice wheels bundle PortAudio on
+# macOS/Windows (self-contained); Linux also needs the system lib
+# (`apt install libportaudio2`). A Whisper model downloads once on first use.
 voice = ["sounddevice", "faster-whisper"]
 all-providers = ["langchain-openai", "langchain-google-genai", "langchain-aws", "boto3"]
 dev = [

--- a/src/scrum_agent/voice.py
+++ b/src/scrum_agent/voice.py
@@ -17,8 +17,9 @@ Design notes / architectural decisions:
   `faster_whisper` for transcription) are imported *inside* functions, mirroring
   the optional-provider pattern in `agent/llm.py`. Importing this module never
   fails; the deps are only needed when voice is actually used. Install with:
-  ``uv sync --extra voice`` (also needs the PortAudio native lib, e.g.
-  ``brew install portaudio`` on macOS).
+  ``uv sync --extra voice``. The sounddevice wheels bundle PortAudio on macOS
+  and Windows (nothing else to install); on Linux the wheel is pure-Python and
+  needs the system library too (e.g. ``sudo apt install libportaudio2``).
 - **Cheap availability probe.** :func:`is_voice_available` uses
   ``importlib.util.find_spec`` so a per-render hint check never triggers the
   heavy ``faster_whisper`` / ``ctranslate2`` import; real mic/model failures are
@@ -74,7 +75,7 @@ def is_voice_available() -> tuple[bool, str]:
     available, otherwise a short human-readable explanation for the UI.
     """
     if not _installed("sounddevice"):
-        return False, "Install voice extra: uv sync --extra voice (needs PortAudio)"
+        return False, "Install voice extra: uv sync --extra voice (Linux also: apt install libportaudio2)"
     if not _installed("faster_whisper"):
         return False, "Install voice extra: uv sync --extra voice"
     return True, ""


### PR DESCRIPTION
Corrects install guidance I got wrong: **`uv tool install "scrum-agent[voice]"` is self-contained on macOS/Windows** — the `sounddevice` wheels bundle PortAudio, so `brew install portaudio` is **not** needed.

**Verified empirically:** sounddevice loaded PortAudio from inside its own package (`_sounddevice_data/portaudio-binaries/libportaudio.dylib`), not from Homebrew. PyPI ships platform wheels for macOS/Windows (bundle PortAudio) but only a generic `py3-none-any` wheel for Linux (no bundle) — so **Linux** still needs `sudo apt install libportaudio2`.

Fixes the "needs PortAudio / brew install portaudio" wording in README, .env.example, the pyproject `voice` extra comment, `voice.py` docstring, and the `is_voice_available` reason string.

No version bump — merging is a release no-op. Bump `pyproject.toml` to `1.4.1` if you want the corrected in-app message published.

Lint/format clean; `test_voice.py` 26 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)