### PR TITLE
Rotating, dismissible welcome-screen tips

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,12 @@ CONFLUENCE_SPACE_KEY=MYSPACE
 # Larger = more accurate but slower and a bigger one-time download.
 VOICE_MODEL=base
 
+# On-screen tips
+# Rotating discoverability tips on the welcome screen + inline voice hints.
+# Default on; set to false to hide all tips. Toggle live by pressing "t" on the
+# welcome screen (the choice is saved back here automatically).
+TIPS_ENABLED=true
+
 # Session management
 # Auto-prune sessions older than N days (default 30, set to 0 to disable)
 SESSION_PRUNE_DAYS=30

--- a/TODO.md
+++ b/TODO.md
@@ -1164,3 +1164,12 @@ _Bring Azure DevOps to full feature parity with Jira — read board/velocity, cr
 - [x] Route all raw error surfaces through it: team analysis (both flows), epic export (Jira+AzDO), Jira/AzDO sync-all
 - [x] Top-level cli.py catch-all shows a friendly one-line message + log pointer instead of silent blank
 - [x] Unit tests `tests/unit/test_ui_error_classification.py` (16 cases incl. the real 401 dump)
+
+## Phase 20: Rotating, Dismissible Welcome-Screen Tips
+- [x] `ui/shared/_tips.py` — curated general tips (voice + `--resume`, Jira/AzDO export, HTML/JSON export, questionnaire, themes, headless); voice tip stays availability-aware; `@lru_cache`d list; `current_tip(tick)` rotates every `TIP_ROTATE_SECONDS` off the existing render tick (no new timer)
+- [x] `is_tips_enabled()` / `set_tips_enabled()` in `config.py` — `TIPS_ENABLED` env var (default on), persisted via `dotenv.set_key` (single-key, preserves other config), applied to `os.environ` immediately
+- [x] Welcome screen (`_screens.py`) renders the rotating tip + "press t to hide"; blanks the reserved row when off
+- [x] `t` key in the mode-select loop toggles + persists; hides/shows instantly
+- [x] Inline `_voice_hint()` returns "" when tips off (silences input-screen hints too); setup-wizard onboarding line gated on tips
+- [x] Settings page "Tips: on/off" row + `TIPS_ENABLED` in `_collect_settings_data`; `.env.example` documented
+- [x] Unit tests: `tests/unit/test_tips.py`, `tests/unit/test_tips_ui.py`, plus `TIPS_ENABLED` cases in `test_config.py`

--- a/src/scrum_agent/config.py
+++ b/src/scrum_agent/config.py
@@ -70,6 +70,33 @@ def is_langsmith_enabled() -> bool:
     return os.getenv("LANGSMITH_TRACING", "").lower() == "true" and bool(os.getenv("LANGSMITH_API_KEY"))
 
 
+def is_tips_enabled() -> bool:
+    """Return True if on-screen discoverability tips should be shown (default on).
+
+    Controls the rotating welcome-screen tip banner and the inline voice hints on
+    text-entry screens. Any value other than "false" (case-insensitive) keeps tips
+    on, so an unset var means enabled — the feature should be visible by default.
+    """
+    return os.getenv("TIPS_ENABLED", "true").strip().lower() != "false"
+
+
+def set_tips_enabled(enabled: bool) -> None:
+    """Persist the tips on/off preference to ~/.scrum-agent/.env and apply it now.
+
+    Uses dotenv's set_key so only this one key is updated — save_config() rewrites
+    the whole file and would drop any keys not passed to it. os.environ is updated
+    too so the running session reflects the change immediately (no reload needed).
+    """
+    from dotenv import set_key
+
+    value = "true" if enabled else "false"
+    config_file = get_config_file()
+    # set_key creates the file if missing and preserves existing keys/comments.
+    set_key(str(config_file), "TIPS_ENABLED", value)
+    os.environ["TIPS_ENABLED"] = value
+    logger.info("Tips %s (persisted to %s)", "enabled" if enabled else "disabled", config_file)
+
+
 # Proxy environment variables to check (both uppercase and lowercase conventions).
 _PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy")
 

--- a/src/scrum_agent/setup_wizard.py
+++ b/src/scrum_agent/setup_wizard.py
@@ -256,16 +256,19 @@ def run_setup_wizard(console: Console) -> bool:
     console.print(f"\n[green]Setup complete! Config saved to {config_file}[/green]")
 
     # Onboarding tip: voice input is optional and off by default. Mention it so
-    # new users discover they can dictate answers instead of typing.
+    # new users discover they can dictate answers instead of typing. Skipped
+    # entirely when the user has switched tips off.
+    from scrum_agent.config import is_tips_enabled
     from scrum_agent.voice import is_voice_available
 
-    if is_voice_available():
-        console.print("[dim]🎤 Voice input is ready — double-tap Space in any text field to dictate.[/dim]")
-    else:
-        console.print(
-            "[dim]🎤 Tip: enable voice input to dictate answers — "
-            "run [/dim][cyan]uv sync --extra voice[/cyan][dim] (works offline, any LLM provider).[/dim]"
-        )
+    if is_tips_enabled():
+        if is_voice_available():
+            console.print("[dim]🎤 Voice input is ready — double-tap Space in any text field to dictate.[/dim]")
+        else:
+            console.print(
+                "[dim]🎤 Tip: enable voice input to dictate answers — "
+                "run [/dim][cyan]uv sync --extra voice[/cyan][dim] (works offline, any LLM provider).[/dim]"
+            )
 
     logger.info("Setup wizard completed successfully")
     return True

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -1097,6 +1097,7 @@ def _collect_settings_data() -> dict:
         "LOG_LEVEL",
         "SESSION_PRUNE_DAYS",
         "LANGSMITH_TRACING",
+        "TIPS_ENABLED",
     ]
     for k in _keys:
         data[k] = os.environ.get(k, "")
@@ -1199,6 +1200,13 @@ def select_mode(
                     continue
                 elif key in ("q", "esc"):
                     return None
+                elif key == "t":
+                    # Toggle the rotating tips on/off and persist the choice. The
+                    # live.update() at the bottom of the loop re-renders with the
+                    # new state, so the tip banner hides/shows instantly.
+                    from scrum_agent.config import is_tips_enabled, set_tips_enabled
+
+                    set_tips_enabled(not is_tips_enabled())
 
                 elapsed = time.monotonic() - select_time
                 reveal = elapsed * _DESC_SCROLL_SPEED  # float for sub-char fade

--- a/src/scrum_agent/ui/mode_select/screens/_screens.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens.py
@@ -178,6 +178,52 @@ def _build_mode_row(
     return items
 
 
+# Colour anchors for the tip cross-fade. Each is (background, full) — the tip
+# lerps from the near-black background up to its full colour by tip_brightness(),
+# so tips dissolve in and out instead of snapping.
+_TIP_BG = (28, 28, 34)
+_TIP_BODY = (198, 198, 208)  # soft grey-white for the tip text
+_TIP_DOT_DIM = (70, 70, 82)  # inactive position dots (matches the app's hollow ○)
+_TIP_DOT_ON = (226, 186, 96)  # warm accent for the active dot
+_TIP_KEY = (210, 210, 220)  # the "t" keycap glyph
+
+
+def _build_tip_rows(shimmer_tick: float) -> list[Text]:
+    """Build the bottom tip block: a rotating, cross-fading tip + a control row.
+
+    Returns two centred rows so the mode list above stays vertically stable
+    whether tips are on or off. When off, both rows are blank. The tip fades in
+    and out via ``tip_brightness`` (see README: "Architecture" — shared UI layer).
+    """
+    from scrum_agent.config import is_tips_enabled
+    from scrum_agent.ui.shared._animations import lerp_color
+    from scrum_agent.ui.shared._tips import current_tip, tip_brightness, tip_count
+
+    if not is_tips_enabled():
+        return [Text(""), Text("")]
+
+    idx, tip_text = current_tip(shimmer_tick)
+    b = tip_brightness(shimmer_tick)
+
+    # Row 1 — the tip, faded from background toward full body colour.
+    tip_line = Text(tip_text, style=lerp_color(b, _TIP_BG, _TIP_BODY), justify="center")
+
+    # Row 2 — position dots (active one accented) + a quiet keycap control hint.
+    dot_dim = lerp_color(b, _TIP_BG, _TIP_DOT_DIM)
+    dot_on = lerp_color(b, _TIP_BG, _TIP_DOT_ON)
+    control = Text(justify="center")
+    for i in range(tip_count()):
+        if i:
+            control.append(" ")
+        control.append("●" if i == idx else "○", style=dot_on if i == idx else dot_dim)
+    control.append("     ")
+    control.append("press ", style=dot_dim)
+    control.append("t", style=f"bold {lerp_color(b, _TIP_BG, _TIP_KEY)}")
+    control.append(" to hide", style=dot_dim)
+
+    return [tip_line, control]
+
+
 def _build_mode_screen(
     selected: int,
     *,
@@ -222,21 +268,16 @@ def _build_mode_screen(
             body.append(Text(""))
             body_h += 1
 
-    # Bottom-pinned discoverability tip for voice input — so users learn the
-    # feature exists from the very first screen, not only inside a session.
-    from scrum_agent.voice import is_voice_available
+    # Bottom-pinned discoverability tip — so users learn features exist from the
+    # very first screen, not only inside a session. Tips rotate every few seconds
+    # off the render loop's shimmer_tick, cross-fading between one another, and can
+    # be switched off entirely. Rendered as two quiet rows: the tip itself, then
+    # position dots + a keycap control hint.
+    tip_rows = _build_tip_rows(shimmer_tick)
 
-    _voice_ok, _ = is_voice_available()
-    tip_text = (
-        "\U0001f3a4  Tip: double-tap Space in any text field to dictate"
-        if _voice_ok
-        else "\U0001f3a4  Voice input supported — enable with: uv sync --extra voice"
-    )
-    tip = Text(tip_text, style="dim", justify="center")
-
-    # Reserve the last row for the tip; centre the mode rows in the space above.
+    # Reserve two rows for the tip block; centre the mode rows in the space above.
     inner_h = height - 4
-    body_area = max(0, inner_h - 1)
+    body_area = max(0, inner_h - len(tip_rows))
     mid_top = max(0, (body_area - body_h) // 2)
     mid_bot = max(0, body_area - body_h - mid_top)
 
@@ -244,7 +285,7 @@ def _build_mode_screen(
         *[Text("") for _ in range(mid_top)],
         *body,
         *[Text("") for _ in range(mid_bot)],
-        tip,
+        *tip_rows,
     )
 
     return Panel(

--- a/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
@@ -3439,6 +3439,9 @@ def _build_settings_screen(
     _heading("Advanced")
     _row("Log Level", config_data.get("LOG_LEVEL", "WARNING"))
     _row("Session Prune Days", config_data.get("SESSION_PRUNE_DAYS", "30"))
+    # Tips default on; only the literal "false" disables them (matches is_tips_enabled).
+    _tips_on = config_data.get("TIPS_ENABLED", "").strip().lower() != "false"
+    _row("Tips", "on" if _tips_on else "off", value_style=theme.good if _tips_on else theme.muted)
     langsmith = "enabled" if config_data.get("LANGSMITH_TRACING") == "true" else "disabled"
     _row("LangSmith", langsmith)
     _row("Config File", config_data.get("_config_path", ""))

--- a/src/scrum_agent/ui/session/screens/_screens_input.py
+++ b/src/scrum_agent/ui/session/screens/_screens_input.py
@@ -25,12 +25,17 @@ _INPUT_BOX_W_MAX = 74
 def _voice_hint() -> str:
     """Return a discoverability suffix for voice input on text-entry screens.
 
-    Always advertises the feature so users know it exists. When the voice extra
-    is installed it prompts to speak; otherwise it shows how to enable it —
-    hiding it entirely (the old behaviour) meant the feature was invisible to
-    anyone who hadn't already set it up.
+    Advertises the feature so users know it exists. When the voice extra is
+    installed it prompts to speak; otherwise it shows how to enable it — hiding
+    it entirely meant the feature was invisible to anyone who hadn't set it up.
+    Returns "" when tips are switched off, so disabling tips hides this inline
+    hint too (the double-tap Space shortcut still works regardless).
     """
+    from scrum_agent.config import is_tips_enabled
     from scrum_agent.voice import is_voice_available
+
+    if not is_tips_enabled():
+        return ""
 
     available, _reason = is_voice_available()
     if available:

--- a/src/scrum_agent/ui/shared/_tips.py
+++ b/src/scrum_agent/ui/shared/_tips.py
@@ -1,0 +1,98 @@
+"""Rotating discoverability tips for the welcome screen.
+
+Single source of truth for the tip list and the (pure) rotation math. Kept out of
+the screen builders so it can be unit-tested without a Rich Console and reused if
+other screens want to surface a tip.
+
+# See README: "Architecture" — pure helpers with no side effects; the screen
+# builder decides how to render them.
+
+Design notes:
+- **Driven by the existing render tick.** The mode-select loop already re-renders
+  at 60 FPS and threads a continuous ``shimmer_tick`` (seconds since the loop
+  started) into the screen builder. :func:`current_tip` turns that float into a
+  tip index with plain modulo arithmetic — no timer or background thread.
+- **Availability-aware voice tip.** The first tip adapts to whether the optional
+  voice extra is installed, mirroring ``_voice_hint()`` in the input screens.
+- **Cached list.** Voice availability can't change during a process, so the tip
+  list is memoised — this keeps the per-frame render from re-running the
+  ``find_spec`` availability probe 60×/second.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+# Seconds each tip stays on screen before the next one rotates in.
+TIP_ROTATE_SECONDS = 6.0
+
+# General product tips shown after the voice tip. Keep them short (one line) and
+# action-oriented — they render centered and dimmed under the mode list.
+_GENERAL_TIPS: tuple[str, ...] = (
+    "\U0001f4a1 Tip: resume your last session any time with --resume",
+    "\U0001f4a1 Tip: push epics & stories straight to Jira or Azure DevOps",
+    "\U0001f4a1 Tip: export a plan to HTML or JSON for sharing and CI/CD",
+    "\U0001f4a1 Tip: import a filled-in questionnaire with --questionnaire",
+    "\U0001f4a1 Tip: switch between --theme dark and --theme light",
+    "\U0001f4a1 Tip: run headless with --non-interactive for scripts & pipelines",
+)
+
+
+@lru_cache(maxsize=1)
+def get_tips() -> tuple[str, ...]:
+    """Return the ordered tips shown on the welcome screen.
+
+    The first entry is the voice tip and adapts to whether the voice extra is
+    installed; the rest are static product tips. Memoised because voice
+    availability is fixed for the life of the process.
+    """
+    from scrum_agent.voice import is_voice_available
+
+    available, _reason = is_voice_available()
+    voice_tip = (
+        "\U0001f3a4 Tip: double-tap Space in any text field to dictate"
+        if available
+        else "\U0001f3a4 Tip: enable dictation with — uv sync --extra voice"
+    )
+    return (voice_tip, *_GENERAL_TIPS)
+
+
+def tip_count() -> int:
+    """Number of tips in rotation (used to render position dots)."""
+    return len(get_tips())
+
+
+def current_tip(tick: float, rotate_seconds: float = TIP_ROTATE_SECONDS) -> tuple[int, str]:
+    """Return ``(index, text)`` for the tip visible at ``tick`` seconds.
+
+    ``tick`` is the monotonic elapsed time already threaded through the render
+    loop. The tip advances every ``rotate_seconds``; the index wraps around the
+    tip list so rotation is continuous.
+    """
+    tips = get_tips()
+    if not tips:  # pragma: no cover - defensive; the list is always populated
+        return 0, ""
+    period = rotate_seconds if rotate_seconds > 0 else TIP_ROTATE_SECONDS
+    idx = int(max(0.0, tick) / period) % len(tips)
+    return idx, tips[idx]
+
+
+# Fraction of each rotation window spent fading in (and, symmetrically, out).
+_FADE_FRACTION = 0.16
+
+
+def tip_brightness(tick: float, rotate_seconds: float = TIP_ROTATE_SECONDS) -> float:
+    """Return a 0..1 brightness for the current tip so it can cross-fade.
+
+    Each tip fades up from the background over the first ``_FADE_FRACTION`` of
+    its window, holds at full brightness, then fades back down over the last
+    ``_FADE_FRACTION`` — so one tip dissolves out as the next dissolves in. The
+    caller lerps its text/dot colours by this value. Pure and testable; no I/O.
+    """
+    period = rotate_seconds if rotate_seconds > 0 else TIP_ROTATE_SECONDS
+    phase = (max(0.0, tick) % period) / period  # position within this tip's window, 0..1
+    if phase < _FADE_FRACTION:
+        return phase / _FADE_FRACTION
+    if phase > 1.0 - _FADE_FRACTION:
+        return max(0.0, (1.0 - phase) / _FADE_FRACTION)
+    return 1.0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,7 +12,9 @@ from scrum_agent.config import (
     get_config_file,
     get_session_prune_days,
     is_langsmith_enabled,
+    is_tips_enabled,
     load_user_config,
+    set_tips_enabled,
 )
 
 
@@ -43,6 +45,54 @@ def test_langsmith_disabled_when_tracing_off(monkeypatch):
     monkeypatch.setenv("LANGSMITH_TRACING", "false")
     monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2-test-key")
     assert is_langsmith_enabled() is False
+
+
+def test_tips_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("TIPS_ENABLED", raising=False)
+    assert is_tips_enabled() is True
+
+
+def test_tips_enabled_true_value(monkeypatch):
+    monkeypatch.setenv("TIPS_ENABLED", "true")
+    assert is_tips_enabled() is True
+
+
+def test_tips_disabled_when_false(monkeypatch):
+    monkeypatch.setenv("TIPS_ENABLED", "false")
+    assert is_tips_enabled() is False
+
+
+def test_tips_disabled_case_insensitive(monkeypatch):
+    monkeypatch.setenv("TIPS_ENABLED", "FALSE")
+    assert is_tips_enabled() is False
+
+
+def test_set_tips_enabled_round_trips(monkeypatch, tmp_path):
+    # Point config at a temp file so we don't touch the real ~/.scrum-agent/.env.
+    config_file = tmp_path / ".env"
+    monkeypatch.setattr("scrum_agent.config.get_config_file", lambda: config_file)
+    monkeypatch.delenv("TIPS_ENABLED", raising=False)
+
+    set_tips_enabled(False)
+    assert os.environ["TIPS_ENABLED"] == "false"
+    assert "TIPS_ENABLED" in config_file.read_text()
+    assert is_tips_enabled() is False
+
+    set_tips_enabled(True)
+    assert os.environ["TIPS_ENABLED"] == "true"
+    assert is_tips_enabled() is True
+
+
+def test_set_tips_enabled_preserves_other_keys(monkeypatch, tmp_path):
+    config_file = tmp_path / ".env"
+    config_file.write_text("ANTHROPIC_API_KEY=sk-existing\n")
+    monkeypatch.setattr("scrum_agent.config.get_config_file", lambda: config_file)
+
+    set_tips_enabled(False)
+
+    contents = config_file.read_text()
+    assert "ANTHROPIC_API_KEY=sk-existing" in contents
+    assert "TIPS_ENABLED" in contents
 
 
 class TestProxyDetection:

--- a/tests/unit/test_tips.py
+++ b/tests/unit/test_tips.py
@@ -1,0 +1,121 @@
+"""Tests for the rotating welcome-screen tips (ui/shared/_tips.py)."""
+
+from scrum_agent.ui.shared import _tips
+from scrum_agent.ui.shared._tips import (
+    TIP_ROTATE_SECONDS,
+    current_tip,
+    get_tips,
+    tip_brightness,
+    tip_count,
+)
+
+
+def _clear_cache():
+    # get_tips is lru_cached; reset so a monkeypatched availability is re-read.
+    get_tips.cache_clear()
+
+
+def test_get_tips_non_empty(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    tips = get_tips()
+    assert len(tips) > 1
+    assert all(isinstance(t, str) and t for t in tips)
+    _clear_cache()
+
+
+def test_voice_tip_when_available(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    voice_tip = get_tips()[0]
+    assert "double-tap Space" in voice_tip
+    _clear_cache()
+
+
+def test_voice_tip_when_unavailable(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (False, "reason"))
+    voice_tip = get_tips()[0]
+    assert "uv sync --extra voice" in voice_tip
+    _clear_cache()
+
+
+def test_current_tip_advances_with_tick(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    idx0, _ = current_tip(0.0)
+    idx1, _ = current_tip(TIP_ROTATE_SECONDS + 0.1)
+    assert idx0 == 0
+    assert idx1 == 1
+    _clear_cache()
+
+
+def test_current_tip_stable_within_window(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    idx_a, text_a = current_tip(0.0)
+    idx_b, text_b = current_tip(TIP_ROTATE_SECONDS - 0.01)
+    assert idx_a == idx_b
+    assert text_a == text_b
+    _clear_cache()
+
+
+def test_current_tip_wraps_around(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    n = len(get_tips())
+    # After a full cycle we return to the first tip.
+    idx_first, _ = current_tip(0.0)
+    idx_wrapped, _ = current_tip(n * TIP_ROTATE_SECONDS + 0.1)
+    assert idx_first == idx_wrapped == 0
+    _clear_cache()
+
+
+def test_current_tip_handles_negative_tick(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    idx, text = current_tip(-5.0)
+    assert idx == 0
+    assert text
+    _clear_cache()
+
+
+def test_rotate_seconds_override(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    # With a 1s window, tick=1.5 lands on the second tip.
+    idx, _ = current_tip(1.5, rotate_seconds=1.0)
+    assert idx == 1
+    _clear_cache()
+
+
+def test_module_constant_present():
+    assert _tips.TIP_ROTATE_SECONDS > 0
+
+
+def test_tip_count_matches_get_tips(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    assert tip_count() == len(get_tips())
+    _clear_cache()
+
+
+def test_tip_brightness_full_mid_window():
+    # Mid-window (well away from either edge) is fully visible.
+    assert tip_brightness(TIP_ROTATE_SECONDS / 2) == 1.0
+
+
+def test_tip_brightness_fades_in_at_start():
+    # Just after a tip appears it is dimmer than mid-window.
+    assert 0.0 <= tip_brightness(0.05) < 1.0
+
+
+def test_tip_brightness_fades_out_before_switch():
+    # Just before the next tip it is dimming back toward the background.
+    assert 0.0 <= tip_brightness(TIP_ROTATE_SECONDS - 0.05) < 1.0
+
+
+def test_tip_brightness_in_unit_range():
+    for t in (0.0, 0.5, 2.9, 3.0, 5.9, 6.1, 42.0):
+        b = tip_brightness(t)
+        assert 0.0 <= b <= 1.0

--- a/tests/unit/test_tips_ui.py
+++ b/tests/unit/test_tips_ui.py
@@ -1,0 +1,44 @@
+"""Tests for tips rendering in the TUI: the mode-screen banner and inline hint."""
+
+from rich.panel import Panel
+
+from scrum_agent.ui.mode_select.screens._screens import _build_mode_screen
+from scrum_agent.ui.session.screens._screens_input import _voice_hint
+
+
+def test_voice_hint_empty_when_tips_disabled(monkeypatch):
+    monkeypatch.setattr("scrum_agent.config.is_tips_enabled", lambda: False)
+    assert _voice_hint() == ""
+
+
+def test_voice_hint_present_when_available_and_enabled(monkeypatch):
+    monkeypatch.setattr("scrum_agent.config.is_tips_enabled", lambda: True)
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
+    hint = _voice_hint()
+    assert "double-tap Space" in hint
+
+
+def test_voice_hint_shows_install_when_unavailable(monkeypatch):
+    monkeypatch.setattr("scrum_agent.config.is_tips_enabled", lambda: True)
+    monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (False, "x"))
+    hint = _voice_hint()
+    assert "uv sync --extra voice" in hint
+
+
+def test_mode_screen_renders_with_tips_on(monkeypatch):
+    monkeypatch.setattr("scrum_agent.config.is_tips_enabled", lambda: True)
+    result = _build_mode_screen(0, width=80, height=24, shimmer_tick=0.0)
+    assert isinstance(result, Panel)
+
+
+def test_mode_screen_renders_with_tips_off(monkeypatch):
+    monkeypatch.setattr("scrum_agent.config.is_tips_enabled", lambda: False)
+    result = _build_mode_screen(0, width=80, height=24, shimmer_tick=0.0)
+    assert isinstance(result, Panel)
+
+
+def test_mode_screen_renders_at_various_ticks(monkeypatch):
+    monkeypatch.setattr("scrum_agent.config.is_tips_enabled", lambda: True)
+    for tick in (0.0, 6.5, 42.0):
+        result = _build_mode_screen(0, width=80, height=24, shimmer_tick=tick)
+        assert isinstance(result, Panel)


### PR DESCRIPTION
## What & why

The welcome screen showed a single **static** voice tip (and it truncated on narrow terminals). This turns it into a rotating carousel of general product tips so users discover more features from the first screen, and adds a way to switch tips off completely.

## Changes

**Rotation & UI**
- Rotating carousel of ~7 general tips (voice, `--resume`, Jira/Azure export, HTML/JSON export, questionnaire import, themes, headless). The voice tip stays availability-aware.
- Advances every ~6s driven off the render loop's existing `shimmer_tick` — **no new timer/thread**.
- **Cross-fade** between tips (each dissolves in/out via a pure `tip_brightness()` colour lerp) instead of snapping.
- Two-row layout: the tip, then **position dots** (`● ○ ○ …`, active one accented) + a keycap `press t to hide` control. Fixes the previous truncation.

**Toggle (persistent)**
- Press **`t`** on the welcome screen to hide/show tips instantly.
- Or set `TIPS_ENABLED` (default on). Persisted via `dotenv.set_key` — single key, preserves other config — and applied to `os.environ` immediately.
- Turning tips off also silences the inline `🎤 double-tap Space` hints on input screens and the setup-wizard onboarding line (double-tap Space still works).
- Settings page shows a **Tips: on/off** row.

## Files
- **New:** `ui/shared/_tips.py` (cached tip list + pure rotation/fade helpers)
- `config.py` (`is_tips_enabled`/`set_tips_enabled`), `_screens.py` (two-row cross-fading render), mode_select `__init__.py` (`t` handler + settings key), `_screens_input.py`, `_screens_secondary.py`, `setup_wizard.py`, `.env.example`, `TODO.md`

## Testing
- New `tests/unit/test_tips.py` (rotation, fade, availability-aware voice tip) and `tests/unit/test_tips_ui.py` (render on/off, `_voice_hint` toggle), plus `TIPS_ENABLED` cases in `test_config.py`.
- **2206 unit tests pass**; lint + format clean. (The repo's pre-existing contract-test cassette failures are unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)