### PR TITLE
Automate version bumping: LLM classifies each PR and bumps on the branch

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,0 +1,107 @@
+name: Auto Version Bump
+
+# Classify each PR and, for release-worthy changes, bump the version in
+# pyproject.toml on the PR branch. Merging then triggers publish.yml (which
+# releases whenever the version has no matching tag) — so releases happen with no
+# manual version bump. Cheap deterministic guards run first; the LLM is only asked
+# to choose the semver level when the change actually ships code.
+#
+# The bump lands on the PR *branch* (not main) on purpose: the human merge is what
+# pushes to main and triggers publish.yml. A workflow pushing to main with the
+# default GITHUB_TOKEN would NOT re-trigger publish.yml, so this avoids needing a PAT.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+
+concurrency:
+  group: auto-version-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    name: Decide & apply version bump
+    # Same-repo PRs only (forks can't push to the head branch or read secrets).
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # commit the bump to the PR branch
+      pull-requests: write # post the explanation comment
+      id-token: write # claude-code-action OIDC
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Deterministic guards
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR: ${{ github.event.pull_request.number }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          ver() { sed -nE 's/^version = "([^"]+)".*/\1/p' | head -1; }
+          git fetch --no-tags origin "$BASE_REF"
+          BASE_V=$(git show "FETCH_HEAD:pyproject.toml" | ver)
+          HEAD_V=$(ver < pyproject.toml)
+          echo "base=$BASE_V head=$HEAD_V labels=[$LABELS]"
+
+          # 1) Already bumped in this PR (manual, or a prior auto run) -> skip.
+          #    Keeps re-runs on `synchronize` idempotent and respects manual bumps.
+          if [ "$HEAD_V" != "$BASE_V" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::version already changed in this PR ($BASE_V -> $HEAD_V); skipping."
+            exit 0
+          fi
+
+          # 2) A semver:* / release:skip label forces the LLM step to run.
+          case ",$LABELS," in
+            *,semver:major,*|*,semver:minor,*|*,semver:patch,*|*,semver:none,*|*,release:skip,*)
+              echo "skip=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+          esac
+
+          # 3) Trivial PR? No shipping code changed -> skip (docs/chore/tests/CI only).
+          if gh pr diff "$PR" --name-only | grep -qE '^src/scrum_agent/'; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::no src/scrum_agent changes; skipping version bump."
+          fi
+
+      - name: Classify & bump with Claude
+        if: steps.guard.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowedTools "Bash,Read,Edit,Write"'
+          prompt: |
+            You are the release-versioning bot for this repository. Pull request #${{ github.event.pull_request.number }} is open; decide whether and how to bump the project version. The version lives only in pyproject.toml.
+
+            Follow these steps exactly:
+
+            1. Choose a semver level, in this priority order:
+               a. Labels win. If the PR has label `semver:major`, `semver:minor`, or `semver:patch`, use that level. If it has `release:skip` or `semver:none`, treat the level as "none".
+               b. Otherwise classify this PR's diff:
+                  - "major": a backward-incompatible change (removed/renamed CLI flags, changed output formats, breaking behavior or public API).
+                  - "minor": a new user-facing capability or feature.
+                  - "patch": a bug fix, performance, or internal refactor with no new user-facing surface.
+                  - "none": the diff only touches docs, comments, tests, or CI/workflow files.
+
+            2. If the level is "none": do NOT modify any file. Post one short PR comment: "🏷️ auto-version: no release-worthy change — skipping bump." Then stop.
+
+            3. Otherwise run exactly this command (it rewrites pyproject.toml and prints the NEW version):
+                 python scripts/bump_version.py <level>
+               Commit ONLY the pyproject.toml change to this PR branch and push it. Use commit message:
+                 chore: bump version to <new-version> [auto]
+               with trailer:
+                 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+
+            4. Post one short PR comment naming the level, the new version, and a one-sentence reason.
+
+            Rules: only ever edit pyproject.toml; never bump more than once; keep the comment to one or two lines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,6 +401,13 @@ Version is **single-sourced in `pyproject.toml`** (`version = "…"`). `src/scru
 
 **Releasing is automatic on a version bump.** To ship a release: bump `version` in `pyproject.toml` (semver) and merge to `main`. On that push, `publish.yml` detects there's no `v<version>` tag yet and runs test → build → PyPI publish (OIDC) → creates the `v<version>` tag + GitHub Release. Merges that don't change the version are a no-op. Never tag manually — the workflow owns tagging.
 
+**The bump itself is automated too (`auto-version.yml`).** On each PR, cheap deterministic guards run first (skip if the version was already changed in the PR, or if no `src/scrum_agent/**` files changed and no `semver:*` label is present); otherwise Claude classifies the diff into a semver level and commits `chore: bump version to X.Y.Z [auto]` **to the PR branch** — so merging fires `publish.yml` with no manual step. Rules:
+- **Bump on the PR branch, not `main`** — a workflow pushing to `main` with the default `GITHUB_TOKEN` would not re-trigger `publish.yml` (recursion suppression); the human merge does. This means no PAT is needed.
+- **Override with a label**: `semver:major` / `semver:minor` / `semver:patch` forces the level; `release:skip` (or `semver:none`) suppresses the bump.
+- **Manual bumps still work** — if you edit `version` yourself, the guard sees it already differs from `main` and leaves it alone.
+- **Mechanics** live in `scripts/bump_version.py` (pure `bump()` + `make bump-patch|bump-minor|bump-major`); the LLM only chooses the level.
+- **Known limitation**: two PRs branched off the same version can pick the same next version — whichever merges second finds the tag already exists and won't publish separately. Acceptable for this repo; the fix (post-merge serialized bump on `main`) would need a PAT to re-trigger `publish.yml`.
+
 Distribution is PyPI-only (via `uv tool install` / `pipx install`); Homebrew is not supported because a required dependency (`sqlite-vec`) ships no sdist, so the `omardin14/homebrew-tap` formula is permanently disabled.
 
 ## CI/CD
@@ -410,6 +417,7 @@ Workflows in `.github/workflows/`:
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `ci.yml` | Every push | Lint + test |
+| `auto-version.yml` | PR | Claude classifies the diff and commits a `chore: bump version…` to the PR branch (skips docs/chore-only PRs; `semver:*` / `release:skip` labels override) |
 | `publish.yml` | Push to `main` | if `pyproject.toml` version has no tag yet: test → build → PyPI publish (OIDC) → tag + GitHub Release (else no-op) |
 | `smoke.yml` | Weekly cron | Live API smoke tests |
 | `claude.yml` | PR | Claude Code review |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UV := $(or $(shell command -v uv 2>/dev/null),$(HOME)/.local/bin/uv)
 
-.PHONY: install dev test test-fast test-v test-all lint format run run-dry clean env pre-commit graph eval contract record smoke-test snapshot-update budget-report build publish help
+.PHONY: install dev test test-fast test-v test-all lint format run run-dry clean env pre-commit graph eval contract record smoke-test snapshot-update budget-report bump-patch bump-minor bump-major build publish help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -63,6 +63,15 @@ budget-report: ## Show live prompt token counts for trend monitoring (runs token
 
 graph: ## Generate agent graph visualisation PNG
 	$(UV) run python scripts/generate_graph_png.py
+
+bump-patch: ## Bump the patch version in pyproject.toml (X.Y.Z -> X.Y.Z+1)
+	$(UV) run python scripts/bump_version.py patch
+
+bump-minor: ## Bump the minor version in pyproject.toml (X.Y.Z -> X.Y+1.0)
+	$(UV) run python scripts/bump_version.py minor
+
+bump-major: ## Bump the major version in pyproject.toml (X.Y.Z -> X+1.0.0)
+	$(UV) run python scripts/bump_version.py major
 
 build: ## Build sdist + wheel into dist/
 	$(UV) build

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Bump the single-source project version in ``pyproject.toml``.
+
+The version lives only in ``pyproject.toml`` (``src/scrum_agent/__init__.py`` reads
+it from the installed package metadata). ``publish.yml`` releases whenever that
+version has no matching ``v<version>`` tag on ``main``, so bumping this one line is
+the whole release trigger.
+
+This helper keeps the arithmetic deterministic and testable so the ``auto-version``
+GitHub workflow only has to *choose the level* — the LLM never hand-computes a
+version. It's equally handy for humans:
+
+    python scripts/bump_version.py minor     # 1.5.0 -> 1.6.0, rewrites pyproject
+    python scripts/bump_version.py --current # print current version, no change
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+# The version line publish.yml greps: `^version = "X.Y.Z"`. Match exactly that so
+# the single source of truth (and that grep) keep working.
+_VERSION_RE = re.compile(r'^version = "([^"]+)"', re.MULTILINE)
+_LEVELS = ("major", "minor", "patch")
+_DEFAULT_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def bump(version: str, level: str) -> str:
+    """Return ``version`` bumped by semver ``level`` (major | minor | patch).
+
+    A ``major`` bump zeroes minor+patch; a ``minor`` bump zeroes patch. Expects a
+    plain ``X.Y.Z`` version (the format this project uses).
+    """
+    if level not in _LEVELS:
+        raise ValueError(f"level must be one of {_LEVELS}, got {level!r}")
+    parts = version.split(".")
+    if len(parts) != 3 or not all(p.isdigit() for p in parts):
+        raise ValueError(f"expected an X.Y.Z version, got {version!r}")
+    major, minor, patch = (int(p) for p in parts)
+    if level == "major":
+        return f"{major + 1}.0.0"
+    if level == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def read_current(pyproject: Path = _DEFAULT_PYPROJECT) -> str:
+    """Return the current version string from ``pyproject.toml``."""
+    match = _VERSION_RE.search(pyproject.read_text())
+    if not match:
+        raise SystemExit(f'no `version = "..."` line found in {pyproject}')
+    return match.group(1)
+
+
+def write_version(new_version: str, pyproject: Path = _DEFAULT_PYPROJECT) -> None:
+    """Rewrite the version line in ``pyproject.toml`` to ``new_version``."""
+    text = pyproject.read_text()
+    new_text, count = _VERSION_RE.subn(f'version = "{new_version}"', text, count=1)
+    if count != 1:
+        raise SystemExit(f"could not update the version line in {pyproject}")
+    pyproject.write_text(new_text)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Bump the version in pyproject.toml")
+    parser.add_argument("level", nargs="?", choices=_LEVELS, help="semver level to bump")
+    parser.add_argument("--current", action="store_true", help="print the current version and exit")
+    args = parser.parse_args(argv)
+
+    current = read_current()
+    if args.current:
+        print(current)
+        return
+    if not args.level:
+        parser.error("a level (major|minor|patch) is required unless --current is given")
+
+    new_version = bump(current, args.level)
+    write_version(new_version)
+    print(new_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_bump_version.py
+++ b/tests/unit/test_bump_version.py
@@ -1,0 +1,66 @@
+"""Tests for scripts/bump_version.py — the deterministic version bumper."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not a package, so load the module straight from its file path.
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "bump_version.py"
+_spec = importlib.util.spec_from_file_location("bump_version", _MODULE_PATH)
+bump_version = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bump_version)
+
+
+@pytest.mark.parametrize(
+    ("version", "level", "expected"),
+    [
+        ("1.5.0", "patch", "1.5.1"),
+        ("1.5.0", "minor", "1.6.0"),
+        ("1.5.0", "major", "2.0.0"),
+        ("1.5.3", "minor", "1.6.0"),  # minor resets patch
+        ("1.5.3", "major", "2.0.0"),  # major resets minor + patch
+        ("0.0.0", "patch", "0.0.1"),
+        ("10.9.9", "major", "11.0.0"),
+    ],
+)
+def test_bump(version, level, expected):
+    assert bump_version.bump(version, level) == expected
+
+
+def test_bump_rejects_bad_level():
+    with pytest.raises(ValueError):
+        bump_version.bump("1.2.3", "mega")
+
+
+@pytest.mark.parametrize("bad", ["1.2", "1.2.3.4", "1.x.0", "v1.2.3", ""])
+def test_bump_rejects_bad_version(bad):
+    with pytest.raises(ValueError):
+        bump_version.bump(bad, "patch")
+
+
+def _write_pyproject(tmp_path: Path, version: str) -> Path:
+    p = tmp_path / "pyproject.toml"
+    p.write_text(f'[project]\nname = "scrum-agent"\nversion = "{version}"\nrequires-python = ">=3.11"\n')
+    return p
+
+
+def test_read_current(tmp_path):
+    p = _write_pyproject(tmp_path, "1.5.0")
+    assert bump_version.read_current(p) == "1.5.0"
+
+
+def test_write_version_round_trip(tmp_path):
+    p = _write_pyproject(tmp_path, "1.5.0")
+    bump_version.write_version("1.6.0", p)
+    assert bump_version.read_current(p) == "1.6.0"
+    # Only the version line changes; the rest of the file is preserved.
+    assert 'name = "scrum-agent"' in p.read_text()
+    assert 'requires-python = ">=3.11"' in p.read_text()
+
+
+def test_read_current_missing_version(tmp_path):
+    p = tmp_path / "pyproject.toml"
+    p.write_text('[project]\nname = "scrum-agent"\n')
+    with pytest.raises(SystemExit):
+        bump_version.read_current(p)


### PR DESCRIPTION
## Why

`publish.yml` already releases automatically **once the version changes** (it publishes whenever `pyproject.toml`'s version has no matching `v<version>` tag on `main`). The only manual step left was **bumping the version** — which is easy to forget. This automates it end-to-end.

## How it works

On every PR, `auto-version.yml`:

1. **Deterministic guards run first** (no LLM cost):
   - Skip if the version was already changed in the PR (respects manual bumps; makes re-runs idempotent).
   - Skip if no `src/scrum_agent/**` files changed **and** no `semver:*` label is present (docs/chore/test/CI-only PRs don't release).
2. **Claude classifies the diff** into `major` / `minor` / `patch` / `none` and, for real changes, runs `python scripts/bump_version.py <level>` and commits `chore: bump version to X.Y.Z [auto]` **to the PR branch**.
3. Merging the PR pushes to `main` → the existing `publish.yml` sees the new version and releases.

### Key design choice — bump on the PR branch, not `main`

A workflow pushing to `main` with the default `GITHUB_TOKEN` would **not** re-trigger `publish.yml` (GitHub suppresses workflow recursion), so it'd need a PAT. Landing the bump on the PR branch means the **human merge** is what pushes to `main` — which triggers `publish.yml` normally. **No new secrets** — reuses the `CLAUDE_CODE_OAUTH_TOKEN` already used by `claude-code-review.yml`.

## Overrides

| Label | Effect |
|-------|--------|
| `semver:major` / `semver:minor` / `semver:patch` | Force the level |
| `release:skip` / `semver:none` | Suppress the bump |

Manual edits to `version` still work — the guard sees it already differs from `main` and leaves it alone.

## Contents

- `scripts/bump_version.py` — deterministic, unit-tested bumper (pure `bump()` + pyproject read/write + CLI). The LLM only picks the level.
- `.github/workflows/auto-version.yml` — the classify-and-commit workflow.
- `make bump-patch|bump-minor|bump-major` convenience targets.
- Docs: CLAUDE.md Version Management + CI/CD table.

## Testing

- `tests/unit/test_bump_version.py` — 16 cases (level math, resets, bad input, pyproject round-trip). Full unit suite green (2222 passed); `ruff` clean; workflow YAML parses.
- Note: this PR touches no `src/scrum_agent/**`, so it intentionally won't auto-bump/release itself.

## Known limitation

Two PRs branched off the same version can pick the same next version; whichever merges second finds the tag exists and won't publish separately. Acceptable for this mostly-solo repo; the fix (post-merge serialized bump) would require a PAT to re-trigger `publish.yml`. Documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)