### PR TITLE
Make the planner smarter: intake modes, repo-informed stack + low-code, ceremony history

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1246,3 +1246,30 @@ _Bring Azure DevOps to full feature parity with Jira — read board/velocity, cr
 - [x] Popovers (`.pop`, one-at-a-time, click-outside/Esc close) for Music (play/volume/mood), Timer (segmented presets + custom + start/stop), Theme (colour **swatches**); running timer shows inline `MM:SS` on its button; mini-viz appears only while playing
 - [x] `[data-theme="midnight"]` block added so the default theme's swatch renders correctly; theme applied via `data-theme` attribute
 - [x] Tests updated (compact-toolbar markers, swatch/theme-pop, others-only presence) + no-dangling-id guard; live Chrome smoke (Midnight + Synthwave, popovers, inline timer, mini-viz) — zero console errors
+
+## Phase 28: Planning — three intake modes (Small project / Epic wide / Offline)
+- [x] `prompts/intake.py` — `SMALL_PROJECT_ESSENTIALS` (Q2/Q3/Q4/Q6/Q8/Q11); legacy REPL `INTAKE_MODE_MENU` left unchanged (TUI drives the new modes)
+- [x] TUI cards (`ui/mode_select/screens/_screens.py`) — `_INTAKE_CARDS` is now **Small / Epic wide / Offline** (Epic wide reuses the existing `smart` engine)
+- [x] `agent/nodes.py` — `_essentials_for_mode()` + `_is_small_project_mode()` helpers; `small_project` added to the smart-style extraction + gap-filling paths
+- [x] Capacity gating for Small mode — `_extract_capacity_deductions` returns zeros, `_prepare_bank_holiday_choices` no-ops, PTO skipped, sprint-overflow advisory + per-sprint velocity skipped, velocity breakdown → one-liner
+- [x] Advisory scope detection — `project_analyzer` coerces Small plans flat (skip_features, ≤2 sprints) and sets `_small_project_oversized` when the analyzer judges the project bigger; advisory panel appended to the review display; `ScrumState._small_project_oversized` field
+- [x] Switch to Epic wide — `apply_epic_switch()` + `_reopen_intake_for_epic()` (nodes.py); `QuestionnaireState._reopen_for_epic` flag; **Switch to Epic** action on the analysis review (`_phases.py`) + `_BTN_COLORS` entry; Phases B→D wrapped in a re-run loop in `ui/session/__init__.py`. Answers preserved; only the extra Epic questions are asked
+- [x] Tests: `tests/unit/nodes/test_small_project.py` (essentials, capacity gating, advisory + coercion, apply_epic_switch, reopen), state field + intake_mode round-trip in `test_state.py`; full end-to-end switch verified through the compiled graph (no LLM call)
+
+## Phase 29: Smarter smart-intake (repo signals + low-code) & retire the 30-question mode
+- [x] Remove the legacy 30-question "standard" intake mode: `INTAKE_MODE_MENU`/`INTAKE_MODE_ORDER` → `(smart, offline)`; `--full-intake` CLI flag removed; `project_intake` coerces any lingering `standard` → `smart` at first invocation and the standard first-invocation block is deleted; REPL menu reprompt → "1 or 2"; obsolete assertions updated in `test_repl.py`/`test_cli.py`/`test_intake.py`/`test_graph.py`
+- [x] `agent/repo_signals.py` (new) — graceful multi-source scan (Q17 URL or configured GitHub) → `RepoSignals` (detected_stack, integrations, low_code); pure `analyze_context()` parses the tool summary (`Languages:`/`Key files detected:`); `LOW_CODE_MARKERS` + `INTEGRATION_SDK_MARKERS` + `FRAMEWORK_MARKERS` vocabularies; manifest-content parsing for SDK/framework inference
+- [x] Low-code state — `ProjectAnalysis.is_low_code` / `low_code_reason` (defaulted, back-compat); analyzer `_JSON_SCHEMA` + parsing; `_dict_to_analysis` reconstruction
+- [x] Intake wiring — `_apply_repo_signals()` scans once at first invocation, pre-fills Q11 (suggestion) + Q12 (integrations), stashes raw scan + low-code verdict on `QuestionnaireState` (transient `_repo_context`/`_repo_low_code`/`_repo_low_code_reason`)
+- [x] Analyzer wiring — reuses the stashed scan (no double-scan), passes a deterministic `Detected stack` hint to the prompt, and ORs the LLM/deterministic/stashed low-code verdicts
+- [x] Lighter plan — `is_low_code` threaded into `story_writer` (smaller points) + `task_decomposer` (config/setup tasks) prompts; `⚙ Low-code project` surfaced in the analysis panel + Markdown export
+- [x] Tests — `test_repo_signals.py` (parsers, analyze_context, low-code detection, graceful scan) + `test_low_code.py` (analyzer reconciliation, `_apply_repo_signals`, prompt clauses, render, serialization round-trip); `make test` green except the pre-existing date-dependent standup failure; `make lint` clean
+
+## Phase 30: Feed Standup + Retro history into Planning & Analysis
+- [x] Team-wide store reads: `RetroStore.get_recent_reports(limit, project_name)` (project-first) + `get_all_history`; `StandupStore.get_recent_reports` (recency; success-only) + `get_all_history`
+- [x] `agent/ceremony_history.py` (new) — `CeremonyContext` + `gather_ceremony_context(project_name)` (graceful, team-wide, opens stores on `get_sessions_db`); deterministic `_describe_cadence` (interval-based, no "now"), `_confidence_trend`, `_top_themes`, `_dedup_action_items`; `format_ceremony_history_md`
+- [x] Planning analyzer — `get_analyzer_prompt(ceremony_history=…)` "## Standup & Retro History" section; `project_analyzer` gathers once, injects, stashes `_ceremony_action_items` / `_ceremony_history` (ScrumState transient fields)
+- [x] Seed backlog — `story_writer` `carry_over_items` param → "[Retro]"-badged stories for open retro action items; node passes `_ceremony_action_items`
+- [x] Sprint planner — `get_sprint_planner_prompt(ceremony_history=…)` section (sequence [Retro] stories early; conservative load on low confidence); node passes `_ceremony_history`
+- [x] Analysis mode — `export_team_profile_html/md(ceremony=…)` "Ceremony Cadence & Trends" section (cadence + confidence trend + recurring themes); both TUI export sites gather `gather_ceremony_context(project_key)` (project-first)
+- [x] Tests — `test_ceremony_history.py` (cadence/trend/themes/dedup/gather/store project-first) + `test_ceremony_integration.py` (prompt injection, backlog seeding, exporter section, analyzer wiring); `make test` green except the pre-existing date-dependent standup failure; `make lint` clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "1.7.0"
+version = "2.0.0"
 description = "A terminal-based AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/agent/ceremony_history.py
+++ b/src/scrum_agent/agent/ceremony_history.py
@@ -1,0 +1,255 @@
+"""Team ceremony history (Daily Standup + Retro) for Planning & Analysis.
+
+# See README: "Session Management" — SQLite persistence
+# See README: "Prompt Construction" — ARC framework (optional context sections)
+
+Standup and Retro modes each persist a report per run to the shared
+``~/.scrum-agent/sessions.db``. This module reads that history back **team-wide**
+(across all sessions, retros prioritised project-first) and distils it into
+deterministic signals the Planning analyzer / sprint planner and the Analysis
+report can consume:
+
+- **action_items** — deduped, unresolved retro action-item card texts (newest wins),
+  fed to the story writer to seed the backlog (badged ``[Retro]``).
+- **themes** — recurring "what went well" / "what didn't go well" topics.
+- **cadence** — how often retros / standups actually run (from run timestamps).
+- **confidence_trend** — average sprint-confidence from standups and its direction.
+
+Design mirrors ``agent/repo_signals.py``: a graceful I/O entry point
+(``gather_ceremony_context``) that never raises, plus pure helpers that are
+trivially unit-testable. Cadence is derived from the *intervals between runs*, so
+it needs no notion of "now" and is fully deterministic.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+# Minimum times a normalised card text must recur to count as a "theme".
+_THEME_MIN_COUNT = 2
+# How many themes to surface per grid.
+_MAX_THEMES = 5
+
+
+@dataclass
+class CeremonyContext:
+    """Distilled, deterministic view of the team's recent standups + retros.
+
+    Transient — never persisted. ``summary_md`` is the block injected into the
+    planning prompts; ``action_items`` seed the backlog; the rest drives the
+    Analysis "Ceremony Cadence & Trends" section.
+    """
+
+    summary_md: str = ""
+    action_items: tuple[str, ...] = ()
+    retro_count: int = 0
+    standup_count: int = 0
+    retro_cadence: str = ""
+    standup_cadence: str = ""
+    confidence_trend: str = ""
+    went_well_themes: tuple[tuple[str, int], ...] = ()
+    didnt_go_well_themes: tuple[tuple[str, int], ...] = ()
+
+    @property
+    def is_empty(self) -> bool:
+        return self.retro_count == 0 and self.standup_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no I/O, deterministic (no dependence on the current time).
+# ---------------------------------------------------------------------------
+
+
+def _normalise(text: str) -> str:
+    """Lowercase + collapse whitespace so near-identical cards group together."""
+    return " ".join((text or "").lower().split())
+
+
+def _parse_ts(value: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp, tolerating a trailing 'Z'."""
+    try:
+        return datetime.fromisoformat((value or "").replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def _avg_interval_days(run_ats: list[str]) -> float | None:
+    """Average gap in days between consecutive runs (order-independent).
+
+    Returns None when fewer than two parseable timestamps are present.
+    """
+    stamps = sorted(ts for ts in (_parse_ts(r) for r in run_ats) if ts is not None)
+    if len(stamps) < 2:
+        return None
+    gaps = [(b - a).total_seconds() / 86400.0 for a, b in zip(stamps, stamps[1:], strict=False)]
+    return sum(gaps) / len(gaps) if gaps else None
+
+
+def _describe_cadence(run_ats: list[str], noun: str) -> str:
+    """Human phrase for how often something runs (e.g. "~every 14 days over 4 runs")."""
+    count = len([r for r in run_ats if _parse_ts(r) is not None])
+    if count == 0:
+        return f"no {noun}s recorded"
+    if count == 1:
+        return f"1 {noun} recorded (not yet a cadence)"
+    avg = _avg_interval_days(run_ats)
+    if avg is None:
+        return f"{count} {noun}s recorded"
+    if avg < 1:
+        freq = "roughly daily"
+    elif avg <= 10:
+        freq = f"~every {round(avg)} day(s)"
+    else:
+        freq = f"~every {round(avg / 7)} week(s)"
+    return f"{freq} ({count} {noun}s)"
+
+
+def _confidence_trend(history: list[dict]) -> tuple[str, int | None]:
+    """Average sprint-confidence + direction from standup history (newest first).
+
+    Compares the recent half to the older half. Returns (phrase, avg_pct) — or
+    ("", None) when there isn't enough data.
+    """
+    pcts = [int(h.get("confidence_pct", 0)) for h in history if h.get("status", "success") == "success"]
+    pcts = [p for p in pcts if p > 0]
+    if not pcts:
+        return "", None
+    avg = round(sum(pcts) / len(pcts))
+    if len(pcts) < 4:
+        return f"{avg}% average confidence", avg
+    # history is newest-first: the first half is the recent window.
+    mid = len(pcts) // 2
+    recent = sum(pcts[:mid]) / mid
+    older = sum(pcts[mid:]) / (len(pcts) - mid)
+    delta = recent - older
+    direction = "improving" if delta >= 5 else ("declining" if delta <= -5 else "flat")
+    return f"{avg}% average confidence, {direction}", avg
+
+
+def _top_themes(reports, grid: str) -> tuple[tuple[str, int], ...]:
+    """Most frequent (normalised) card texts in a grid across reports.
+
+    Returns (representative_text, count) pairs for texts recurring at least
+    ``_THEME_MIN_COUNT`` times, most frequent first, capped at ``_MAX_THEMES``.
+    """
+    counts: Counter[str] = Counter()
+    representative: dict[str, str] = {}
+    for report in reports:
+        for card in report.cards:
+            if card.grid != grid or not card.text.strip():
+                continue
+            key = _normalise(card.text)
+            counts[key] += 1
+            representative.setdefault(key, card.text.strip())
+    themes = [(representative[k], n) for k, n in counts.most_common() if n >= _THEME_MIN_COUNT]
+    return tuple(themes[:_MAX_THEMES])
+
+
+def _dedup_action_items(reports) -> tuple[str, ...]:
+    """Distinct action-item card texts across reports, newest-report first.
+
+    ``reports`` is newest-first; the first occurrence of each normalised text
+    wins so the freshest wording is kept. AI-suggested and human cards both count.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for report in reports:
+        for card in report.cards:
+            if card.grid != "action_items":
+                continue
+            text = card.text.strip()
+            key = _normalise(text)
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            out.append(text)
+    return tuple(out)
+
+
+def _bullets(items) -> str:
+    return "\n".join(f"- {it}" for it in items)
+
+
+def format_ceremony_history_md(ctx: CeremonyContext) -> str:
+    """Render a CeremonyContext into the markdown block injected into prompts."""
+    if ctx.is_empty:
+        return ""
+    parts: list[str] = []
+    if ctx.action_items:
+        parts.append("**Open retro action items:**\n" + _bullets(ctx.action_items))
+    if ctx.didnt_go_well_themes:
+        parts.append(
+            "**Recurring pain points (retro 'didn't go well'):**\n"
+            + _bullets(f"{t} ({n}×)" for t, n in ctx.didnt_go_well_themes)
+        )
+    if ctx.went_well_themes:
+        parts.append(
+            "**What's been working (retro 'went well'):**\n" + _bullets(f"{t} ({n}×)" for t, n in ctx.went_well_themes)
+        )
+    if ctx.confidence_trend:
+        parts.append(f"**Recent standup confidence:** {ctx.confidence_trend}.")
+    cadence_bits = [b for b in (ctx.retro_cadence, ctx.standup_cadence) if b]
+    if cadence_bits:
+        parts.append("**Cadence:** retros " + ctx.retro_cadence + "; standups " + ctx.standup_cadence + ".")
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# I/O entry point — graceful (never raises); mirrors repo_signals.scan_*.
+# ---------------------------------------------------------------------------
+
+
+def gather_ceremony_context(
+    project_name: str = "", *, retro_limit: int = 5, standup_limit: int = 10
+) -> CeremonyContext:
+    """Read the team's recent retros + standups and distil them (team-wide).
+
+    Retros are fetched project-first (matching ``project_name`` sort ahead of
+    others); standups are recency-based (their table has no project column).
+    Graceful: a missing DB / empty tables / any error yields an empty context —
+    planning/analysis then behave exactly as before.
+
+    # See README: "Session Management" — SQLite persistence
+    """
+    try:
+        from scrum_agent.config import get_sessions_db
+        from scrum_agent.retro.store import RetroStore
+        from scrum_agent.standup.store import StandupStore
+
+        db_path = get_sessions_db()
+        if not db_path.exists():
+            return CeremonyContext()
+
+        with RetroStore(db_path) as rstore:
+            retros = rstore.get_recent_reports(retro_limit, project_name)
+            retro_hist = rstore.get_all_history(100)
+        with StandupStore(db_path) as sstore:
+            standups = sstore.get_recent_reports(standup_limit)
+            standup_hist = sstore.get_all_history(100)
+    except Exception:  # noqa: BLE001 — ceremony history is best-effort; never abort a plan
+        logger.debug("gather_ceremony_context failed (non-fatal)", exc_info=True)
+        return CeremonyContext()
+
+    ctx = CeremonyContext(
+        action_items=_dedup_action_items(retros),
+        retro_count=len(retros),
+        standup_count=len(standups),
+        retro_cadence=_describe_cadence([h["run_at"] for h in retro_hist], "retro"),
+        standup_cadence=_describe_cadence([h["run_at"] for h in standup_hist], "standup"),
+        confidence_trend=_confidence_trend(standup_hist)[0],
+        went_well_themes=_top_themes(retros, "went_well"),
+        didnt_go_well_themes=_top_themes(retros, "didnt_go_well"),
+    )
+    ctx.summary_md = format_ceremony_history_md(ctx)
+    logger.info(
+        "ceremony_history: %d retro(s), %d standup(s), %d action item(s)",
+        ctx.retro_count,
+        ctx.standup_count,
+        len(ctx.action_items),
+    )
+    return ctx

--- a/src/scrum_agent/agent/nodes.py
+++ b/src/scrum_agent/agent/nodes.py
@@ -1057,7 +1057,7 @@ def _fetch_active_sprint_number(preferred: str = "") -> tuple[int | None, str | 
 
 
 # ---------------------------------------------------------------------------
-# Intake-mode helpers — Small project / Epic wide / Offline.
+# Intake-mode helpers — Small project / Large / Offline.
 # See README: "Project Intake Questionnaire" — intake modes.
 #
 # "small_project" is a lightweight mode for 1-2 tickets in one quick sprint.
@@ -1071,7 +1071,7 @@ def _fetch_active_sprint_number(preferred: str = "") -> tuple[int | None, str | 
 def _essentials_for_mode(intake_mode: str) -> frozenset[int]:
     """Return the essential-question set for the given intake mode.
 
-    Smart (Epic wide) is the default; quick and small_project are leaner subsets.
+    Smart (Large) is the default; quick and small_project are leaner subsets.
     """
     if intake_mode == "quick":
         return QUICK_ESSENTIALS
@@ -3233,7 +3233,7 @@ def _show_summary_or_pto(questionnaire: QuestionnaireState, prefix: str = "") ->
 
 
 def apply_epic_switch(graph_state: dict) -> None:
-    """Reset session state to switch from Small project → Epic wide intake.
+    """Reset session state to switch from Small project → Large intake.
 
     See README: "Guardrails" — human-in-the-loop (advisory)
 
@@ -3270,7 +3270,7 @@ def apply_epic_switch(graph_state: dict) -> None:
 
 
 def _reopen_intake_for_epic(state: ScrumState, questionnaire: QuestionnaireState) -> dict:
-    """Ask the next Epic essential after a Small → Epic switch (no answer to record).
+    """Ask the next Large-mode essential after a Small → Large switch (no answer to record).
 
     Reuses the same gap-finding helpers as the smart-mode intake loop. Dynamic
     Q27 tracker menus are populated on the subsequent normal gap pass, so here we
@@ -3281,23 +3281,23 @@ def _reopen_intake_for_epic(state: ScrumState, questionnaire: QuestionnaireState
     essential_set = _essentials_for_mode(questionnaire.intake_mode)
     gaps = _find_essential_gaps(questionnaire, essential_set)
     if not gaps:
-        # Every Epic essential is already answered — go straight to the summary
+        # Every Large-mode essential is already answered — go straight to the summary
         # (with bank-holiday detection + PTO, which Small mode had skipped).
         _prepare_bank_holiday_choices(questionnaire)
         return _show_summary_or_pto(
             questionnaire,
-            prefix="Switched to **Epic wide** — using your existing answers.\n\n",
+            prefix="Switched to **Large** — using your existing answers.\n\n",
         )
     prompt_text, q_nums = _build_gap_prompt(gaps, questionnaire)
     questionnaire._pending_merged_questions = q_nums
     questionnaire.current_question = q_nums[0]
-    logger.info("Small→Epic switch: asking remaining Epic essentials %s", sorted(gaps))
+    logger.info("Small→Large switch: asking remaining Large-mode essentials %s", sorted(gaps))
     return {
         "questionnaire": questionnaire,
         "messages": [
             AIMessage(
                 content=(
-                    "Switched to **Epic wide** — I kept all your answers. "
+                    "Switched to **Large** — I kept all your answers. "
                     "Just a few more questions for the fuller plan:\n\n" + prompt_text
                 )
             )
@@ -3358,13 +3358,13 @@ def project_intake(state: ScrumState) -> dict:
     else:
         _pending_tracker_pref = ""
 
-    # ── Small project → Epic wide switch re-entry ────────────────────────
+    # ── Small project → Large switch re-entry ────────────────────────
     # See README: "Guardrails" — human-in-the-loop (advisory)
     #
     # When the user switched modes at the analysis review, the questionnaire is
     # re-opened in Epic (smart) mode with all Small-project answers preserved.
     # There's no answer to record on this pass — jump straight to asking the
-    # remaining Epic essentials (Q7/Q10/Q27), or the summary if none are missing.
+    # remaining Large-mode essentials (Q7/Q10/Q27), or the summary if none are missing.
     if questionnaire is not None and getattr(questionnaire, "_reopen_for_epic", False):
         return _reopen_intake_for_epic(state, questionnaire)
 
@@ -5491,7 +5491,7 @@ def project_analyzer(state: ScrumState) -> dict:
     # downstream nodes stay lean — but FIRST read the analyzer's honest size
     # estimate. If it judged the project bigger (needs feature grouping, >2
     # sprints, or many goals), we set _small_project_oversized so the analysis
-    # review can advise switching to Epic wide (answers are preserved on switch).
+    # review can advise switching to Large (answers are preserved on switch).
     small_mode = _is_small_project_mode(state.get("_intake_mode"))
     oversized = False
     honest_target = analysis.target_sprints
@@ -5515,7 +5515,7 @@ def project_analyzer(state: ScrumState) -> dict:
     )
 
     # When the Small-project scope looks bigger than 1-2 tickets, append a
-    # non-blocking advisory. The analysis review adds a "Switch to Epic wide"
+    # non-blocking advisory. The analysis review adds a "Switch to Large"
     # action (see _phases_review / _review) — switching preserves the user's
     # answers so they never re-type anything.
     if oversized:
@@ -5524,7 +5524,7 @@ def project_analyzer(state: ScrumState) -> dict:
             "> ⚠ **This looks bigger than a small project.**\n"
             f"> Your answers point to multiple feature areas (~{honest_target} sprint(s) of work).\n"
             "> Small-project mode will keep this as a flat 1-2 ticket plan. You can\n"
-            "> **continue** as a small project, or **switch to Epic wide** for full\n"
+            "> **continue** as a small project, or **switch to Large** for full\n"
             "> epic / story / sprint planning — your answers are kept, nothing is re-typed."
         )
 

--- a/src/scrum_agent/agent/nodes.py
+++ b/src/scrum_agent/agent/nodes.py
@@ -24,7 +24,9 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from langchain_core.tools import BaseTool
 from langgraph.graph import END
 
+from scrum_agent.agent.ceremony_history import gather_ceremony_context
 from scrum_agent.agent.llm import get_llm
+from scrum_agent.agent.repo_signals import analyze_context, scan_repo_signals
 from scrum_agent.agent.state import (
     DOD_ITEMS,
     PHASE_QUESTION_RANGES,
@@ -67,6 +69,7 @@ from scrum_agent.prompts.intake import (
     QUICK_ESSENTIALS,
     QUICK_FALLBACK_DEFAULTS,
     SCRUM_MD_HINT,
+    SMALL_PROJECT_ESSENTIALS,
     SMART_ESSENTIALS,
     AnswerSource,
     ValidationWarning,
@@ -1053,6 +1056,35 @@ def _fetch_active_sprint_number(preferred: str = "") -> tuple[int | None, str | 
     return None, None, "No tracker configured"
 
 
+# ---------------------------------------------------------------------------
+# Intake-mode helpers — Small project / Epic wide / Offline.
+# See README: "Project Intake Questionnaire" — intake modes.
+#
+# "small_project" is a lightweight mode for 1-2 tickets in one quick sprint.
+# It reuses the smart-intake extraction engine but asks fewer questions
+# (SMALL_PROJECT_ESSENTIALS) and switches OFF the capacity machinery: no bank
+# holidays, no PTO, no per-sprint velocity, no capacity-overflow advisory.
+# "smart" is the Epic-wide engine (full capacity planning), unchanged.
+# ---------------------------------------------------------------------------
+
+
+def _essentials_for_mode(intake_mode: str) -> frozenset[int]:
+    """Return the essential-question set for the given intake mode.
+
+    Smart (Epic wide) is the default; quick and small_project are leaner subsets.
+    """
+    if intake_mode == "quick":
+        return QUICK_ESSENTIALS
+    if intake_mode == "small_project":
+        return SMALL_PROJECT_ESSENTIALS
+    return SMART_ESSENTIALS
+
+
+def _is_small_project_mode(intake_mode: str | None) -> bool:
+    """True when the intake is running in the lightweight Small-project mode."""
+    return intake_mode == "small_project"
+
+
 def _extract_capacity_deductions(questionnaire: QuestionnaireState) -> dict:
     """Parse all capacity questions (Q27-Q30) from intake answers.
 
@@ -1069,6 +1101,18 @@ def _extract_capacity_deductions(questionnaire: QuestionnaireState) -> dict:
     Returns:
         A dict with all capacity fields for ScrumState.
     """
+    # Small-project mode does no capacity planning — return zero deductions so
+    # net velocity equals gross velocity (no bank holidays / PTO / discovery tax).
+    if _is_small_project_mode(questionnaire.intake_mode):
+        return {
+            "capacity_bank_holiday_days": 0,
+            "capacity_planned_leave_days": 0,
+            "capacity_unplanned_leave_pct": 0,
+            "capacity_onboarding_engineer_sprints": 0,
+            "capacity_ktlo_engineers": 0,
+            "capacity_discovery_pct": 0,
+        }
+
     # Q28 — bank holidays (auto-detected, confirmed by user as a choice)
     # The _detected_bank_holiday_days transient field is set during Q28 processing.
     # Fall back to parsing the Q28 answer text for a count.
@@ -2017,6 +2061,40 @@ def _scan_repo_context(questionnaire: QuestionnaireState) -> tuple[str | None, d
     return None, {"name": "Repository", "status": "error", "detail": f"{platform} scan returned no data"}
 
 
+def _apply_repo_signals(qs: QuestionnaireState) -> None:
+    """Scan the repo once at intake and apply repo-informed suggestions.
+
+    Runs `repo_signals.scan_repo_signals` (graceful — never raises, no-ops when
+    no repo is configured/available), stashes the raw scan + low-code verdict on
+    the questionnaire for `project_analyzer` to reuse, and pre-fills:
+
+    - **Q11 (tech stack)** — the detected stack as a *suggestion* (shown when Q11
+      is asked; the user confirms or overrides). Only when the user hasn't
+      already given / been suggested a stack.
+    - **Q12 (integrations)** — manifest-detected SDKs, auto-applied so they
+      surface (editable) in the confirmation summary. Only when Q12 is unanswered.
+
+    # See README: "Project Intake Questionnaire" — smart intake
+    """
+    try:
+        raw_context, signals, _status = scan_repo_signals(qs)
+    except Exception:  # noqa: BLE001 — scan is best-effort; never block intake
+        logger.debug("repo_signals scan failed (non-fatal)", exc_info=True)
+        return
+
+    qs._repo_context = raw_context or ""
+    qs._repo_low_code = signals.low_code
+    qs._repo_low_code_reason = signals.low_code_reasons[0] if signals.low_code_reasons else ""
+
+    if signals.detected_stack and 11 not in qs.answers and 11 not in qs.suggested_answers:
+        qs.suggested_answers[11] = ", ".join(signals.detected_stack)
+        logger.info("repo_signals: suggested tech stack for Q11: %s", signals.detected_stack)
+
+    if signals.integrations and 12 not in qs.answers:
+        _auto_apply_extractions(qs, {12: ", ".join(signals.integrations)})
+        logger.info("repo_signals: applied integrations for Q12: %s", signals.integrations)
+
+
 def _sync_platform_from_url(questionnaire: QuestionnaireState) -> None:
     """Auto-update Q16 (platform) when Q17 (repo URL) is stored.
 
@@ -2306,6 +2384,15 @@ def _prepare_bank_holiday_choices(questionnaire: QuestionnaireState) -> None:
     Args:
         questionnaire: The mutable QuestionnaireState to update.
     """
+    # Small-project mode skips bank-holiday planning entirely. Zero the
+    # transient fields so downstream capacity code sees "no holidays" and the
+    # confirmation summary shows no bank-holiday line. This single guard
+    # neutralizes every _prepare_bank_holiday_choices call site for Small mode.
+    if _is_small_project_mode(questionnaire.intake_mode):
+        questionnaire._detected_bank_holiday_days = 0
+        questionnaire._detected_bank_holidays = []
+        return
+
     from scrum_agent.tools.calendar_tools import detect_bank_holidays
 
     q8 = questionnaire.answers.get(8, "2 weeks")
@@ -2873,20 +2960,26 @@ def _build_intake_summary(questionnaire: QuestionnaireState) -> str:
 
         # Use override if set
         override = questionnaire._velocity_override
-        net_vel, breakdown = _build_velocity_breakdown(
-            velocity_per_sprint=vel,
-            velocity_source=velocity_source,
-            team_size=ts,
-            sprint_length_weeks=sprint_weeks,
-            target_sprints=target,
-            bank_holiday_days=capacity["capacity_bank_holiday_days"],
-            planned_leave_days=capacity["capacity_planned_leave_days"],
-            unplanned_leave_pct=capacity["capacity_unplanned_leave_pct"],
-            onboarding_engineer_sprints=capacity["capacity_onboarding_engineer_sprints"],
-            ktlo_engineers=capacity["capacity_ktlo_engineers"],
-            discovery_pct=capacity["capacity_discovery_pct"],
-            planned_leave_entries=list(questionnaire._planned_leave_entries),
-        )
+        if _is_small_project_mode(questionnaire.intake_mode):
+            # Small-project mode does no capacity planning — net equals gross
+            # velocity and there is no bank-holiday / PTO / discovery breakdown.
+            net_vel = vel
+            breakdown = f"**Small project** — no bank-holiday or capacity deductions (using {vel} pts/sprint)."
+        else:
+            net_vel, breakdown = _build_velocity_breakdown(
+                velocity_per_sprint=vel,
+                velocity_source=velocity_source,
+                team_size=ts,
+                sprint_length_weeks=sprint_weeks,
+                target_sprints=target,
+                bank_holiday_days=capacity["capacity_bank_holiday_days"],
+                planned_leave_days=capacity["capacity_planned_leave_days"],
+                unplanned_leave_pct=capacity["capacity_unplanned_leave_pct"],
+                onboarding_engineer_sprints=capacity["capacity_onboarding_engineer_sprints"],
+                ktlo_engineers=capacity["capacity_ktlo_engineers"],
+                discovery_pct=capacity["capacity_discovery_pct"],
+                planned_leave_entries=list(questionnaire._planned_leave_entries),
+            )
 
         if override is not None:
             display_vel = override
@@ -3102,9 +3195,11 @@ def _show_summary_or_pto(questionnaire: QuestionnaireState, prefix: str = "") ->
     # After PTO is resolved (or skipped), the confirmation summary is shown
     # with the velocity choice menu as usual.
     """
-    # Check if PTO should be asked before the summary
+    # Check if PTO should be asked before the summary. Quick and small_project
+    # modes skip PTO — small_project does no capacity planning at all, quick
+    # auto-defaults to "no planned leave".
     if (
-        questionnaire.intake_mode != "quick"
+        questionnaire.intake_mode not in ("quick", "small_project")
         and not questionnaire._leave_input_stage
         and not questionnaire._awaiting_leave_input
         and not questionnaire._planned_leave_entries
@@ -3134,6 +3229,79 @@ def _show_summary_or_pto(questionnaire: QuestionnaireState, prefix: str = "") ->
         "questionnaire": questionnaire,
         "messages": [AIMessage(content=f"{prefix}{summary}{_CONFIRM_PROMPT}")],
         "pending_review": "project_intake",
+    }
+
+
+def apply_epic_switch(graph_state: dict) -> None:
+    """Reset session state to switch from Small project → Epic wide intake.
+
+    See README: "Guardrails" — human-in-the-loop (advisory)
+
+    Called when the user accepts the "this looks bigger than a small project"
+    advisory. Preserves the questionnaire ANSWERS and project description (so the
+    user re-types nothing), flips the mode to Epic (smart), and clears the
+    analysis + downstream artifacts so the pipeline regenerates them. The
+    _reopen_for_epic flag tells project_intake to ask only the still-missing Epic
+    essentials on the next pass.
+    """
+    qs = graph_state.get("questionnaire")
+    if qs is not None:
+        qs.intake_mode = "smart"
+        qs.completed = False
+        qs.awaiting_confirmation = False
+        qs.editing_question = None
+        qs._reopen_for_epic = True
+    graph_state["_intake_mode"] = "smart"
+    # Drop the analysis + all generated artifacts + review bookkeeping so the
+    # pipeline re-runs cleanly under Epic-wide rules. Answers are untouched.
+    for key in (
+        "project_analysis",
+        "features",
+        "stories",
+        "tasks",
+        "sprints",
+        "pending_review",
+        "_small_project_oversized",
+        "_epic_reviewed",
+        "last_review_decision",
+        "last_review_feedback",
+    ):
+        graph_state.pop(key, None)
+
+
+def _reopen_intake_for_epic(state: ScrumState, questionnaire: QuestionnaireState) -> dict:
+    """Ask the next Epic essential after a Small → Epic switch (no answer to record).
+
+    Reuses the same gap-finding helpers as the smart-mode intake loop. Dynamic
+    Q27 tracker menus are populated on the subsequent normal gap pass, so here we
+    just surface the first missing essential (or the summary if none remain).
+    """
+    questionnaire._reopen_for_epic = False
+    questionnaire.awaiting_confirmation = False
+    essential_set = _essentials_for_mode(questionnaire.intake_mode)
+    gaps = _find_essential_gaps(questionnaire, essential_set)
+    if not gaps:
+        # Every Epic essential is already answered — go straight to the summary
+        # (with bank-holiday detection + PTO, which Small mode had skipped).
+        _prepare_bank_holiday_choices(questionnaire)
+        return _show_summary_or_pto(
+            questionnaire,
+            prefix="Switched to **Epic wide** — using your existing answers.\n\n",
+        )
+    prompt_text, q_nums = _build_gap_prompt(gaps, questionnaire)
+    questionnaire._pending_merged_questions = q_nums
+    questionnaire.current_question = q_nums[0]
+    logger.info("Small→Epic switch: asking remaining Epic essentials %s", sorted(gaps))
+    return {
+        "questionnaire": questionnaire,
+        "messages": [
+            AIMessage(
+                content=(
+                    "Switched to **Epic wide** — I kept all your answers. "
+                    "Just a few more questions for the fuller plan:\n\n" + prompt_text
+                )
+            )
+        ],
     }
 
 
@@ -3190,6 +3358,16 @@ def project_intake(state: ScrumState) -> dict:
     else:
         _pending_tracker_pref = ""
 
+    # ── Small project → Epic wide switch re-entry ────────────────────────
+    # See README: "Guardrails" — human-in-the-loop (advisory)
+    #
+    # When the user switched modes at the analysis review, the questionnaire is
+    # re-opened in Epic (smart) mode with all Small-project answers preserved.
+    # There's no answer to record on this pass — jump straight to asking the
+    # remaining Epic essentials (Q7/Q10/Q27), or the summary if none are missing.
+    if questionnaire is not None and getattr(questionnaire, "_reopen_for_epic", False):
+        return _reopen_intake_for_epic(state, questionnaire)
+
     if questionnaire is None:
         # First call — initialize questionnaire and attempt adaptive skip.
         # See README: "Project Intake Questionnaire" — adaptive skip logic
@@ -3205,9 +3383,13 @@ def project_intake(state: ScrumState) -> dict:
             qs._preferred_tracker = _pending_tracker_pref
 
         # Read intake_mode from the REPL-injected state key.
-        # Default to "standard" for backward compatibility with tests that
-        # don't set _intake_mode.
-        intake_mode = state.get("_intake_mode", "standard")
+        # The legacy 30-question "standard" flow has been retired — smart intake
+        # is the single interactive path. Default to (and coerce any legacy
+        # "standard" / unknown value from old sessions to) "smart" so the
+        # pipeline always follows one code path below.
+        intake_mode = state.get("_intake_mode") or "smart"
+        if intake_mode not in ("smart", "quick", "small_project"):
+            intake_mode = "smart"
         qs.intake_mode = intake_mode
 
         # Extract initial description from the first message (if present).
@@ -3293,7 +3475,7 @@ def project_intake(state: ScrumState) -> dict:
         # In smart/quick mode, extracted answers are auto-accepted (not
         # shown for confirmation). Defaults are auto-applied to all
         # non-essential questions. Only essential gaps are asked.
-        if intake_mode in ("smart", "quick"):
+        if intake_mode in ("smart", "quick", "small_project"):
             logger.debug("BANK_HOLIDAY: entering %s intake mode", intake_mode)
             # Store SCRUM.md provenance so the preamble can report it
             qs._scrum_md_questions = _scrum_md_contributed
@@ -3304,7 +3486,7 @@ def project_intake(state: ScrumState) -> dict:
                 qs.answer_sources[1] = AnswerSource.EXTRACTED
 
             # Pick essential set based on mode (needed before extraction split)
-            essential_set = QUICK_ESSENTIALS if intake_mode == "quick" else SMART_ESSENTIALS
+            essential_set = _essentials_for_mode(intake_mode)
             # If analysis provides velocity, skip Q9 from essentials (auto-accept).
             # Q11 (tech stack) stays essential so it appears as a suggestion
             # the user can confirm or override.
@@ -3329,6 +3511,16 @@ def project_intake(state: ScrumState) -> dict:
 
             # Auto-default all non-essential, non-answered questions
             _auto_default_remaining(qs, essential_set, fallbacks)
+
+            # ── Repository-informed suggestions ──────────────────────────
+            # Scan the project's repo (the Q17 URL, or a configured GitHub repo)
+            # and derive a suggested tech stack + integrations, plus a low-code
+            # verdict. Graceful: no configured/available repo → a no-op that only
+            # applies description-based low-code markers. Runs once here at first
+            # invocation; the raw scan + verdict are stashed on the questionnaire
+            # for project_analyzer to reuse (avoids a second live scan).
+            # See README: "Project Intake Questionnaire" — smart intake
+            _apply_repo_signals(qs)
 
             # Derive Q15 from Q2 if available
             _derive_q15_from_q2(qs)
@@ -3504,35 +3696,9 @@ def project_intake(state: ScrumState) -> dict:
                 "messages": [AIMessage(content=f"{preamble}{remaining_text}\n\n{prompt_text}")],
             }
 
-        # ── Standard mode first-invocation (original 26-Q flow) ─────
-        if extracted:
-            # Store extracted answers as confirmable suggestions — the user
-            # will see each one inline and can press Enter to confirm or
-            # type a different answer. Questions are NOT skipped.
-            qs.suggested_answers.update(extracted)
-
-        # Always start at Q1 — even with suggestions, we walk through
-        # every question so the user can confirm or override.
-        question = INTAKE_QUESTIONS[1]
-        phase_label = PHASE_LABELS[qs.current_phase]
-        phase_intro = PHASE_INTROS.get(qs.current_phase, "")
-        intro_line = f"*{phase_intro}*\n\n" if phase_intro else ""
-
-        # If Q1 has a suggestion from the description, show it inline
-        suggestion = qs.suggested_answers.get(1)
-        suggest_line = f"\n\n> Suggested: **{suggestion}**" if suggestion else ""
-
-        preamble = ""
-        if extracted:
-            preamble = (
-                f"I picked up **{len(extracted)}** detail(s) from your description "
-                "— I'll show each one for you to confirm or change.\n\n"
-            )
-
-        return {
-            "questionnaire": qs,
-            "messages": [AIMessage(content=f"{preamble}**{phase_label}**\n\n{intro_line}{question}{suggest_line}")],
-        }
+        # NOTE: the legacy "standard" (30-question, one-at-a-time) first-invocation
+        # flow used to live here. It has been retired — intake_mode is coerced to
+        # smart/quick/small_project above, so the branch just above always returns.
 
     # Record the user's answer to the current question.
     # The last message in state is always the HumanMessage with the user's reply.
@@ -3579,7 +3745,7 @@ def project_intake(state: ScrumState) -> dict:
     # answer, derive Q15 if Q2 was just answered, then find the next
     # gap or show the summary.
     if (
-        questionnaire.intake_mode in ("smart", "quick")
+        questionnaire.intake_mode in ("smart", "quick", "small_project")
         and not questionnaire.awaiting_confirmation
         and questionnaire.editing_question is None
     ):
@@ -3802,7 +3968,7 @@ def project_intake(state: ScrumState) -> dict:
             questionnaire._follow_up_choices.pop(28, None)
 
         # Find remaining essential gaps
-        essential_set = QUICK_ESSENTIALS if questionnaire.intake_mode == "quick" else SMART_ESSENTIALS
+        essential_set = _essentials_for_mode(questionnaire.intake_mode)
         gaps = _find_essential_gaps(questionnaire, essential_set)
 
         if not gaps:
@@ -4170,8 +4336,6 @@ def project_intake(state: ScrumState) -> dict:
         ts = extracted.get("team_size", 1)
         vel = extracted.get("velocity_per_sprint", ts * _VELOCITY_PER_ENGINEER)
         sprint_weeks = _parse_first_int(questionnaire.answers.get(8, "2 weeks")) or 2
-        q10_nums = re.findall(r"\d+", questionnaire.answers.get(10, ""))
-        target = int(q10_nums[-1]) if q10_nums else 6
 
         # Determine sprint start date — use _resolve_sprint_start_date which
         # computes the offset for future sprints (e.g. Sprint 107 when active is 104).
@@ -4182,50 +4346,61 @@ def project_intake(state: ScrumState) -> dict:
         if sprint_num_match:
             starting_sprint = int(sprint_num_match.group(1))
 
-        # Map detected holidays and PTO to sprint windows for per-sprint velocity
-        holidays_by_sprint = _assign_holidays_to_sprints(
-            questionnaire._detected_bank_holidays,
-            sprint_start,
-            sprint_weeks,
-            target,
-        )
-        leave_by_sprint = _assign_leave_to_sprints(
-            questionnaire._planned_leave_entries,
-            sprint_start,
-            sprint_weeks,
-            target,
-        )
-        sprint_caps = _compute_per_sprint_velocities(
-            team_size=ts,
-            velocity_per_sprint=vel,
-            sprint_length_weeks=sprint_weeks,
-            target_sprints=target,
-            holidays_by_sprint=holidays_by_sprint,
-            planned_leave_days=capacity["capacity_planned_leave_days"],
-            unplanned_leave_pct=capacity["capacity_unplanned_leave_pct"],
-            onboarding_engineer_sprints=capacity["capacity_onboarding_engineer_sprints"],
-            ktlo_engineers=capacity["capacity_ktlo_engineers"],
-            discovery_pct=capacity["capacity_discovery_pct"],
-            leave_by_sprint=leave_by_sprint,
-        )
-
-        # Use minimum per-sprint velocity as the conservative net velocity
-        # (for backward compat and capacity overflow checks)
-        if sprint_caps:
-            net_vel = min(sc["net_velocity"] for sc in sprint_caps)
+        if _is_small_project_mode(questionnaire.intake_mode):
+            # Small-project mode: no capacity planning. Net velocity equals gross,
+            # and there is no per-sprint breakdown (project_analyzer caps the plan
+            # at 1-2 sprints). Leave sprint_caps empty so the sprint_planner uses a
+            # simple velocity × target_sprints allocation.
+            sprint_caps = []
+            net_vel = vel
         else:
-            net_vel = _compute_net_velocity(
+            q10_nums = re.findall(r"\d+", questionnaire.answers.get(10, ""))
+            target = int(q10_nums[-1]) if q10_nums else 6
+
+            # Map detected holidays and PTO to sprint windows for per-sprint velocity
+            holidays_by_sprint = _assign_holidays_to_sprints(
+                questionnaire._detected_bank_holidays,
+                sprint_start,
+                sprint_weeks,
+                target,
+            )
+            leave_by_sprint = _assign_leave_to_sprints(
+                questionnaire._planned_leave_entries,
+                sprint_start,
+                sprint_weeks,
+                target,
+            )
+            sprint_caps = _compute_per_sprint_velocities(
                 team_size=ts,
                 velocity_per_sprint=vel,
                 sprint_length_weeks=sprint_weeks,
                 target_sprints=target,
-                bank_holiday_days=capacity["capacity_bank_holiday_days"],
+                holidays_by_sprint=holidays_by_sprint,
                 planned_leave_days=capacity["capacity_planned_leave_days"],
                 unplanned_leave_pct=capacity["capacity_unplanned_leave_pct"],
                 onboarding_engineer_sprints=capacity["capacity_onboarding_engineer_sprints"],
                 ktlo_engineers=capacity["capacity_ktlo_engineers"],
                 discovery_pct=capacity["capacity_discovery_pct"],
+                leave_by_sprint=leave_by_sprint,
             )
+
+            # Use minimum per-sprint velocity as the conservative net velocity
+            # (for backward compat and capacity overflow checks)
+            if sprint_caps:
+                net_vel = min(sc["net_velocity"] for sc in sprint_caps)
+            else:
+                net_vel = _compute_net_velocity(
+                    team_size=ts,
+                    velocity_per_sprint=vel,
+                    sprint_length_weeks=sprint_weeks,
+                    target_sprints=target,
+                    bank_holiday_days=capacity["capacity_bank_holiday_days"],
+                    planned_leave_days=capacity["capacity_planned_leave_days"],
+                    unplanned_leave_pct=capacity["capacity_unplanned_leave_pct"],
+                    onboarding_engineer_sprints=capacity["capacity_onboarding_engineer_sprints"],
+                    ktlo_engineers=capacity["capacity_ktlo_engineers"],
+                    discovery_pct=capacity["capacity_discovery_pct"],
+                )
 
         # Apply user override if set
         if questionnaire._velocity_override is not None:
@@ -4842,6 +5017,8 @@ def _parse_analysis_response(
             skip_features=bool(parsed.get("skip_features", False))
             and target_sprints <= 2
             and len(to_str_tuple(parsed.get("goals"))) <= 3,
+            is_low_code=bool(parsed.get("is_low_code", False)),
+            low_code_reason=str(parsed.get("low_code_reason", "")),
             scrum_md_contributions=to_str_tuple(parsed.get("scrum_md_contributions")),
         )
 
@@ -4946,10 +5123,16 @@ def _format_analysis(
             return "  - _(none)_"
         return "\n".join(f"  - {item}" for item in items)
 
+    low_code_line = ""
+    if analysis.is_low_code:
+        reason = f" — {analysis.low_code_reason}" if analysis.low_code_reason else ""
+        low_code_line = f"**⚙ Low-code project{reason}** (estimates and tasks scaled lighter)\n\n"
+
     sections = [
         f"# Project Analysis: {analysis.project_name}\n",
         f"**Description:** {analysis.project_description}\n",
         f"**Type:** {analysis.project_type}\n",
+        low_code_line,
         f"## Goals\n{_bullet_list(analysis.goals)}\n",
         f"## End Users\n{_bullet_list(analysis.end_users)}\n",
         f"## Target State\n{analysis.target_state or '_(not specified)_'}\n",
@@ -5194,11 +5377,27 @@ def project_analyzer(state: ScrumState) -> dict:
         review_feedback = parts[0].strip()
         previous_output = parts[1].strip()
 
-    # Scan repo if Q17 has a URL — grounds analysis in real codebase data.
-    # Each function returns (context_str | None, status_dict) so we can track
-    # what sources were used, skipped, or failed for user transparency.
-    # See README: "Tools" — read-only tool pattern
-    repo_context, repo_status = _scan_repo_context(questionnaire)
+    # Repository signals — grounds analysis in real codebase data and drives the
+    # deterministic low-code verdict + the detected-stack hint. To avoid scanning
+    # the repo twice, reuse the raw scan stashed by project_intake if present;
+    # either way analyze_context re-derives the structured signals (cheap, pure)
+    # from the current questionnaire answers.
+    # See README: "Project Intake Questionnaire" — smart intake
+    _stashed_repo_context = getattr(questionnaire, "_repo_context", "")
+    if _stashed_repo_context:
+        repo_context = _stashed_repo_context
+        repo_status = {"name": "Repository", "status": "success", "detail": "reused intake scan"}
+    else:
+        # _scan_repo_context is kept as the analysis-time scan seam (many
+        # integration/golden tests monkeypatch it to skip live scans).
+        repo_context, repo_status = _scan_repo_context(questionnaire)
+    # Re-derive structured signals from the raw scan (pure, no I/O) so the
+    # detected-stack hint and low-code verdict reflect the current answers.
+    repo_signals = analyze_context(
+        repo_context or "",
+        description=questionnaire.answers.get(1, "") or "",
+        tech_stack=questionnaire.answers.get(11, "") or "",
+    )
 
     # Load SCRUM.md first — the user's own project context file. Loaded before
     # Confluence so that any Confluence URLs in SCRUM.md can be fetched directly.
@@ -5228,6 +5427,13 @@ def project_analyzer(state: ScrumState) -> dict:
     )
     team_profile_summary = team_calibration_text.strip()
 
+    # Gather the team's recent Standup + Retro history (team-wide, graceful — an
+    # empty context when nothing has run). Recency-dominant here: pre-analysis we
+    # have no reliable project name to match on, so we pass "" and let the most
+    # recent ceremonies inform the plan. Action items are stashed for story_writer.
+    # See README: "Session Management" — SQLite persistence
+    ceremony = gather_ceremony_context()
+
     # Build the formatted answers block for the prompt
     answers_block = _build_answers_block(questionnaire)
     prompt = get_analyzer_prompt(
@@ -5235,9 +5441,11 @@ def project_analyzer(state: ScrumState) -> dict:
         team_size,
         velocity,
         repo_context=repo_context,
+        detected_stack=repo_signals.detected_stack or None,
         confluence_context=confluence_context,
         user_context=user_context,
         team_profile_summary=team_profile_summary,
+        ceremony_history=ceremony.summary_md,
         review_feedback=review_feedback if review_mode else None,
         review_mode=review_mode,
         previous_output=previous_output,
@@ -5260,6 +5468,41 @@ def project_analyzer(state: ScrumState) -> dict:
     quality = compute_prompt_quality(questionnaire, has_user_context=user_context is not None)
     analysis = dataclasses.replace(analysis, prompt_quality=quality)
 
+    # ── Low-code reconciliation ──────────────────────────────────────────
+    # Three inputs OR together (a strong signal from any one wins): the analyzer
+    # LLM's is_low_code, the deterministic verdict stashed by project_intake's
+    # broadened scan, and a fresh analyze_context pass over the reused raw scan.
+    stashed_low_code = getattr(questionnaire, "_repo_low_code", False)
+    stashed_reason = getattr(questionnaire, "_repo_low_code_reason", "")
+    det_reason = stashed_reason or (repo_signals.low_code_reasons[0] if repo_signals.low_code_reasons else "")
+    final_low_code = analysis.is_low_code or repo_signals.low_code or stashed_low_code
+    if final_low_code != analysis.is_low_code:
+        analysis = dataclasses.replace(analysis, is_low_code=final_low_code)
+    if final_low_code and not analysis.low_code_reason:
+        analysis = dataclasses.replace(analysis, low_code_reason=det_reason)
+    if final_low_code:
+        logger.info("project_analyzer: low-code project detected (reason: %s)", analysis.low_code_reason or det_reason)
+
+    # ── Small-project scope detection & coercion ─────────────────────────
+    # See README: "Guardrails" — human-in-the-loop (advisory)
+    #
+    # In Small-project mode the plan is always kept flat: a single implicit epic
+    # (skip_features) and 1-2 sprints max. We coerce the analysis so the
+    # downstream nodes stay lean — but FIRST read the analyzer's honest size
+    # estimate. If it judged the project bigger (needs feature grouping, >2
+    # sprints, or many goals), we set _small_project_oversized so the analysis
+    # review can advise switching to Epic wide (answers are preserved on switch).
+    small_mode = _is_small_project_mode(state.get("_intake_mode"))
+    oversized = False
+    honest_target = analysis.target_sprints
+    if small_mode:
+        oversized = not analysis.skip_features or analysis.target_sprints > 2 or len(analysis.goals) > 3
+        analysis = dataclasses.replace(
+            analysis,
+            skip_features=True,
+            target_sprints=min(max(analysis.target_sprints or 1, 1), 2),
+        )
+
     # Format the analysis for display — include capacity data so the user
     # sees velocity breakdown and per-sprint bank holiday impact on this screen.
     display = _format_analysis(
@@ -5271,6 +5514,20 @@ def project_analyzer(state: ScrumState) -> dict:
         velocity_source=state.get("velocity_source"),
     )
 
+    # When the Small-project scope looks bigger than 1-2 tickets, append a
+    # non-blocking advisory. The analysis review adds a "Switch to Epic wide"
+    # action (see _phases_review / _review) — switching preserves the user's
+    # answers so they never re-type anything.
+    if oversized:
+        display += (
+            "\n\n---\n\n"
+            "> ⚠ **This looks bigger than a small project.**\n"
+            f"> Your answers point to multiple feature areas (~{honest_target} sprint(s) of work).\n"
+            "> Small-project mode will keep this as a flat 1-2 ticket plan. You can\n"
+            "> **continue** as a small project, or **switch to Epic wide** for full\n"
+            "> epic / story / sprint planning — your answers are kept, nothing is re-typed."
+        )
+
     # Set pending_review so the REPL intercepts the next user input for
     # the [Accept / Edit / Reject] review flow — same pattern as features/stories.
     return_dict: dict = {
@@ -5280,6 +5537,11 @@ def project_analyzer(state: ScrumState) -> dict:
         "sprint_length_weeks": analysis.sprint_length_weeks,
         "target_sprints": analysis.target_sprints,
         "pending_review": "project_analyzer",
+        "_small_project_oversized": oversized,
+        # Unresolved retro action items — story_writer seeds the backlog from these
+        # (badged [Retro]); sprint_planner reuses the ceremony summary for load caution.
+        "_ceremony_action_items": ceremony.action_items,
+        "_ceremony_history": ceremony.summary_md,
         "messages": [AIMessage(content=display)],
         # Context source diagnostics — tells the REPL which external sources
         # were used, skipped, or failed so the user gets transparency.
@@ -6614,6 +6876,8 @@ def story_writer(state: ScrumState) -> dict:
         out_of_scope=_format_epic_list(analysis.out_of_scope),
         team_calibration=team_calibration_text,
         dod_items=_dod,
+        is_low_code=analysis.is_low_code,
+        carry_over_items=tuple(state.get("_ceremony_action_items", ()) or ()),
         review_feedback=review_feedback if review_mode else None,
         review_mode=review_mode,
         previous_output=previous_output,
@@ -6964,6 +7228,7 @@ def _parallel_task_decompose(
     tech_stack: str,
     doc_context: str | None,
     team_calibration: str = "",
+    is_low_code: bool = False,
 ) -> list[Task]:
     """Decompose stories into tasks with parallel LLM calls per feature.
 
@@ -7013,6 +7278,7 @@ def _parallel_task_decompose(
             stories_block=stories_block,
             doc_context=doc_context,
             team_calibration=team_calibration,
+            is_low_code=is_low_code,
         )
 
         try:
@@ -7125,6 +7391,7 @@ def task_decomposer(state: ScrumState) -> dict:
             stories_block=stories_block,
             doc_context=doc_context,
             team_calibration=team_calibration_text,
+            is_low_code=analysis.is_low_code,
             review_feedback=review_feedback,
             review_mode=review_mode,
             previous_output=previous_output,
@@ -7147,6 +7414,7 @@ def task_decomposer(state: ScrumState) -> dict:
             tech_stack=tech_stack_str,
             doc_context=doc_context,
             team_calibration=team_calibration_text,
+            is_low_code=analysis.is_low_code,
         )
 
     # Format the tasks for display
@@ -7834,8 +8102,16 @@ def sprint_planner(state: ScrumState) -> dict:
     elif capacity_override == -1:
         # User rejected — proceed with the original target_sprints but enforce it.
         enforce_target = True
-    elif capacity_override == 0 and target_sprints > 0 and velocity > 0 and not review_mode:
+    elif (
+        capacity_override == 0
+        and target_sprints > 0
+        and velocity > 0
+        and not review_mode
+        and not _is_small_project_mode(state.get("_intake_mode"))
+    ):
         # First time through — check if scope fits in the target.
+        # Small-project mode skips this overflow advisory — it targets 1-2 sprints
+        # of tiny scope, so the "you need more sprints/team" warning is just noise.
         # Use per-sprint velocities for a more accurate capacity check.
         total_points = sum(s.story_points for s in stories)
         if sprint_caps:
@@ -7898,6 +8174,7 @@ def sprint_planner(state: ScrumState) -> dict:
         sprint_capacities=sprint_caps or None,
         team_override_from=original_team_size if state.get("_capacity_team_override", 0) > 0 else None,
         team_calibration=team_calibration_text,
+        ceremony_history=state.get("_ceremony_history", "") or "",
         review_feedback=review_feedback if review_mode else None,
         review_mode=review_mode,
         previous_output=previous_output,

--- a/src/scrum_agent/agent/repo_signals.py
+++ b/src/scrum_agent/agent/repo_signals.py
@@ -1,0 +1,504 @@
+"""Deterministic repository / tech signals for the smart intake.
+
+# See README: "Tools" — read-only tool pattern
+# See README: "Project Intake Questionnaire" — smart intake
+
+The `project_analyzer` node already scans a repository (the URL from Q17) and
+feeds the raw text to the LLM to ground `tech_stack` / `project_type`. This
+module turns that same scan into **structured, deterministic signals** so the
+smart intake can:
+
+1. **Suggest a tech stack** (`detected_stack`) and **integrations**
+   (`integrations`) — pre-filled into Q11 / Q12 via the normal extraction flow,
+   editable at the confirmation summary.
+2. **Detect "low-code" projects** (`low_code`) — mostly configuration / content /
+   no-code-platform work — so the plan can be scaled lighter downstream.
+
+Design: the scan fans out across sources with **graceful per-source skip**,
+mirroring `standup/collector.py` — a missing SDK, bad credentials, or any error
+degrades a source to "skipped" and never raises. The pure `analyze_context()`
+core parses the tool output strings (github_read_repo / read_codebase share one
+`Languages:` / `Key files detected:` format), so it is trivially unit-testable
+without any live API calls.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Marker vocabularies. Kept here (not in prompts/intake.py) because they drive
+# deterministic detection, not prompt text. LAN peers / repo contents are
+# untrusted free text, so every match is a plain case-insensitive word match.
+# ---------------------------------------------------------------------------
+
+# Low-code / no-code platform + content-shop markers. When any appears in the
+# project description, the stated tech stack, or the repo's key files, the
+# project is flagged low-code (mostly configuration / content, little
+# engineering). Multi-word markers are matched as phrases.
+LOW_CODE_MARKERS: frozenset[str] = frozenset(
+    {
+        "salesforce",
+        "apex",
+        "force.com",
+        "power apps",
+        "powerapps",
+        "power automate",
+        "power platform",
+        "sharepoint",
+        "dynamics 365",
+        "zapier",
+        "make.com",
+        "integromat",
+        "workato",
+        "tray.io",
+        "boomi",
+        "retool",
+        "webflow",
+        "wordpress",
+        "wix",
+        "squarespace",
+        "shopify",
+        "magento",
+        "bigcommerce",
+        "airtable",
+        "bubble.io",
+        "mendix",
+        "outsystems",
+        "appsheet",
+        "glide",
+        "softr",
+        "servicenow",
+        "hubspot",
+        "no-code",
+        "no code",
+        "low-code",
+        "low code",
+        "headless cms",
+        "contentful",
+        "sanity",
+        "drupal",
+        "content only",
+        "configuration only",
+        "config-only",
+    }
+)
+
+# Dependency-name substring → integration display name. Applied to fetched
+# manifest contents (package.json / pyproject.toml). Richer than the
+# description-keyword scan in _keyword_extract_fallback because it sees the
+# project's *actual* declared dependencies. Third-party services only — infra
+# libraries (pg, redis) are intentionally omitted to keep this to integrations.
+INTEGRATION_SDK_MARKERS: dict[str, str] = {
+    "stripe": "Stripe",
+    "twilio": "Twilio",
+    "sendgrid": "SendGrid",
+    "mailgun": "Mailgun",
+    "boto3": "AWS",
+    "aws-sdk": "AWS",
+    "firebase": "Firebase",
+    "auth0": "Auth0",
+    "okta": "Okta",
+    "clerk": "Clerk",
+    "plaid": "Plaid",
+    "algolia": "Algolia",
+    "openai": "OpenAI",
+    "anthropic": "Anthropic",
+    "segment": "Segment",
+    "analytics-node": "Segment",
+    "datadog": "Datadog",
+    "dd-trace": "Datadog",
+    "sentry": "Sentry",
+    "pusher": "Pusher",
+    "launchdarkly": "LaunchDarkly",
+    "contentful": "Contentful",
+    "shopify": "Shopify",
+    "slack": "Slack",
+}
+
+# Dependency-name substring → framework/library display name. Applied to
+# manifest contents to enrich `detected_stack` beyond the language breakdown.
+FRAMEWORK_MARKERS: dict[str, str] = {
+    "react": "React",
+    "next": "Next.js",
+    "vue": "Vue",
+    "nuxt": "Nuxt",
+    "@angular": "Angular",
+    "svelte": "Svelte",
+    "express": "Express",
+    "fastify": "Fastify",
+    "nestjs": "NestJS",
+    "fastapi": "FastAPI",
+    "flask": "Flask",
+    "django": "Django",
+    "rails": "Rails",
+    "spring-boot": "Spring Boot",
+    "laravel": "Laravel",
+    "tailwindcss": "Tailwind CSS",
+    "prisma": "Prisma",
+    "sqlalchemy": "SQLAlchemy",
+    "graphql": "GraphQL",
+    "pytorch": "PyTorch",
+    "tensorflow": "TensorFlow",
+    "langchain": "LangChain",
+}
+
+# Key-file basename → tool/platform display name, folded into `detected_stack`.
+KEY_FILE_TOOLS: dict[str, str] = {
+    "Dockerfile": "Docker",
+    "docker-compose.yml": "Docker",
+    "docker-compose.yaml": "Docker",
+    "terraform.tf": "Terraform",
+    "main.tf": "Terraform",
+    "Chart.yaml": "Kubernetes",
+    "vite.config.ts": "Vite",
+    "vite.config.js": "Vite",
+    "webpack.config.js": "Webpack",
+}
+
+# Manifest files whose *contents* we fetch for framework / integration inference.
+MANIFEST_FILES: tuple[str, ...] = ("package.json", "pyproject.toml", "requirements.txt", "Gemfile", "composer.json")
+
+# A repo with at most this many source files and ≤1 detected language reads as
+# "barely any code" — a low-code signal when combined with an actual scan.
+LOW_CODE_MAX_SOURCE_FILES = 6
+
+
+@dataclass
+class RepoSignals:
+    """Structured, deterministic signals derived from a repository scan.
+
+    Transient — never persisted directly. `detected_stack` / `integrations` are
+    folded into the questionnaire as Q11 / Q12 suggestions; `low_code` is
+    reconciled into `ProjectAnalysis.is_low_code` at analysis time.
+    """
+
+    detected_stack: list[str] = field(default_factory=list)
+    integrations: list[str] = field(default_factory=list)
+    low_code: bool = False
+    low_code_reasons: list[str] = field(default_factory=list)
+    source: str = ""  # "github" | "azdevops" | "local" | "" (nothing scanned)
+
+
+# ---------------------------------------------------------------------------
+# Pure parsing helpers — operate on the formatted tool output string, so they
+# are unit-testable without any live API/filesystem access.
+# ---------------------------------------------------------------------------
+
+
+def _parse_section(raw: str, header: str) -> list[str]:
+    """Return the indented lines under a `header:` section of a tool summary.
+
+    Both github_read_repo and read_codebase emit sections like::
+
+        Languages:
+          Python: 80.0%
+          TypeScript: 20.0%
+
+    Parsing stops at the first blank line or the next unindented header.
+    """
+    lines = raw.splitlines()
+    out: list[str] = []
+    in_section = False
+    for line in lines:
+        if line.strip() == header:
+            in_section = True
+            continue
+        if in_section:
+            if not line.strip():
+                break
+            if line.startswith((" ", "\t")):
+                out.append(line.strip())
+            else:
+                break
+    return out
+
+
+def _parse_languages(raw: str) -> list[str]:
+    """Extract language names (in order) from the `Languages:` section."""
+    langs: list[str] = []
+    for entry in _parse_section(raw, "Languages:"):
+        # "Python: 80.0%" → "Python"
+        name = entry.split(":", 1)[0].strip()
+        if name:
+            langs.append(name)
+    return langs
+
+
+def _parse_key_files(raw: str) -> list[str]:
+    """Extract key-file paths from the `Key files detected:` section."""
+    return [entry.strip() for entry in _parse_section(raw, "Key files detected:") if entry.strip()]
+
+
+def _parse_total_files(raw: str) -> int | None:
+    """Extract the source-file count from a `Total files scanned: N` line."""
+    m = re.search(r"Total files scanned:\s*(\d+)", raw)
+    return int(m.group(1)) if m else None
+
+
+def _word_match(marker: str, haystack: str) -> bool:
+    """Case-insensitive whole-word/phrase match of `marker` in `haystack`."""
+    return re.search(rf"(?<![\w-]){re.escape(marker)}(?![\w-])", haystack, re.IGNORECASE) is not None
+
+
+def _markers_in_text(haystack: str, markers) -> list[str]:
+    """Return the markers that appear as whole words/phrases in `haystack`."""
+    return [m for m in markers if _word_match(m, haystack)]
+
+
+def _basename(path: str) -> str:
+    return path.rsplit("/", 1)[-1]
+
+
+def _detect_low_code(
+    *,
+    description: str,
+    tech_stack: str,
+    languages: list[str],
+    key_files: list[str],
+    total_files: int | None,
+) -> tuple[bool, list[str]]:
+    """Deterministically decide whether a project is low-code, with reasons.
+
+    Three independent signals (any one flags it):
+    1. A low-code / no-code platform or content-shop marker appears in the
+       description, the stated stack, or the repo's key files.
+    2. A repo was scanned but no source-code language was detected (all config /
+       content / docs).
+    3. A scanned repo has barely any source files (≤ LOW_CODE_MAX_SOURCE_FILES)
+       and at most one language.
+    """
+    reasons: list[str] = []
+
+    # 1) Platform / content markers (most reliable — works even with no repo).
+    haystack = " ".join([description, tech_stack, " ".join(_basename(f) for f in key_files)])
+    hits = _markers_in_text(haystack, LOW_CODE_MARKERS)
+    if hits:
+        # De-duplicate while preserving order; report up to three.
+        seen: list[str] = []
+        for h in hits:
+            if h not in seen:
+                seen.append(h)
+        reasons.append("mentions " + ", ".join(seen[:3]) + " (low-code / no-code platform or content tooling)")
+
+    # 2) A repo was scanned (we have key files or a file count) but no code.
+    scanned = bool(key_files) or total_files is not None
+    if scanned and not languages:
+        reasons.append("no source-code languages detected in the repository")
+
+    # 3) Barely any source files.
+    if total_files is not None and total_files <= LOW_CODE_MAX_SOURCE_FILES and len(languages) <= 1:
+        reasons.append(f"very small codebase ({total_files} source file(s))")
+
+    return bool(reasons), reasons
+
+
+def _stack_from_manifests(manifests: dict[str, str]) -> tuple[list[str], list[str]]:
+    """Return (frameworks, integrations) inferred from fetched manifest contents.
+
+    Manifest bodies are just text (JSON / TOML / plain deps); a whole-word match
+    on the declared dependency names is enough to recognise well-known SDKs.
+    """
+    blob = "\n".join(manifests.values())
+    frameworks = _dedupe([FRAMEWORK_MARKERS[m] for m in FRAMEWORK_MARKERS if _word_match(m, blob)])
+    integrations = _dedupe([INTEGRATION_SDK_MARKERS[m] for m in INTEGRATION_SDK_MARKERS if _word_match(m, blob)])
+    return frameworks, integrations
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    """Order-preserving de-duplication."""
+    out: list[str] = []
+    for it in items:
+        if it not in out:
+            out.append(it)
+    return out
+
+
+def analyze_context(
+    raw_context: str,
+    *,
+    description: str = "",
+    tech_stack: str = "",
+    manifests: dict[str, str] | None = None,
+    source: str = "",
+) -> RepoSignals:
+    """Derive structured signals from a repo scan string (pure, no I/O).
+
+    Args:
+        raw_context: The github_read_repo / read_codebase summary text.
+        description: Q1 project description (for low-code marker matching).
+        tech_stack: Q11 stated tech stack, if any (for marker matching).
+        manifests: Optional {filename: contents} for framework / integration
+            inference. When omitted, only the language breakdown drives the stack.
+        source: Which source produced the scan ("github" / "azdevops" / "local").
+
+    Returns:
+        A populated RepoSignals. Empty/degenerate input yields an all-empty
+        result (low_code may still be True from description markers alone).
+    """
+    raw = raw_context or ""
+    languages = _parse_languages(raw)
+    key_files = _parse_key_files(raw)
+    total_files = _parse_total_files(raw)
+
+    frameworks: list[str] = []
+    integrations: list[str] = []
+    if manifests:
+        frameworks, integrations = _stack_from_manifests(manifests)
+
+    tools = _dedupe([KEY_FILE_TOOLS[_basename(f)] for f in key_files if _basename(f) in KEY_FILE_TOOLS])
+    detected_stack = _dedupe([*languages, *frameworks, *tools])
+
+    low_code, reasons = _detect_low_code(
+        description=description,
+        tech_stack=tech_stack,
+        languages=languages,
+        key_files=key_files,
+        total_files=total_files,
+    )
+
+    return RepoSignals(
+        detected_stack=detected_stack,
+        integrations=integrations,
+        low_code=low_code,
+        low_code_reasons=reasons,
+        source=source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# I/O entry point — graceful per-source fan-out (mirrors standup/collector.py).
+# ---------------------------------------------------------------------------
+
+
+def _fetch_manifests_github(url: str, key_files: list[str]) -> dict[str, str]:
+    """Best-effort fetch of manifest file contents from a GitHub repo."""
+    from scrum_agent.tools.github import github_read_file
+
+    out: dict[str, str] = {}
+    for path in key_files:
+        if _basename(path) in MANIFEST_FILES:
+            try:
+                content = github_read_file.invoke({"repo_url": url, "file_path": path})
+                if content and not content.startswith(("Error:", "GitHub rate limit")):
+                    out[path] = content
+            except Exception:  # noqa: BLE001 — best-effort; a bad manifest never aborts the scan
+                logger.debug("Manifest fetch failed for %s (non-fatal)", path, exc_info=True)
+    return out
+
+
+def _fetch_manifests_local(root: str, key_files: list[str]) -> dict[str, str]:
+    """Best-effort fetch of manifest file contents from a local repo."""
+    from scrum_agent.tools.codebase import read_local_file
+
+    out: dict[str, str] = {}
+    for path in key_files:
+        if _basename(path) in MANIFEST_FILES:
+            try:
+                content = read_local_file.invoke({"repo_path": root, "file_path": path})
+                if content and not content.startswith("Error:"):
+                    out[path] = content
+            except Exception:  # noqa: BLE001 — best-effort
+                logger.debug("Local manifest fetch failed for %s (non-fatal)", path, exc_info=True)
+    return out
+
+
+def _resolve_repo_target(questionnaire) -> tuple[str, str]:
+    """Return (url_or_path, platform) to scan, or ("", "") if none is available.
+
+    Prefers the URL the user gave in Q17; otherwise falls back to a configured
+    GitHub repo (STANDUP_GITHUB_REPO + a token). Azure DevOps has no single-repo
+    env var, so it is only scanned when the user supplies a Q17 URL.
+    """
+    from scrum_agent.config import get_github_token, get_standup_github_repo
+    from scrum_agent.prompts.intake import QUESTION_DEFAULTS
+
+    url = (questionnaire.answers.get(17, "") or "").strip()
+    if url and url != QUESTION_DEFAULTS.get(17):
+        platform = questionnaire.answers.get(16, "GitHub") or "GitHub"
+        return url, platform
+
+    # Fallback: a configured GitHub repo (owner/repo) scanned for context.
+    gh_repo = get_standup_github_repo().strip()
+    if gh_repo and get_github_token():
+        return gh_repo, "GitHub"
+
+    return "", ""
+
+
+def scan_repo_signals(questionnaire) -> tuple[str | None, RepoSignals, dict]:
+    """Scan the project's repository and return (raw_context, signals, status).
+
+    Graceful: any missing SDK / credential / API error degrades to
+    (None, empty-but-marker-aware RepoSignals, status) — it never raises. Even
+    when nothing is scanned, description-based low-code markers are still applied
+    so a "Zapier + Webflow" project is flagged without any repo.
+
+    # See README: "Tools" — read-only tool pattern
+    """
+    description = questionnaire.answers.get(1, "") or ""
+    tech_stack = questionnaire.answers.get(11, "") or ""
+
+    target, platform = _resolve_repo_target(questionnaire)
+
+    raw_context: str | None = None
+    manifests: dict[str, str] = {}
+    source = ""
+    status = {"name": "Repository", "status": "skipped", "detail": "no repo to scan"}
+
+    if target:
+        logger.info("repo_signals: scanning %s (%s)", target, platform)
+        try:
+            if platform == "GitHub":
+                from scrum_agent.tools.github import github_read_repo
+
+                result = github_read_repo.invoke({"repo_url": target})
+                if result and not result.startswith(("Error:", "GitHub rate limit")):
+                    raw_context = result
+                    source = "github"
+                    manifests = _fetch_manifests_github(target, _parse_key_files(result))
+            elif platform == "Azure DevOps":
+                from scrum_agent.tools.azure_devops import azdevops_read_repo
+
+                result = azdevops_read_repo.invoke({"repo_url": target})
+                if result and not result.startswith("Error:"):
+                    raw_context = result
+                    source = "azdevops"
+            elif not target.startswith(("http://", "https://")):
+                from scrum_agent.tools.codebase import read_codebase
+
+                result = read_codebase.invoke({"path": target})
+                if result and not result.startswith("Error:"):
+                    raw_context = result
+                    source = "local"
+                    manifests = _fetch_manifests_local(target, _parse_key_files(result))
+        except Exception as e:  # noqa: BLE001 — never let a scan error abort intake
+            logger.warning("repo_signals scan failed for %s: %s", target, e)
+            status = {"name": "Repository", "status": "error", "detail": str(e)[:80]}
+
+    signals = analyze_context(
+        raw_context or "",
+        description=description,
+        tech_stack=tech_stack,
+        manifests=manifests,
+        source=source,
+    )
+
+    if raw_context is not None:
+        detail = f"{platform} — {len(signals.detected_stack)} stack item(s)"
+        if signals.low_code:
+            detail += ", low-code"
+        status = {"name": "Repository", "status": "success", "detail": detail}
+        logger.info(
+            "repo_signals: source=%s stack=%s integrations=%s low_code=%s",
+            source,
+            signals.detected_stack,
+            signals.integrations,
+            signals.low_code,
+        )
+
+    return raw_context, signals, status

--- a/src/scrum_agent/agent/state.py
+++ b/src/scrum_agent/agent/state.py
@@ -417,6 +417,14 @@ class ProjectAnalysis:
     # AND goals ≤ 3). Default False so existing projects are unaffected.
     # See README: "Scrum Standards" — feature generation
     skip_features: bool = False
+    # When True, the project is mostly configuration / content / no-code-platform
+    # work rather than engineering. Set by reconciling the deterministic
+    # repo_signals scan with the analyzer LLM's own read; drives lighter estimation
+    # and config-oriented task decomposition downstream. Default False so ordinary
+    # engineering projects are unaffected (and old saved sessions still deserialize).
+    # See README: "Scrum Standards" — estimation
+    is_low_code: bool = False
+    low_code_reason: str = ""  # human-readable why, shown in the analysis panel
     scrum_md_contributions: tuple[str, ...] = ()  # JSON field names enriched by SCRUM.md
     # Deterministic quality rating for the user's intake input. Computed by
     # compute_prompt_quality() in nodes.py from QuestionnaireState tracking sets.
@@ -477,10 +485,25 @@ class QuestionnaireState:
     # See README: "Project Intake Questionnaire" — edit flow
     editing_question: int | None = None
     # Intake mode — controls how many questions are shown interactively.
-    # "standard" (default) preserves backward compat for existing tests.
-    # The REPL explicitly sets "smart" (the new default UX).
+    # The legacy 30-question "standard" flow has been retired as a user-facing
+    # path: project_intake coerces any "standard" value to "smart" at its first
+    # invocation. The dataclass default is left as "standard" only so directly
+    # constructed states (in tests / shared subsequent-call helpers) keep their
+    # historical value; production always sets this from _intake_mode.
     # See README: "Project Intake Questionnaire" — smart intake
-    intake_mode: str = "standard"  # "smart" | "standard" | "quick"
+    intake_mode: str = "standard"  # coerced to "smart" | "quick" | "small_project"
+    # Transient: set when the user switches Small project → Epic wide at the
+    # analysis review. On the next project_intake pass we skip answer-recording
+    # and ask the remaining Epic essentials instead (answers are preserved).
+    _reopen_for_epic: bool = False
+    # Transient repository-scan carry-over. project_intake runs repo_signals once
+    # at first invocation (broadened to configured repos) and stashes the raw
+    # scan + deterministic low-code verdict here; project_analyzer reuses them so
+    # the repo isn't scanned twice. Not serialized — a resumed session re-scans.
+    # See README: "Project Intake Questionnaire" — smart intake
+    _repo_context: str = ""
+    _repo_low_code: bool = False
+    _repo_low_code_reason: str = ""
     # Tracks which question numbers had answers auto-applied from the
     # initial description (via LLM extraction). Used for provenance
     # markers in the intake summary ("from your description").
@@ -688,6 +711,21 @@ class ScrumState(_RequiredState, total=False):
     # instead of using enforce_target. 0 = not set (default).
     # See README: "Guardrails" — human-in-the-loop pattern
     _capacity_team_override: int
+
+    # Small-project scope advisory. Set True by project_analyzer when the intake
+    # ran in "small_project" mode but the analyzer judged the project bigger than
+    # 1-2 tickets (needs feature grouping, > 2 sprints, or many goals). The
+    # analysis review surfaces a "Switch to Epic wide" action when this is True.
+    # See README: "Guardrails" — human-in-the-loop (advisory)
+    _small_project_oversized: bool
+
+    # Team ceremony (Standup + Retro) history gathered by project_analyzer and
+    # reused downstream: _ceremony_action_items seeds story_writer's backlog
+    # ([Retro] stories); _ceremony_history is the markdown block reused by
+    # sprint_planner. Transient; serialize harmlessly across --resume.
+    # See README: "Session Management" — SQLite persistence
+    _ceremony_action_items: tuple[str, ...]
+    _ceremony_history: str
 
     # Capacity deductions — all collected during intake (Phase 6: Capacity Planning).
     # Q27 (sprint selection / bank holidays auto-detected), Q28 (planned leave),

--- a/src/scrum_agent/agent/state.py
+++ b/src/scrum_agent/agent/state.py
@@ -492,9 +492,9 @@ class QuestionnaireState:
     # historical value; production always sets this from _intake_mode.
     # See README: "Project Intake Questionnaire" — smart intake
     intake_mode: str = "standard"  # coerced to "smart" | "quick" | "small_project"
-    # Transient: set when the user switches Small project → Epic wide at the
+    # Transient: set when the user switches Small project → Large at the
     # analysis review. On the next project_intake pass we skip answer-recording
-    # and ask the remaining Epic essentials instead (answers are preserved).
+    # and ask the remaining Large-mode essentials instead (answers are preserved).
     _reopen_for_epic: bool = False
     # Transient repository-scan carry-over. project_intake runs repo_signals once
     # at first invocation (broadened to configured repos) and stashes the raw
@@ -715,7 +715,7 @@ class ScrumState(_RequiredState, total=False):
     # Small-project scope advisory. Set True by project_analyzer when the intake
     # ran in "small_project" mode but the analyzer judged the project bigger than
     # 1-2 tickets (needs feature grouping, > 2 sprints, or many goals). The
-    # analysis review surfaces a "Switch to Epic wide" action when this is True.
+    # analysis review surfaces a "Switch to Large" action when this is True.
     # See README: "Guardrails" — human-in-the-loop (advisory)
     _small_project_oversized: bool
 

--- a/src/scrum_agent/cli.py
+++ b/src/scrum_agent/cli.py
@@ -270,7 +270,6 @@ def build_parser() -> argparse.ArgumentParser:
             "examples:\n"
             "  scrum-agent                        interactive mode (recommended)\n"
             "  scrum-agent --quick                quick intake (2 questions only)\n"
-            "  scrum-agent --full-intake          full 30-question intake\n"
             "  scrum-agent --questionnaire q.md   import pre-filled questionnaire\n"
             "  scrum-agent --export-only --quick  non-interactive, auto-accept all\n"
             "  scrum-agent --resume               resume last session (interactive picker)\n"
@@ -326,18 +325,14 @@ def build_parser() -> argparse.ArgumentParser:
     # Intake mode flags — mutually exclusive.
     # Smart mode is the default when neither flag is given.
     # See README: "Project Intake Questionnaire" — smart intake
+    # The legacy --full-intake (30-question "standard" mode) has been removed —
+    # smart intake is the single interactive path. --quick remains for power users.
     intake_group = parser.add_mutually_exclusive_group()
     intake_group.add_argument(
         "--quick",
         action="store_true",
         default=False,
         help="Quick intake — only ask team size and tech stack, auto-fill everything else.",
-    )
-    intake_group.add_argument(
-        "--full-intake",
-        action="store_true",
-        default=False,
-        help="Full 30-question intake (standard mode).",
     )
 
     parser.add_argument(
@@ -1094,7 +1089,7 @@ def main(argv: list[str] | None = None) -> None:
     # Determine early whether we'll use the old REPL or the fullscreen TUI.
     # The TUI path keeps alt-screen active from splash → select_mode seamlessly.
     # The old REPL path needs to exit alt-screen and print info to the terminal.
-    use_old_repl = args.mode is not None or args.quick or args.full_intake or args.questionnaire is not None
+    use_old_repl = args.mode is not None or args.quick or args.questionnaire is not None
 
     team_learning_flag = args.learn or args.team_profile or args.retro is not None
     if use_old_repl or args.resume is not None or args.list_sessions or args.clear_sessions or team_learning_flag:
@@ -1191,8 +1186,6 @@ def main(argv: list[str] | None = None) -> None:
     # See README: "Project Intake Questionnaire" — smart intake
     if args.quick:
         intake_mode = "quick"
-    elif args.full_intake:
-        intake_mode = "standard"
     else:
         intake_mode = None
 
@@ -1208,9 +1201,9 @@ def main(argv: list[str] | None = None) -> None:
     #
     # Three paths:
     #   1. --mode flag → bypass UI, use old REPL (backwards compat for scripted runs)
-    #   2. --quick/--full-intake/--questionnaire → bypass UI, use old REPL
+    #   2. --quick/--questionnaire → bypass UI, use old REPL
     #   3. Interactive → full-screen TUI mode selector, which launches the TUI
-    #      session (run_session) for Smart/Full intake inside its Live context
+    #      session (run_session) for smart intake inside its Live context
     #
     # See README: "Architecture" — mode selection is a CLI-layer concern.
     if use_old_repl:

--- a/src/scrum_agent/formatters.py
+++ b/src/scrum_agent/formatters.py
@@ -176,6 +176,15 @@ def render_analysis_panel(analysis: ProjectAnalysis, *, compact: bool = False) -
     sections.append(f"[bold]Description:[/bold] {analysis.project_description}")
     sections.append(f"[bold]Type:[/bold] {analysis.project_type}")
 
+    # Low-code advisory — mostly configuration/content/no-code work. Estimation
+    # and task decomposition are scaled lighter downstream (see story_writer /
+    # task_decomposer prompts). Shown prominently near the top of the panel.
+    if getattr(analysis, "is_low_code", False):
+        reason = f" — {analysis.low_code_reason}" if analysis.low_code_reason else ""
+        sections.append(
+            f"[yellow]⚙ [bold]Low-code project[/bold]{reason} · estimates and tasks scaled lighter.[/yellow]"
+        )
+
     sections.append(f"\n[bold]Goals:[/bold]\n{_bullet_list(analysis.goals)}")
     if not compact:
         sections.append(f"[bold]End Users:[/bold]\n{_bullet_list(analysis.end_users)}")

--- a/src/scrum_agent/prompts/analyzer.py
+++ b/src/scrum_agent/prompts/analyzer.py
@@ -41,6 +41,8 @@ _JSON_SCHEMA = """\
   "out_of_scope": ["string array — explicit exclusions from Q23"],
   "assumptions": ["string array — any defaulted or skipped answers that required assumptions"],
   "skip_features": "boolean — true when project is small enough that feature grouping adds no value. Default false.",
+  "is_low_code": "boolean — true for mostly config/content/no-code projects, not custom engineering. Default false.",
+  "low_code_reason": "string — short phrase why is_low_code is true (e.g. 'Webflow + Zapier site'). Empty when false.",
   "scrum_md_contributions": "JSON field names whose values came from SCRUM.md. Empty list if no SCRUM.md was present."
 }"""
 
@@ -51,9 +53,11 @@ def get_analyzer_prompt(
     velocity_per_sprint: int,
     *,
     repo_context: str | None = None,
+    detected_stack: list[str] | None = None,
     confluence_context: str | None = None,
     user_context: str | None = None,
     team_profile_summary: str = "",
+    ceremony_history: str = "",
     review_feedback: str | None = None,
     review_mode: str | None = None,
     previous_output: str | None = None,
@@ -103,12 +107,16 @@ def get_analyzer_prompt(
     # Inject repo scan results when available, placed between Team Metrics and
     # Questionnaire Answers so the LLM can ground tech_stack / project_type
     # extraction in real codebase data rather than user descriptions alone.
+    # A deterministic "detected stack" (languages + frameworks parsed from the
+    # scan) is offered as a hint so the LLM anchors tech_stack on real signals.
+    detected_stack_line = f"Detected stack (from repo scan): {', '.join(detected_stack)}\n\n" if detected_stack else ""
     repo_section = (
         (
             "\n## Repository Scan\n\n"
             "The following was retrieved directly from the repository. "
             "Use it to ground your tech_stack, project_type, and constraint extraction "
             "— prefer repo-detected data over user descriptions where they conflict.\n\n"
+            f"{detected_stack_line}"
             f"{repo_context}\n"
         )
         if repo_context
@@ -161,6 +169,24 @@ def get_analyzer_prompt(
         else ""
     )
 
+    # Inject the team's recent Standup + Retro history when available. Retro action
+    # items and recurring pain points, plus recent standup confidence, are ground
+    # truth about how delivery is actually going — fold them into risks,
+    # assumptions, and scope so the plan carries the team's own lessons forward.
+    ceremony_section = (
+        (
+            "\n## Standup & Retro History\n\n"
+            "The following summarises the team's recent retrospectives and daily "
+            "standups. Treat it as real signal about delivery: reflect open retro "
+            "action items and recurring pain points in `risks` / `assumptions` / "
+            "`out_of_scope`, and let a low or declining standup confidence make your "
+            "scope and target_sprints more conservative.\n\n"
+            f"{ceremony_history}\n"
+        )
+        if ceremony_history
+        else ""
+    )
+
     base = (
         "You are a project analyst synthesizing intake questionnaire answers into "
         "a structured project analysis.\n\n"
@@ -170,7 +196,8 @@ def get_analyzer_prompt(
         f"{repo_section}"
         f"{confluence_section}"
         f"{user_section}"
-        f"{team_section}\n"
+        f"{team_section}"
+        f"{ceremony_section}\n"
         f"## Questionnaire Answers ({TOTAL_QUESTIONS} questions)\n\n"
         f"{answers_block}\n\n"
         "## Task\n\n"

--- a/src/scrum_agent/prompts/intake.py
+++ b/src/scrum_agent/prompts/intake.py
@@ -323,7 +323,7 @@ QUICK_ESSENTIALS: frozenset[int] = frozenset({6, 11})
 #   Q27 (sprint selection) / Q28-Q30 (bank holidays, unplanned %, onboarding)
 #       → skipped entirely; small mode does no capacity/bank-holiday planning.
 # The project_analyzer still runs honestly so its size signal can trigger the
-# "this looks bigger than a small project" advisory (offer to switch to Epic wide).
+# "this looks bigger than a small project" advisory (offer to switch to Large).
 SMALL_PROJECT_ESSENTIALS: frozenset[int] = frozenset({2, 3, 4, 6, 8, 11})
 
 # Conditional essentials — questions that become essential when their
@@ -415,7 +415,7 @@ QUESTION_SHORT_LABELS: dict[int, str] = {
 
 #
 # NOTE: This is the *legacy REPL* menu (CLI-flag flows). The full-screen TUI uses
-# a separate three-card menu — Small project / Epic wide / Offline — defined by
+# a separate three-card menu — Small project / Large / Offline — defined by
 # `_INTAKE_CARDS` in ui/mode_select/screens/_screens.py. The Small-project mode
 # ("small_project" intake_mode) is offered there; this legacy menu is unchanged.
 INTAKE_MODE_MENU: dict[str, tuple[str, str]] = {

--- a/src/scrum_agent/prompts/intake.py
+++ b/src/scrum_agent/prompts/intake.py
@@ -292,12 +292,12 @@ QUESTION_METADATA: dict[int, QuestionMeta] = {
 # Intake mode constants — controls how many questions are asked.
 # See README: "Project Intake Questionnaire" — smart intake
 #
-# Three modes:
-#   "smart" (new default in REPL) — auto-apply extracted answers + defaults,
-#       only ask unfilled essential gaps. Typical: 2-4 questions.
+# Intake modes (the legacy 30-question "standard" flow has been retired):
+#   "smart" (default) — auto-apply extracted answers + defaults, only ask
+#       unfilled essential gaps. Typical: 2-4 questions.
 #   "quick" — only Q6 (team size) and Q11 (tech stack) as gaps; everything
 #       else auto-filled with extraction + defaults + fallbacks.
-#   "standard" — the original 30-question one-at-a-time flow.
+#   "small_project" — quick intake for 1-2 tickets, no capacity planning.
 #
 # ESSENTIAL_QUESTIONS is the full set of questions with no sensible default.
 # SMART_ESSENTIALS is the subset asked in smart mode (Q1 comes from the
@@ -314,6 +314,17 @@ ESSENTIAL_QUESTIONS: frozenset[int] = frozenset({1, 2, 3, 4, 6, 11, 15})
 # Q8 (sprint length) excluded — always defaults to "2 weeks" in smart mode.
 SMART_ESSENTIALS: frozenset[int] = frozenset({2, 3, 4, 6, 10, 11, 27})
 QUICK_ESSENTIALS: frozenset[int] = frozenset({6, 11})
+
+# SMALL_PROJECT_ESSENTIALS — the "Small project (1-2 tickets)" mode. A quick
+# intake for tiny scopes: project type (Q2), problem/DoD (Q3, Q4), team size
+# (Q6), sprint length (Q8), and tech stack (Q11). Q1 comes from the description.
+# Deliberately EXCLUDES the capacity questions asked in smart mode:
+#   Q10 (target sprints)  → defaulted to 1 (max 2); small work is one quick sprint
+#   Q27 (sprint selection) / Q28-Q30 (bank holidays, unplanned %, onboarding)
+#       → skipped entirely; small mode does no capacity/bank-holiday planning.
+# The project_analyzer still runs honestly so its size signal can trigger the
+# "this looks bigger than a small project" advisory (offer to switch to Epic wide).
+SMALL_PROJECT_ESSENTIALS: frozenset[int] = frozenset({2, 3, 4, 6, 8, 11})
 
 # Conditional essentials — questions that become essential when their
 # prerequisite has a real (non-defaulted) answer. This keeps smart mode
@@ -402,17 +413,16 @@ QUESTION_SHORT_LABELS: dict[int, str] = {
 # a mode before the first question is asked.
 # ---------------------------------------------------------------------------
 
+#
+# NOTE: This is the *legacy REPL* menu (CLI-flag flows). The full-screen TUI uses
+# a separate three-card menu — Small project / Epic wide / Offline — defined by
+# `_INTAKE_CARDS` in ui/mode_select/screens/_screens.py. The Small-project mode
+# ("small_project" intake_mode) is offered there; this legacy menu is unchanged.
 INTAKE_MODE_MENU: dict[str, tuple[str, str]] = {
     "smart": (
         "Smart intake (recommended)",
         "I'll extract answers from your description and only ask 2-4 essential\n"
         "      follow-ups. Good for most projects.",
-    ),
-    "standard": (
-        "Full intake",
-        "All 30 questions, one at a time. Includes follow-up probes when answers\n"
-        "      are vague. Best for complex projects spanning multiple years or\n"
-        "      requiring multiple teams.",
     ),
     "offline": (
         "Offline questionnaire",
@@ -421,7 +431,10 @@ INTAKE_MODE_MENU: dict[str, tuple[str, str]] = {
     ),
 }
 
-INTAKE_MODE_ORDER: tuple[str, ...] = ("smart", "standard", "offline")
+# The legacy 30-question "standard" flow has been retired — smart intake is the
+# single interactive path. Only smart / offline remain here (and small_project /
+# quick as internal modes via the TUI cards / CLI flags).
+INTAKE_MODE_ORDER: tuple[str, ...] = ("smart", "offline")
 
 # ---------------------------------------------------------------------------
 # Offline questionnaire sub-menu — shown when the user picks [3] Offline.
@@ -450,7 +463,7 @@ STARTUP_MODE_MENU: dict[str, tuple[str, str]] = {
     "project-planning": (
         "Project Planning",
         "Decompose your project into epics, user stories, tasks, and a sprint plan.\n"
-        "      Includes smart / full / offline intake questionnaire.",
+        "      Includes smart / offline intake questionnaire.",
     ),
     "coming-soon-1": (
         "Code Review  [dim](coming soon)[/dim]",

--- a/src/scrum_agent/prompts/sprint_planner.py
+++ b/src/scrum_agent/prompts/sprint_planner.py
@@ -48,6 +48,7 @@ def get_sprint_planner_prompt(
     sprint_capacities: list[dict] | None = None,
     team_override_from: int | None = None,
     team_calibration: str = "",
+    ceremony_history: str = "",
     review_feedback: str | None = None,
     review_mode: str | None = None,
     previous_output: str | None = None,
@@ -163,6 +164,21 @@ def get_sprint_planner_prompt(
         )
         cot_step3 = "3. Fill each sprint up to the velocity cap, respecting priority order.\n"
 
+    # Recent Standup + Retro signals: sequence retro-sourced ([Retro]) stories
+    # early, and stay conservative on load when standup confidence has been low.
+    ceremony_section = (
+        (
+            "## Recent Standup & Retro Signals\n\n"
+            "Use these when ordering and loading sprints — schedule stories that "
+            "address open retro action items (often titled `[Retro] …`) early, and if "
+            "recent standup confidence has been low or declining, keep earlier sprints "
+            "a little under capacity to absorb risk.\n\n"
+            f"{ceremony_history}\n\n"
+        )
+        if ceremony_history
+        else ""
+    )
+
     base = (
         "You are a Senior Scrum Master with expertise in sprint planning and capacity allocation.\n\n"
         "## Project Context\n\n"
@@ -171,7 +187,10 @@ def get_sprint_planner_prompt(
         f"{velocity_section}\n"
         f"**{target_note}**\n\n"
         "## Stories to Allocate\n\n"
-        f"{stories_block}\n\n" + (team_calibration + "\n" if team_calibration else "") + "## Task\n\n"
+        f"{stories_block}\n\n"
+        + ceremony_section
+        + (team_calibration + "\n" if team_calibration else "")
+        + "## Task\n\n"
         "Allocate ALL stories above into sprints. Return a JSON array matching this exact schema:\n\n"
         f"```json\n{_JSON_SCHEMA}\n```\n\n"
         "## Rules\n\n"

--- a/src/scrum_agent/prompts/story_writer.py
+++ b/src/scrum_agent/prompts/story_writer.py
@@ -148,6 +148,8 @@ def get_story_writer_prompt(
     out_of_scope: str = "",
     team_calibration: str = "",
     dod_items: tuple[str, ...] | None = None,
+    is_low_code: bool = False,
+    carry_over_items: tuple[str, ...] = (),
     review_feedback: str | None = None,
     review_mode: str | None = None,
     previous_output: str | None = None,
@@ -213,19 +215,53 @@ def get_story_writer_prompt(
         count_rule = f"1. Produce {MIN_STORIES_PER_FEATURE}-{MAX_STORIES_PER_FEATURE} stories per feature.\n"
     id_rule = "2. Use sequential IDs per feature: US-F1-001, US-F1-002, US-F2-001, etc.\n"
 
+    # Low-code projects are mostly configuration / content / no-code-platform
+    # work — the stories should reflect that (setup, configuration, content,
+    # integration wiring) and carry SMALLER point estimates than custom builds.
+    low_code_note = (
+        "\n**This is a LOW-CODE project** — mostly configuration, content, and "
+        "no-code / low-code platform work rather than custom engineering. Prefer "
+        "configuration / setup / content / integration-wiring stories over "
+        "heavy build-from-scratch stories, and bias story points SMALLER "
+        "(a task that would be 5 points as custom code is often 2-3 when it is "
+        "platform configuration).\n"
+        if is_low_code
+        else ""
+    )
+
+    # Unresolved action items carried over from the team's recent retrospectives.
+    # These are real, agreed follow-ups the team hasn't closed — turn each into a
+    # dedicated story (unless a feature above already covers it) so they aren't lost.
+    carry_over_section = ""
+    if carry_over_items:
+        items = "\n".join(f"- {it}" for it in carry_over_items)
+        carry_over_section = (
+            "## Carry-over from Recent Retros\n\n"
+            "These are open action items the team agreed in past retrospectives. "
+            "For each one NOT already covered by a feature above, add ONE dedicated "
+            'user story: prefix its title with "[Retro] ", attach it to the most '
+            "relevant feature (or the first feature if none fits), and estimate it "
+            "like any other story. Skip any that duplicate existing scope.\n\n"
+            f"{items}\n\n"
+        )
+
     base = (
         "You are a Senior Scrum Master with expertise in user story decomposition.\n\n"
         "## Project Context\n\n"
         f"**Project:** {project_name}\n"
         f"**Description:** {project_description}\n"
-        f"**Type:** {project_type}\n\n"
+        f"**Type:** {project_type}\n"
+        f"{low_code_note}\n"
         f"### Goals\n{goals}\n\n"
         f"### End Users\n{end_users}\n\n"
         f"### Tech Stack\n{tech_stack}\n\n"
         f"### Constraints\n{constraints}\n\n"
         f"### Out of Scope\n{out_of_scope}\n\n"
         "## Features to Decompose\n\n"
-        f"{features_block}\n\n" + (team_calibration + "\n" if team_calibration else "") + "## Task\n\n"
+        f"{features_block}\n\n"
+        + carry_over_section
+        + (team_calibration + "\n" if team_calibration else "")
+        + "## Task\n\n"
         f"{task_instruction}"
         "## Rules\n\n"
         f"{count_rule}"

--- a/src/scrum_agent/prompts/task_decomposer.py
+++ b/src/scrum_agent/prompts/task_decomposer.py
@@ -45,6 +45,7 @@ def get_task_decomposer_prompt(
     *,
     doc_context: str | None = None,
     team_calibration: str = "",
+    is_low_code: bool = False,
     review_feedback: str | None = None,
     review_mode: str | None = None,
     previous_output: str | None = None,
@@ -123,11 +124,23 @@ def get_task_decomposer_prompt(
             "Include Testing and Documentation tasks — not just Code.\n"
         )
 
+    # Low-code projects need configuration / setup / content tasks rather than
+    # build-from-scratch coding — nudge the decomposition accordingly.
+    low_code_note = (
+        "\n**This is a LOW-CODE project** — favour configuration, setup, content, "
+        "and integration-wiring tasks over custom coding. Keep tasks lightweight; "
+        "many will be `Infrastructure` (platform/config) or `Documentation` rather "
+        "than `Code`.\n"
+        if is_low_code
+        else ""
+    )
+
     base = (
         "You are a Senior Technical Lead with expertise in task decomposition.\n\n"
         "## Project Context\n\n"
         f"**Project:** {project_name}\n"
-        f"**Type:** {project_type}\n\n"
+        f"**Type:** {project_type}\n"
+        f"{low_code_note}\n"
         f"### Tech Stack\n{tech_stack}\n"
         f"{doc_context_section}\n"
         + (team_calibration + "\n" if team_calibration else "")

--- a/src/scrum_agent/repl/__init__.py
+++ b/src/scrum_agent/repl/__init__.py
@@ -188,10 +188,10 @@ def run_repl(
         questionnaire: Pre-populated questionnaire state (from --questionnaire flag).
             When provided, the intake summary is shown immediately and the user
             can confirm or edit before proceeding.
-        intake_mode: Intake questionnaire mode — "smart", "quick", "standard",
-            or None. When None (default), an interactive mode selection menu is
-            shown before the first prompt. CLI flags (--quick, --full-intake)
-            bypass the menu by passing the mode directly.
+        intake_mode: Intake questionnaire mode — "smart", "quick",
+            "small_project", or None. When None (default), an interactive mode
+            selection menu is shown before the first prompt. The --quick CLI flag
+            bypasses the menu by passing the mode directly.
         export_only: When True, auto-accept all review checkpoints and exit
             after the full plan is generated. Writes scrum-plan.md on completion.
         bell: When True (default), ring the terminal bell after pipeline steps
@@ -371,9 +371,9 @@ def run_repl(
         console.print(f"\n{REVIEW_HINT}")
     else:
         # Interactive mode selection — when no CLI flag was given, show a
-        # numbered menu so the user understands the three intake modes and
-        # picks one before the first question. CLI flags (--quick, --full-intake)
-        # bypass this by passing the mode directly.
+        # numbered menu so the user understands the intake modes and
+        # picks one before the first question. The --quick CLI flag
+        # bypasses this by passing the mode directly.
         if intake_mode is None:
             _render_intake_mode_menu(console)
             while True:
@@ -385,10 +385,10 @@ def run_repl(
                 intake_mode = _resolve_intake_mode(choice.strip())
                 if intake_mode is not None:
                     break
-                console.print("[warning]Please pick 1, 2, or 3.[/warning]")
+                console.print("[warning]Please pick 1 or 2.[/warning]")
 
         # ── Offline questionnaire flow ────────────────────────────────
-        # When the user picks [3] Offline, show a sub-menu to export a
+        # When the user picks [2] Offline, show a sub-menu to export a
         # blank template or import a filled one. Export writes the file
         # and exits; import loads the file and enters the confirm flow.
         if intake_mode == "offline":

--- a/src/scrum_agent/repl/_intake_menu.py
+++ b/src/scrum_agent/repl/_intake_menu.py
@@ -15,8 +15,8 @@ def _render_intake_mode_menu(console: Console) -> None:
 
     # See README: "Project Intake Questionnaire" — smart intake
     #
-    # Shown once at startup when no CLI flag (--quick / --full-intake) was given.
-    # The user picks 1/2/3/4 before the conversational opener is displayed.
+    # Shown once at startup when no CLI flag (--quick) was given.
+    # The user picks 1/2 (Smart / Offline) before the conversational opener.
     # Follows the same [N] styling pattern as _render_choice_options().
 
     Args:
@@ -35,7 +35,7 @@ def _render_intake_mode_menu(console: Console) -> None:
 def _resolve_intake_mode(user_input: str) -> str | None:
     """Resolve numeric input to an intake mode key.
 
-    Maps "1" → "smart", "2" → "standard", "3" → "offline".
+    Maps "1" → "smart", "2" → "offline" (indices follow INTAKE_MODE_ORDER).
     Returns None for any other input (invalid selection).
 
     Args:

--- a/src/scrum_agent/retro/store.py
+++ b/src/scrum_agent/retro/store.py
@@ -171,3 +171,42 @@ class RetroStore:
             (session_id, limit),
         ).fetchall()
         return [{"run_at": r[0], "retro_date": r[1], "project_name": r[2], "card_count": r[3]} for r in rows]
+
+    # ── Team-wide (cross-session) reads — used by ceremony_history to feed
+    #    Planning / Analysis with the team's recent retros regardless of which
+    #    session they ran under. See README: "Session Management".
+
+    def get_recent_reports(self, limit: int = 5, project_name: str = "") -> list[RetroReport]:
+        """Return recent RetroReports across ALL sessions, newest first.
+
+        When ``project_name`` is given, rows matching it sort first (project-first),
+        then by recency — so a plan for project X sees X's retros ahead of others'.
+        """
+        if project_name:
+            # (project_name = ?) is 1 for matches, 0 otherwise → matches sort first.
+            rows = self._conn.execute(
+                "SELECT report_json FROM retro_history ORDER BY (project_name = ?) DESC, run_at DESC LIMIT ?",
+                (project_name, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT report_json FROM retro_history ORDER BY run_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        reports: list[RetroReport] = []
+        for row in rows:
+            if not row[0]:
+                continue
+            try:
+                reports.append(_dict_to_retro_report(json.loads(row[0])))
+            except (json.JSONDecodeError, TypeError, KeyError) as exc:
+                logger.warning("Failed to deserialize a retro report: %s", exc)
+        return reports
+
+    def get_all_history(self, limit: int = 100) -> list[dict]:
+        """Return recent retro run metadata across ALL sessions (for cadence)."""
+        rows = self._conn.execute(
+            "SELECT run_at, retro_date, project_name, card_count FROM retro_history ORDER BY run_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [{"run_at": r[0], "retro_date": r[1], "project_name": r[2], "card_count": r[3]} for r in rows]

--- a/src/scrum_agent/sessions.py
+++ b/src/scrum_agent/sessions.py
@@ -270,6 +270,8 @@ def _dict_to_questionnaire(d: dict) -> QuestionnaireState:
         completed=d.get("completed", False),
         awaiting_confirmation=d.get("awaiting_confirmation", False),
         editing_question=d.get("editing_question"),
+        # Legacy sessions may still store "standard"; project_intake coerces it to
+        # "smart" at its first invocation, so the stored/default value is harmless.
         intake_mode=d.get("intake_mode", "standard"),
         extracted_questions=set(d.get("extracted_questions", [])),
         _pending_merged_questions=d.get("_pending_merged_questions", []),
@@ -298,6 +300,9 @@ def _dict_to_analysis(d: dict) -> ProjectAnalysis:
         risks=tuple(d.get("risks", ())),
         out_of_scope=tuple(d.get("out_of_scope", ())),
         assumptions=tuple(d.get("assumptions", ())),
+        skip_features=d.get("skip_features", False),
+        is_low_code=d.get("is_low_code", False),
+        low_code_reason=d.get("low_code_reason", ""),
         scrum_md_contributions=tuple(d.get("scrum_md_contributions", ())),
     )
 

--- a/src/scrum_agent/standup/store.py
+++ b/src/scrum_agent/standup/store.py
@@ -322,3 +322,35 @@ class StandupStore:
             }
             for r in rows
         ]
+
+    # ── Team-wide (cross-session) reads — used by ceremony_history to feed
+    #    Planning / Analysis with the team's recent standups. standup_history has
+    #    no project_name column, so these are recency-based (team-wide).
+
+    def get_recent_reports(self, limit: int = 10) -> list[StandupReport]:
+        """Return recent StandupReports across ALL sessions, newest first."""
+        rows = self._conn.execute(
+            "SELECT report_json FROM standup_history WHERE status = 'success' ORDER BY run_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        reports: list[StandupReport] = []
+        for row in rows:
+            if not row[0]:
+                continue
+            try:
+                reports.append(_dict_to_standup_report(json.loads(row[0])))
+            except (json.JSONDecodeError, TypeError, KeyError) as exc:
+                logger.warning("Failed to deserialize a standup report: %s", exc)
+        return reports
+
+    def get_all_history(self, limit: int = 100) -> list[dict]:
+        """Return recent standup run metadata across ALL sessions (for cadence)."""
+        rows = self._conn.execute(
+            "SELECT run_at, standup_date, sprint_day, confidence_pct, status "
+            "FROM standup_history ORDER BY run_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [
+            {"run_at": r[0], "standup_date": r[1], "sprint_day": r[2], "confidence_pct": r[3], "status": r[4]}
+            for r in rows
+        ]

--- a/src/scrum_agent/team_profile_exporter.py
+++ b/src/scrum_agent/team_profile_exporter.py
@@ -74,14 +74,60 @@ def _kv_table(rows: list[tuple[str, str]]) -> str:
     return f'<div class="card" style="padding:0;overflow:hidden;"><table class="data-table">{trs}</table></div>'
 
 
+def _ceremony_rows(ceremony) -> list[tuple[str, str]]:
+    """Cadence / trend key-value rows shared by the HTML and MD renderers."""
+    rows: list[tuple[str, str]] = []
+    if ceremony.retro_cadence:
+        rows.append(("Retro cadence", ceremony.retro_cadence))
+    if ceremony.standup_cadence:
+        rows.append(("Standup cadence", ceremony.standup_cadence))
+    if ceremony.confidence_trend:
+        rows.append(("Standup confidence", ceremony.confidence_trend))
+    if ceremony.action_items:
+        rows.append(("Open retro action items", str(len(ceremony.action_items))))
+    return rows
+
+
+def _ceremony_html(ceremony) -> str:
+    """Render the 'Ceremony Cadence & Trends' section content (HTML)."""
+    parts = [_kv_table(_ceremony_rows(ceremony))]
+    for title, themes in (
+        ("What's been working", ceremony.went_well_themes),
+        ("Recurring pain points", ceremony.didnt_go_well_themes),
+    ):
+        if themes:
+            items = "".join(f"<li>{_e(t)} <span style='color:var(--text-muted);'>({n}×)</span></li>" for t, n in themes)
+            parts.append(f'<div class="card"><strong>{_e(title)}</strong><ul>{items}</ul></div>')
+    return "".join(parts)
+
+
+def _ceremony_md(ceremony) -> list[str]:
+    """Render the 'Ceremony Cadence & Trends' section (Markdown lines)."""
+    lines = ["## Ceremony Cadence & Trends", ""]
+    lines.extend(f"- **{lbl}:** {val}" for lbl, val in _ceremony_rows(ceremony))
+    for title, themes in (
+        ("What's been working", ceremony.went_well_themes),
+        ("Recurring pain points", ceremony.didnt_go_well_themes),
+    ):
+        if themes:
+            lines.extend(["", f"**{title}:**"])
+            lines.extend(f"- {t} ({n}×)" for t, n in themes)
+    lines.append("")
+    return lines
+
+
 def export_team_profile_html(
     profile: TeamProfile,
     output_dir: Path | None = None,
     *,
     examples: dict | None = None,
     sprint_names: list[str] | None = None,
+    ceremony=None,
 ) -> Path:
     """Generate a self-contained HTML report matching the TUI results screen.
+
+    ``ceremony`` is an optional CeremonyContext (agent/ceremony_history.py). When
+    present and non-empty, a "Ceremony Cadence & Trends" section is added.
 
     Returns the path to the generated file.
     """
@@ -176,6 +222,11 @@ def export_team_profile_html(
 
     _nav("velocity", "Velocity")
     sections.append(_section("velocity", "Team &amp; Velocity", _kv_table(vel_rows)))
+
+    # ── Ceremony cadence & trends (Standup + Retro history) ─────────
+    if ceremony is not None and not ceremony.is_empty:
+        _nav("ceremonies", "Ceremonies")
+        sections.append(_section("ceremonies", "Ceremony Cadence &amp; Trends", _ceremony_html(ceremony)))
 
     # ── Recurring work ──────────────────────────────────────────────
     rec_count = ex.get("recurring_count", 0)
@@ -1252,8 +1303,12 @@ def export_team_profile_md(
     *,
     examples: dict | None = None,
     sprint_names: list[str] | None = None,
+    ceremony=None,
 ) -> Path:
     """Generate a Markdown report matching the TUI results screen.
+
+    ``ceremony`` is an optional CeremonyContext; when non-empty, a "Ceremony
+    Cadence & Trends" section is appended after Team & Velocity.
 
     Returns the path to the generated file.
     """
@@ -1283,6 +1338,10 @@ def export_team_profile_md(
                 if isinstance(r, dict):
                     lines.append(f">   - `{r.get('issue_key', '')}` {r.get('summary', '')}")
         lines.append("")
+
+    # ── Ceremony cadence & trends (Standup + Retro history) ─────────
+    if ceremony is not None and not ceremony.is_empty:
+        lines.extend(_ceremony_md(ceremony))
 
     # ── Team & Velocity ─────────────────────────────────────────────
     lines.extend(["## Team & Velocity", ""])

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -467,13 +467,16 @@ def _run_preview_flow(
     def _do_export():
         """Cumulative export — includes analysis profile + all accepted samples."""
         logger.info("Preview: exporting analysis (HTML + MD)")
+        from scrum_agent.agent.ceremony_history import gather_ceremony_context
         from scrum_agent.team_profile_exporter import (
             export_team_profile_html,
             export_team_profile_md,
         )
 
-        html_path = export_team_profile_html(ta_profile, examples=ta_examples)
-        md_path = export_team_profile_md(ta_profile, examples=ta_examples)
+        # Project-first here — the analysed project_key is known, so its retros sort ahead.
+        ceremony = gather_ceremony_context(ta_profile.project_key)
+        html_path = export_team_profile_html(ta_profile, examples=ta_examples, ceremony=ceremony)
+        md_path = export_team_profile_md(ta_profile, examples=ta_examples, ceremony=ceremony)
         w, h = console.size
         from scrum_agent.ui.mode_select.screens._screens_secondary import (
             _build_project_export_success_screen,
@@ -1687,8 +1690,8 @@ def select_mode(
     """Show full-screen mode selection, then project list → intake mode for Planning.
 
     Returns (mode_key, intake_mode, questionnaire_path) tuple or None if cancelled.
-    - Smart:  ("project-planning", "smart", None)
-    - Full:   ("project-planning", "standard", None)
+    - Small:  ("project-planning", "small_project", None)
+    - Epic:   ("project-planning", "smart", None)
     - Import: ("project-planning", None, "/path/to/questionnaire.md")
     - Export/Cancel: None
     Only available modes can be selected.
@@ -2057,14 +2060,17 @@ def select_mode(
                                     with TeamProfileStore(_tp_db) as _s:
                                         _full_p, _st_ex = _s.load_with_examples(_sel_p.team_id)
                                 if _full_p:
+                                    from scrum_agent.agent.ceremony_history import gather_ceremony_context
+
+                                    _cer = gather_ceremony_context(_full_p.project_key)
                                     if _ana_sub_sel == 0:
                                         from scrum_agent.team_profile_exporter import export_team_profile_html
 
-                                        _ep = export_team_profile_html(_full_p, examples=_st_ex)
+                                        _ep = export_team_profile_html(_full_p, examples=_st_ex, ceremony=_cer)
                                     else:
                                         from scrum_agent.team_profile_exporter import export_team_profile_md
 
-                                        _ep = export_team_profile_md(_full_p, examples=_st_ex)
+                                        _ep = export_team_profile_md(_full_p, examples=_st_ex, ceremony=_cer)
                                     w, h = console.size
                                     live.update(
                                         _build_project_export_success_screen(

--- a/src/scrum_agent/ui/mode_select/screens/_screens.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens.py
@@ -73,9 +73,18 @@ _MODE_CARDS: list[dict[str, Any]] = [
 
 _INTAKE_CARDS: list[dict[str, Any]] = [
     {
+        "key": "small_project",
+        "title": "Small",
+        "description": "1-2 tickets, one quick sprint. Just goal, team, and stack — no capacity planning.",
+        "available": True,
+        "color": "rgb(70,100,180)",
+    },
+    {
+        # Key stays "smart" — Epic wide reuses the existing smart intake engine
+        # (full capacity, bank-holiday, and multi-sprint planning). See intake.py.
         "key": "smart",
-        "title": "Smart",
-        "description": "Recommended — I'll extract answers from your description and only ask 2-4 follow-ups.",
+        "title": "Epic wide",
+        "description": "Multi-ticket epics with full capacity, bank-holiday, and multi-sprint planning.",
         "available": True,
         "color": "rgb(70,100,180)",
     },

--- a/src/scrum_agent/ui/mode_select/screens/_screens.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens.py
@@ -80,10 +80,10 @@ _INTAKE_CARDS: list[dict[str, Any]] = [
         "color": "rgb(70,100,180)",
     },
     {
-        # Key stays "smart" — Epic wide reuses the existing smart intake engine
+        # Key stays "smart" — Large reuses the existing smart intake engine
         # (full capacity, bank-holiday, and multi-sprint planning). See intake.py.
         "key": "smart",
-        "title": "Epic wide",
+        "title": "Large",
         "description": "Multi-ticket epics with full capacity, bank-holiday, and multi-sprint planning.",
         "available": True,
         "color": "rgb(70,100,180)",

--- a/src/scrum_agent/ui/session/__init__.py
+++ b/src/scrum_agent/ui/session/__init__.py
@@ -107,7 +107,7 @@ def run_session(
     Args:
         live: The Rich Live instance from mode_select.py (already active).
         console: The Rich Console for size queries.
-        intake_mode: "smart" or "standard" — which intake flow to use.
+        intake_mode: "smart" / "small_project" / "quick" — which intake flow to use.
         questionnaire: Pre-populated questionnaire (from import flow). Usually None.
         resume_project_id: If resuming, the existing project ID to reuse.
         resume_graph_state: If resuming, the pre-loaded graph state dict.
@@ -313,43 +313,64 @@ def _run_session_body(
             # Save Point A — persist after description processing
             save_project_snapshot(project_id, graph_state)
 
-    # Determine resume point — skip phases that are already complete.
-    # See README: "Memory & State" — when resuming a saved session, we jump
-    # to the earliest incomplete phase rather than replaying from the start.
-    qs = graph_state.get("questionnaire")
-    _intake_done = qs is not None and hasattr(qs, "completed") and qs.completed
-    _pipeline_done = bool(graph_state.get("sprints")) and not graph_state.get("pending_review")
+    # Phases B→D run in a loop so a Small project → Epic wide switch (chosen at
+    # the analysis review) can re-run intake for the extra Epic questions with
+    # the user's answers preserved. Normal runs execute the body exactly once.
+    # See README: "Guardrails" — human-in-the-loop (advisory).
+    while True:
+        # Determine resume point — skip phases that are already complete.
+        # See README: "Memory & State" — when resuming a saved session, we jump
+        # to the earliest incomplete phase rather than replaying from the start.
+        qs = graph_state.get("questionnaire")
+        _intake_done = qs is not None and hasattr(qs, "completed") and qs.completed
+        _pipeline_done = bool(graph_state.get("sprints")) and not graph_state.get("pending_review")
 
-    # ── Phase B: Intake Questions ──────────────────────────────────────
-    # Loop through intake questions until the questionnaire is complete.
-    if not _intake_done:
-        logger.info("Phase transition: intake_questions")
-        graph_state = _phase_intake_questions(live, console, graph, graph_state, _key, export_only)
-        if graph_state is None:
-            return
+        # ── Phase B: Intake Questions ──────────────────────────────────────
+        # Loop through intake questions until the questionnaire is complete.
+        if not _intake_done:
+            logger.info("Phase transition: intake_questions")
+            graph_state = _phase_intake_questions(live, console, graph, graph_state, _key, export_only)
+            if graph_state is None:
+                return
 
-        # Save Point A2 — persist after intake questions so answers survive restarts.
-        # Without this, exiting at the review screen would lose all questionnaire answers.
-        save_project_snapshot(project_id, graph_state)
+            # Save Point A2 — persist after intake questions so answers survive restarts.
+            # Without this, exiting at the review screen would lose all questionnaire answers.
+            save_project_snapshot(project_id, graph_state)
 
-    # ── Phase C: Intake Summary + Review ───────────────────────────────
-    if not _intake_done:
-        logger.info("Phase transition: intake_review")
-        graph_state = _phase_intake_review(live, console, graph, graph_state, _key, export_only)
-        if graph_state is None:
-            return
+        # ── Phase C: Intake Summary + Review ───────────────────────────────
+        if not _intake_done:
+            logger.info("Phase transition: intake_review")
+            graph_state = _phase_intake_review(live, console, graph, graph_state, _key, export_only)
+            if graph_state is None:
+                return
 
-        # Save Point B — persist after intake review acceptance
-        save_project_snapshot(project_id, graph_state)
+            # Save Point B — persist after intake review acceptance
+            save_project_snapshot(project_id, graph_state)
 
-    # ── Phase D: Pipeline Stages ───────────────────────────────────────
-    if not _pipeline_done:
-        logger.info("Phase transition: pipeline")
-        graph_state = _phase_pipeline(
-            live, console, graph, graph_state, _key, export_only, bell, project_id, dry_run=dry_run
-        )
-        if graph_state is None:
-            return
+        # ── Phase D: Pipeline Stages ───────────────────────────────────────
+        if not _pipeline_done:
+            logger.info("Phase transition: pipeline")
+            graph_state = _phase_pipeline(
+                live, console, graph, graph_state, _key, export_only, bell, project_id, dry_run=dry_run
+            )
+            if graph_state is None:
+                return
+
+        # Small → Epic wide switch requested at the analysis review: re-run the
+        # loop. apply_epic_switch() already reset the questionnaire (mode=smart,
+        # completed=False, _reopen_for_epic=True) and cleared artifacts. Invoke
+        # the graph once (no LLM) so project_intake produces the first Epic gap
+        # question before Phase B re-runs.
+        if graph_state is not None and graph_state.pop("_switch_to_epic_pending", False):
+            logger.info("Switching Small project → Epic wide; re-running intake")
+            if graph is not None:
+                try:
+                    graph_state = graph.invoke(graph_state)
+                except Exception:
+                    logger.warning("Epic-switch re-invoke failed", exc_info=True)
+            save_project_snapshot(project_id, graph_state)
+            continue
+        break
 
     # Auto-export when running with --export-only flag
     if export_only and graph_state is not None:

--- a/src/scrum_agent/ui/session/__init__.py
+++ b/src/scrum_agent/ui/session/__init__.py
@@ -313,8 +313,8 @@ def _run_session_body(
             # Save Point A — persist after description processing
             save_project_snapshot(project_id, graph_state)
 
-    # Phases B→D run in a loop so a Small project → Epic wide switch (chosen at
-    # the analysis review) can re-run intake for the extra Epic questions with
+    # Phases B→D run in a loop so a Small project → Large switch (chosen at
+    # the analysis review) can re-run intake for the extra Large-mode questions with
     # the user's answers preserved. Normal runs execute the body exactly once.
     # See README: "Guardrails" — human-in-the-loop (advisory).
     while True:
@@ -356,13 +356,13 @@ def _run_session_body(
             if graph_state is None:
                 return
 
-        # Small → Epic wide switch requested at the analysis review: re-run the
+        # Small → Large switch requested at the analysis review: re-run the
         # loop. apply_epic_switch() already reset the questionnaire (mode=smart,
         # completed=False, _reopen_for_epic=True) and cleared artifacts. Invoke
-        # the graph once (no LLM) so project_intake produces the first Epic gap
-        # question before Phase B re-runs.
+        # the graph once (no LLM) so project_intake produces the first Large-mode
+        # gap question before Phase B re-runs.
         if graph_state is not None and graph_state.pop("_switch_to_epic_pending", False):
-            logger.info("Switching Small project → Epic wide; re-running intake")
+            logger.info("Switching Small project → Large; re-running intake")
             if graph is not None:
                 try:
                     graph_state = graph.invoke(graph_state)

--- a/src/scrum_agent/ui/session/phases/_phases.py
+++ b/src/scrum_agent/ui/session/phases/_phases.py
@@ -1162,6 +1162,10 @@ def _phase_pipeline(
         is_sprint_stage = pending == "sprint_planner"
         if is_story_stage or is_feature_stage or is_task_stage or is_sprint_stage:
             actions = ["Accept", "Edit", "Regenerate", "Export"]
+        elif is_analysis_stage and graph_state.get("_small_project_oversized"):
+            # Small-project scope advisory — offer a switch to Epic wide (answers
+            # are preserved). See README: "Guardrails" — human-in-the-loop (advisory).
+            actions = ["Accept", "Edit", "Switch to Epic", "Export"]
         else:
             actions = ["Accept", "Edit", "Export"]
 
@@ -1246,10 +1250,23 @@ def _phase_pipeline(
                     graph_state.pop("pending_review", None)
                     graph_state.pop("last_review_decision", None)
                     graph_state.pop("last_review_feedback", None)
+                    graph_state.pop("_small_project_oversized", None)
                     # Save Point C — persist after each pipeline stage acceptance
                     if project_id:
                         save_project_snapshot(project_id, graph_state)
                     break
+                elif action == "Switch to Epic":
+                    # Small → Epic wide switch. Preserve answers, clear artifacts,
+                    # and signal _run_session_body to re-run intake for the extra
+                    # Epic questions. See README: "Guardrails" — human-in-the-loop.
+                    logger.info("Review decision: Switch to Epic wide")
+                    from scrum_agent.agent.nodes import apply_epic_switch
+
+                    apply_epic_switch(graph_state)
+                    graph_state["_switch_to_epic_pending"] = True
+                    if project_id:
+                        save_project_snapshot(project_id, graph_state)
+                    return graph_state
                 elif action == "Edit":
                     logger.info("Review decision: Edit for %s", pending)
                     if is_story_stage and selected_story is not None:

--- a/src/scrum_agent/ui/session/phases/_phases.py
+++ b/src/scrum_agent/ui/session/phases/_phases.py
@@ -1163,9 +1163,9 @@ def _phase_pipeline(
         if is_story_stage or is_feature_stage or is_task_stage or is_sprint_stage:
             actions = ["Accept", "Edit", "Regenerate", "Export"]
         elif is_analysis_stage and graph_state.get("_small_project_oversized"):
-            # Small-project scope advisory — offer a switch to Epic wide (answers
+            # Small-project scope advisory — offer a switch to Large (answers
             # are preserved). See README: "Guardrails" — human-in-the-loop (advisory).
-            actions = ["Accept", "Edit", "Switch to Epic", "Export"]
+            actions = ["Accept", "Edit", "Switch to Large", "Export"]
         else:
             actions = ["Accept", "Edit", "Export"]
 
@@ -1255,11 +1255,11 @@ def _phase_pipeline(
                     if project_id:
                         save_project_snapshot(project_id, graph_state)
                     break
-                elif action == "Switch to Epic":
-                    # Small → Epic wide switch. Preserve answers, clear artifacts,
+                elif action == "Switch to Large":
+                    # Small → Large switch. Preserve answers, clear artifacts,
                     # and signal _run_session_body to re-run intake for the extra
-                    # Epic questions. See README: "Guardrails" — human-in-the-loop.
-                    logger.info("Review decision: Switch to Epic wide")
+                    # Large-mode questions. See README: "Guardrails" — human-in-the-loop.
+                    logger.info("Review decision: Switch to Large")
                     from scrum_agent.agent.nodes import apply_epic_switch
 
                     apply_epic_switch(graph_state)

--- a/src/scrum_agent/ui/shared/_components.py
+++ b/src/scrum_agent/ui/shared/_components.py
@@ -71,7 +71,7 @@ _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
     "Share Remotely": ("rgb(50,170,170)", "rgb(90,220,220)", "rgb(40,52,52)", "rgb(50,62,62)"),
     "Stop Sharing": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
     # Advisory action on the analysis review when a Small project looks bigger.
-    "Switch to Epic": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
+    "Switch to Large": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
 }
 _BTN_DEFAULT = ("rgb(100,100,120)", "rgb(140,140,160)", "rgb(40,40,50)", "rgb(50,50,60)")
 _BTN_MIN_W = 12

--- a/src/scrum_agent/ui/shared/_components.py
+++ b/src/scrum_agent/ui/shared/_components.py
@@ -70,6 +70,8 @@ _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
     "Close": ("rgb(100,100,120)", "rgb(140,140,160)", "rgb(40,40,50)", "rgb(50,50,60)"),
     "Share Remotely": ("rgb(50,170,170)", "rgb(90,220,220)", "rgb(40,52,52)", "rgb(50,62,62)"),
     "Stop Sharing": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
+    # Advisory action on the analysis review when a Small project looks bigger.
+    "Switch to Epic": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
 }
 _BTN_DEFAULT = ("rgb(100,100,120)", "rgb(140,140,160)", "rgb(40,40,50)", "rgb(50,50,60)")
 _BTN_MIN_W = 12

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -99,18 +99,12 @@ class TestArgParsing:
         parser = build_parser()
         args = parser.parse_args(["--quick"])
         assert args.quick is True
-        assert args.full_intake is False
 
-    def test_full_intake_flag(self):
-        parser = build_parser()
-        args = parser.parse_args(["--full-intake"])
-        assert args.full_intake is True
-        assert args.quick is False
-
-    def test_quick_and_full_intake_mutually_exclusive(self):
+    def test_full_intake_flag_removed(self):
+        # The 30-question "standard" mode (--full-intake) has been retired.
         parser = build_parser()
         with pytest.raises(SystemExit):
-            parser.parse_args(["--quick", "--full-intake"])
+            parser.parse_args(["--full-intake"])
 
 
 class TestNonInteractiveFlags:
@@ -362,12 +356,6 @@ class TestMain:
         main(argv=["--quick", "--mode", "project-planning"])
         call_kwargs = mock_repl.call_args[1]
         assert call_kwargs["intake_mode"] == "quick"
-
-    @patch("scrum_agent.cli.run_repl")
-    def test_full_intake_flag_passes_standard(self, mock_repl):
-        main(argv=["--full-intake", "--mode", "project-planning"])
-        call_kwargs = mock_repl.call_args[1]
-        assert call_kwargs["intake_mode"] == "standard"
 
     @patch("scrum_agent.cli.run_repl")
     def test_default_intake_mode_is_none(self, mock_repl):

--- a/tests/integration/test_graph.py
+++ b/tests/integration/test_graph.py
@@ -17,7 +17,6 @@ from scrum_agent.agent.state import (
     Task,
     UserStory,
 )
-from scrum_agent.prompts.intake import INTAKE_QUESTIONS
 
 # ── Realistic mock data ────────────────────────────────────────────
 # Used by TestFeatureGenerationScenario and TestMultiTurnFeatureConversation
@@ -523,19 +522,24 @@ class TestIntakeRouting:
     """Tests that the graph routes to intake or agent based on questionnaire state."""
 
     def test_routes_to_intake_without_questionnaire(self):
-        """Without a questionnaire in state, the graph should route to project_intake and ask Q1."""
+        """Without a questionnaire in state, the graph routes to project_intake.
+
+        The default flow is smart intake (the 30-question "standard" Q1-first flow
+        was retired), so it initializes a questionnaire and asks an essential gap
+        rather than starting at Q1.
+        """
         graph = create_graph()
         result = graph.invoke({"messages": []})
 
-        # project_intake should have initialized a QuestionnaireState
+        # project_intake should have initialized a QuestionnaireState in smart mode
         assert "questionnaire" in result
         assert isinstance(result["questionnaire"], QuestionnaireState)
-        assert result["questionnaire"].current_question == 1
+        assert result["questionnaire"].intake_mode == "smart"
 
-        # The AI message should contain Q1
+        # An intake question should have been asked.
         last_msg = result["messages"][-1]
         assert isinstance(last_msg, AIMessage)
-        assert INTAKE_QUESTIONS[1] in last_msg.content
+        assert last_msg.content.strip()
 
     def test_routes_to_analyzer_with_complete_questionnaire(self, monkeypatch):
         """With a completed questionnaire but no analysis, graph routes to project_analyzer."""

--- a/tests/integration/test_repl.py
+++ b/tests/integration/test_repl.py
@@ -1410,13 +1410,12 @@ class TestIntakeModeMenu:
     def test_resolve_intake_mode_1_is_smart(self):
         assert _resolve_intake_mode("1") == "smart"
 
-    def test_resolve_intake_mode_2_is_standard(self):
-        assert _resolve_intake_mode("2") == "standard"
-
-    def test_resolve_intake_mode_3_is_offline(self):
-        assert _resolve_intake_mode("3") == "offline"
+    def test_resolve_intake_mode_2_is_offline(self):
+        # The 30-question "standard" mode was retired; offline is now option 2.
+        assert _resolve_intake_mode("2") == "offline"
 
     def test_resolve_intake_mode_invalid_number(self):
+        assert _resolve_intake_mode("3") is None
         assert _resolve_intake_mode("4") is None
         assert _resolve_intake_mode("0") is None
 
@@ -1429,7 +1428,7 @@ class TestIntakeModeMenu:
         _render_intake_mode_menu(console)
         output = _strip_ansi(buf.getvalue())
         assert "Smart intake (recommended)" in output
-        assert "Full intake" in output
+        assert "Full intake" not in output  # retired 30-question mode
         assert "Quick intake" not in output
         assert "Offline questionnaire" in output
 
@@ -1468,19 +1467,12 @@ class TestIntakeModeMenu:
         call_state = mock_graph.invoke.call_args[0][0]
         assert call_state["_intake_mode"] == "smart"
 
-    def test_mode_2_selects_standard(self, monkeypatch):
-        """Typing '2' at the menu sets standard mode."""
-        mock_graph = _mock_graph_factory()
-        monkeypatch.setattr("scrum_agent.repl.create_graph", lambda: mock_graph)
-        monkeypatch.setattr("scrum_agent.repl.PromptSession", _mock_session_factory(["2", "my project", "exit"]))
-        console, buf = _make_console()
-        run_repl(console=console, intake_mode=None)
-        call_state = mock_graph.invoke.call_args[0][0]
-        assert call_state["_intake_mode"] == "standard"
+    def test_mode_2_selects_offline(self, monkeypatch):
+        """Typing '2' at the menu enters the offline questionnaire flow.
 
-    def test_mode_3_selects_offline(self, monkeypatch):
-        """Typing '3' at the menu enters the offline questionnaire flow."""
-        monkeypatch.setattr("scrum_agent.repl.PromptSession", _mock_session_factory(["3", "1", "exit"]))
+        (Option 2 was the retired "standard" mode; offline moved up from 3 to 2.)
+        """
+        monkeypatch.setattr("scrum_agent.repl.PromptSession", _mock_session_factory(["2", "1", "exit"]))
         monkeypatch.setattr("scrum_agent.repl.export_questionnaire_md", lambda qs, path: path)
         console, buf = _make_console()
         run_repl(console=console, intake_mode=None)
@@ -1497,14 +1489,14 @@ class TestIntakeModeMenu:
         assert "Tell me about your project" in output
 
     def test_invalid_input_reprompts(self, monkeypatch):
-        """Invalid input shows 'pick 1, 2, or 3' then accepts a valid choice."""
-        monkeypatch.setattr("scrum_agent.repl.PromptSession", _mock_session_factory(["foo", "7", "2", "exit"]))
+        """Invalid input shows 'pick 1 or 2' then accepts a valid choice."""
+        monkeypatch.setattr("scrum_agent.repl.PromptSession", _mock_session_factory(["foo", "7", "1", "exit"]))
         console, buf = _make_console()
         run_repl(console=console, intake_mode=None)
         output = _strip_ansi(buf.getvalue())
         # Should have shown the reprompt message twice (for "foo" and "7")
-        assert output.count("Please pick 1, 2, or 3.") == 2
-        # Should still proceed to the opener after valid input
+        assert output.count("Please pick 1 or 2.") == 2
+        # Should still proceed to the opener after valid input ("1" = smart)
         assert "Tell me about your project" in output
 
     def test_ctrl_c_during_menu_exits_gracefully(self, monkeypatch):
@@ -1529,14 +1521,14 @@ class TestIntakeModeMenu:
         output = _strip_ansi(buf.getvalue())
         assert "Goodbye!" in output
 
-    # --- Offline (option 3) integration tests ---
+    # --- Offline (option 2) integration tests ---
 
     def test_mode_3_export_writes_file_and_exits(self, monkeypatch, tmp_path):
-        """Picking [3] then [1] exports the questionnaire and exits."""
+        """Picking [2] then [1] exports the questionnaire and exits."""
         export_path = tmp_path / "scrum-questionnaire.md"
         monkeypatch.setattr("scrum_agent.repl.DEFAULT_EXPORT_FILENAME", str(export_path))
-        # "3" selects offline, "1" selects export — should return immediately
-        monkeypatch.setattr("scrum_agent.repl.PromptSession", _mock_session_factory(["3", "1"]))
+        # "2" selects offline, "1" selects export — should return immediately
+        monkeypatch.setattr("scrum_agent.repl.PromptSession", _mock_session_factory(["2", "1"]))
         console, buf = _make_console()
         run_repl(console=console, intake_mode=None)
         output = _strip_ansi(buf.getvalue())
@@ -1552,7 +1544,7 @@ class TestIntakeModeMenu:
         md_file.write_text("## Q1\nMy project\n\n## Q2\nGreenfield\n")
         monkeypatch.setattr(
             "scrum_agent.repl.PromptSession",
-            _mock_session_factory(["3", "2", str(md_file), "exit"]),
+            _mock_session_factory(["2", "2", str(md_file), "exit"]),
         )
         # Mock _import_questionnaire_file to avoid needing real parse logic
         imported = False
@@ -1578,10 +1570,10 @@ class TestIntakeModeMenu:
         md_file = tmp_path / "scrum-questionnaire.md"
         md_file.write_text("## Q1\nMy project\n")
         monkeypatch.setattr("scrum_agent.repl.DEFAULT_EXPORT_FILENAME", str(md_file))
-        # "3" → offline, "2" → import, "" → press Enter (default path), "exit" → quit
+        # "2" → offline, "2" → import, "" → press Enter (default path), "exit" → quit
         monkeypatch.setattr(
             "scrum_agent.repl.PromptSession",
-            _mock_session_factory(["3", "2", "", "exit"]),
+            _mock_session_factory(["2", "2", "", "exit"]),
         )
         imported_path = None
 
@@ -1603,7 +1595,7 @@ class TestIntakeModeMenu:
         md_file.write_text("## Q1\nMy project\n")
         monkeypatch.setattr(
             "scrum_agent.repl.PromptSession",
-            _mock_session_factory(["3", "2", "/no/such/file.md", str(md_file), "exit"]),
+            _mock_session_factory(["2", "2", "/no/such/file.md", str(md_file), "exit"]),
         )
 
         def fake_import(console, path, state):
@@ -1623,7 +1615,7 @@ class TestIntakeModeMenu:
         monkeypatch.setattr("scrum_agent.repl.DEFAULT_EXPORT_FILENAME", str(export_path))
         monkeypatch.setattr(
             "scrum_agent.repl.PromptSession",
-            _mock_session_factory(["3", "foo", "5", "1"]),
+            _mock_session_factory(["2", "foo", "5", "1"]),
         )
         console, buf = _make_console()
         run_repl(console=console, intake_mode=None)

--- a/tests/unit/nodes/test_ceremony_history.py
+++ b/tests/unit/nodes/test_ceremony_history.py
@@ -1,0 +1,219 @@
+"""Tests for ceremony history — feeding Standup + Retro data into Planning &
+Analysis (team-wide gather, deterministic cadence/trends/themes, prompt injection,
+backlog seeding, and the Analysis-report ceremony section).
+
+See README: "Session Management" — SQLite persistence.
+"""
+
+import json
+from dataclasses import asdict
+
+from scrum_agent.agent.ceremony_history import (
+    CeremonyContext,
+    _avg_interval_days,
+    _confidence_trend,
+    _dedup_action_items,
+    _describe_cadence,
+    _top_themes,
+    format_ceremony_history_md,
+    gather_ceremony_context,
+)
+from scrum_agent.agent.state import RetroCard, RetroReport, StandupReport
+from scrum_agent.retro.store import RetroStore
+from scrum_agent.standup.store import StandupStore
+
+# ── Seeding helpers (insert rows with explicit run_at for deterministic cadence) ──
+
+
+def _seed_retro(store, session_id, run_at, project_name, cards):
+    report = RetroReport(date=run_at[:10], session_id=session_id, project_name=project_name, cards=tuple(cards))
+    store._conn.execute(
+        "INSERT INTO retro_history (session_id, run_at, retro_date, project_name, card_count, report_json) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (session_id, run_at, run_at[:10], project_name, len(cards), json.dumps(asdict(report))),
+    )
+
+
+def _seed_standup(store, session_id, run_at, confidence_pct, status="success"):
+    report = StandupReport(date=run_at[:10], session_id=session_id, confidence_pct=confidence_pct)
+    store._conn.execute(
+        "INSERT INTO standup_history "
+        "(session_id, run_at, standup_date, sprint_day, confidence_pct, report_json, status) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (session_id, run_at, run_at[:10], 1, confidence_pct, json.dumps(asdict(report)), status),
+    )
+
+
+def _ac(text):
+    return RetroCard(grid="action_items", text=text, author="A")
+
+
+# ── Pure helpers ────────────────────────────────────────────────────────────
+
+
+class TestCadence:
+    def test_no_runs(self):
+        assert "no" in _describe_cadence([], "retro")
+
+    def test_single_run(self):
+        assert "1 retro" in _describe_cadence(["2026-06-01T10:00:00+00:00"], "retro")
+
+    def test_weekly_cadence(self):
+        runs = ["2026-06-01T10:00:00+00:00", "2026-06-15T10:00:00+00:00", "2026-06-29T10:00:00+00:00"]
+        out = _describe_cadence(runs, "retro")
+        assert "week" in out and "3 retros" in out
+
+    def test_daily_cadence(self):
+        runs = ["2026-06-01T09:00:00+00:00", "2026-06-02T09:00:00+00:00", "2026-06-03T09:00:00+00:00"]
+        assert "day" in _describe_cadence(runs, "standup")
+
+    def test_avg_interval_needs_two(self):
+        assert _avg_interval_days(["2026-06-01T00:00:00+00:00"]) is None
+        assert _avg_interval_days([]) is None
+
+    def test_avg_interval_ignores_unparseable(self):
+        runs = ["bad", "2026-06-01T00:00:00+00:00", "2026-06-03T00:00:00+00:00"]
+        assert _avg_interval_days(runs) == 2.0
+
+
+class TestConfidenceTrend:
+    def test_empty(self):
+        assert _confidence_trend([]) == ("", None)
+
+    def test_average_only_when_few(self):
+        hist = [{"confidence_pct": 60, "status": "success"}, {"confidence_pct": 80, "status": "success"}]
+        phrase, avg = _confidence_trend(hist)
+        assert avg == 70 and "70%" in phrase and "improving" not in phrase
+
+    def test_improving(self):
+        # newest-first: recent high, older low → improving
+        hist = [{"confidence_pct": p, "status": "success"} for p in (85, 80, 60, 55)]
+        phrase, _ = _confidence_trend(hist)
+        assert "improving" in phrase
+
+    def test_declining(self):
+        hist = [{"confidence_pct": p, "status": "success"} for p in (55, 60, 82, 85)]
+        phrase, _ = _confidence_trend(hist)
+        assert "declining" in phrase
+
+
+class TestThemesAndActionItems:
+    def test_top_themes_counts_recurring(self):
+        reports = [
+            RetroReport(cards=(RetroCard(grid="didnt_go_well", text="Flaky CI"),)),
+            RetroReport(cards=(RetroCard(grid="didnt_go_well", text="flaky ci"),)),  # normalises to same
+            RetroReport(cards=(RetroCard(grid="didnt_go_well", text="Slow reviews"),)),  # only once → excluded
+        ]
+        themes = _top_themes(reports, "didnt_go_well")
+        assert themes == (("Flaky CI", 2),)
+
+    def test_dedup_action_items_newest_wins(self):
+        reports = [
+            RetroReport(cards=(_ac("Fix CI"), _ac("Add dashboards"))),  # newest
+            RetroReport(cards=(_ac("fix ci"),)),  # duplicate (normalised) → skipped
+        ]
+        items = _dedup_action_items(reports)
+        assert items == ("Fix CI", "Add dashboards")
+
+
+class TestFormat:
+    def test_empty_context_renders_empty(self):
+        assert format_ceremony_history_md(CeremonyContext()) == ""
+
+    def test_non_empty_has_sections(self):
+        ctx = CeremonyContext(
+            action_items=("Fix CI",),
+            retro_count=2,
+            didnt_go_well_themes=(("Flaky CI", 3),),
+            confidence_trend="70% average confidence, improving",
+            retro_cadence="~every 2 week(s) (2 retros)",
+            standup_cadence="roughly daily (10 standups)",
+        )
+        md = format_ceremony_history_md(ctx)
+        assert "Open retro action items" in md and "Fix CI" in md
+        assert "Flaky CI (3×)" in md
+        assert "70% average confidence" in md
+        assert "Cadence" in md
+
+
+# ── gather_ceremony_context (temp DB, team-wide, project-first) ───────────────
+
+
+class TestGather:
+    def _db(self, tmp_path):
+        return tmp_path / "sessions.db"
+
+    def _point_config_at(self, monkeypatch, db):
+        monkeypatch.setattr("scrum_agent.config.get_sessions_db", lambda: db)
+
+    def test_missing_db_is_empty(self, tmp_path, monkeypatch):
+        self._point_config_at(monkeypatch, self._db(tmp_path))  # file never created
+        ctx = gather_ceremony_context("Alpha")
+        assert ctx.is_empty
+        assert ctx.summary_md == ""
+
+    def test_gathers_and_distils(self, tmp_path, monkeypatch):
+        db = self._db(tmp_path)
+        with RetroStore(db) as r:
+            runs = ["2026-06-01T10:00:00+00:00", "2026-06-15T10:00:00+00:00", "2026-06-29T10:00:00+00:00"]
+            for i, run in enumerate(runs):
+                _seed_retro(
+                    r,
+                    f"s{i}",
+                    run,
+                    "Alpha",
+                    [
+                        RetroCard(grid="went_well", text="Good pairing"),
+                        RetroCard(grid="didnt_go_well", text="Flaky CI"),
+                        _ac("Fix flaky CI"),
+                        _ac(f"Add dashboard {i}"),
+                    ],
+                )
+        with StandupStore(db) as s:
+            for i, (run, pct) in enumerate(
+                [
+                    ("2026-06-20T09:00:00+00:00", 60),
+                    ("2026-06-21T09:00:00+00:00", 65),
+                    ("2026-06-24T09:00:00+00:00", 78),
+                    ("2026-06-25T09:00:00+00:00", 82),
+                ]
+            ):
+                _seed_standup(s, "s0", run, pct)
+
+        self._point_config_at(monkeypatch, db)
+        ctx = gather_ceremony_context("Alpha")
+
+        assert ctx.retro_count == 3
+        assert ctx.standup_count == 4
+        # "Fix flaky CI" recurs across all 3 retros but is deduped to one action item.
+        assert ctx.action_items.count("Fix flaky CI") == 1
+        assert "week" in ctx.retro_cadence
+        assert "improving" in ctx.confidence_trend
+        assert ("Flaky CI", 3) in ctx.didnt_go_well_themes
+        assert "Open retro action items" in ctx.summary_md
+
+    def test_project_first_ordering(self, tmp_path, monkeypatch):
+        db = self._db(tmp_path)
+        with RetroStore(db) as r:
+            # 'Beta' is more recent, but a project-first query for 'Alpha' must surface Alpha.
+            _seed_retro(r, "a", "2026-06-01T00:00:00+00:00", "Alpha", [_ac("Alpha item")])
+            _seed_retro(r, "b", "2026-07-01T00:00:00+00:00", "Beta", [_ac("Beta item")])
+            reports = r.get_recent_reports(limit=1, project_name="Alpha")
+        assert reports[0].project_name == "Alpha"
+
+    def test_get_all_history_spans_sessions(self, tmp_path):
+        db = self._db(tmp_path)
+        with RetroStore(db) as r:
+            _seed_retro(r, "a", "2026-06-01T00:00:00+00:00", "Alpha", [_ac("x")])
+            _seed_retro(r, "b", "2026-07-01T00:00:00+00:00", "Beta", [_ac("y")])
+            hist = r.get_all_history(limit=10)
+        assert len(hist) == 2
+        assert {h["project_name"] for h in hist} == {"Alpha", "Beta"}
+
+    def test_standup_recent_reports_skips_failed(self, tmp_path):
+        db = self._db(tmp_path)
+        with StandupStore(db) as s:
+            _seed_standup(s, "s0", "2026-06-01T00:00:00+00:00", 70, status="success")
+            _seed_standup(s, "s0", "2026-06-02T00:00:00+00:00", 0, status="error")
+            reports = s.get_recent_reports(limit=10)
+        assert len(reports) == 1

--- a/tests/unit/nodes/test_ceremony_integration.py
+++ b/tests/unit/nodes/test_ceremony_integration.py
@@ -1,0 +1,120 @@
+"""Tests that ceremony history flows into the planning prompts, seeds the backlog,
+and renders in the Analysis report — each section appears only when data is present.
+
+See README: "Prompt Construction" — optional context sections.
+"""
+
+from unittest.mock import MagicMock
+
+from langchain_core.messages import HumanMessage
+
+from scrum_agent.agent.ceremony_history import CeremonyContext
+from scrum_agent.agent.nodes import project_analyzer
+from scrum_agent.prompts.analyzer import get_analyzer_prompt
+from scrum_agent.prompts.sprint_planner import get_sprint_planner_prompt
+from scrum_agent.prompts.story_writer import get_story_writer_prompt
+from scrum_agent.team_profile import TeamProfile
+from scrum_agent.team_profile_exporter import export_team_profile_md
+from tests._node_helpers import VALID_ANALYSIS_JSON, make_completed_questionnaire
+
+
+class TestAnalyzerInjection:
+    def test_section_present_when_history(self):
+        p = get_analyzer_prompt("Q&A", 3, 15, ceremony_history="Open retro action items:\n- Fix CI")
+        assert "Standup & Retro History" in p
+        assert "Fix CI" in p
+
+    def test_section_absent_when_empty(self):
+        assert "Standup & Retro History" not in get_analyzer_prompt("Q&A", 3, 15)
+
+
+class TestStoryWriterSeeding:
+    def _prompt(self, items):
+        return get_story_writer_prompt(
+            "P", "d", "greenfield", "goals", "users", "TS", "constraints", "feats", carry_over_items=items
+        )
+
+    def test_carry_over_creates_retro_stories(self):
+        p = self._prompt(("Fix flaky CI", "Add dashboards"))
+        assert "Carry-over from Recent Retros" in p
+        assert "[Retro]" in p
+        assert "Fix flaky CI" in p
+
+    def test_no_carry_over_no_section(self):
+        assert "Carry-over from Recent Retros" not in self._prompt(())
+
+
+class TestSprintPlannerInjection:
+    def test_section_present(self):
+        p = get_sprint_planner_prompt("P", "d", 20, 3, "stories", ceremony_history="70% confidence, declining")
+        assert "Recent Standup & Retro Signals" in p
+        assert "declining" in p
+
+    def test_section_absent(self):
+        assert "Recent Standup & Retro Signals" not in get_sprint_planner_prompt("P", "d", 20, 3, "stories")
+
+
+class TestAnalysisExport:
+    def _profile(self):
+        return TeamProfile(team_id="jira-PROJ", source="jira", project_key="PROJ", sample_sprints=5, sample_stories=30)
+
+    def _ceremony(self):
+        return CeremonyContext(
+            summary_md="x",
+            retro_count=3,
+            standup_count=8,
+            retro_cadence="~every 2 week(s) (3 retros)",
+            standup_cadence="roughly daily (8 standups)",
+            confidence_trend="72% average confidence, improving",
+            didnt_go_well_themes=(("Flaky CI", 3),),
+            went_well_themes=(("Good pairing", 2),),
+            action_items=("Fix CI",),
+        )
+
+    def test_md_includes_ceremony_section(self, tmp_path):
+        path = export_team_profile_md(self._profile(), tmp_path, examples={}, ceremony=self._ceremony())
+        text = path.read_text()
+        assert "## Ceremony Cadence & Trends" in text
+        assert "Retro cadence" in text
+        assert "Flaky CI (3×)" in text
+        assert "72% average confidence, improving" in text
+
+    def test_md_omits_ceremony_when_absent(self, tmp_path):
+        path = export_team_profile_md(self._profile(), tmp_path, examples={}, ceremony=None)
+        assert "Ceremony Cadence" not in path.read_text()
+
+    def test_md_omits_ceremony_when_empty(self, tmp_path):
+        path = export_team_profile_md(self._profile(), tmp_path, examples={}, ceremony=CeremonyContext())
+        assert "Ceremony Cadence" not in path.read_text()
+
+
+class TestAnalyzerWiring:
+    """project_analyzer gathers ceremony history, injects it, and stashes action items."""
+
+    def test_action_items_stashed_and_injected(self, monkeypatch):
+        captured = {}
+
+        def _fake_prompt(*args, **kwargs):
+            captured["ceremony_history"] = kwargs.get("ceremony_history", "")
+            return "PROMPT"
+
+        ctx = CeremonyContext(summary_md="Open retro action items:\n- Fix CI", action_items=("Fix CI",), retro_count=1)
+        monkeypatch.setattr("scrum_agent.agent.nodes.gather_ceremony_context", lambda *a, **k: ctx)
+        monkeypatch.setattr("scrum_agent.agent.nodes.get_analyzer_prompt", _fake_prompt)
+        monkeypatch.setattr("scrum_agent.agent.nodes._scan_repo_context", lambda *a, **k: (None, {}))
+        fake = MagicMock()
+        fake.content = VALID_ANALYSIS_JSON
+        llm = MagicMock()
+        llm.invoke.return_value = fake
+        monkeypatch.setattr("scrum_agent.agent.nodes.get_llm", lambda **kw: llm)
+
+        state = {
+            "messages": [HumanMessage(content="continue")],
+            "questionnaire": make_completed_questionnaire(),
+            "team_size": 3,
+            "velocity_per_sprint": 15,
+        }
+        result = project_analyzer(state)
+        assert result["_ceremony_action_items"] == ("Fix CI",)
+        assert result["_ceremony_history"] == ctx.summary_md
+        assert "Fix CI" in captured["ceremony_history"]

--- a/tests/unit/nodes/test_intake.py
+++ b/tests/unit/nodes/test_intake.py
@@ -65,26 +65,15 @@ class TestProjectIntake:
         monkeypatch.setattr("scrum_agent.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
 
     def test_first_call_initializes_questionnaire(self):
-        """No questionnaire in state → returns a new QuestionnaireState."""
+        """No questionnaire in state → returns a new QuestionnaireState (smart mode)."""
         state = {"messages": []}
         result = project_intake(state)
         assert "questionnaire" in result
         assert isinstance(result["questionnaire"], QuestionnaireState)
-        assert result["questionnaire"].current_question == 1
-
-    def test_first_call_asks_first_question(self):
-        """First invocation should ask Q1 text."""
-        state = {"messages": []}
-        result = project_intake(state)
-        ai_msg = result["messages"][0]
-        assert isinstance(ai_msg, AIMessage)
-        assert INTAKE_QUESTIONS[1] in ai_msg.content
-
-    def test_first_call_includes_phase_label(self):
-        """First invocation should include the Phase 1 header."""
-        state = {"messages": []}
-        result = project_intake(state)
-        assert "Phase 1: Project Context" in result["messages"][0].content
+        # The default (smart) flow asks an essential gap, not Q1-first — that
+        # Q1-first behavior belonged to the retired "standard" mode.
+        assert result["questionnaire"].intake_mode == "smart"
+        assert isinstance(result["messages"][0], AIMessage)
 
     def test_records_answer(self):
         """After answering, the answer should be stored in questionnaire.answers."""
@@ -352,82 +341,12 @@ class TestAdaptiveSkipIntegration:
             lambda desc: extracted,
         )
 
-    def test_first_call_stores_suggestions(self, monkeypatch):
-        """First call with a description should store extracted answers as suggestions."""
-        self._mock_extract(monkeypatch, {1: "A todo app", 6: "3 engineers", 11: "React"})
-        state = {"messages": [HumanMessage(content="Building a todo app with 3 engineers using React")]}
-
-        result = project_intake(state)
-        qs = result["questionnaire"]
-        # Suggestions stored — NOT in answers or skipped_questions
-        assert qs.suggested_answers == {1: "A todo app", 6: "3 engineers", 11: "React"}
-        assert len(qs.answers) == 0
-        assert len(qs.skipped_questions) == 0
-
-    def test_first_call_shows_suggestion_count(self, monkeypatch):
-        """First call should mention how many details were picked up."""
-        self._mock_extract(monkeypatch, {1: "A todo app", 6: "3 engineers"})
-        state = {"messages": [HumanMessage(content="Building a todo app with 3 engineers")]}
-
-        result = project_intake(state)
-        content = result["messages"][0].content
-        assert "2" in content  # picked up 2 details
-        assert "confirm" in content.lower() or "change" in content.lower()
-
-    def test_first_call_always_starts_at_q1(self, monkeypatch):
-        """With extraction, should still start at Q1 (not skip to next unanswered)."""
-        self._mock_extract(monkeypatch, {1: "A todo app"})
-        state = {"messages": [HumanMessage(content="Building a todo app")]}
-
-        result = project_intake(state)
-        qs = result["questionnaire"]
-        assert qs.current_question == 1
-        assert INTAKE_QUESTIONS[1] in result["messages"][0].content
-
-    def test_suggestion_shown_inline(self, monkeypatch):
-        """When Q1 has a suggestion, it should be shown inline with the question."""
-        self._mock_extract(monkeypatch, {1: "A todo app"})
-        state = {"messages": [HumanMessage(content="Building a todo app")]}
-
-        result = project_intake(state)
-        content = result["messages"][0].content
-        assert "Suggested" in content
-        assert "A todo app" in content
-
-    def test_empty_messages_falls_back_to_q1(self, monkeypatch):
-        """Empty messages list → no description → falls back to asking Q1."""
-        self._mock_extract(monkeypatch, {})
-        state = {"messages": []}
-
-        result = project_intake(state)
-        qs = result["questionnaire"]
-        assert qs.current_question == 1
-        assert INTAKE_QUESTIONS[1] in result["messages"][0].content
-
-    def test_llm_failure_falls_back_to_q1(self, monkeypatch):
-        """If extraction returns {} (LLM failure) → falls back to asking Q1."""
-        self._mock_extract(monkeypatch, {})
-        state = {"messages": [HumanMessage(content="Building a todo app with 3 engineers")]}
-
-        result = project_intake(state)
-        qs = result["questionnaire"]
-        assert qs.current_question == 1
-        assert len(qs.skipped_questions) == 0
-        assert len(qs.suggested_answers) == 0
-
-    def test_all_questions_extracted_still_starts_at_q1(self, monkeypatch):
-        """If all 26 questions are extracted → still starts at Q1 with suggestion."""
-        all_answers = {i: f"answer {i}" for i in range(1, TOTAL_QUESTIONS + 1)}
-        self._mock_extract(monkeypatch, all_answers)
-        state = {"messages": [HumanMessage(content="Very detailed description")]}
-
-        result = project_intake(state)
-        qs = result["questionnaire"]
-        # Should NOT auto-complete — starts at Q1 for confirmation
-        assert qs.current_question == 1
-        assert qs.awaiting_confirmation is False
-        assert qs.completed is False
-        assert len(qs.suggested_answers) == TOTAL_QUESTIONS
+    # NOTE: the first-call "adaptive skip" tests that lived here asserted the
+    # retired "standard" mode's behavior (extractions stored as suggested_answers,
+    # always start at Q1, show a "picked up N details" count). That flow has been
+    # removed — smart mode (the default) auto-applies non-essential extractions and
+    # asks the first essential gap instead. Smart first-invocation is covered by
+    # TestSmartIntakeMode and test_smart_mode_first_invocation_* below.
 
     def test_suggestion_shown_on_subsequent_question(self, monkeypatch):
         """When advancing to a question with a suggestion, it should show inline."""
@@ -2067,12 +1986,10 @@ class TestPhaseIntros:
         for phase in PHASE_INTROS:
             assert PHASE_INTROS[phase] != PHASE_LABELS[phase]
 
-    def test_phase_intro_appears_in_first_question(self):
-        """When asking Q1, the phase intro should appear in the message."""
-        state = {"messages": []}
-        result = project_intake(state)
-        msg = result["messages"][0].content
-        assert PHASE_INTROS["project_context"] in msg
+    # NOTE: the former test_phase_intro_appears_in_first_question asserted the
+    # retired "standard" mode's Q1-first phase-intro banner. Smart mode (the
+    # default) asks an essential gap first, so that banner no longer appears on
+    # the first call. Phase intros still render in the shared subsequent-call flow.
 
 
 # ── Defaults command tests ───────────────────────────────────────────
@@ -2697,8 +2614,13 @@ class TestSmartIntakeMode:
         # Q4 should be the next gap asked
         assert qs_out.current_question == 4
 
-    def test_standard_mode_unchanged(self, monkeypatch):
-        """Standard mode (default) still asks Q1 as the first question."""
+    def test_standard_mode_coerced_to_smart(self, monkeypatch):
+        """The retired "standard" mode is coerced to smart at first invocation.
+
+        The legacy 30-question one-at-a-time flow has been removed; any lingering
+        "standard" value (old sessions, stale state) now follows the smart path,
+        which asks only essential gaps rather than starting at Q1.
+        """
         monkeypatch.setattr(
             "scrum_agent.agent.nodes._extract_answers_from_description",
             lambda desc: {},
@@ -2709,11 +2631,9 @@ class TestSmartIntakeMode:
         }
         result = project_intake(state)
         qs = result["questionnaire"]
-        assert qs.intake_mode == "standard"
-        assert qs.current_question == 1
-        # Should show Q1 text
-        ai_msg = result["messages"][0].content
-        assert "Phase 1" in ai_msg
+        assert qs.intake_mode == "smart"
+        # Smart flow does not walk Q1-first; it jumps to essential gaps.
+        assert qs.current_question != 1
 
     def test_vague_answer_triggers_follow_up(self, monkeypatch):
         """Smart mode: a vague answer should trigger a follow-up probe."""

--- a/tests/unit/nodes/test_low_code.py
+++ b/tests/unit/nodes/test_low_code.py
@@ -1,0 +1,187 @@
+"""Tests for low-code detection wiring: analyzer reconciliation, intake
+suggestions, the lighter-plan prompt clauses, rendering, and serialization.
+
+See README: "Scrum Standards" — estimation; "Project Intake Questionnaire".
+"""
+
+import dataclasses
+from dataclasses import asdict
+from io import StringIO
+from unittest.mock import MagicMock
+
+from langchain_core.messages import HumanMessage
+from rich.console import Console
+
+from scrum_agent.agent.nodes import _apply_repo_signals, project_analyzer
+from scrum_agent.agent.repo_signals import RepoSignals
+from scrum_agent.agent.state import QuestionnaireState
+from scrum_agent.formatters import render_analysis_panel
+from scrum_agent.prompts.story_writer import get_story_writer_prompt
+from scrum_agent.prompts.task_decomposer import get_task_decomposer_prompt
+from scrum_agent.sessions import _dict_to_analysis
+from tests._node_helpers import VALID_ANALYSIS_JSON, make_completed_questionnaire, make_dummy_analysis
+
+
+def _render(panel) -> str:
+    buf = StringIO()
+    Console(file=buf, force_terminal=False, width=100, highlight=False).print(panel)
+    return buf.getvalue()
+
+
+def _mock_llm(monkeypatch, content: str):
+    fake = MagicMock()
+    fake.content = content
+    llm = MagicMock()
+    llm.invoke.return_value = fake
+    monkeypatch.setattr("scrum_agent.agent.nodes.get_llm", lambda **kw: llm)
+
+
+def _analyzer_state(description: str) -> dict:
+    qs = make_completed_questionnaire()
+    qs.answers[1] = description
+    return {
+        "messages": [HumanMessage(content="continue")],
+        "questionnaire": qs,
+        "team_size": 3,
+        "velocity_per_sprint": 15,
+    }
+
+
+class TestAnalyzerReconciliation:
+    """project_analyzer ORs the LLM verdict with the deterministic one."""
+
+    def test_deterministic_marker_flips_low_code(self, monkeypatch):
+        # LLM JSON has no is_low_code (→ False), but the description trips a marker.
+        _mock_llm(monkeypatch, VALID_ANALYSIS_JSON)
+        monkeypatch.setattr("scrum_agent.agent.nodes._scan_repo_context", lambda *a, **kw: (None, {}))
+        result = project_analyzer(_analyzer_state("Build a Webflow + Zapier marketing site"))
+        analysis = result["project_analysis"]
+        assert analysis.is_low_code is True
+        assert analysis.low_code_reason  # a reason was attached
+
+    def test_llm_true_is_respected(self, monkeypatch):
+        import json
+
+        parsed = json.loads(VALID_ANALYSIS_JSON)
+        parsed["is_low_code"] = True
+        parsed["low_code_reason"] = "config-only integration"
+        _mock_llm(monkeypatch, json.dumps(parsed))
+        monkeypatch.setattr("scrum_agent.agent.nodes._scan_repo_context", lambda *a, **kw: (None, {}))
+        # A plain description (no markers) — the flag must come from the LLM.
+        result = project_analyzer(_analyzer_state("An internal reporting tool"))
+        assert result["project_analysis"].is_low_code is True
+
+    def test_ordinary_project_not_low_code(self, monkeypatch):
+        _mock_llm(monkeypatch, VALID_ANALYSIS_JSON)
+        monkeypatch.setattr("scrum_agent.agent.nodes._scan_repo_context", lambda *a, **kw: (None, {}))
+        result = project_analyzer(_analyzer_state("A FastAPI backend with a React frontend"))
+        assert result["project_analysis"].is_low_code is False
+
+    def test_display_shows_low_code_notice(self, monkeypatch):
+        _mock_llm(monkeypatch, VALID_ANALYSIS_JSON)
+        monkeypatch.setattr("scrum_agent.agent.nodes._scan_repo_context", lambda *a, **kw: (None, {}))
+        result = project_analyzer(_analyzer_state("A WordPress content site, no custom code"))
+        assert "Low-code" in result["messages"][0].content
+
+
+class TestApplyRepoSignals:
+    """_apply_repo_signals stashes the scan and pre-fills Q11/Q12."""
+
+    def _patch_scan(self, monkeypatch, signals: RepoSignals, raw="RAW"):
+        monkeypatch.setattr(
+            "scrum_agent.agent.nodes.scan_repo_signals",
+            lambda qs: (raw, signals, {"status": "success"}),
+        )
+
+    def test_suggests_stack_and_integrations(self, monkeypatch):
+        self._patch_scan(
+            monkeypatch,
+            RepoSignals(detected_stack=["TypeScript", "Next.js"], integrations=["Stripe"], source="github"),
+        )
+        qs = QuestionnaireState(intake_mode="smart")
+        _apply_repo_signals(qs)
+        assert qs.suggested_answers[11] == "TypeScript, Next.js"
+        assert qs.answers[12] == "Stripe"
+        assert qs._repo_context == "RAW"
+
+    def test_stashes_low_code_verdict(self, monkeypatch):
+        self._patch_scan(
+            monkeypatch,
+            RepoSignals(low_code=True, low_code_reasons=["mentions zapier (low-code ...)"]),
+            raw="",
+        )
+        qs = QuestionnaireState(intake_mode="smart")
+        _apply_repo_signals(qs)
+        assert qs._repo_low_code is True
+        assert "zapier" in qs._repo_low_code_reason
+
+    def test_does_not_override_user_stack(self, monkeypatch):
+        self._patch_scan(monkeypatch, RepoSignals(detected_stack=["Go"]))
+        qs = QuestionnaireState(intake_mode="smart")
+        qs.answers[11] = "Rust"  # user already answered
+        _apply_repo_signals(qs)
+        assert 11 not in qs.suggested_answers  # not suggested over a real answer
+
+    def test_no_signals_is_noop(self, monkeypatch):
+        self._patch_scan(monkeypatch, RepoSignals(), raw="")
+        qs = QuestionnaireState(intake_mode="smart")
+        _apply_repo_signals(qs)
+        assert 11 not in qs.suggested_answers
+        assert 12 not in qs.answers
+
+
+class TestLowCodePrompts:
+    """The lighter-plan clause appears only when is_low_code is True."""
+
+    def _story_prompt(self, is_low_code: bool) -> str:
+        return get_story_writer_prompt(
+            "P", "desc", "greenfield", "goals", "users", "TS", "constraints", "features", is_low_code=is_low_code
+        )
+
+    def test_story_writer_includes_clause(self):
+        assert "LOW-CODE" in self._story_prompt(True)
+
+    def test_story_writer_omits_clause(self):
+        assert "LOW-CODE" not in self._story_prompt(False)
+
+    def test_task_decomposer_includes_clause(self):
+        p = get_task_decomposer_prompt("P", "greenfield", "TS", "stories", is_low_code=True)
+        assert "LOW-CODE" in p
+
+    def test_task_decomposer_omits_clause(self):
+        p = get_task_decomposer_prompt("P", "greenfield", "TS", "stories", is_low_code=False)
+        assert "LOW-CODE" not in p
+
+
+class TestLowCodeRender:
+    def test_panel_shows_low_code_when_set(self):
+        analysis = make_dummy_analysis(is_low_code=True, low_code_reason="Webflow site")
+        out = _render(render_analysis_panel(analysis))
+        assert "Low-code" in out
+        assert "Webflow site" in out
+
+    def test_panel_hides_low_code_when_unset(self):
+        out = _render(render_analysis_panel(make_dummy_analysis()))
+        assert "Low-code" not in out
+
+
+class TestLowCodeSerialization:
+    def test_round_trip_via_dict(self):
+        analysis = make_dummy_analysis(is_low_code=True, low_code_reason="Zapier flow")
+        restored = _dict_to_analysis(asdict(analysis))
+        assert restored.is_low_code is True
+        assert restored.low_code_reason == "Zapier flow"
+
+    def test_missing_keys_default_false(self):
+        # Old saved sessions predate the fields — reconstruction must not raise.
+        d = asdict(make_dummy_analysis())
+        d.pop("is_low_code", None)
+        d.pop("low_code_reason", None)
+        restored = _dict_to_analysis(d)
+        assert restored.is_low_code is False
+        assert restored.low_code_reason == ""
+
+    def test_replace_keeps_defaults(self):
+        # is_low_code has a default → frozen dataclass replace works for old shapes.
+        base = make_dummy_analysis()
+        assert dataclasses.replace(base, is_low_code=True).is_low_code is True

--- a/tests/unit/nodes/test_repo_signals.py
+++ b/tests/unit/nodes/test_repo_signals.py
@@ -1,0 +1,230 @@
+"""Tests for repo_signals — deterministic repository/tech signals for the smart
+intake (tech-stack + integration suggestion, low-code detection).
+
+See README: "Project Intake Questionnaire" — smart intake.
+"""
+
+from unittest.mock import MagicMock
+
+from scrum_agent.agent.repo_signals import (
+    INTEGRATION_SDK_MARKERS,
+    LOW_CODE_MARKERS,
+    RepoSignals,
+    _detect_low_code,
+    _parse_key_files,
+    _parse_languages,
+    _parse_total_files,
+    analyze_context,
+    scan_repo_signals,
+)
+from scrum_agent.agent.state import QuestionnaireState
+
+# A github_read_repo / read_codebase style summary — the two tools share format.
+_GH_SUMMARY = """Repository: acme/storefront
+Default branch: main
+
+File tree (top level):
+  src/
+  content/
+
+Key files detected:
+  package.json
+  Dockerfile
+
+Languages:
+  TypeScript: 68.0%
+  CSS: 32.0%
+
+Stars: 4  Forks: 1  Open issues: 3"""
+
+_LOCAL_SUMMARY = """Local repository: /tmp/site
+Total files scanned: 3
+
+File tree:
+  content/
+
+Key files detected:
+  README.md"""
+
+
+class TestParsers:
+    def test_parse_languages(self):
+        assert _parse_languages(_GH_SUMMARY) == ["TypeScript", "CSS"]
+
+    def test_parse_languages_absent(self):
+        assert _parse_languages("Repository: x\n\nNo languages here") == []
+
+    def test_parse_key_files(self):
+        assert _parse_key_files(_GH_SUMMARY) == ["package.json", "Dockerfile"]
+
+    def test_parse_total_files(self):
+        assert _parse_total_files(_LOCAL_SUMMARY) == 3
+        assert _parse_total_files(_GH_SUMMARY) is None
+
+
+class TestAnalyzeContextStack:
+    def test_detected_stack_from_languages_and_key_files(self):
+        s = analyze_context(_GH_SUMMARY, description="storefront", tech_stack="TypeScript")
+        # Languages first, then key-file tools (Docker).
+        assert "TypeScript" in s.detected_stack
+        assert "CSS" in s.detected_stack
+        assert "Docker" in s.detected_stack
+
+    def test_frameworks_and_integrations_from_manifests(self):
+        manifests = {"package.json": '{"dependencies": {"next": "14", "stripe": "12", "@sendgrid/mail": "7"}}'}
+        s = analyze_context(_GH_SUMMARY, manifests=manifests, source="github")
+        assert "Next.js" in s.detected_stack  # framework from manifest
+        assert "Stripe" in s.integrations
+        assert "SendGrid" in s.integrations
+
+    def test_detected_stack_deduplicated(self):
+        # "TypeScript" appears as a language; ensure no duplicates in output.
+        s = analyze_context(_GH_SUMMARY)
+        assert s.detected_stack.count("TypeScript") == 1
+
+    def test_empty_context_yields_empty_stack(self):
+        s = analyze_context("", description="", tech_stack="")
+        assert s.detected_stack == []
+        assert s.integrations == []
+        assert s.low_code is False
+
+
+class TestLowCodeDetection:
+    def test_marker_in_description(self):
+        low, reasons = _detect_low_code(
+            description="Set up a Zapier + Webflow content site",
+            tech_stack="",
+            languages=[],
+            key_files=[],
+            total_files=None,
+        )
+        assert low is True
+        assert any("zapier" in r.lower() or "webflow" in r.lower() for r in reasons)
+
+    def test_marker_multiword_phrase(self):
+        low, _ = _detect_low_code(
+            description="A Power Platform automation",
+            tech_stack="",
+            languages=[],
+            key_files=[],
+            total_files=None,
+        )
+        assert low is True
+
+    def test_no_languages_but_scanned(self):
+        low, reasons = _detect_low_code(
+            description="docs site",
+            tech_stack="",
+            languages=[],
+            key_files=["README.md"],
+            total_files=None,
+        )
+        assert low is True
+        assert any("no source-code" in r for r in reasons)
+
+    def test_very_small_codebase(self):
+        low, reasons = _detect_low_code(
+            description="tiny",
+            tech_stack="",
+            languages=["Python"],
+            key_files=["pyproject.toml"],
+            total_files=3,
+        )
+        assert low is True
+        assert any("very small" in r for r in reasons)
+
+    def test_healthy_repo_not_low_code(self):
+        low, reasons = _detect_low_code(
+            description="A FastAPI backend service",
+            tech_stack="Python, FastAPI, PostgreSQL",
+            languages=["Python", "Shell"],
+            key_files=["pyproject.toml", "Dockerfile"],
+            total_files=120,
+        )
+        assert low is False
+        assert reasons == []
+
+    def test_marker_word_boundary_no_false_positive(self):
+        # "wix" must not match inside an unrelated word like "wixel".
+        low, _ = _detect_low_code(
+            description="Building a wixel firmware toolchain",
+            tech_stack="",
+            languages=["C"],
+            key_files=["Makefile"],
+            total_files=200,
+        )
+        assert low is False
+
+    def test_analyze_context_low_code_via_description(self):
+        s = analyze_context("", description="WordPress marketing site", tech_stack="")
+        assert s.low_code is True
+
+
+class TestVocabularies:
+    def test_markers_are_lowercase(self):
+        assert all(m == m.lower() for m in LOW_CODE_MARKERS)
+
+    def test_integration_markers_map_to_names(self):
+        assert INTEGRATION_SDK_MARKERS["stripe"] == "Stripe"
+        assert INTEGRATION_SDK_MARKERS["boto3"] == "AWS"
+
+
+class TestScanRepoSignals:
+    """The graceful I/O entry — no target → no-op; description markers still apply."""
+
+    def test_no_repo_no_target_skips_gracefully(self):
+        qs = QuestionnaireState()
+        qs.answers[1] = "A plain internal tool"
+        raw, signals, status = scan_repo_signals(qs)
+        assert raw is None
+        assert isinstance(signals, RepoSignals)
+        assert status["status"] == "skipped"
+
+    def test_description_markers_flag_low_code_without_repo(self):
+        qs = QuestionnaireState()
+        qs.answers[1] = "Configure a Salesforce workflow, no custom code"
+        raw, signals, _status = scan_repo_signals(qs)
+        assert raw is None
+        assert signals.low_code is True
+
+    def test_github_scan_applies_signals(self, monkeypatch):
+        qs = QuestionnaireState()
+        qs.answers[1] = "A storefront"
+        qs.answers[16] = "GitHub"
+        qs.answers[17] = "https://github.com/acme/storefront"
+
+        fake_repo = MagicMock()
+        fake_repo.invoke.return_value = _GH_SUMMARY
+        fake_file = MagicMock()
+        fake_file.invoke.return_value = '{"dependencies": {"stripe": "12"}}'
+        monkeypatch.setattr("scrum_agent.tools.github.github_read_repo", fake_repo)
+        monkeypatch.setattr("scrum_agent.tools.github.github_read_file", fake_file)
+
+        raw, signals, status = scan_repo_signals(qs)
+        assert raw == _GH_SUMMARY
+        assert status["status"] == "success"
+        assert "TypeScript" in signals.detected_stack
+        assert "Stripe" in signals.integrations
+        assert signals.source == "github"
+
+    def test_github_error_result_degrades(self, monkeypatch):
+        qs = QuestionnaireState()
+        qs.answers[17] = "https://github.com/acme/missing"
+        fake_repo = MagicMock()
+        fake_repo.invoke.return_value = "Error: 404 Not Found"
+        monkeypatch.setattr("scrum_agent.tools.github.github_read_repo", fake_repo)
+
+        raw, signals, _status = scan_repo_signals(qs)
+        assert raw is None  # error string is not treated as context
+        assert signals.detected_stack == []
+
+    def test_scan_exception_never_raises(self, monkeypatch):
+        qs = QuestionnaireState()
+        qs.answers[17] = "https://github.com/acme/boom"
+        fake_repo = MagicMock()
+        fake_repo.invoke.side_effect = RuntimeError("network down")
+        monkeypatch.setattr("scrum_agent.tools.github.github_read_repo", fake_repo)
+
+        raw, signals, status = scan_repo_signals(qs)  # must not raise
+        assert raw is None
+        assert status["status"] == "error"

--- a/tests/unit/nodes/test_small_project.py
+++ b/tests/unit/nodes/test_small_project.py
@@ -1,5 +1,5 @@
 """Tests for Small-project intake mode: essentials, capacity gating, and the
-Small → Epic wide switch (advisory + re-entry).
+Small → Large switch (advisory + re-entry).
 
 See README: "Project Intake Questionnaire" — intake modes and
 "Guardrails" — human-in-the-loop (advisory).
@@ -32,7 +32,7 @@ class TestModeConstants:
 
     def test_tui_cards_are_small_epic_offline(self):
         # The full-screen TUI offers three intake modes; the middle one ("smart"
-        # engine, relabelled "Epic wide") reuses the existing smart pipeline.
+        # engine, relabelled "Large") reuses the existing smart pipeline.
         from scrum_agent.ui.mode_select.screens._screens import _INTAKE_CARDS
 
         keys = [c["key"] for c in _INTAKE_CARDS]
@@ -143,7 +143,7 @@ class TestSmallProjectAdvisory:
         result = project_analyzer(self._small_state())
         text = result["messages"][0].content
         assert "bigger than a small project" in text
-        assert "switch to epic wide" in text.lower()
+        assert "switch to large" in text.lower()
 
     def test_not_flagged_in_smart_mode(self, monkeypatch):
         self._mock_llm(monkeypatch)
@@ -218,7 +218,7 @@ class TestReopenIntakeForEpic:
         result = _reopen_intake_for_epic({"_intake_mode": "smart"}, qs)
         assert qs._reopen_for_epic is False
         assert isinstance(result["messages"][0], AIMessage)
-        assert "Epic wide" in result["messages"][0].content
+        assert "Large" in result["messages"][0].content
         # Not yet at the confirmation summary — a real question was asked.
         assert result.get("pending_review") != "project_intake"
 

--- a/tests/unit/nodes/test_small_project.py
+++ b/tests/unit/nodes/test_small_project.py
@@ -1,0 +1,238 @@
+"""Tests for Small-project intake mode: essentials, capacity gating, and the
+Small → Epic wide switch (advisory + re-entry).
+
+See README: "Project Intake Questionnaire" — intake modes and
+"Guardrails" — human-in-the-loop (advisory).
+"""
+
+from unittest.mock import MagicMock
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from scrum_agent.agent.nodes import (
+    _essentials_for_mode,
+    _extract_capacity_deductions,
+    _is_small_project_mode,
+    _prepare_bank_holiday_choices,
+    _reopen_intake_for_epic,
+    apply_epic_switch,
+    project_analyzer,
+)
+from scrum_agent.agent.state import ProjectAnalysis, QuestionnaireState
+from scrum_agent.prompts.intake import (
+    QUICK_ESSENTIALS,
+    SMALL_PROJECT_ESSENTIALS,
+    SMART_ESSENTIALS,
+)
+from tests._node_helpers import VALID_ANALYSIS_JSON, make_completed_questionnaire
+
+
+class TestModeConstants:
+    """The three TUI intake cards and the Small essential set."""
+
+    def test_tui_cards_are_small_epic_offline(self):
+        # The full-screen TUI offers three intake modes; the middle one ("smart"
+        # engine, relabelled "Epic wide") reuses the existing smart pipeline.
+        from scrum_agent.ui.mode_select.screens._screens import _INTAKE_CARDS
+
+        keys = [c["key"] for c in _INTAKE_CARDS]
+        assert keys == ["small_project", "smart", "offline"]
+
+    def test_small_essentials_include_sprint_length(self):
+        # Small essentials = project type, problem, DoD, team size, sprint length, stack.
+        assert SMALL_PROJECT_ESSENTIALS == frozenset({2, 3, 4, 6, 8, 11})
+
+    def test_small_essentials_drop_capacity_questions(self):
+        # No target sprints (Q10) or sprint selection (Q27) — Small does no capacity work.
+        assert 10 not in SMALL_PROJECT_ESSENTIALS
+        assert 27 not in SMALL_PROJECT_ESSENTIALS
+
+
+class TestEssentialsForMode:
+    """_essentials_for_mode() picks the right set per intake mode."""
+
+    def test_quick(self):
+        assert _essentials_for_mode("quick") is QUICK_ESSENTIALS
+
+    def test_small_project(self):
+        assert _essentials_for_mode("small_project") is SMALL_PROJECT_ESSENTIALS
+
+    def test_smart_default(self):
+        assert _essentials_for_mode("smart") is SMART_ESSENTIALS
+
+    def test_unknown_falls_back_to_smart(self):
+        assert _essentials_for_mode("standard") is SMART_ESSENTIALS
+
+
+class TestIsSmallProjectMode:
+    def test_true_only_for_small_project(self):
+        assert _is_small_project_mode("small_project") is True
+        assert _is_small_project_mode("smart") is False
+        assert _is_small_project_mode("quick") is False
+        assert _is_small_project_mode(None) is False
+
+
+class TestCapacityGating:
+    """Small mode zeroes out all capacity deductions and bank-holiday detection."""
+
+    def test_extract_capacity_returns_zeros_for_small(self):
+        qs = QuestionnaireState(intake_mode="small_project")
+        qs._detected_bank_holiday_days = 5  # would normally count
+        qs.answers[29] = "20%"
+        cap = _extract_capacity_deductions(qs)
+        assert cap == {
+            "capacity_bank_holiday_days": 0,
+            "capacity_planned_leave_days": 0,
+            "capacity_unplanned_leave_pct": 0,
+            "capacity_onboarding_engineer_sprints": 0,
+            "capacity_ktlo_engineers": 0,
+            "capacity_discovery_pct": 0,
+        }
+
+    def test_extract_capacity_still_counts_for_smart(self):
+        qs = QuestionnaireState(intake_mode="smart")
+        qs._detected_bank_holiday_days = 3
+        cap = _extract_capacity_deductions(qs)
+        assert cap["capacity_bank_holiday_days"] == 3
+
+    def test_prepare_bank_holidays_noop_for_small(self):
+        qs = QuestionnaireState(intake_mode="small_project")
+        qs._detected_bank_holiday_days = 4
+        qs._detected_bank_holidays = [{"name": "X"}]
+        _prepare_bank_holiday_choices(qs)
+        assert qs._detected_bank_holiday_days == 0
+        assert qs._detected_bank_holidays == []
+
+
+class TestSmallProjectAdvisory:
+    """project_analyzer flags oversized Small projects and coerces the plan flat."""
+
+    def _small_state(self) -> dict:
+        qs = make_completed_questionnaire()
+        return {
+            "messages": [HumanMessage(content="continue")],
+            "questionnaire": qs,
+            "team_size": 3,
+            "velocity_per_sprint": 15,
+            "_intake_mode": "small_project",
+        }
+
+    def _mock_llm(self, monkeypatch):
+        fake = MagicMock()
+        fake.content = VALID_ANALYSIS_JSON  # target_sprints=4, skip_features absent
+        llm = MagicMock()
+        llm.invoke.return_value = fake
+        monkeypatch.setattr("scrum_agent.agent.nodes.get_llm", lambda **kw: llm)
+
+    def test_oversized_flag_set_when_analyzer_says_bigger(self, monkeypatch):
+        self._mock_llm(monkeypatch)
+        result = project_analyzer(self._small_state())
+        # 4 target sprints + no skip_features → looks bigger than a small project.
+        assert result["_small_project_oversized"] is True
+
+    def test_analysis_coerced_flat_in_small_mode(self, monkeypatch):
+        self._mock_llm(monkeypatch)
+        result = project_analyzer(self._small_state())
+        analysis = result["project_analysis"]
+        assert analysis.skip_features is True
+        assert analysis.target_sprints <= 2
+        assert result["target_sprints"] <= 2
+
+    def test_advisory_text_in_message(self, monkeypatch):
+        self._mock_llm(monkeypatch)
+        result = project_analyzer(self._small_state())
+        text = result["messages"][0].content
+        assert "bigger than a small project" in text
+        assert "switch to epic wide" in text.lower()
+
+    def test_not_flagged_in_smart_mode(self, monkeypatch):
+        self._mock_llm(monkeypatch)
+        state = self._small_state()
+        state["_intake_mode"] = "smart"
+        result = project_analyzer(state)
+        assert result["_small_project_oversized"] is False
+        # Smart mode keeps the analyzer's own values (not coerced to a flat plan).
+        assert result["project_analysis"].target_sprints == 4
+
+
+class TestApplyEpicSwitch:
+    """apply_epic_switch() preserves answers and clears artifacts for the switch."""
+
+    def _switched_state(self) -> dict:
+        qs = QuestionnaireState(intake_mode="small_project", completed=True)
+        qs.answers = {2: "Greenfield", 3: "solve X", 6: "3 engineers"}
+        return {
+            "_intake_mode": "small_project",
+            "questionnaire": qs,
+            "project_analysis": ProjectAnalysis(
+                project_name="P",
+                project_description="d",
+                project_type="greenfield",
+                goals=("g",),
+                end_users=("u",),
+                target_state="t",
+                tech_stack=("py",),
+                integrations=(),
+                constraints=(),
+                sprint_length_weeks=2,
+                target_sprints=1,
+                risks=(),
+                out_of_scope=(),
+                assumptions=(),
+            ),
+            "features": ["f"],
+            "stories": ["s"],
+            "tasks": ["t"],
+            "sprints": ["sp"],
+            "pending_review": "project_analyzer",
+            "_small_project_oversized": True,
+        }
+
+    def test_preserves_answers_and_switches_mode(self):
+        state = self._switched_state()
+        apply_epic_switch(state)
+        qs = state["questionnaire"]
+        assert qs.intake_mode == "smart"
+        assert state["_intake_mode"] == "smart"
+        assert qs.completed is False
+        assert qs._reopen_for_epic is True
+        # Answers untouched — the whole point: no re-typing.
+        assert qs.answers == {2: "Greenfield", 3: "solve X", 6: "3 engineers"}
+
+    def test_clears_artifacts(self):
+        state = self._switched_state()
+        apply_epic_switch(state)
+        for key in ("project_analysis", "features", "stories", "tasks", "sprints", "_small_project_oversized"):
+            assert key not in state
+
+
+class TestReopenIntakeForEpic:
+    """_reopen_intake_for_epic() asks the remaining Epic essentials (or the summary)."""
+
+    def test_asks_gap_when_essentials_missing(self):
+        # Only Small essentials answered — Epic still needs Q10/Q27, so a gap remains.
+        qs = QuestionnaireState(intake_mode="smart")
+        qs._reopen_for_epic = True
+        for q in SMALL_PROJECT_ESSENTIALS:
+            qs.answers[q] = "answered"
+        result = _reopen_intake_for_epic({"_intake_mode": "smart"}, qs)
+        assert qs._reopen_for_epic is False
+        assert isinstance(result["messages"][0], AIMessage)
+        assert "Epic wide" in result["messages"][0].content
+        # Not yet at the confirmation summary — a real question was asked.
+        assert result.get("pending_review") != "project_intake"
+
+    def test_shows_summary_when_no_gaps(self):
+        # Every question answered (incl. conditional essentials Q7/Q12/Q13) →
+        # no gaps remain, so we fall through to the summary/PTO gate rather than
+        # asking another essential. (Smart mode asks PTO before the summary.)
+        qs = make_completed_questionnaire()
+        qs.intake_mode = "smart"
+        qs.completed = False
+        qs.awaiting_confirmation = False
+        qs._reopen_for_epic = True
+        result = _reopen_intake_for_epic({"_intake_mode": "smart"}, qs)
+        # Either the confirmation summary (pending_review) or the PTO gate — both
+        # are the "no more essentials to ask" outcome, not a fresh gap question.
+        reached_summary_gate = result.get("pending_review") == "project_intake" or qs._awaiting_leave_input
+        assert reached_summary_gate

--- a/tests/unit/test_standup_activity.py
+++ b/tests/unit/test_standup_activity.py
@@ -5,7 +5,7 @@ normalizes into the shared {author, kind, title, timestamp, key} shape.
 """
 
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -106,7 +106,9 @@ class TestGithubRecentActivity:
             merged=True,
             state="closed",
             user=SimpleNamespace(login="carol"),
-            updated_at=datetime(2026, 7, 10, 7, 0, tzinfo=UTC),
+            # Relative to now so the PR always falls inside the days=1 window —
+            # a fixed date made this test fail once the clock passed it.
+            updated_at=datetime.now(UTC) - timedelta(hours=1),
         )
         repo = MagicMock()
         repo.get_pulls.return_value = [pr]

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -644,6 +644,34 @@ class TestQuestionnaireIntakeMode:
         qs = QuestionnaireState(intake_mode="smart")
         assert qs.intake_mode == "smart"
 
+    def test_small_project_mode_can_be_set(self):
+        qs = QuestionnaireState(intake_mode="small_project")
+        assert qs.intake_mode == "small_project"
+
+    def test_reopen_for_epic_default_false(self):
+        qs = QuestionnaireState()
+        assert qs._reopen_for_epic is False
+
+    def test_intake_mode_survives_round_trip(self):
+        """small_project intake_mode persists across session serialization."""
+        from scrum_agent.sessions import _dict_to_questionnaire, _questionnaire_to_dict
+
+        qs = QuestionnaireState(intake_mode="small_project")
+        restored = _dict_to_questionnaire(_questionnaire_to_dict(qs))
+        assert restored.intake_mode == "small_project"
+
+
+class TestSmallProjectOversizedField:
+    """The _small_project_oversized advisory flag round-trips through session state."""
+
+    def test_round_trip(self):
+        from scrum_agent.sessions import _deserialize_state, _serialize_state
+
+        state = {"messages": [], "_small_project_oversized": True, "_intake_mode": "small_project"}
+        restored = _deserialize_state(_serialize_state(state))
+        assert restored["_small_project_oversized"] is True
+        assert restored["_intake_mode"] == "small_project"
+
 
 class TestStateGraphCompatibility:
     def test_stategraph_accepts_scrum_state(self):


### PR DESCRIPTION
## Summary

Three related feature sets that give **Planning** and **Analysis** more context to work from. Every new signal is **optional and graceful** — with no repo or no ceremony history, behaviour is unchanged.

### 1. Three intake modes — Small project / Epic wide / Offline
- New **Small project** mode (`small_project`): quick intake for 1–2 tickets, no bank-holiday/capacity planning.
- Non-blocking advisory when a small project looks bigger, with a one-click **Switch to Epic wide** that preserves all answers and only asks the extra capacity questions.
- **Retires the legacy 30-question "standard" intake** (TUI card, `--full-intake` flag, REPL menu entry); `project_intake` coerces any lingering `"standard"` → `"smart"`.

### 2. Repo-informed tech stack + low-code detection
- New `agent/repo_signals.py`: scans the project's repo (the Q17 URL **or** a configured GitHub repo) to **suggest a tech stack (Q11)** and **integrations (Q12)** from manifest parsing — graceful multi-source fan-out.
- **Low-code / no-code / content-heavy detection** (platform markers + repo shape): surfaces a `⚙ Low-code project` flag and scales estimation + task decomposition **lighter** (`story_writer` / `task_decomposer`).

### 3. Standup + Retro history → Planning & Analysis
- New `agent/ceremony_history.py`: gathers the team's recent retros + standups **team-wide (project-first)** and distils deterministic **cadence, confidence trend, recurring themes, and open action items**.
- **Planner (inform):** injects the history into the analyzer + sprint-planner prompts.
- **Planner (seed backlog):** open retro action items become **`[Retro]`-badged** candidate stories, deduped by the LLM.
- **Analysis:** adds a **"Ceremony Cadence & Trends"** section to the team-profile HTML/MD report.

## Design notes
- All three lean on the codebase's existing **optional-context-section** pattern (like `team_profile_summary`) and **graceful fan-out** (like `standup/collector.py`). Deterministic pure cores make everything unit-testable without live services.
- Ceremony cadence is computed from **intervals between run timestamps** (no dependence on "now") so it's fully reproducible.
- Small/Epic/low-code/ceremony share core files (`nodes.py`, `state.py`, `prompts/*`), so this is a single commit to keep intermediate builds working.

## Testing
- **~90 new unit tests** across `test_small_project.py`, `test_repo_signals.py`, `test_low_code.py`, `test_ceremony_history.py`, `test_ceremony_integration.py`.
- `make test` — **3156 passed**, 7 skipped. The single failure (`test_standup_activity::test_prs_normalized_and_merged_status`) is **pre-existing and unrelated** — a date-dependent fixture that fails identically on a clean `main`.
- `make lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
