### PR TITLE
Add LLM model selection to setup wizard and settings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -308,6 +308,7 @@ Replacing inline text prompts with full-screen, block-character dashboard screen
 - [x] Create `ui/_logos.py` — block-character ASCII art logos (Claude, Gemini, OpenAI)
 - [x] Create `ui/provider_select.py` — full-screen provider selection (Step 1 of setup wizard)
 - [x] Wire `_collect_provider()` in `setup_wizard.py` to use new full-screen selector
+- [x] Model-selection sub-step after API-key verify — per-provider preset list + `Custom…` typed entry, live-validated via `_verify_model()`, persists `LLM_MODEL` (appears in setup wizard + Settings → Configure)
 - [ ] Polish provider select layout — centering, card sizing, brand colours
 - [ ] Full-screen API key entry screen (Step 2 of setup wizard)
 - [ ] Full-screen integrations screen (Step 3 of setup wizard)

--- a/src/scrum_agent/setup_wizard.py
+++ b/src/scrum_agent/setup_wizard.py
@@ -225,6 +225,12 @@ def run_setup_wizard(console: Console) -> bool:
             return False
         collected[provider["env_var"]] = key
 
+    # Model choice from the full-screen model-selection step (LLM_MODEL is also
+    # persisted at selection time by _save_progress; this keeps the path explicit).
+    llm_model = result.get("llm_model")
+    if llm_model:
+        collected["LLM_MODEL"] = llm_model
+
     # ── Step 3: Version control (collected in full-screen UI) ─────────────
     vc_env_var = result.get("vc_env_var")
     vc_token = result.get("vc_token")

--- a/src/scrum_agent/ui/provider_select/__init__.py
+++ b/src/scrum_agent/ui/provider_select/__init__.py
@@ -12,6 +12,7 @@ Transitions between states use a common fade animation pattern.
 
 from __future__ import annotations
 
+import logging
 import math
 import time
 
@@ -21,8 +22,13 @@ from scrum_agent.ui.provider_select._config import _save_progress  # noqa: F401
 from scrum_agent.ui.provider_select._constants import _PROVIDER_CARDS, _VC_OPTIONS
 from scrum_agent.ui.provider_select._phase_issue_tracking import _run_issue_tracking  # noqa: F401
 from scrum_agent.ui.provider_select._transitions import _transition_to_input  # noqa: F401
-from scrum_agent.ui.provider_select._verification import _verify_api_key, _verify_vc_token
-from scrum_agent.ui.provider_select.screens._screens import _build_input_screen, _build_select_screen
+from scrum_agent.ui.provider_select._verification import _verify_api_key, _verify_model, _verify_vc_token
+from scrum_agent.ui.provider_select.screens._screens import (
+    _build_input_screen,
+    _build_model_input_screen,
+    _build_model_select_screen,
+    _build_select_screen,
+)
 from scrum_agent.ui.provider_select.screens._screens_vc import (
     _build_vc_input_screen,
     _build_vc_select_screen,
@@ -31,6 +37,8 @@ from scrum_agent.ui.shared._animations import COLOR_RGB, FADE_IN_LEVELS, FADE_OU
 from scrum_agent.ui.shared._input import disable_bracketed_paste, enable_bracketed_paste
 from scrum_agent.ui.shared._input import read_key as _read_key  # noqa: F401 — re-export for compat
 from scrum_agent.ui.shared._music_bar import make_live
+
+logger = logging.getLogger(__name__)
 
 
 def _detect_aws_region() -> str | None:
@@ -111,6 +119,7 @@ def select_provider(
     # State preserved across steps (so going back retains previous choices)
     provider = None
     api_key = ""
+    llm_model = ""
     vc = None
     vc_token = ""
     step = 0
@@ -122,6 +131,167 @@ def select_provider(
         refresh_per_second=30,
         screen=True,
     ) as live:
+
+        def _run_model_phase(api_key_val: str) -> str | None:
+            """Model-selection sub-step of Step 0.
+
+            Shows a list of the provider's preset models (plus any detected/current
+            model and a "Custom…" entry). Validates the chosen or typed model with a
+            live call so we never save a model the credentials can't run.
+
+            Returns the validated model id, or None if the user pressed Esc to go back
+            to the API-key input.
+            """
+            models_cfg = provider.get("models") or {}
+            presets = list(models_cfg.get("presets") or [])
+            default_model = models_cfg.get("default", "")
+
+            # A detected Bedrock model (from OpenClaw) or a previously-saved LLM_MODEL
+            # is offered at the top of the list and pre-selected, preserving zero-config.
+            detected = None
+            if provider.get("provider_val") == "bedrock":
+                try:
+                    from scrum_agent.setup_wizard import _detect_openclaw_bedrock_model
+
+                    detected = _detect_openclaw_bedrock_model()
+                except Exception:
+                    detected = None
+            existing_model = (existing_config or {}).get("LLM_MODEL", "")
+
+            model_ids: list[str] = []  # actual model id per entry ("" marks Custom…)
+            labels: list[str] = []  # display label per entry
+
+            def _add(mid: str, tag: str = "") -> None:
+                if mid and mid not in model_ids:
+                    model_ids.append(mid)
+                    labels.append(f"{mid}  {tag}" if tag else mid)
+
+            _add(detected, "(detected)")
+            _add(existing_model, "(current)")
+            for m in presets:
+                _add(m)
+            model_ids.append("")  # Custom… sentinel
+            labels.append("Custom…")
+
+            pre = detected or existing_model or default_model
+            selected = model_ids.index(pre) if pre in model_ids else 0
+
+            def _verify_pulsing(model_id: str, render) -> tuple[bool, str]:
+                """Run _verify_model on a thread while `render(border_style)` pulses."""
+                import threading
+
+                result: list[tuple[bool, str]] = []
+
+                def _do() -> None:
+                    result.append(_verify_model(provider, api_key_val, model_id))
+
+                thread = threading.Thread(target=_do, daemon=True)
+                thread.start()
+                pulse_start = time.monotonic()
+                while thread.is_alive():
+                    elapsed = time.monotonic() - pulse_start
+                    intensity = (math.sin(elapsed * 6) + 1) / 2
+                    v = int(60 + 140 * intensity)
+                    render(f"rgb({v},{v},{v})")
+                    time.sleep(FRAME_TIME_30FPS)
+                thread.join()
+                return result[0]
+
+            def _run_custom_input() -> str | None:
+                """Text-input loop for a typed model id. Returns id or None (back)."""
+                val = existing_model if existing_model not in presets else ""
+                err = ""
+                verified: bool | None = None
+                while True:
+                    w, h = console.size
+                    live.update(
+                        _build_model_input_screen(provider, val, width=w, height=h, error=err, verified=verified)
+                    )
+                    key = read_key()
+                    if key == "enter":
+                        if not val.strip():
+                            err = "Model id is required"
+                            verified = False
+                            continue
+                        model_id = val.strip()
+
+                        def _render(border: str) -> None:
+                            w2, h2 = console.size
+                            live.update(
+                                _build_model_input_screen(
+                                    provider, val, width=w2, height=h2, verifying=True, border_override=border
+                                )
+                            )
+
+                        ok, msg = _verify_pulsing(model_id, _render)
+                        if ok:
+                            logger.info("LLM model verified (custom): %s", model_id)
+                            w, h = console.size
+                            live.update(_build_model_input_screen(provider, val, width=w, height=h, verified=True))
+                            time.sleep(0.5)
+                            return model_id
+                        logger.warning("LLM model verification failed (custom): %s — %s", model_id, msg)
+                        err = msg
+                        verified = False
+                    elif key == "esc":
+                        return None
+                    elif key == "clear":
+                        val = ""
+                        err = ""
+                        verified = None
+                    elif key == "backspace":
+                        val = val[:-1]
+                        err = ""
+                        verified = None
+                    elif key.startswith("paste:"):
+                        val += key[6:]
+                        err = ""
+                        verified = None
+                    elif len(key) == 1 and key.isprintable():
+                        val += key
+                        err = ""
+                        verified = None
+
+            # Preset-list selection loop.
+            err = ""
+            start_time = time.monotonic()
+            while True:
+                w, h = console.size
+                tick = time.monotonic() - start_time
+                live.update(
+                    _build_model_select_screen(
+                        provider, labels, selected, width=w, height=h, shimmer_tick=tick, error=err
+                    )
+                )
+                key = read_key(timeout=FRAME_TIME_30FPS) if _supports_timeout else read_key()
+                if key in ("up", "scroll_up"):
+                    selected = (selected - 1) % len(labels)
+                    err = ""
+                elif key in ("down", "scroll_down"):
+                    selected = (selected + 1) % len(labels)
+                    err = ""
+                elif key == "enter":
+                    chosen_id = model_ids[selected]
+                    if chosen_id == "":  # Custom…
+                        typed = _run_custom_input()
+                        if typed is not None:
+                            return typed
+                        continue  # Esc from custom input → back to preset list
+                    logger.info("LLM model chosen (preset): %s", chosen_id)
+
+                    def _render(_border: str) -> None:
+                        w2, h2 = console.size
+                        live.update(_build_model_select_screen(provider, labels, selected, width=w2, height=h2))
+
+                    ok, msg = _verify_pulsing(chosen_id, _render)
+                    if ok:
+                        logger.info("LLM model verified (preset): %s", chosen_id)
+                        return chosen_id
+                    logger.warning("LLM model verification failed (preset): %s — %s", chosen_id, msg)
+                    err = msg
+                elif key in ("q", "esc"):
+                    return None
+
         while step < 3:
             # ══════════════════════════════════════════════════════════════
             # Step 0: LLM Provider selection + API key input
@@ -233,8 +403,21 @@ def select_provider(
                             time.sleep(0.6)
                             api_key = input_value.strip()
                             _save_progress({"LLM_PROVIDER": provider["provider_val"], provider["env_var"]: api_key})
-                            _step0_done = True
-                            break
+
+                            # Model-selection sub-step. Esc returns None → fall back
+                            # to this API-key input loop (context preserved).
+                            chosen_model = _run_model_phase(api_key)
+                            if chosen_model is not None:
+                                llm_model = chosen_model
+                                _save_progress({"LLM_MODEL": chosen_model})
+                                _step0_done = True
+                                break
+                            # Back from model phase — re-show the verified key input.
+                            w, h = console.size
+                            live.update(
+                                _build_input_screen(provider, input_value, width=w, height=h, verified=True)
+                            )
+                            continue
                         else:
                             w, h = console.size
                             live.update(
@@ -306,6 +489,7 @@ def select_provider(
                     _dummy_vc,
                     "",
                     live=live,
+                    llm_model=llm_model,
                 )
 
                 if result is not None:

--- a/src/scrum_agent/ui/provider_select/_constants.py
+++ b/src/scrum_agent/ui/provider_select/_constants.py
@@ -12,6 +12,12 @@ from typing import Any
 # Provider definitions (order matters — matches row layout top-to-bottom)
 # ---------------------------------------------------------------------------
 
+# Per-provider model presets shown in the model-selection step. Each card's
+# models["default"] MUST equal agent/llm.py::_PROVIDER_DEFAULTS[provider_val]
+# (a unit test asserts this) so the wizard pre-selects the same model the app
+# falls back to when LLM_MODEL is unset. The on-screen list is always
+# presets + ["Custom\u2026"]; the "Custom\u2026" entry lets users type any newer model
+# id, validated live against their credentials.
 _PROVIDER_CARDS: list[dict[str, Any]] = [
     {
         "name": "Anthropic",
@@ -21,6 +27,16 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
         "prefix": "sk-ant-",
         "instructions": "Get yours at: https://console.anthropic.com \u2192 API Keys",
         "color": "rgb(70,100,180)",
+        "models": {
+            "default": "claude-sonnet-4-20250514",
+            "presets": [
+                "claude-sonnet-4-20250514",
+                "claude-opus-4-8",
+                "claude-sonnet-5",
+                "claude-sonnet-4-6",
+                "claude-haiku-4-5",
+            ],
+        },
     },
     {
         "name": "Gemini",
@@ -30,6 +46,14 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
         "prefix": "AIza",
         "instructions": "Get yours at: https://aistudio.google.com \u2192 Get API key",
         "color": "rgb(70,100,180)",
+        "models": {
+            "default": "gemini-2.0-flash",
+            "presets": [
+                "gemini-2.0-flash",
+                "gemini-1.5-pro",
+                "gemini-1.5-flash",
+            ],
+        },
     },
     {
         "name": "OpenAI",
@@ -39,6 +63,15 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
         "prefix": "sk-",
         "instructions": "Get yours at: https://platform.openai.com \u2192 API keys",
         "color": "rgb(70,100,180)",
+        "models": {
+            "default": "gpt-4o",
+            "presets": [
+                "gpt-4o",
+                "gpt-4o-mini",
+                "gpt-4-turbo",
+                "o1",
+            ],
+        },
     },
     {
         "name": "Bedrock",
@@ -49,6 +82,14 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
         "instructions": "Uses IAM credentials from instance role, ~/.aws/credentials, or env vars",
         "color": "rgb(70,100,180)",
         "is_region_input": True,
+        # Bedrock's real model id is usually auto-detected from OpenClaw and
+        # prepended at runtime; the default here keeps parity with _PROVIDER_DEFAULTS.
+        "models": {
+            "default": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            "presets": [
+                "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            ],
+        },
     },
 ]
 

--- a/src/scrum_agent/ui/provider_select/_phase_issue_tracking.py
+++ b/src/scrum_agent/ui/provider_select/_phase_issue_tracking.py
@@ -35,6 +35,7 @@ def _run_issue_tracking(
     vc_token: str,
     *,
     live: Live | None = None,
+    llm_model: str = "",
 ) -> dict[str, str] | None:
     """Run the issue tracking phase with provider selection.
 
@@ -121,6 +122,7 @@ def _run_issue_tracking(
                 "prefix": provider["prefix"],
                 "instructions": provider["instructions"],
                 "api_key": api_key,
+                "llm_model": llm_model,
                 "vc_env_var": vc["env_var"],
                 "vc_token": vc_token,
                 "issue_tracking": {},
@@ -290,6 +292,7 @@ def _run_issue_tracking(
                         "prefix": provider["prefix"],
                         "instructions": provider["instructions"],
                         "api_key": api_key,
+                        "llm_model": llm_model,
                         "vc_env_var": vc["env_var"],
                         "vc_token": vc_token,
                         "issue_tracking": issue_data,

--- a/src/scrum_agent/ui/provider_select/_verification.py
+++ b/src/scrum_agent/ui/provider_select/_verification.py
@@ -6,7 +6,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 def _validate_key(provider: dict[str, Any], value: str) -> tuple[str, str]:
@@ -131,6 +134,128 @@ def _verify_api_key(provider: dict[str, Any], api_key: str) -> tuple[bool, str]:
         return False, f"Connection error: {e}"
 
     return False, "Unknown provider"
+
+
+def _verify_model(provider: dict[str, Any], api_key: str, model: str) -> tuple[bool, str]:
+    """Make a lightweight API call to verify the chosen model is usable by the key.
+
+    Mirrors _verify_api_key's structure but exercises the *specific* model so we
+    can confirm the user's credentials can actually run it (e.g. a newly released
+    model typed via the Custom… entry). For Bedrock, ``api_key`` is the region.
+
+    Returns (success, message).
+    """
+    provider_val = provider["provider_val"]
+
+    try:
+        if provider_val == "anthropic":
+            import httpx
+
+            # Cheapest possible ping against the target model. No thinking/sampling
+            # params so we never hit model-family parameter constraints.
+            resp = httpx.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "max_tokens": 1,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                timeout=10,
+            )
+            if resp.status_code in (200, 201):
+                return True, "Model verified"
+            if resp.status_code == 404:
+                return False, "Model not found or not available for this key"
+            if resp.status_code == 400:
+                # A 400 often means the model id is unknown/unavailable — surface detail.
+                detail = _extract_error_message(resp)
+                return False, detail or "Model not accepted"
+            if resp.status_code == 401:
+                return False, "Invalid API key"
+            if resp.status_code == 403:
+                return False, "Key lacks access to this model"
+            return False, f"Unexpected response: {resp.status_code}"
+
+        elif provider_val == "openai":
+            import httpx
+
+            resp = httpx.get(
+                f"https://api.openai.com/v1/models/{model}",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                return True, "Model verified"
+            if resp.status_code == 404:
+                return False, "Unknown model for this account"
+            if resp.status_code == 401:
+                return False, "Invalid API key"
+            return False, f"Unexpected response: {resp.status_code}"
+
+        elif provider_val == "google":
+            import httpx
+
+            # Google model ids are used bare in the path (e.g. gemini-2.0-flash).
+            resp = httpx.get(
+                f"https://generativelanguage.googleapis.com/v1/models/{model}?key={api_key}",
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                return True, "Model verified"
+            if resp.status_code == 404:
+                return False, "Unknown model"
+            if resp.status_code in (400, 401, 403):
+                return False, "Invalid API key"
+            return False, f"Unexpected response: {resp.status_code}"
+
+        elif provider_val == "bedrock":
+            # api_key is the AWS region. Inference-profile ids (leading us./eu./
+            # global.) — which is what OpenClaw auto-detects — are NOT returned by
+            # list_foundation_models, so soft-accept those once the region resolves.
+            if model.split(".", 1)[0] in ("us", "eu", "global", "apac"):
+                return True, "Inference profile accepted (region verified)"
+
+            import boto3
+
+            from scrum_agent.config import get_aws_profile
+
+            profile = get_aws_profile()
+            session = boto3.Session(profile_name=profile, region_name=api_key)
+            client = session.client("bedrock", region_name=api_key)
+            resp = client.list_foundation_models(byOutputModality="TEXT")
+            model_ids = {m.get("modelId", "") for m in resp.get("modelSummaries") or []}
+            if model in model_ids:
+                return True, "Model verified"
+            return False, "Model not available in this region"
+
+    except Exception as e:
+        err_str = str(e)
+        if "NoCredentialsError" in type(e).__name__ or "NoCredentialsError" in err_str:
+            return False, "No AWS credentials found — configure IAM role, ~/.aws/credentials, or env vars"
+        if "InvalidIdentityToken" in err_str or "AccessDenied" in err_str or "403" in err_str:
+            return False, "AWS credentials lack Bedrock permissions"
+        return False, f"Connection error: {e}"
+
+    return False, "Unknown provider"
+
+
+def _extract_error_message(resp: Any) -> str:
+    """Best-effort extraction of a human-readable error message from a JSON response."""
+    try:
+        data = resp.json()
+        err = data.get("error")
+        if isinstance(err, dict):
+            return str(err.get("message", "")).strip()
+        if isinstance(err, str):
+            return err.strip()
+    except Exception:
+        pass
+    return ""
 
 
 def _verify_vc_token(vc: dict[str, Any], token: str) -> tuple[bool, str]:

--- a/src/scrum_agent/ui/provider_select/screens/_screens.py
+++ b/src/scrum_agent/ui/provider_select/screens/_screens.py
@@ -277,6 +277,19 @@ def _build_input_screen(
     else:
         error_text = Text("")
 
+    # Keyboard hint — makes editing/clearing discoverable. Without this, a saved
+    # value pre-filled on a Settings → Configure re-run looks un-editable because
+    # typing just appends to the (masked) existing value. Hidden while verifying,
+    # after success, and during fade animations.
+    if verifying or verified is True or input_fade:
+        hint_text = Text("")
+    else:
+        hint_text = Text(
+            "⌫ backspace  ·  Ctrl+U clear  ·  Enter to verify  ·  Esc back",
+            style="dim",
+            justify="center",
+        )
+
     body = [
         Align.center(provider_text),
         Text(""),
@@ -285,8 +298,9 @@ def _build_input_screen(
         Align.center(input_box),
         Align.center(status_text),
         Align.center(error_text),
+        Align.center(hint_text),
     ]
-    body_h = 10  # provider(2) + blank + instructions(1) + blank + input_box(5) + status + error
+    body_h = 11  # provider(2) + blank + instructions(1) + blank + input_box(5) + status + error + hint
 
     return _build_screen_frame(
         subtitle="Enter your API key",
@@ -295,4 +309,153 @@ def _build_input_screen(
         body_height=body_h,
         width=width,
         height=height,
+    )
+
+
+def _build_model_select_screen(
+    provider: dict[str, Any],
+    entries: list[str],
+    selected: int,
+    *,
+    width: int = 80,
+    height: int = 24,
+    shimmer_tick: float = 0.0,
+    error: str = "",
+) -> Panel:
+    """Build the model-selection screen — an arrow-selectable list of model ids.
+
+    Unlike _build_select_screen (which renders 2-line ASCII art), model ids are
+    long plain strings, so each entry is a single centred line. ``entries`` is the
+    full display list, typically presets + ["Custom…"] (a detected/current model
+    may be prepended by the caller with a "(detected)"/"(current)" label).
+    """
+    rows: list[Text] = []
+    for i, label in enumerate(entries):
+        if i == selected:
+            # Per-character shimmer on the selected entry (matches provider rows).
+            line = Text(justify="center")
+            total = max(len(label), 1)
+            for j, ch in enumerate(label):
+                line.append(ch, style=shimmer_style(provider["color"], j, total, shimmer_tick))
+        else:
+            line = Text(label, style="dim", justify="center")
+        rows.append(line)
+
+    body = [item for row in rows for item in (Align.center(row), Text(""))]
+    if body:
+        body = body[:-1]  # remove trailing blank
+
+    if error:
+        body.append(Text(""))
+        body.append(Align.center(Text(f"✗ {error}", style="bright_red", justify="center")))
+
+    body_h = len(rows) * 2 - 1 if rows else 0
+    if error:
+        body_h += 2
+
+    return _build_screen_frame(
+        subtitle="Choose a model",
+        step=0,
+        body_items=body,
+        body_height=body_h,
+        width=width,
+        height=height,
+        title_text=provider["name"],
+    )
+
+
+def _build_model_input_screen(
+    provider: dict[str, Any],
+    input_value: str,
+    *,
+    width: int = 80,
+    height: int = 24,
+    error: str = "",
+    verified: bool | None = None,
+    verifying: bool = False,
+    border_override: str = "",
+) -> Panel:
+    """Build the custom-model text-input screen.
+
+    A near-clone of _build_input_screen, but model ids are never secrets — the
+    value is always shown in plaintext (no masking).
+    """
+    import rich.box
+
+    style = provider["color"]
+    lines = render_ascii_text(provider["name"])
+    provider_text = Text(justify="center")
+    provider_text.append(lines[0] + "\n", style=style)
+    provider_text.append(lines[1], style=style)
+
+    instructions = Text("Enter any model id supported by your account", style="dim", justify="center")
+
+    box_inner_w = min(70, width - 10) - 2 - 4
+    display_val = input_value
+    cursor = "█" if not verifying else ""
+    full_text = display_val + cursor
+    avail = box_inner_w - 4
+
+    input_content = Text(justify="left", no_wrap=True, overflow="crop")
+    if len(full_text) <= avail:
+        input_content.append("  " + full_text, style="bold white")
+    else:
+        visible = full_text[-(avail - 1) :]
+        input_content.append(" ◂", style="dim")
+        input_content.append(visible, style="bold white")
+
+    if border_override:
+        border_color = border_override
+    elif verified is True:
+        border_color = "bright_green"
+    elif verified is False or error:
+        border_color = "bright_red"
+    else:
+        border_color = "white"
+
+    input_box = Panel(
+        input_content,
+        title=" LLM_MODEL ",
+        title_align="left",
+        border_style=border_color,
+        box=rich.box.ROUNDED,
+        padding=(1, 2),
+        width=min(70, width - 10),
+    )
+
+    if verifying or verified is True:
+        status_text = Text("")
+    elif verified is False or error:
+        status_text = Text(f"✗ {error}", style="bright_red", justify="center")
+    else:
+        status_text = Text("")
+
+    if verifying or verified is True:
+        hint_text = Text("")
+    else:
+        hint_text = Text(
+            "⌫ backspace  ·  Ctrl+U clear  ·  Enter to verify  ·  Esc back",
+            style="dim",
+            justify="center",
+        )
+
+    body = [
+        Align.center(provider_text),
+        Text(""),
+        Align.center(instructions),
+        Text(""),
+        Align.center(input_box),
+        Align.center(status_text),
+        Align.center(hint_text),
+    ]
+    body_h = 10  # provider(2) + blank + instructions(1) + blank + input_box(5) + status + hint
+
+    return _build_screen_frame(
+        subtitle="Type a model id",
+        step=0,
+        body_items=body,
+        body_height=body_h,
+        width=width,
+        height=height,
+        title_text=provider["name"],
     )

--- a/tests/unit/test_provider_model_select.py
+++ b/tests/unit/test_provider_model_select.py
@@ -1,0 +1,284 @@
+"""Tests for the LLM model-selection step of the provider setup wizard.
+
+Covers:
+- ``_verify_model`` live-validation per provider (happy + error paths, mocked).
+- The two new screen builders (render, plaintext-not-masked, states).
+- Data integrity: each card's default model matches ``_PROVIDER_DEFAULTS``.
+- ``run_setup_wizard`` propagates the chosen model to ``LLM_MODEL``.
+"""
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+from rich.panel import Panel
+
+from scrum_agent.agent.llm import _PROVIDER_DEFAULTS
+from scrum_agent.setup_wizard import _PROVIDERS, run_setup_wizard
+from scrum_agent.ui.provider_select._constants import _PROVIDER_CARDS
+from scrum_agent.ui.provider_select._verification import _verify_model
+from scrum_agent.ui.provider_select.screens._screens import (
+    _build_model_input_screen,
+    _build_model_select_screen,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _card(provider_val: str) -> dict:
+    return next(c for c in _PROVIDER_CARDS if c["provider_val"] == provider_val)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _render(panel: Panel) -> str:
+    console = Console(file=StringIO(), width=80, highlight=False)
+    console.print(panel)
+    return console.file.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _verify_model — Anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyModelAnthropic:
+    def test_success(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "post", lambda *a, **kw: _FakeResponse(200))
+        ok, _ = _verify_model(_card("anthropic"), "sk-ant-key", "claude-opus-4-8")
+        assert ok is True
+
+    def test_unknown_model_404(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "post", lambda *a, **kw: _FakeResponse(404))
+        ok, msg = _verify_model(_card("anthropic"), "sk-ant-key", "claude-nope")
+        assert ok is False
+        assert "not" in msg.lower()
+
+    def test_bad_request_surfaces_detail(self, monkeypatch):
+        import httpx
+
+        payload = {"error": {"message": "model: claude-nope is not supported"}}
+        monkeypatch.setattr(httpx, "post", lambda *a, **kw: _FakeResponse(400, payload))
+        ok, msg = _verify_model(_card("anthropic"), "sk-ant-key", "claude-nope")
+        assert ok is False
+        assert "not supported" in msg
+
+    def test_bad_credentials_401(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "post", lambda *a, **kw: _FakeResponse(401))
+        ok, msg = _verify_model(_card("anthropic"), "sk-ant-bad", "claude-opus-4-8")
+        assert ok is False
+        assert "Invalid" in msg
+
+    def test_connection_error(self, monkeypatch):
+        import httpx
+
+        def _boom(*a, **kw):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(httpx, "post", _boom)
+        ok, msg = _verify_model(_card("anthropic"), "sk-ant-key", "claude-opus-4-8")
+        assert ok is False
+        assert "Connection error" in msg
+
+
+# ---------------------------------------------------------------------------
+# _verify_model — OpenAI / Google
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyModelOpenAI:
+    def test_success(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200))
+        ok, _ = _verify_model(_card("openai"), "sk-key", "gpt-4o")
+        assert ok is True
+
+    def test_unknown_model(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(404))
+        ok, msg = _verify_model(_card("openai"), "sk-key", "gpt-nope")
+        assert ok is False
+        assert "Unknown" in msg
+
+
+class TestVerifyModelGoogle:
+    def test_success(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200))
+        ok, _ = _verify_model(_card("google"), "AIzaKey", "gemini-2.0-flash")
+        assert ok is True
+
+    def test_unknown_model(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(404))
+        ok, msg = _verify_model(_card("google"), "AIzaKey", "gemini-nope")
+        assert ok is False
+        assert "Unknown" in msg
+
+
+# ---------------------------------------------------------------------------
+# _verify_model — Bedrock (api_key is the region)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyModelBedrock:
+    def test_inference_profile_soft_accepted_without_api_call(self):
+        # Leading us./eu./global. ids aren't in list_foundation_models — accept
+        # once the region resolves. No boto3 needed, so no mock required.
+        ok, _ = _verify_model(_card("bedrock"), "us-east-1", "us.anthropic.claude-sonnet-4-20250514-v1:0")
+        assert ok is True
+
+    def _inject_boto3(self, monkeypatch, model_summaries):
+        """Inject a fake boto3 module (the real one is an optional extra)."""
+        import sys
+        import types
+
+        class _Client:
+            def list_foundation_models(self, **kw):
+                return {"modelSummaries": model_summaries}
+
+        class _Session:
+            def __init__(self, *a, **kw):
+                pass
+
+            def client(self, *a, **kw):
+                return _Client()
+
+        fake = types.ModuleType("boto3")
+        fake.Session = _Session
+        monkeypatch.setitem(sys.modules, "boto3", fake)
+        monkeypatch.setattr("scrum_agent.config.get_aws_profile", lambda: None)
+
+    def test_plain_model_id_found_in_region(self, monkeypatch):
+        self._inject_boto3(monkeypatch, [{"modelId": "anthropic.claude-3-sonnet"}])
+        ok, _ = _verify_model(_card("bedrock"), "us-east-1", "anthropic.claude-3-sonnet")
+        assert ok is True
+
+    def test_plain_model_id_missing_in_region(self, monkeypatch):
+        self._inject_boto3(monkeypatch, [])
+        ok, msg = _verify_model(_card("bedrock"), "us-east-1", "anthropic.claude-3-sonnet")
+        assert ok is False
+        assert "not available" in msg.lower()
+
+
+class TestVerifyModelUnknownProvider:
+    def test_unknown_provider_returns_false(self):
+        ok, msg = _verify_model({"provider_val": "mystery"}, "key", "some-model")
+        assert ok is False
+        assert "Unknown provider" in msg
+
+
+# ---------------------------------------------------------------------------
+# Screen builders
+# ---------------------------------------------------------------------------
+
+
+class TestModelSelectScreen:
+    def test_returns_panel(self):
+        panel = _build_model_select_screen(_card("anthropic"), ["claude-opus-4-8", "Custom…"], 0)
+        assert isinstance(panel, Panel)
+
+    def test_single_entry(self):
+        panel = _build_model_select_screen(_card("openai"), ["Custom…"], 0)
+        assert isinstance(panel, Panel)
+
+    def test_long_model_id_renders(self):
+        entries = ["us.anthropic.claude-sonnet-4-20250514-v1:0", "Custom…"]
+        out = _render(_build_model_select_screen(_card("bedrock"), entries, 0))
+        # The id is long enough it may wrap/crop; a distinctive fragment survives.
+        assert "claude-sonnet-4" in out
+
+    def test_error_line_shown(self):
+        out = _render(_build_model_select_screen(_card("openai"), ["gpt-4o", "Custom…"], 0, error="Unknown model"))
+        assert "Unknown model" in out
+
+
+class TestModelInputScreen:
+    def test_returns_panel(self):
+        assert isinstance(_build_model_input_screen(_card("anthropic"), ""), Panel)
+
+    def test_value_is_plaintext_not_masked(self):
+        # Model ids are not secrets — the typed value must render as-is, no bullets.
+        out = _render(_build_model_input_screen(_card("anthropic"), "claude-opus-4-8"))
+        assert "claude-opus-4-8" in out
+        assert "•" not in out
+
+    def test_verified_state(self):
+        assert isinstance(_build_model_input_screen(_card("openai"), "gpt-4o", verified=True), Panel)
+
+    def test_error_state(self):
+        out = _render(_build_model_input_screen(_card("openai"), "gpt-nope", verified=False, error="Unknown model"))
+        assert "Unknown model" in out
+
+    def test_verifying_state(self):
+        panel = _build_model_input_screen(
+            _card("google"), "gemini-2.0-flash", verifying=True, border_override="rgb(1,1,1)"
+        )
+        assert isinstance(panel, Panel)
+
+
+# ---------------------------------------------------------------------------
+# Data integrity — preset defaults must match _PROVIDER_DEFAULTS
+# ---------------------------------------------------------------------------
+
+
+class TestModelDataIntegrity:
+    @pytest.mark.parametrize("card", _PROVIDER_CARDS, ids=lambda c: c["provider_val"])
+    def test_default_matches_provider_defaults(self, card):
+        default = card["models"]["default"]
+        assert default == _PROVIDER_DEFAULTS[card["provider_val"]]
+        # The default is always offered as a preset the user can pick.
+        assert default in card["models"]["presets"]
+
+
+# ---------------------------------------------------------------------------
+# Wizard propagation — LLM_MODEL is written when select_provider returns it
+# ---------------------------------------------------------------------------
+
+
+class TestWizardModelPropagation:
+    def _patch_config_file(self, monkeypatch, tmp_path):
+        config_file = tmp_path / ".env"
+        monkeypatch.setattr("scrum_agent.setup_wizard.get_config_file", lambda: config_file)
+        monkeypatch.setattr("scrum_agent.config.get_config_file", lambda: config_file)
+        return config_file
+
+    def test_llm_model_written_to_env(self, monkeypatch, tmp_path):
+        config_file = self._patch_config_file(monkeypatch, tmp_path)
+        result = dict(_PROVIDERS["1"])
+        result["api_key"] = "sk-ant-key"
+        result["llm_model"] = "claude-opus-4-8"
+        monkeypatch.setattr("scrum_agent.setup_wizard.select_provider", lambda *a, **kw: result)
+        console = Console(file=StringIO(), highlight=False)
+        run_setup_wizard(console)
+        content = config_file.read_text()
+        assert "LLM_MODEL=claude-opus-4-8" in content
+
+    def test_no_llm_model_leaves_env_unset(self, monkeypatch, tmp_path):
+        config_file = self._patch_config_file(monkeypatch, tmp_path)
+        result = dict(_PROVIDERS["1"])
+        result["api_key"] = "sk-ant-key"  # no llm_model key
+        monkeypatch.setattr("scrum_agent.setup_wizard.select_provider", lambda *a, **kw: result)
+        console = Console(file=StringIO(), highlight=False)
+        run_setup_wizard(console)
+        content = config_file.read_text()
+        assert "LLM_MODEL" not in content


### PR DESCRIPTION
## What & why

Today the setup wizard and Settings let a user pick an LLM **provider** (Anthropic / Google / OpenAI / Bedrock) and verify its API key, but never the **model** — it was always the hardcoded per-provider default. This adds a model-selection step so users can pick from a curated preset list **or type any model id** (e.g. a newly released model), with the choice **validated by a live call** so nothing unusable gets saved.

Folded into the wizard's Step 0 (after key verification), so it appears in both first-run signup **and** Settings → Configure automatically. The read path already existed (`config.get_llm_model()` → `LLM_MODEL`); this only adds the UI to set it.

Confirmed product decisions: **must-pass validation** (block until a model validates; Esc goes back) and a **curated current preset set** per provider with the existing default pre-selected.

## Changes

- **`_constants.py`** — per-provider `"models"` (`default` + `presets`); `default` stays in sync with `agent/llm.py::_PROVIDER_DEFAULTS` (asserted by a test).
- **`_verification.py`** — `_verify_model()`: Anthropic 1-token ping, OpenAI/Google model lookup, Bedrock `list_foundation_models` (soft-accepts `us./eu./global.` inference-profile ids). Adds a module logger.
- **`screens/_screens.py`** — `_build_model_select_screen` (single-line list) and `_build_model_input_screen` (plaintext, never masked). Also adds a **keyboard hint** (`⌫ backspace · Ctrl+U clear · Enter to verify · Esc back`) on the key/model input screens, fixing a reported "can't edit a pre-filled key" confusion — the field was always editable, just not discoverably so.
- **`provider_select/__init__.py`** — model sub-step inside Step 0; Esc returns to the key input; persists `LLM_MODEL`.
- **`_phase_issue_tracking.py` / `setup_wizard.py`** — thread `llm_model` through to `collected["LLM_MODEL"]`.
- **tests** — new `tests/unit/test_provider_model_select.py` (28 tests): `_verify_model` happy/error per provider, Bedrock soft-accept, both screen builders (incl. plaintext-not-masked), data integrity, wizard propagation.

## Verification

- `make test` → **3185 passed, 7 skipped**
- `make lint` → clean

Manual: `--setup` → pick provider → verify key → **model picker** → preset or `Custom…` (validated) → confirm `LLM_MODEL` in `~/.scrum-agent/.env`; a bad id is blocked with an inline error.

> Note: base is `feature/smarter-planning` (this work is stacked on it, so the diff stays scoped to model selection). Retarget to `main` once that branch merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)