### PR TITLE
Add Notion as a doc tool across analysis, planning, and standup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,14 @@ JIRA_PROJECT_KEY=MYPROJ
 # Space key is the short identifier visible in your Confluence space URL
 CONFLUENCE_SPACE_KEY=MYSPACE
 
+# Notion (optional — its own doc tool, independent of Jira/Confluence)
+# Create an internal integration at https://www.notion.so/my-integrations, then
+# share the pages/databases you want the agent to read with that integration.
+NOTION_TOKEN=ntn_your-notion-integration-token
+# Optional: a root page or database ID used as the default parent for created
+# pages. Notion has no "space key"; search spans whatever the integration is granted.
+NOTION_ROOT_PAGE_ID=
+
 # Voice input (optional — double-tap Space in any text field to dictate)
 # Transcription runs locally & offline via faster-whisper (works with ANY LLM
 # provider, no API key). Install with: uv sync --extra voice

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,7 @@ src/scrum_agent/
     azure_devops.py     — Azure DevOps repo/file/work items/board/velocity/create (9 tools)
     jira.py             — Jira board/velocity/sprint/epic/story (6 tools)
     confluence.py       — Confluence search/read/write (5 tools)
+    notion.py           — Notion search/read/write (5 tools) + recent-pages helper (own token, not Atlassian auth)
     codebase.py         — Local repo scanning (3 tools)
     calendar_tools.py   — Bank holiday detection (1 tool)
     llm_tools.py        — LLM-powered estimation and AC generation (2 tools)
@@ -437,6 +438,8 @@ The `_dict_to_*()` functions in `sessions.py` use `.get()` for optional fields s
 - `AZURE_DEVOPS_ORG_URL`, `AZURE_DEVOPS_PROJECT`, `AZURE_DEVOPS_TEAM` — optional, for Azure DevOps board sync
 - `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, `JIRA_PROJECT_KEY` — optional, for Jira integration
 - `CONFLUENCE_SPACE_KEY` — optional, shares Atlassian auth with Jira
+- `NOTION_TOKEN` — optional, Notion integration token (independent doc tool; its own auth, not shared with Jira/Confluence). Enables the 5 `notion_*` tools + analysis/standup context.
+- `NOTION_ROOT_PAGE_ID` — optional, default parent for created Notion pages; also gates the Notion source in the Daily Standup activity feed (the Confluence-space-key analog)
 - `STANDUP_USER_NAME` — optional, your display name for your own standup update (default: "Me")
 - `STANDUP_GITHUB_REPO` — optional, GitHub repo (owner/repo) scanned for Daily Standup code activity
 - `SLACK_WEBHOOK_URL` — optional, Slack incoming-webhook URL for Daily Standup delivery

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ yeaboi --non-interactive --description @project-brief.txt --output html --team-s
 
 📊 **Capacity Planning** — Bank holidays (100+ countries), PTO/leave tracking, unplanned absence %, onboarding ramp-up, per-sprint velocity
 
-🔌 **30 Tools** — GitHub, Azure DevOps, Jira, Confluence, local codebase scanning, bank holiday detection, LLM-powered estimation
+🔌 **35 Tools** — GitHub, Azure DevOps, Jira, Confluence, Notion, local codebase scanning, bank holiday detection, LLM-powered estimation
 
 📤 **5 Export Formats** — Markdown, HTML, JSON, Jira sync, Azure DevOps Boards sync
 
@@ -137,7 +137,7 @@ yeaboi --non-interactive --description @project-brief.txt --output html --team-s
 
 📄 **SCRUM.md Context** — Drop a `SCRUM.md` in your project directory; the agent reads it to pre-fill answers and ground output
 
-☀️ **Daily Standup** — Detects team activity (Jira/AzDO/GitHub/Confluence/git), infers per-person updates or takes your own, scores sprint-day confidence, and delivers to terminal/desktop/Slack/email — on an OS schedule that runs even when the app is closed
+☀️ **Daily Standup** — Detects team activity (Jira/AzDO/GitHub/Confluence/Notion/git), infers per-person updates or takes your own, scores sprint-day confidence, and delivers to terminal/desktop/Slack/email — on an OS schedule that runs even when the app is closed
 
 🔬 **Team Analysis Mode** — Connect your Jira or Azure DevOps board to analyze your team's real patterns: velocity, sprint cadence, story structure, acceptance criteria style, naming conventions, and per-developer breakdown
 
@@ -830,7 +830,7 @@ Open it from the mode-selection screen (the magenta **Standup** card) or run it 
 
 ### What it does
 
-1. **Detects recent activity** across every configured source — Jira issues, Azure DevOps work items, GitHub commits + PRs, recently-updated Confluence pages, and a local git log. Each source is best-effort: an unconfigured or failing source is skipped, never fatal. An **authentication failure (401/403) surfaces as a Notice**, not silence.
+1. **Detects recent activity** across every configured source — Jira issues, Azure DevOps work items, GitHub commits + PRs, recently-updated Confluence pages, recently-edited Notion pages, and a local git log. Each source is best-effort: an unconfigured or failing source is skipped, never fatal. An **authentication failure (401/403) surfaces as a Notice**, not silence.
 2. **Asks for your own update first**, then infers everyone else. Press **Generate** and it prompts for your update (Enter to skip); people without a self-report get an inferred summary from a single LLM call.
 3. **Computes sprint day + confidence** deterministically (no LLM): which working day of the sprint you're on (weekends and bank holidays excluded), and how actual "Done" points compare to the ideal linear burn-down → **On track / At risk / Behind**.
 4. **Delivers** the summary to any combination of **terminal, desktop notification, Slack, and email**.
@@ -1289,6 +1289,21 @@ The agent has access to 30 tools, organized by integration:
 | `confluence_read_space` | Read space metadata and page list | Low |
 | `confluence_create_page` | Create a new page | High (requires confirmation) |
 | `confluence_update_page` | Update an existing page | High (requires confirmation) |
+
+</details>
+
+<details>
+<summary>📓 Notion (5 tools)</summary>
+
+Notion is an independent doc tool with its **own** integration token (`NOTION_TOKEN`) — it does not share Atlassian auth like Confluence. It feeds the same analysis / planning / standup workflows.
+
+| Tool | Description | Risk |
+|------|-------------|------|
+| `notion_search_pages` | Search pages by keyword across granted pages | Low |
+| `notion_read_page` | Read a page (blocks flattened to text) by ID | Low |
+| `notion_read_database` | List entries in a database / data source | Low |
+| `notion_create_page` | Create a new page | High (requires confirmation) |
+| `notion_update_page` | Append content to a page (and optionally rename) | High (requires confirmation) |
 
 </details>
 
@@ -2004,6 +2019,7 @@ src/scrum_agent/
 │   ├── calendar_tools.py       #   Bank holiday detection
 │   ├── codebase.py             #   Local repo scanning
 │   ├── confluence.py           #   Confluence search/read/write
+│   ├── notion.py               #   Notion search/read/write (own token)
 │   ├── github.py               #   GitHub repo/file/issues/readme
 │   ├── jira.py                 #   Jira board/velocity/sprint/epic/story
 │   └── llm_tools.py            #   LLM-powered estimation and AC generation
@@ -2060,6 +2076,8 @@ src/scrum_agent/
 | `JIRA_API_TOKEN` | If using Jira | Jira API token |
 | `JIRA_PROJECT_KEY` | If using Jira | Project key (e.g. `MYPROJ`) |
 | `CONFLUENCE_SPACE_KEY` | No | Confluence space key (shares Atlassian auth with Jira) |
+| `NOTION_TOKEN` | No | Notion integration token (its own auth; enables Notion doc tools) |
+| `NOTION_ROOT_PAGE_ID` | No | Default parent for created Notion pages; enables the Notion standup source |
 | `LANGSMITH_TRACING` | No | Enable LangSmith tracing (`true`) |
 | `LANGSMITH_API_KEY` | No | LangSmith API key |
 | `LANGSMITH_PROJECT` | No | LangSmith project name |
@@ -2083,7 +2101,7 @@ src/scrum_agent/
 |-------|---------|
 | **Unit Tests** | Prompt formatting, tool input/output validation, state transitions, artifact immutability |
 | **Integration Tests** | CLI argument parsing, graph compilation, multi-node flows, session persistence |
-| **Contract Tests** | VCR cassettes for GitHub, Jira, Confluence API responses |
+| **Contract Tests** | VCR cassettes for GitHub, Jira, Confluence, Notion API responses |
 | **Golden Datasets** | Curated project descriptions with expected feature/story breakdowns |
 | **Smoke Tests** | Live API tests (require real credentials) |
 | **Token Budget Tests** | Monitor prompt token counts for trend analysis |

--- a/TODO.md
+++ b/TODO.md
@@ -294,6 +294,23 @@ Comprehensive task list for building the project. Check items off as they're com
 - [x] Add user confirmation before any Confluence write operation
 - [x] Truncate large pages at 8 000 chars (same pattern as GitHub/AzDO file tools)
 
+#### Notion
+
+Independent doc tool with its own integration token (NOTION_TOKEN) — not shared Atlassian auth. Mirrors Confluence across analysis / planning / standup.
+
+- [x] Set up Notion authentication (own `NOTION_TOKEN`; optional `NOTION_ROOT_PAGE_ID` scoping)
+- [x] `notion_search_pages` — keyword search across granted pages to locate docs before planning
+- [x] `notion_read_page` — fetch a page and flatten its blocks to plain text (truncate at 8 000 chars)
+- [x] `notion_read_database` — list entries in a database / data source (2025 data-sources API)
+- [x] Feed Notion context into `project_analyzer` — `## Notion Documentation` section alongside repo/Confluence/Jira
+- [x] `notion_create_page` — publish the sprint plan / brief as a Notion page (with user confirmation)
+- [x] `notion_update_page` — append content to an existing page, optional rename (with user confirmation)
+- [x] `notion_recent_pages` — recently-edited pages feed for Daily Standup (graceful skip; 401/403 → Notice)
+- [x] Handle Notion API errors gracefully (401/403/404/429)
+- [x] Add user confirmation before any Notion write operation (`_HIGH_RISK_TOOLS`)
+- [x] Dedicated "Docs / Notion" setup-wizard step with live token verification + Settings display
+- [x] Unit tests (`test_tools_notion.py`) + contract cassettes (`test_notion_contract.py`)
+
 ### Tool Registration
 
 - [x] Register all tools with `@tool` decorator and descriptive docstrings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
     "azure-devops",
     "jira",
     "atlassian-python-api",
+    # Notion doc tools (tools/notion.py) — official SDK, mirrors how Confluence
+    # uses atlassian-python-api. Notion has its own integration token (NOTION_TOKEN).
+    "notion-client",
     # SQLite-backed checkpoint store for Phase 8 session persistence.
     # SqliteSaver is used as a standalone store; the graph itself stays
     # stateless for now (Phase 8B wires it as a full LangGraph checkpointer).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "2.2.0"
+version = "2.3.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/agent/nodes.py
+++ b/src/scrum_agent/agent/nodes.py
@@ -127,7 +127,7 @@ def _is_llm_auth_or_billing_error(exc: Exception) -> bool:
 # High-risk tool constants
 # ---------------------------------------------------------------------------
 
-# These are write operations that modify external systems (Jira, Confluence).
+# These are write operations that modify external systems (Jira, Confluence, Notion).
 # They require explicit user confirmation before execution — the agent must ask
 # and receive a "yes" before the graph routes to the ToolNode.
 # See README: "Guardrails" — human-in-the-loop pattern (Tool layer)
@@ -138,6 +138,8 @@ _HIGH_RISK_TOOLS: frozenset[str] = frozenset(
         "jira_create_sprint",
         "confluence_create_page",
         "confluence_update_page",
+        "notion_create_page",
+        "notion_update_page",
     }
 )
 
@@ -1996,6 +1998,108 @@ def _fetch_confluence_context(
     except Exception as e:
         logger.debug("Confluence context fetch failed (non-fatal)", exc_info=True)
         return None, {"name": "Confluence", "status": "error", "detail": str(e)[:80]}
+
+
+def _extract_notion_page_ids(text: str) -> list[str]:
+    """Extract Notion page IDs from URLs found in free-form text (e.g. SCRUM.md).
+
+    # See README: "Tools" — read-only tool pattern
+    #
+    # Notion URLs end with a 32-hex-character page ID (optionally dash-formatted),
+    # usually appended to a slugified title, e.g.:
+    #   https://www.notion.so/My-Runbook-1234567890abcdef1234567890abcdef
+    #   https://www.notion.so/workspace/Title-12345678-90ab-cdef-1234-567890abcdef
+    # We extract the raw 32-hex id (stripping dashes) so we can call notion_read_page
+    # directly instead of relying on keyword search which often misses specific pages.
+    """
+    ids: list[str] = []
+    # Match a 32-hex run, allowing the dash-separated 8-4-4-4-12 UUID form too.
+    hex32 = r"[0-9a-fA-F]{32}"
+    uuid = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    for m in re.findall(rf"({hex32}|{uuid})", text):
+        ids.append(m.replace("-", ""))
+    return ids
+
+
+def _fetch_notion_context(
+    questionnaire: QuestionnaireState,
+    user_context: str | None = None,
+) -> tuple[str | None, dict]:
+    """Search Notion for docs related to the project and return combined context + status.
+
+    # See README: "Tools" — read-only tool pattern
+    #
+    # Mirrors _fetch_confluence_context exactly, with two strategies:
+    # 1. Keyword search using the project name (Q1) — broad discovery.
+    # 2. Direct page fetch for any Notion URLs found in SCRUM.md — precise
+    #    targeting of pages the user has explicitly linked.
+    #
+    # Falls back to (None, status) when Notion is not configured; the caller
+    # proceeds gracefully with reduced context when None is returned.
+
+    Args:
+        questionnaire: The completed QuestionnaireState with Q1 (project name).
+        user_context: Raw SCRUM.md content — scanned for Notion URLs to fetch directly.
+
+    Returns:
+        Tuple of (context string or None, status dict with name/status/detail).
+    """
+    try:
+        from scrum_agent.config import get_notion_token
+
+        # Only proceed if the Notion integration token is configured.
+        if not get_notion_token():
+            return None, {"name": "Notion", "status": "skipped", "detail": "not configured"}
+
+        from scrum_agent.tools.notion import notion_read_page, notion_search_pages
+
+        parts: list[str] = []
+
+        # Strategy 1: Keyword search using project name (Q1).
+        project_name = questionnaire.answers.get(1, "").strip()
+        if project_name and project_name != QUESTION_DEFAULTS.get(1):
+            result = notion_search_pages.invoke({"query": project_name, "limit": 5})
+            if result and not result.startswith("Error") and not result.startswith("No Notion"):
+                parts.append(result)
+                logger.debug("NOTION: keyword search returned results for %r", project_name)
+            else:
+                logger.debug("NOTION: keyword search returned no results for %r", project_name)
+
+        # Strategy 2: Fetch pages directly from Notion URLs in SCRUM.md.
+        if user_context:
+            page_ids = _extract_notion_page_ids(user_context)
+            logger.debug("NOTION: extracted %d page ID(s) from user_context: %s", len(page_ids), page_ids[:10])
+            seen = set()
+            for pid in page_ids:
+                if pid in seen:
+                    continue
+                seen.add(pid)
+                try:
+                    logger.debug("NOTION: fetching page ID %s", pid)
+                    page_content = notion_read_page.invoke({"page_id": pid})
+                    if page_content and not page_content.startswith("Error"):
+                        parts.append(page_content)
+                        logger.debug("NOTION: fetched page ID %s (%d chars)", pid, len(page_content))
+                    else:
+                        logger.debug(
+                            "NOTION: page ID %s returned error: %s",
+                            pid,
+                            page_content[:100] if page_content else "empty",
+                        )
+                except Exception:
+                    logger.debug("NOTION: failed to fetch page %s (non-fatal)", pid, exc_info=True)
+        else:
+            logger.debug("NOTION: no user_context provided, skipping URL extraction")
+
+        if not parts:
+            return None, {"name": "Notion", "status": "error", "detail": "no docs found"}
+
+        combined = "\n\n---\n\n".join(parts)
+        detail = f"search + {len(parts) - 1} linked page(s)" if len(parts) > 1 else f"docs for '{project_name}'"
+        return combined, {"name": "Notion", "status": "success", "detail": detail}
+    except Exception as e:
+        logger.debug("Notion context fetch failed (non-fatal)", exc_info=True)
+        return None, {"name": "Notion", "status": "error", "detail": str(e)[:80]}
 
 
 def _scan_repo_context(questionnaire: QuestionnaireState) -> tuple[str | None, dict]:
@@ -5434,6 +5538,13 @@ def project_analyzer(state: ScrumState) -> dict:
         "CONFLUENCE: result status=%s detail=%s", confluence_status.get("status"), confluence_status.get("detail")
     )
 
+    # Same two-strategy discovery for Notion (keyword search + direct page fetch
+    # from URLs in SCRUM.md). Notion is an independent doc source with its own
+    # token — graceful (None, status) when it's not configured or no docs found.
+    # See README: "Tools" — read-only tool pattern
+    notion_context, notion_status = _fetch_notion_context(questionnaire, user_context=user_context)
+    logger.debug("NOTION: result status=%s detail=%s", notion_status.get("status"), notion_status.get("detail"))
+
     # Load team profile for calibration-aware analysis.
     # Non-fatal — if no profile exists, the prompt runs without calibration context.
     # See README: "Scrum Standards" — team learning, self-calibrating estimates
@@ -5465,6 +5576,7 @@ def project_analyzer(state: ScrumState) -> dict:
         repo_context=repo_context,
         detected_stack=repo_signals.detected_stack or None,
         confluence_context=confluence_context,
+        notion_context=notion_context,
         user_context=user_context,
         team_profile_summary=team_profile_summary,
         ceremony_history=ceremony.summary_md,
@@ -5570,15 +5682,17 @@ def project_analyzer(state: ScrumState) -> dict:
         "messages": [AIMessage(content=display)],
         # Context source diagnostics — tells the REPL which external sources
         # were used, skipped, or failed so the user gets transparency.
-        "context_sources": [repo_status, confluence_status, user_status],
+        "context_sources": [repo_status, confluence_status, notion_status, user_status],
     }
-    # Only write repo_context / confluence_context / user_context when present —
-    # avoids overwriting a prior value on re-runs (e.g. edit review) where
-    # the scan might silently fail (network down, token expired, file deleted).
+    # Only write repo_context / confluence_context / notion_context / user_context
+    # when present — avoids overwriting a prior value on re-runs (e.g. edit review)
+    # where the scan might silently fail (network down, token expired, file deleted).
     if repo_context is not None:
         return_dict["repo_context"] = repo_context
     if confluence_context is not None:
         return_dict["confluence_context"] = confluence_context
+    if notion_context is not None:
+        return_dict["notion_context"] = notion_context
     if user_context is not None:
         return_dict["user_context"] = user_context
     return return_dict
@@ -6976,6 +7090,11 @@ def _build_doc_context(state: ScrumState) -> str | None:
     confluence = state.get("confluence_context", "")
     if confluence and confluence.strip():
         parts.append(f"- **Confluence:** {confluence.strip()[:500]}")
+
+    # Notion context — scraped page content from notion_search_pages / notion_read_page
+    notion = state.get("notion_context", "")
+    if notion and notion.strip():
+        parts.append(f"- **Notion:** {notion.strip()[:500]}")
 
     # User context from SCRUM.md — may contain wiki URLs, design doc links, etc.
     user_ctx = state.get("user_context", "")

--- a/src/scrum_agent/agent/state.py
+++ b/src/scrum_agent/agent/state.py
@@ -932,6 +932,13 @@ class ScrumState(_RequiredState, total=False):
     # See README: "Tools" — tool types, read-only tool pattern
     confluence_context: str
 
+    # Notion context — concatenated plain-text content from notion_search_pages and
+    # notion_read_page tool calls during the intake phase. Notion is an independent
+    # doc source (its own integration token); surfaced in the project_analyzer prompt
+    # alongside repo and Confluence context. Empty string if no Notion tools were called.
+    # See README: "Tools" — tool types, read-only tool pattern
+    notion_context: str
+
     # User-provided context from SCRUM.md — free-form markdown the user places in
     # their project root (URLs, design notes, screenshots as links, tech decisions,
     # team conventions). Read once by project_analyzer; injected into the prompt so

--- a/src/scrum_agent/config.py
+++ b/src/scrum_agent/config.py
@@ -218,6 +218,25 @@ def get_confluence_space_key() -> str | None:
     return os.getenv("CONFLUENCE_SPACE_KEY") or None
 
 
+def get_notion_token() -> str | None:
+    """Return the Notion integration token, or None if not set.
+
+    Unlike Confluence (which reuses Jira's Atlassian auth), Notion has its own
+    OAuth2 integration token — the only credential its SDK needs.
+    """
+    return os.getenv("NOTION_TOKEN") or None
+
+
+def get_notion_root_page_id() -> str | None:
+    """Return the optional Notion root page/database ID, or None if not set.
+
+    Notion has no "space key" — search spans whatever pages the integration is
+    granted. This optional ID scopes the default parent for page creation and the
+    standup recent-pages feed (analogous to CONFLUENCE_SPACE_KEY).
+    """
+    return os.getenv("NOTION_ROOT_PAGE_ID") or None
+
+
 # ---------------------------------------------------------------------------
 # Daily Standup configuration
 # ---------------------------------------------------------------------------

--- a/src/scrum_agent/prompts/analyzer.py
+++ b/src/scrum_agent/prompts/analyzer.py
@@ -55,6 +55,7 @@ def get_analyzer_prompt(
     repo_context: str | None = None,
     detected_stack: list[str] | None = None,
     confluence_context: str | None = None,
+    notion_context: str | None = None,
     user_context: str | None = None,
     team_profile_summary: str = "",
     ceremony_history: str = "",
@@ -93,6 +94,9 @@ def get_analyzer_prompt(
             excerpts). When provided, a "Confluence Documentation" section is
             injected so the LLM can ground constraints and integrations in
             existing architecture docs, ADRs, and runbooks.
+        notion_context: Search results / page content from Notion. When provided,
+            a "Notion Documentation" section is injected — same purpose as
+            confluence_context, for teams whose docs live in Notion.
         user_context: Content of SCRUM.md and/or scrum-docs/ files from the
             user's project root. When provided, a "User Context" section is
             injected so the LLM can incorporate PRDs, design docs, and notes.
@@ -136,6 +140,20 @@ def get_analyzer_prompt(
             f"{confluence_context}\n"
         )
         if confluence_context
+        else ""
+    )
+
+    # Inject Notion search results / page content when available. Same role as the
+    # Confluence section — Notion is the doc home for teams that don't use Confluence.
+    notion_section = (
+        (
+            "\n## Notion Documentation\n\n"
+            "The following pages were found in the team's Notion workspace. "
+            "Use them to identify existing architecture decisions, integrations, "
+            "constraints, and tech_stack details that the questionnaire may not capture.\n\n"
+            f"{notion_context}\n"
+        )
+        if notion_context
         else ""
     )
 
@@ -213,6 +231,7 @@ def get_analyzer_prompt(
         f"- Velocity: {velocity_per_sprint} story points per sprint\n"
         f"{repo_section}"
         f"{confluence_section}"
+        f"{notion_section}"
         f"{user_section}"
         f"{team_section}"
         f"{ceremony_section}"

--- a/src/scrum_agent/sessions.py
+++ b/src/scrum_agent/sessions.py
@@ -168,6 +168,7 @@ _SCALAR_KEYS = {
     "target_sprints",
     "repo_context",
     "confluence_context",
+    "notion_context",
     "user_context",
     "pending_review",
     "last_review_feedback",

--- a/src/scrum_agent/setup_wizard.py
+++ b/src/scrum_agent/setup_wizard.py
@@ -241,6 +241,10 @@ def run_setup_wizard(console: Console) -> bool:
     issue_tracking = result.get("issue_tracking", {})
     collected.update(issue_tracking)
 
+    # ── Notion (optional doc tool, collected in full-screen UI) ─────────
+    notion = result.get("notion", {})
+    collected.update(notion)
+
     # ── Bedrock: auto-detect model from OpenClaw if available ───────────────
     # OpenClaw's models.json has the exact Bedrock model ID (e.g.
     # global.anthropic.claude-sonnet-4-6). Without this, yeaboi falls

--- a/src/scrum_agent/standup/collector.py
+++ b/src/scrum_agent/standup/collector.py
@@ -27,8 +27,9 @@ SOURCE_AZDO = "azure_devops"
 SOURCE_GITHUB = "github"
 SOURCE_LOCAL_GIT = "local_git"
 SOURCE_CONFLUENCE = "confluence"
+SOURCE_NOTION = "notion"
 
-ALL_SOURCES = (SOURCE_JIRA, SOURCE_AZDO, SOURCE_GITHUB, SOURCE_LOCAL_GIT, SOURCE_CONFLUENCE)
+ALL_SOURCES = (SOURCE_JIRA, SOURCE_AZDO, SOURCE_GITHUB, SOURCE_LOCAL_GIT, SOURCE_CONFLUENCE, SOURCE_NOTION)
 
 
 @dataclass
@@ -66,6 +67,7 @@ def _resolve_sources(
     github_repo: str,
     local_repo_path: str,
     confluence_space: str,
+    notion_root: str = "",
 ) -> set[str]:
     """Decide which sources to attempt.
 
@@ -85,6 +87,8 @@ def _resolve_sources(
         auto.add(SOURCE_LOCAL_GIT)
     if confluence_space:
         auto.add(SOURCE_CONFLUENCE)
+    if notion_root:
+        auto.add(SOURCE_NOTION)
     return auto
 
 
@@ -97,6 +101,7 @@ def collect_recent_activity(
     github_repo: str = "",
     local_repo_path: str = "",
     confluence_space: str = "",
+    notion_root: str = "",
 ) -> ActivityBundle:
     """Gather and normalize recent activity from all enabled sources.
 
@@ -111,6 +116,7 @@ def collect_recent_activity(
         github_repo=github_repo,
         local_repo_path=local_repo_path,
         confluence_space=confluence_space,
+        notion_root=notion_root,
     )
     logger.info("collect_recent_activity: days=%d enabled sources=%s", days, sorted(enabled))
 
@@ -183,6 +189,15 @@ def collect_recent_activity(
             return confluence_recent_pages(confluence_space, days=days)
 
         _run(SOURCE_CONFLUENCE, _conf)
+
+    if SOURCE_NOTION in enabled:
+
+        def _notion() -> list[dict]:
+            from scrum_agent.tools.notion import notion_recent_pages
+
+            return notion_recent_pages(notion_root, days=days)
+
+        _run(SOURCE_NOTION, _notion)
 
     logger.info("collect_recent_activity: %d total item(s) across %d source(s)", bundle.total(), len(bundle.counts))
     return bundle

--- a/src/scrum_agent/standup/engine.py
+++ b/src/scrum_agent/standup/engine.py
@@ -43,18 +43,22 @@ def _resolve_source_params(config: dict | None) -> dict:
     """Resolve collector source identifiers from config/env.
 
     Returns kwargs for collect_recent_activity: jira_project, azdo_project,
-    github_repo, local_repo_path, confluence_space.
+    github_repo, local_repo_path, confluence_space, notion_root.
     """
     from scrum_agent.config import (
         get_azure_devops_project,
         get_confluence_space_key,
         get_jira_project_key,
+        get_notion_root_page_id,
     )
 
     params = {
         "jira_project": get_jira_project_key() or "",
         "azdo_project": get_azure_devops_project() or "",
         "confluence_space": get_confluence_space_key() or "",
+        # Notion's standup source is enabled by NOTION_ROOT_PAGE_ID — the same
+        # "identifying parameter" gate Confluence uses with its space key.
+        "notion_root": get_notion_root_page_id() or "",
         "github_repo": "",
         "local_repo_path": (config or {}).get("repo_path", "") or "",
     }

--- a/src/scrum_agent/tools/__init__.py
+++ b/src/scrum_agent/tools/__init__.py
@@ -85,6 +85,13 @@ def get_tools() -> list[BaseTool]:
         jira_read_board,
     )
     from scrum_agent.tools.llm_tools import estimate_complexity, generate_acceptance_criteria
+    from scrum_agent.tools.notion import (
+        notion_create_page,
+        notion_read_database,
+        notion_read_page,
+        notion_search_pages,
+        notion_update_page,
+    )
     from scrum_agent.tools.team_learning import analyze_team_history, compare_plan_to_actuals
 
     return [
@@ -118,6 +125,11 @@ def get_tools() -> list[BaseTool]:
         confluence_read_space,
         confluence_create_page,
         confluence_update_page,
+        notion_search_pages,
+        notion_read_page,
+        notion_read_database,
+        notion_create_page,
+        notion_update_page,
         analyze_team_history,
         compare_plan_to_actuals,
     ]

--- a/src/scrum_agent/tools/notion.py
+++ b/src/scrum_agent/tools/notion.py
@@ -1,0 +1,484 @@
+"""Notion tools — 3 read-only + 2 write (with user-confirmation guard in docstrings).
+
+# See README: "Tools" — tool types, @tool decorator, risk levels
+#
+# This module mirrors tools/confluence.py exactly — same 5-tool shape (search,
+# read page, list a container, create, update) plus a recent-activity helper for
+# Daily Standup. Read tools are low-risk (fetch page text for the LLM to reason
+# about during project analysis); write tools (create_page, update_page) are
+# high-risk and carry an explicit "only call after user confirms" docstring note.
+#
+# Why notion-client?
+# The official notion-client package wraps the Notion REST API with typed methods,
+# handles the required Notion-Version header, and mirrors how the rest of the
+# project talks to external services through a per-integration SDK
+# (atlassian-python-api for Confluence/Jira, PyGithub for GitHub). This keeps the
+# auth + client-creation model consistent and avoids raw REST calls.
+#
+# Auth: Notion uses its OWN integration token (NOTION_TOKEN) — unlike Confluence,
+# which reuses Jira's Atlassian credentials. The only optional extra is
+# NOTION_ROOT_PAGE_ID (a page/database ID used as the default create parent and to
+# scope the standup feed) — Notion has no "space key" concept.
+#
+# ONE real divergence from Confluence: Notion has no single storage-format "body"
+# to overwrite, so notion_update_page APPENDS content blocks (and can rename the
+# page) rather than replacing the whole body like confluence_update_page.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from langchain_core.tools import tool
+from notion_client import Client
+from notion_client.errors import APIResponseError
+
+from scrum_agent.config import get_notion_root_page_id, get_notion_token
+
+logger = logging.getLogger(__name__)
+
+# Shown whenever the Notion token is missing — single source of truth for the message.
+_MISSING_CONFIG_MSG = "Error: Notion is not configured. Ensure NOTION_TOKEN is set in your .env file."
+
+# Truncate page content at this many characters to avoid flooding the LLM context.
+# See README: "Tools" — scoping tool output for LLM relevance
+_MAX_CONTENT_CHARS = 8_000
+
+# Block types whose rich_text we render as readable plain text. Notion pages are a
+# tree of typed blocks; we pull text from the common textual ones and skip the rest.
+_TEXT_BLOCK_TYPES = (
+    "paragraph",
+    "heading_1",
+    "heading_2",
+    "heading_3",
+    "bulleted_list_item",
+    "numbered_list_item",
+    "to_do",
+    "quote",
+    "callout",
+    "toggle",
+    "code",
+)
+
+
+def _make_notion_client() -> Client | None:
+    """Return an authenticated Notion client, or None if the token is missing.
+
+    Notion authenticates with a single Bearer integration token; the SDK sets the
+    required Notion-Version header internally.
+    """
+    token = get_notion_token()
+    if not token:
+        logger.warning("Notion client not created — missing config")
+        return None
+    logger.debug("Creating Notion client")
+    client = Client(auth=token)
+    logger.debug("Notion client created successfully")
+    return client
+
+
+def _notion_error_msg(e: APIResponseError) -> str:
+    """Return a user-friendly message for common Notion HTTP error codes."""
+    # APIResponseError carries an HTTP status code on .status.
+    code = getattr(e, "status", 0)
+    if code == 401:
+        return "Error: Notion authentication failed. Check NOTION_TOKEN in .env."
+    if code == 403:
+        return "Error: Notion permission denied. Share the page/database with your integration."
+    if code == 404:
+        return f"Error: Notion resource not found — verify the page or database ID. ({e})"
+    if code == 429:
+        return "Error: Notion rate limit reached. Wait a moment and try again."
+    return f"Error: Notion API error {code}: {e}"
+
+
+def _rich_text_to_plain(rich_text: list) -> str:
+    """Join a Notion rich_text array into a plain string.
+
+    Each rich_text item carries a ``plain_text`` field; concatenating them yields
+    the readable text of a block without styling markup.
+    """
+    if not isinstance(rich_text, list):
+        return ""
+    return "".join(rt.get("plain_text", "") for rt in rich_text if isinstance(rt, dict))
+
+
+def _blocks_to_text(blocks: list) -> str:
+    """Convert a list of Notion block dicts to LLM-readable plain text.
+
+    Notion's analog of Confluence's _strip_html_tags: walk each block, pull the
+    rich_text of the textual block types, and join them with newlines. Headings
+    keep a blank line before them; list items get a leading bullet. Unknown/media
+    blocks are skipped.
+    """
+    lines: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type", "")
+        if btype not in _TEXT_BLOCK_TYPES:
+            continue
+        payload = block.get(btype, {}) if isinstance(block.get(btype), dict) else {}
+        text = _rich_text_to_plain(payload.get("rich_text", []))
+        if not text:
+            continue
+        if btype.startswith("heading"):
+            lines.append("")
+            lines.append(text)
+        elif btype in ("bulleted_list_item", "numbered_list_item", "to_do"):
+            lines.append(f"- {text}")
+        else:
+            lines.append(text)
+    return "\n".join(lines).strip()
+
+
+def _text_to_blocks(text: str) -> list:
+    """Convert plain text to Notion paragraph blocks (the inverse of _blocks_to_text).
+
+    Splits the text on double-newlines (paragraph boundaries) and wraps each
+    paragraph in a paragraph block with a single rich_text run. This produces valid
+    block children for pages.create / blocks.children.append without an external
+    conversion step. Analogous to Confluence's _text_to_storage.
+    """
+    paragraphs = [p.strip() for p in text.strip().split("\n\n") if p.strip()]
+    return [
+        {
+            "object": "block",
+            "type": "paragraph",
+            "paragraph": {"rich_text": [{"type": "text", "text": {"content": p}}]},
+        }
+        for p in paragraphs
+    ]
+
+
+def _page_title(page: dict) -> str:
+    """Extract a page's title from its properties (title-type property varies by name)."""
+    props = page.get("properties", {}) if isinstance(page, dict) else {}
+    for prop in props.values():
+        if isinstance(prop, dict) and prop.get("type") == "title":
+            title = _rich_text_to_plain(prop.get("title", []))
+            if title:
+                return title
+    return "Untitled"
+
+
+@tool
+def notion_search_pages(query: str, limit: int = 10) -> str:
+    """Search Notion for pages by keyword or phrase.
+
+    Use this before project analysis to discover architecture docs, ADRs, runbooks,
+    and product specs that should inform the scrum plan. Searches every page the
+    integration has been granted access to. Returns title, page ID, and URL for
+    each result.
+    """
+    # See README: "The ReAct Loop" — this is the Action step; the result is the Observation
+    logger.debug("notion_search_pages called: query=%r, limit=%d", query, limit)
+    client = _make_notion_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    try:
+        results = client.search(
+            query=query,
+            filter={"property": "object", "value": "page"},
+            page_size=limit,
+        )
+        pages = results.get("results", []) if isinstance(results, dict) else []
+
+        if not pages:
+            return f"No Notion pages found for '{query}'."
+
+        lines: list[str] = [f"Notion search results for '{query}':", ""]
+        for page in pages:
+            title = _page_title(page)
+            page_id = page.get("id", "")
+            url = page.get("url", "")
+            lines.append(f"[{title}] (ID: {page_id})")
+            if url:
+                lines.append(f"  URL: {url}")
+            lines.append("")
+
+        logger.debug("notion_search_pages found %d results for %r", len(pages), query)
+        lines.append(f"({len(pages)} results shown)")
+        return "\n".join(lines)
+
+    except APIResponseError as e:
+        logger.error("Notion API error in search_pages: %s", e)
+        return _notion_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in notion_search_pages: %s", e)
+        return f"Error: {e}"
+
+
+@tool
+def notion_read_page(page_id: str) -> str:
+    """Fetch and read a Notion page as plain text.
+
+    Provide the page_id (from a Notion URL or from notion_search_pages results).
+    Retrieves the page title plus its content blocks and flattens them to plain
+    text for LLM context. Truncates at 8 000 characters with a note if the page is
+    larger. Use this to read architecture docs, ADRs, runbooks, and product specs.
+    """
+    logger.debug("notion_read_page called: page_id=%r", page_id)
+    client = _make_notion_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    if not page_id.strip():
+        return "Error: Provide a page_id."
+
+    try:
+        page = client.pages.retrieve(page_id)
+        title = _page_title(page)
+        url = page.get("url", "")
+
+        # Notion stores page body as a tree of child blocks — fetch the top level.
+        children = client.blocks.children.list(page_id, page_size=100)
+        blocks = children.get("results", []) if isinstance(children, dict) else []
+        content = _blocks_to_text(blocks)
+
+        truncated = False
+        if len(content) > _MAX_CONTENT_CHARS:
+            content = content[:_MAX_CONTENT_CHARS]
+            truncated = True
+
+        logger.debug("notion_read_page fetched %r (%d chars)", title, len(content))
+        header = f"=== {title} ===\n"
+        if url:
+            header += f"URL: {url}\n"
+        header += "\n"
+        suffix = f"\n\n[Truncated at {_MAX_CONTENT_CHARS} characters]" if truncated else ""
+        return header + content + suffix
+
+    except APIResponseError as e:
+        logger.error("Notion API error in read_page: %s", e)
+        return _notion_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in notion_read_page: %s", e)
+        return f"Error: {e}"
+
+
+@tool
+def notion_read_database(database_id: str, limit: int = 25) -> str:
+    """List entries in a Notion database to discover available documentation.
+
+    Returns page titles and IDs for up to limit rows. Use this to discover what
+    docs exist (architecture pages, ADRs, runbooks, product specs) before calling
+    notion_read_page on specific ones. This is the discovery equivalent of browsing
+    a Confluence space. Accepts either a database ID or a data-source ID (Notion's
+    2025 API queries data sources, which this resolves from the database if needed).
+    """
+    logger.debug("notion_read_database called: database_id=%r, limit=%d", database_id, limit)
+    client = _make_notion_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    if not database_id.strip():
+        return "Error: Provide a database_id."
+
+    try:
+        # Notion's 2025 API splits a database into one or more "data sources"; you
+        # query a data source, not the database. Try the given id as a data source
+        # id directly; if that 400/404s, resolve the database's first data source.
+        try:
+            results = client.data_sources.query(data_source_id=database_id, page_size=limit)
+        except APIResponseError as e:
+            if getattr(e, "status", 0) not in (400, 404):
+                raise
+            db = client.databases.retrieve(database_id)
+            sources = db.get("data_sources", []) if isinstance(db, dict) else []
+            if not sources:
+                return _notion_error_msg(e)
+            results = client.data_sources.query(data_source_id=sources[0]["id"], page_size=limit)
+        rows = results.get("results", []) if isinstance(results, dict) else []
+
+        if not rows:
+            return f"No entries found in Notion database '{database_id}'."
+
+        lines: list[str] = [f"Entries in Notion database '{database_id}':", ""]
+        for row in rows:
+            title = _page_title(row)
+            page_id = row.get("id", "")
+            url = row.get("url", "")
+            lines.append(f"- {title} (ID: {page_id})")
+            if url:
+                lines.append(f"  URL: {url}")
+
+        logger.debug("notion_read_database listed %d entries in %s", len(rows), database_id)
+        note = "; increase limit to see more" if len(rows) >= limit else ""
+        lines.append("")
+        lines.append(f"({len(rows)} entries shown{note})")
+        return "\n".join(lines)
+
+    except APIResponseError as e:
+        logger.error("Notion API error in read_database: %s", e)
+        return _notion_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in notion_read_database: %s", e)
+        return f"Error: {e}"
+
+
+@tool
+def notion_create_page(title: str, body: str, parent_id: str = "") -> str:
+    """Create a new Notion page with the generated sprint plan or project brief.
+
+    Only call this after the user has explicitly confirmed they want to publish to Notion.
+    body is plain text — it is converted into Notion paragraph blocks automatically.
+    parent_id is the page (or database) to nest the new page under; when omitted it
+    falls back to NOTION_ROOT_PAGE_ID. Notion requires a parent, so one of the two
+    must be set. Returns the new page's title, ID, and URL on success.
+    """
+    logger.debug("notion_create_page called: title=%r, parent=%r", title, parent_id)
+    client = _make_notion_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    parent = parent_id.strip() or (get_notion_root_page_id() or "")
+    if not parent:
+        return "Error: No parent_id provided and NOTION_ROOT_PAGE_ID is not set in .env."
+
+    try:
+        page = client.pages.create(
+            parent={"page_id": parent},
+            properties={"title": [{"type": "text", "text": {"content": title}}]},
+            children=_text_to_blocks(body),
+        )
+        page_id = page.get("id", "")
+        url = page.get("url", "")
+        logger.debug("Created Notion page %s (ID: %s)", title, page_id)
+        return f"Created Notion page: '{title}'\nID: {page_id}\nURL: {url}"
+
+    except APIResponseError as e:
+        logger.error("Notion API error in create_page: %s", e)
+        return _notion_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in notion_create_page: %s", e)
+        return f"Error: {e}"
+
+
+@tool
+def notion_update_page(page_id: str, body: str, title: str = "") -> str:
+    """Update an existing Notion page by appending content (e.g. a new sprint plan).
+
+    Only call this after the user has explicitly confirmed they want to update the page.
+    NOTE: unlike Confluence (which replaces the page body), Notion has no single body
+    to overwrite — so this APPENDS body as new paragraph blocks to the end of the page.
+    If title is provided, the page is also renamed. body is plain text, converted to
+    Notion blocks automatically. Returns the page's title, ID, and URL on success.
+    """
+    logger.debug("notion_update_page called: page_id=%r, title=%r", page_id, title)
+    client = _make_notion_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    if not page_id.strip():
+        return "Error: Provide a page_id."
+
+    try:
+        # Append the new content blocks to the page's children.
+        if body.strip():
+            client.blocks.children.append(page_id, children=_text_to_blocks(body))
+
+        # Optionally rename the page via its title property.
+        if title.strip():
+            client.pages.update(
+                page_id,
+                properties={"title": [{"type": "text", "text": {"content": title}}]},
+            )
+
+        page = client.pages.retrieve(page_id)
+        effective_title = _page_title(page)
+        url = page.get("url", "")
+        logger.debug("Updated Notion page %s (ID: %s)", effective_title, page_id)
+        return f"Updated Notion page: '{effective_title}'\nID: {page_id}\nURL: {url}"
+
+    except APIResponseError as e:
+        logger.error("Notion API error in update_page: %s", e)
+        return _notion_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in notion_update_page: %s", e)
+        return f"Error: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Recent-activity helper for Daily Standup mode
+# ---------------------------------------------------------------------------
+# Plain function (not @tool) the standup collector calls directly. Returns
+# structured data and degrades gracefully to [] on error/missing config.
+# See README: "Daily Standup" — recent-activity collection
+
+
+def notion_recent_pages(root_id: str = "", days: int = 1) -> list[dict]:
+    """Return Notion pages edited within the last ``days`` days.
+
+    Each item: {author, kind='page', title, timestamp, key(id)}. Returns [] when
+    Notion is unconfigured or the search fails. The Notion search API has no
+    server-side date filter, so we sort by last_edited_time descending and filter
+    client-side. ``root_id`` is accepted for signature parity with the other
+    sources but Notion search is workspace-wide (scoped by integration grants).
+    """
+    logger.info("notion_recent_pages: root=%r days=%d", root_id, days)
+    client = _make_notion_client()
+    if client is None:
+        logger.warning("notion_recent_pages skipped — Notion not configured")
+        return []
+
+    cutoff = datetime.now(UTC) - timedelta(days=int(days))
+    # Best-effort cache of user-id → display name so we don't refetch per page.
+    _user_names: dict[str, str] = {}
+
+    def _resolve_author(user_id: str) -> str:
+        if not user_id:
+            return ""
+        if user_id in _user_names:
+            return _user_names[user_id]
+        try:
+            user = client.users.retrieve(user_id)
+            name = user.get("name", "") if isinstance(user, dict) else ""
+        except Exception:
+            name = ""
+        _user_names[user_id] = name
+        return name
+
+    try:
+        results = client.search(
+            filter={"property": "object", "value": "page"},
+            sort={"direction": "descending", "timestamp": "last_edited_time"},
+            page_size=50,
+        )
+        pages = results.get("results", []) if isinstance(results, dict) else []
+        items: list[dict] = []
+        for page in pages:
+            edited = page.get("last_edited_time", "")
+            # last_edited_time is ISO 8601 (e.g. 2026-07-14T10:20:00.000Z).
+            try:
+                edited_dt = datetime.fromisoformat(edited.replace("Z", "+00:00")) if edited else None
+            except ValueError:
+                edited_dt = None
+            if edited_dt is not None and edited_dt < cutoff:
+                # Results are newest-first, so once we pass the cutoff we can stop.
+                break
+            author_id = (
+                page.get("last_edited_by", {}).get("id", "") if isinstance(page.get("last_edited_by"), dict) else ""
+            )
+            items.append(
+                {
+                    "author": _resolve_author(author_id),
+                    "kind": "page",
+                    "title": _page_title(page),
+                    "timestamp": (edited or "")[:19],
+                    "key": page.get("id", ""),
+                }
+            )
+        logger.info("notion_recent_pages: %d page(s) in last %d day(s)", len(items), days)
+        return items
+    except APIResponseError as e:
+        code = getattr(e, "status", 0)
+        if code in (401, 403):
+            from scrum_agent.standup.errors import StandupSourceError
+
+            raise StandupSourceError("notion", "authentication failed — check NOTION_TOKEN") from e
+        logger.warning("notion_recent_pages failed: %s", _notion_error_msg(e))
+        return []
+    except Exception as e:
+        logger.warning("notion_recent_pages unexpected error: %s", e)
+        return []

--- a/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
@@ -4262,6 +4262,12 @@ def _build_settings_screen(
     _heading("GitHub")
     _row("Token", config_data.get("GITHUB_TOKEN", ""), masked=True)
 
+    # ── Notion ────────────────────────────────────────────────────
+    # Independent doc tool (its own integration token, unlike Confluence).
+    _heading("Notion")
+    _row("Token", config_data.get("NOTION_TOKEN", ""), masked=True)
+    _row("Root Page/DB", config_data.get("NOTION_ROOT_PAGE_ID", ""))
+
     # ── Daily Standup delivery ────────────────────────────────────
     # Secrets (Slack webhook, SMTP password) are masked like every other credential.
     _heading("Daily Standup")

--- a/src/scrum_agent/ui/provider_select/__init__.py
+++ b/src/scrum_agent/ui/provider_select/__init__.py
@@ -21,6 +21,7 @@ from rich.console import Console
 from scrum_agent.ui.provider_select._config import _save_progress  # noqa: F401
 from scrum_agent.ui.provider_select._constants import _PROVIDER_CARDS, _VC_OPTIONS
 from scrum_agent.ui.provider_select._phase_issue_tracking import _run_issue_tracking  # noqa: F401
+from scrum_agent.ui.provider_select._phase_notion import _run_notion  # noqa: F401
 from scrum_agent.ui.provider_select._transitions import _transition_to_input  # noqa: F401
 from scrum_agent.ui.provider_select._verification import _verify_api_key, _verify_model, _verify_vc_token
 from scrum_agent.ui.provider_select.screens._screens import (
@@ -99,7 +100,8 @@ def select_provider(
     Organized as a step-based loop so Esc navigates back between steps:
     Step 0: LLM Provider selection + API key verification
     Step 1: Issue Tracking (Jira / Azure DevOps Boards / Skip)
-    Step 2: Version Control (GitHub PAT)
+    Step 2: Docs / Notion (optional integration token)
+    Step 3: Version Control (GitHub PAT)
 
     Returns a dict compatible with setup_wizard._PROVIDERS values (with an
     added 'api_key' field), or None if the user cancelled.
@@ -297,7 +299,7 @@ def select_provider(
                 elif key in ("q", "esc"):
                     return None
 
-        while step < 3:
+        while step < 4:
             # ══════════════════════════════════════════════════════════════
             # Step 0: LLM Provider selection + API key input
             # ══════════════════════════════════════════════════════════════
@@ -503,9 +505,28 @@ def select_provider(
                 continue
 
             # ══════════════════════════════════════════════════════════════
-            # Step 2: Version Control (GitHub PAT)
+            # Step 2: Docs / Notion (optional integration token)
             # ══════════════════════════════════════════════════════════════
             elif step == 2:
+                # Fade out the previous screen into the Notion form.
+                for grey in FADE_OUT_LEVELS:
+                    w, h = console.size
+                    live.update(_build_input_screen(provider, api_key, width=w, height=h, input_fade=grey))
+                    time.sleep(FRAME_TIME_30FPS)
+
+                notion_result = _run_notion(console, read_key, existing_config, live)
+                if notion_result is not None:
+                    # Empty dict = user skipped (optional). Either way, record and advance.
+                    _issue_tracking_result["notion"] = notion_result
+                    step = 3
+                else:
+                    step = 1  # Esc → go back to issue tracking
+                continue
+
+            # ══════════════════════════════════════════════════════════════
+            # Step 3: Version Control (GitHub PAT)
+            # ══════════════════════════════════════════════════════════════
+            elif step == 3:
                 vc_selected = 0
                 vc_n = len(_VC_OPTIONS)
                 vc_start = time.monotonic()
@@ -728,7 +749,7 @@ def select_provider(
                     disable_bracketed_paste()
                     return _issue_tracking_result
                 else:
-                    step = 1  # Esc → go back to issue tracking
+                    step = 2  # Esc → go back to Notion
                     continue
 
     disable_bracketed_paste()

--- a/src/scrum_agent/ui/provider_select/_constants.py
+++ b/src/scrum_agent/ui/provider_select/_constants.py
@@ -189,3 +189,24 @@ _ISSUE_TRACKING_OPTIONS: list[dict[str, Any]] = [
     {"name": "Azure DevOps Boards", "fields": _AZDEVOPS_TRACKING_FIELDS},
     {"name": "Skip", "fields": []},
 ]
+
+# Notion doc-tool fields — a standalone wizard step (step 3). Unlike Confluence
+# (which rides on Jira's Atlassian auth), Notion has its own integration token and
+# no "space key"; the optional root page/database ID scopes page creation and the
+# standup activity feed. Both fields are optional so users without Notion skip past.
+_NOTION_FIELDS: list[dict[str, Any]] = [
+    {
+        "env_var": "NOTION_TOKEN",
+        "label": "Notion Integration Token",
+        "placeholder": "ntn_… / secret_…",
+        "masked": True,
+        "required": False,
+    },
+    {
+        "env_var": "NOTION_ROOT_PAGE_ID",
+        "label": "Root Page/Database ID (optional)",
+        "placeholder": "",
+        "masked": False,
+        "required": False,
+    },
+]

--- a/src/scrum_agent/ui/provider_select/_phase_notion.py
+++ b/src/scrum_agent/ui/provider_select/_phase_notion.py
@@ -1,0 +1,171 @@
+"""Notion (Docs) phase of the provider selection wizard.
+
+# See README: "Architecture" — this module handles the standalone Notion
+# credential step. Unlike Confluence (which rides on Jira's Atlassian auth in the
+# Issue Tracking form), Notion is an independent doc tool with its own integration
+# token, so it gets its own optional wizard step.
+#
+# It reuses the generic multi-field form renderer (_build_issue_tracking_screen,
+# which accepts `fields=` and `subtitle=`) and the same pulsing verify/confirm
+# animation as the Jira/AzDO form — just with _NOTION_FIELDS and a live
+# _verify_notion check.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import termios
+import time
+import tty
+
+from rich.console import Console
+from rich.live import Live
+
+from scrum_agent.ui.provider_select._config import _save_progress
+from scrum_agent.ui.provider_select._constants import _NOTION_FIELDS
+from scrum_agent.ui.provider_select._verification import _verify_notion
+from scrum_agent.ui.provider_select.screens._screens_vc import _build_issue_tracking_screen
+from scrum_agent.ui.shared._animations import FRAME_TIME_30FPS
+
+_SUBTITLE = "Docs / Notion"
+
+
+def _run_notion(
+    console: Console,
+    read_key,
+    existing_config: dict[str, str] | None,
+    live: Live,
+) -> dict[str, str] | None:
+    """Show the optional Notion credential form and verify the token.
+
+    Returns a dict of collected Notion env vars (empty dict when the user skips by
+    pressing Enter with no token), or None when the user presses Esc to go back.
+    Because Notion is optional, an empty token is a valid "skip" — the step never
+    blocks users who don't use Notion.
+    """
+    import threading
+
+    fields = _NOTION_FIELDS
+    n = len(fields)
+    _cfg = existing_config or {}
+    values: dict[int, str] = {i: _cfg.get(field["env_var"], "") for i, field in enumerate(fields)}
+    errors: dict[int, str] = {}
+    verified: dict[int, bool] = {}
+    selected = 0
+
+    # Drain any buffered stdin so a held key from the previous screen doesn't leak in.
+    import select as _sel
+
+    _drain_fd = sys.stdin.fileno()
+    _drain_old = termios.tcgetattr(_drain_fd)
+    try:
+        tty.setcbreak(_drain_fd)
+        while _sel.select([_drain_fd], [], [], 0.05)[0]:
+            sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(_drain_fd, termios.TCSADRAIN, _drain_old)
+
+    def _render(**kw) -> None:
+        w, h = console.size
+        live.update(
+            _build_issue_tracking_screen(
+                selected,
+                values,
+                width=w,
+                height=h,
+                fields=fields,
+                subtitle=_SUBTITLE,
+                **kw,
+            )
+        )
+
+    _render()
+
+    while True:
+        key = read_key()
+
+        if key in ("up", "scroll_up"):
+            selected = (selected - 1) % n
+        elif key in ("down", "scroll_down"):
+            selected = (selected + 1) % n
+        elif key == "enter":
+            token = values.get(0, "").strip()
+
+            # Empty token → skip Notion entirely (it's optional).
+            if not token:
+                return {}
+
+            # Verify the token with a pulsing border while the API call runs.
+            verify_result: list[tuple[bool, str]] = []
+
+            def _do_verify():
+                verify_result.append(_verify_notion(token))
+
+            thread = threading.Thread(target=_do_verify, daemon=True)
+            thread.start()
+
+            pulse_start = time.monotonic()
+            while thread.is_alive():
+                elapsed = time.monotonic() - pulse_start
+                intensity = (math.sin(elapsed * 6) + 1) / 2
+                v = int(60 + 140 * intensity)
+                _render(border_overrides={i: f"rgb({v},{v},{v})" for i in range(n)})
+                time.sleep(FRAME_TIME_30FPS)
+
+            thread.join()
+            ok, msg = verify_result[0]
+
+            if ok:
+                # Green success flash, matching the Jira/VC verify animation.
+                green_r, green_g, green_b = 80, 220, 120
+                for frame in range(10):
+                    t = frame / 9
+                    intensity = math.sin(t * math.pi)
+                    r = int(green_r + (255 - green_r) * intensity)
+                    g = int(green_g + (255 - green_g) * intensity)
+                    b = int(green_b + (255 - green_b) * intensity)
+                    _render(
+                        verified={i: True for i in range(n)},
+                        border_overrides={i: f"rgb({r},{g},{b})" for i in range(n)},
+                    )
+                    time.sleep(FRAME_TIME_30FPS)
+                _render(verified={i: True for i in range(n)})
+                time.sleep(0.6)
+
+                notion_data = {}
+                for i, field in enumerate(fields):
+                    val = values.get(i, "").strip()
+                    if val:
+                        notion_data[field["env_var"]] = val
+                _save_progress(notion_data)
+                return notion_data
+
+            # Verification failed — surface the error on the token field.
+            errors[0] = msg
+            selected = 0
+            _render(errors=errors)
+            continue
+
+        elif key == "esc":
+            return None
+        elif key == "clear":
+            values[selected] = ""
+            errors.pop(selected, None)
+            verified.pop(selected, None)
+        elif key == "backspace":
+            values[selected] = values[selected][:-1]
+            errors.pop(selected, None)
+            verified.pop(selected, None)
+        elif key == "tab":
+            selected = (selected + 1) % n
+        elif key.startswith("paste:"):
+            values[selected] = values.get(selected, "") + key[6:]
+            errors.pop(selected, None)
+            verified.pop(selected, None)
+        elif len(key) == 1 and key.isprintable():
+            values[selected] = values.get(selected, "") + key
+            errors.pop(selected, None)
+            verified.pop(selected, None)
+
+        _render(errors=errors, verified=verified)

--- a/src/scrum_agent/ui/provider_select/_verification.py
+++ b/src/scrum_agent/ui/provider_select/_verification.py
@@ -320,6 +320,34 @@ def _verify_jira(base_url: str, email: str, token: str) -> tuple[bool, str]:
         return False, f"Connection error: {e}"
 
 
+def _verify_notion(token: str) -> tuple[bool, str]:
+    """Verify a Notion integration token with a lightweight API call.
+
+    Hits GET /v1/users/me — the cheapest authenticated endpoint. Notion requires
+    the Notion-Version header on every request.
+    """
+    try:
+        import httpx
+
+        resp = httpx.get(
+            "https://api.notion.com/v1/users/me",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Notion-Version": "2022-06-28",
+            },
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            return True, "Notion verified"
+        if resp.status_code == 401:
+            return False, "Invalid Notion token"
+        if resp.status_code == 403:
+            return False, "Token lacks access — share pages with the integration"
+        return False, f"Unexpected response: {resp.status_code}"
+    except Exception as e:
+        return False, f"Connection error: {e}"
+
+
 def _verify_azdevops(org_url: str, project: str, token: str) -> tuple[bool, str]:
     """Verify Azure DevOps credentials by listing work item types for the project."""
     try:

--- a/tests/contract/cassettes/test_notion_contract/TestNotionCreatePageContract.test_create_page_returns_id_and_url.yaml
+++ b/tests/contract/cassettes/test_notion_contract/TestNotionCreatePageContract.test_create_page_returns_id_and_url.yaml
@@ -1,0 +1,18 @@
+interactions:
+- request:
+    body: '{"parent": {"page_id": "root-page-id"}, "properties": {"title": [{"type": "text", "text": {"content": "Sprint 1 Plan"}}]}, "children": [{"object": "block", "type": "paragraph", "paragraph": {"rich_text": [{"type": "text", "text": {"content": "Sprint goal: ship auth"}}]}}]}'
+    headers:
+      Content-Type:
+      - application/json
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    body:
+      string: '{"object":"page","id":"99999999999999999999999999999999","url":"https://www.notion.so/Sprint-1-Plan-99999999999999999999999999999999","properties":{"title":{"type":"title","title":[{"plain_text":"Sprint 1 Plan"}]}}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contract/cassettes/test_notion_contract/TestNotionErrorResponsesContract.test_401_bad_token.yaml
+++ b/tests/contract/cassettes/test_notion_contract/TestNotionErrorResponsesContract.test_401_bad_token.yaml
@@ -1,0 +1,18 @@
+interactions:
+- request:
+    body: '{"query": "test", "filter": {"property": "object", "value": "page"}, "page_size": 10}'
+    headers:
+      Content-Type:
+      - application/json
+    method: POST
+    uri: https://api.notion.com/v1/search
+  response:
+    body:
+      string: '{"object":"error","status":401,"code":"unauthorized","message":"API token is invalid."}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/tests/contract/cassettes/test_notion_contract/TestNotionReadDatabaseContract.test_read_database_lists_entries.yaml
+++ b/tests/contract/cassettes/test_notion_contract/TestNotionReadDatabaseContract.test_read_database_lists_entries.yaml
@@ -1,0 +1,18 @@
+interactions:
+- request:
+    body: '{"page_size": 25}'
+    headers:
+      Content-Type:
+      - application/json
+    method: POST
+    uri: https://api.notion.com/v1/data_sources/22222222222222222222222222222222/query
+  response:
+    body:
+      string: '{"object":"list","results":[{"object":"page","id":"aaaa1111111111111111111111111111","url":"https://www.notion.so/System-Architecture-aaaa1111111111111111111111111111","properties":{"Name":{"type":"title","title":[{"plain_text":"System Architecture"}]}}},{"object":"page","id":"bbbb2222222222222222222222222222","url":"https://www.notion.so/API-Reference-bbbb2222222222222222222222222222","properties":{"Name":{"type":"title","title":[{"plain_text":"API Reference"}]}}}]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contract/cassettes/test_notion_contract/TestNotionReadPageContract.test_read_page_flattens_blocks.yaml
+++ b/tests/contract/cassettes/test_notion_contract/TestNotionReadPageContract.test_read_page_flattens_blocks.yaml
@@ -1,0 +1,34 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+    method: GET
+    uri: https://api.notion.com/v1/pages/11111111111111111111111111111111
+  response:
+    body:
+      string: '{"object":"page","id":"11111111111111111111111111111111","url":"https://www.notion.so/System-Architecture-11111111111111111111111111111111","properties":{"Name":{"type":"title","title":[{"plain_text":"System Architecture"}]}}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+    method: GET
+    uri: https://api.notion.com/v1/blocks/11111111111111111111111111111111/children?page_size=100
+  response:
+    body:
+      string: '{"object":"list","results":[{"object":"block","type":"heading_1","heading_1":{"rich_text":[{"plain_text":"Overview"}]}},{"object":"block","type":"paragraph","paragraph":{"rich_text":[{"plain_text":"We use a microservices architecture."}]}},{"object":"block","type":"bulleted_list_item","bulleted_list_item":{"rich_text":[{"plain_text":"API Gateway routes requests"}]}}]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contract/cassettes/test_notion_contract/TestNotionSearchContract.test_search_returns_titles_and_urls.yaml
+++ b/tests/contract/cassettes/test_notion_contract/TestNotionSearchContract.test_search_returns_titles_and_urls.yaml
@@ -1,0 +1,18 @@
+interactions:
+- request:
+    body: '{"query": "architecture", "filter": {"property": "object", "value": "page"}, "page_size": 10}'
+    headers:
+      Content-Type:
+      - application/json
+    method: POST
+    uri: https://api.notion.com/v1/search
+  response:
+    body:
+      string: '{"object":"list","results":[{"object":"page","id":"11111111111111111111111111111111","url":"https://www.notion.so/System-Architecture-11111111111111111111111111111111","properties":{"Name":{"type":"title","title":[{"plain_text":"System Architecture"}]}}},{"object":"page","id":"22222222222222222222222222222222","url":"https://www.notion.so/ADR-22222222222222222222222222222222","properties":{"Name":{"type":"title","title":[{"plain_text":"Architecture Decision Records"}]}}}]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contract/test_notion_contract.py
+++ b/tests/contract/test_notion_contract.py
@@ -1,0 +1,97 @@
+"""Contract tests for Notion tools using recorded API responses (VCR.py).
+
+These tests replay hand-crafted cassettes containing realistic Notion REST API
+responses. They verify that our tool functions correctly parse the response shapes
+— catching SDK upgrades, schema changes, and block→text regressions without
+requiring live Notion credentials. Mirrors test_confluence_contract.py.
+
+# See README: "Testing — Contract Tests" for background on VCR.py replay.
+
+Each test is marked with @pytest.mark.vcr so pytest-recording loads the matching
+cassette from tests/contract/cassettes/test_notion_contract/.
+
+To re-record cassettes against a real Notion workspace: make record
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scrum_agent.tools.notion import (
+    notion_create_page,
+    notion_read_database,
+    notion_read_page,
+    notion_search_pages,
+)
+
+
+@pytest.fixture(autouse=True)
+def _notion_env(monkeypatch):
+    """Set required env vars for all Notion contract tests."""
+    monkeypatch.setenv("NOTION_TOKEN", "fake-token-for-vcr")
+    monkeypatch.setenv("NOTION_ROOT_PAGE_ID", "root-page-id")
+
+
+class TestNotionSearchContract:
+    """Contract: notion_search_pages parses search results correctly."""
+
+    @pytest.mark.vcr
+    def test_search_returns_titles_and_urls(self):
+        result = notion_search_pages.invoke({"query": "architecture"})
+
+        assert "System Architecture" in result
+        assert "11111111111111111111111111111111" in result
+        assert "Architecture Decision Records" in result
+        assert "notion.so" in result
+        assert "2 results shown" in result
+
+
+class TestNotionReadPageContract:
+    """Contract: notion_read_page fetches a page + its blocks and flattens to text."""
+
+    @pytest.mark.vcr
+    def test_read_page_flattens_blocks(self):
+        result = notion_read_page.invoke({"page_id": "11111111111111111111111111111111"})
+
+        assert "=== System Architecture ===" in result
+        assert "microservices" in result
+        assert "API Gateway" in result
+        # Block JSON should be flattened — no raw structure leaks through.
+        assert "rich_text" not in result
+        assert "plain_text" not in result
+
+
+class TestNotionReadDatabaseContract:
+    """Contract: notion_read_database lists database entries."""
+
+    @pytest.mark.vcr
+    def test_read_database_lists_entries(self):
+        result = notion_read_database.invoke({"database_id": "22222222222222222222222222222222"})
+
+        assert "System Architecture" in result
+        assert "API Reference" in result
+        assert "2 entries shown" in result
+
+
+class TestNotionCreatePageContract:
+    """Contract: notion_create_page parses the creation response."""
+
+    @pytest.mark.vcr
+    def test_create_page_returns_id_and_url(self):
+        result = notion_create_page.invoke(
+            {"title": "Sprint 1 Plan", "body": "Sprint goal: ship auth", "parent_id": "root-page-id"}
+        )
+
+        assert "Sprint 1 Plan" in result
+        assert "99999999999999999999999999999999" in result
+        assert "notion.so" in result
+
+
+class TestNotionErrorResponsesContract:
+    """Contract: Notion error responses become user-friendly messages."""
+
+    @pytest.mark.vcr
+    def test_401_bad_token(self):
+        result = notion_search_pages.invoke({"query": "test"})
+
+        assert "authentication failed" in result.lower()

--- a/tests/unit/prompts/test_analyzer_prompt.py
+++ b/tests/unit/prompts/test_analyzer_prompt.py
@@ -94,6 +94,35 @@ class TestGetAnalyzerPrompt:
         assert "Repository Scan" in result
         assert "Confluence Documentation" in result
 
+    def test_notion_context_section_present_when_provided(self):
+        """'Notion Documentation' section should appear when notion_context is given."""
+        notion_data = "[Runbook] (ID: abc123)\n  Deploy steps..."
+        result = get_analyzer_prompt("answers", 3, 15, notion_context=notion_data)
+        assert "Notion Documentation" in result
+        assert notion_data in result
+
+    def test_notion_context_section_absent_when_none(self):
+        """'Notion Documentation' section should be absent when notion_context is None."""
+        result = get_analyzer_prompt("answers", 3, 15, notion_context=None)
+        assert "Notion Documentation" not in result
+
+    def test_notion_context_section_absent_by_default(self):
+        """'Notion Documentation' section should be absent when notion_context is omitted."""
+        result = get_analyzer_prompt("answers", 3, 15)
+        assert "Notion Documentation" not in result
+
+    def test_confluence_and_notion_context_together(self):
+        """Both Confluence and Notion sections should appear when both are provided."""
+        result = get_analyzer_prompt(
+            "answers",
+            3,
+            15,
+            confluence_context="Confluence ADRs...",
+            notion_context="Notion specs...",
+        )
+        assert "Confluence Documentation" in result
+        assert "Notion Documentation" in result
+
     def test_user_context_section_present_when_provided(self):
         """'User Context (SCRUM.md / scrum-docs)' section should appear when user_context is given."""
         scrum_data = "# My Project\nWe use React + FastAPI. Budget: £500k."

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -297,3 +297,31 @@ class TestStandupConfig:
         ok, msg = is_llm_configured()
         assert ok is False
         assert "ANTHROPIC_API_KEY" in msg
+
+
+class TestNotionConfig:
+    """Notion has its own integration token (no shared Atlassian auth)."""
+
+    def test_token_returns_value(self, monkeypatch):
+        from scrum_agent.config import get_notion_token
+
+        monkeypatch.setenv("NOTION_TOKEN", "ntn_secret")
+        assert get_notion_token() == "ntn_secret"
+
+    def test_token_none_when_absent(self, monkeypatch):
+        from scrum_agent.config import get_notion_token
+
+        monkeypatch.delenv("NOTION_TOKEN", raising=False)
+        assert get_notion_token() is None
+
+    def test_root_page_id_returns_value(self, monkeypatch):
+        from scrum_agent.config import get_notion_root_page_id
+
+        monkeypatch.setenv("NOTION_ROOT_PAGE_ID", "root123")
+        assert get_notion_root_page_id() == "root123"
+
+    def test_root_page_id_none_when_absent(self, monkeypatch):
+        from scrum_agent.config import get_notion_root_page_id
+
+        monkeypatch.delenv("NOTION_ROOT_PAGE_ID", raising=False)
+        assert get_notion_root_page_id() is None

--- a/tests/unit/test_provider_verify_notion.py
+++ b/tests/unit/test_provider_verify_notion.py
@@ -1,0 +1,60 @@
+"""Tests for the Notion token verification used by the setup wizard's Docs step."""
+
+from unittest.mock import MagicMock
+
+from scrum_agent.ui.provider_select._verification import _verify_notion
+
+
+def _resp(status_code: int) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    return r
+
+
+class TestVerifyNotion:
+    def test_200_ok(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(200))
+        ok, msg = _verify_notion("ntn_token")
+        assert ok is True
+        assert "verified" in msg.lower()
+
+    def test_401_invalid(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(401))
+        ok, msg = _verify_notion("bad")
+        assert ok is False
+        assert "invalid" in msg.lower()
+
+    def test_403_lacks_access(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(403))
+        ok, msg = _verify_notion("scoped")
+        assert ok is False
+        assert "access" in msg.lower()
+
+    def test_unexpected_status(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(500))
+        ok, msg = _verify_notion("t")
+        assert ok is False
+        assert "500" in msg
+
+    def test_sends_notion_version_header(self, monkeypatch):
+        captured = {}
+
+        def fake_get(url, headers=None, timeout=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return _resp(200)
+
+        monkeypatch.setattr("httpx.get", fake_get)
+        _verify_notion("ntn_token")
+        assert captured["url"].endswith("/v1/users/me")
+        assert captured["headers"]["Notion-Version"]
+        assert captured["headers"]["Authorization"] == "Bearer ntn_token"
+
+    def test_connection_error_handled(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr("httpx.get", boom)
+        ok, msg = _verify_notion("t")
+        assert ok is False
+        assert "connection error" in msg.lower()

--- a/tests/unit/test_standup_collector.py
+++ b/tests/unit/test_standup_collector.py
@@ -5,6 +5,7 @@ from scrum_agent.standup.collector import (
     SOURCE_GITHUB,
     SOURCE_JIRA,
     SOURCE_LOCAL_GIT,
+    SOURCE_NOTION,
     ActivityBundle,
     collect_recent_activity,
 )
@@ -50,6 +51,18 @@ class TestResolveSources:
             confluence_space="",
         )
         assert got == {SOURCE_JIRA, SOURCE_GITHUB, SOURCE_LOCAL_GIT}
+
+    def test_auto_enables_notion_from_root(self):
+        got = collector._resolve_sources(
+            None,
+            jira_project="",
+            azdo_project="",
+            github_repo="",
+            local_repo_path="",
+            confluence_space="",
+            notion_root="root123",
+        )
+        assert got == {SOURCE_NOTION}
 
 
 class TestCollect:
@@ -102,6 +115,15 @@ class TestCollect:
         bundle = collect_recent_activity(sources={SOURCE_GITHUB}, github_repo="owner/repo")
         assert dict(bundle.counts) == {SOURCE_GITHUB: 2}
         assert {i["kind"] for i in bundle.items} == {"commit", "pr"}
+
+    def test_notion_source_collected(self, monkeypatch):
+        monkeypatch.setattr(
+            "scrum_agent.tools.notion.notion_recent_pages",
+            lambda root_id, days=1: [{"author": "Alice", "kind": "page", "title": "Doc", "timestamp": "", "key": "1"}],
+        )
+        bundle = collect_recent_activity(sources={SOURCE_NOTION}, notion_root="root123")
+        assert dict(bundle.counts) == {SOURCE_NOTION: 1}
+        assert bundle.items[0]["source"] == SOURCE_NOTION
 
     def test_no_sources_enabled_is_empty(self):
         bundle = collect_recent_activity(sources=set())

--- a/tests/unit/tools/test_tools_azure_devops.py
+++ b/tests/unit/tools/test_tools_azure_devops.py
@@ -567,7 +567,7 @@ class TestAzdevopsFetchActiveIteration:
 class TestGetTools:
     def test_returns_thirty_tools(self):
         tools = get_tools()
-        assert len(tools) == 32
+        assert len(tools) == 37
 
     def test_all_are_base_tools(self):
         from langchain_core.tools import BaseTool
@@ -607,6 +607,11 @@ class TestGetTools:
             "confluence_read_space",
             "confluence_create_page",
             "confluence_update_page",
+            "notion_search_pages",
+            "notion_read_page",
+            "notion_read_database",
+            "notion_create_page",
+            "notion_update_page",
             "jira_fetch_velocity",
             "jira_fetch_active_sprint",
             "load_project_context",

--- a/tests/unit/tools/test_tools_confluence.py
+++ b/tests/unit/tools/test_tools_confluence.py
@@ -512,4 +512,4 @@ class TestConfluenceToolsRegistered:
         assert expected.issubset(names), f"Missing Confluence tools: {expected - names}"
 
     def test_total_tool_count_is_thirty(self):
-        assert len(get_tools()) == 32
+        assert len(get_tools()) == 37

--- a/tests/unit/tools/test_tools_github.py
+++ b/tests/unit/tools/test_tools_github.py
@@ -391,7 +391,7 @@ class TestGithubReadReadme:
 class TestGetTools:
     def test_returns_thirty_tools(self):
         tools = get_tools()
-        assert len(tools) == 32
+        assert len(tools) == 37
 
     def test_all_are_base_tools(self):
         from langchain_core.tools import BaseTool

--- a/tests/unit/tools/test_tools_notion.py
+++ b/tests/unit/tools/test_tools_notion.py
@@ -1,0 +1,478 @@
+"""Tests for Notion tools.
+
+All Notion API calls are mocked via monkeypatch on _make_notion_client so no real
+network requests are made. Tests cover happy paths, error cases, and edge cases for
+each tool, plus helpers and registration in get_tools(). Mirrors
+test_tools_confluence.py.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+
+from scrum_agent.tools import get_tools
+from scrum_agent.tools.notion import (
+    _MISSING_CONFIG_MSG,
+    _blocks_to_text,
+    _notion_error_msg,
+    _page_title,
+    _text_to_blocks,
+    notion_create_page,
+    notion_read_database,
+    notion_read_page,
+    notion_recent_pages,
+    notion_search_pages,
+    notion_update_page,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — build mock Notion API errors and objects
+# ---------------------------------------------------------------------------
+
+
+def _make_api_error(status: int, message: str = "error") -> Exception:
+    """Build a real notion_client APIResponseError with the given status code."""
+    from notion_client.errors import APIResponseError
+
+    return APIResponseError(
+        code=str(status),
+        status=status,
+        message=message,
+        headers=httpx.Headers(),
+        raw_body_text="{}",
+    )
+
+
+def _make_page(page_id: str = "abc123", title: str = "My Page", url: str = "https://notion.so/My-Page-abc123") -> dict:
+    return {
+        "id": page_id,
+        "url": url,
+        "properties": {"Name": {"type": "title", "title": [{"plain_text": title}]}},
+    }
+
+
+def _para_block(text: str) -> dict:
+    return {"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": text}]}}
+
+
+# ---------------------------------------------------------------------------
+# _blocks_to_text
+# ---------------------------------------------------------------------------
+
+
+class TestBlocksToText:
+    def test_paragraph_text(self):
+        assert _blocks_to_text([_para_block("Hello world")]) == "Hello world"
+
+    def test_heading_gets_blank_line_before(self):
+        blocks = [
+            _para_block("Intro"),
+            {"type": "heading_2", "heading_2": {"rich_text": [{"plain_text": "Section"}]}},
+        ]
+        result = _blocks_to_text(blocks)
+        assert "Intro\n\nSection" in result
+
+    def test_list_items_get_bullets(self):
+        blocks = [{"type": "bulleted_list_item", "bulleted_list_item": {"rich_text": [{"plain_text": "one"}]}}]
+        assert _blocks_to_text(blocks) == "- one"
+
+    def test_unknown_block_types_skipped(self):
+        blocks = [{"type": "image", "image": {}}, _para_block("kept")]
+        assert _blocks_to_text(blocks) == "kept"
+
+    def test_empty_blocks(self):
+        assert _blocks_to_text([]) == ""
+
+    def test_non_dict_blocks_ignored(self):
+        assert _blocks_to_text(["nope", None, _para_block("ok")]) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _text_to_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestTextToBlocks:
+    def test_single_paragraph(self):
+        blocks = _text_to_blocks("Hello world")
+        assert len(blocks) == 1
+        assert blocks[0]["paragraph"]["rich_text"][0]["text"]["content"] == "Hello world"
+
+    def test_double_newline_splits(self):
+        blocks = _text_to_blocks("Para 1\n\nPara 2")
+        assert len(blocks) == 2
+
+    def test_empty_paragraphs_skipped(self):
+        blocks = _text_to_blocks("Para 1\n\n\n\nPara 2")
+        assert len(blocks) == 2
+
+    def test_empty_string(self):
+        assert _text_to_blocks("") == []
+
+    def test_roundtrip_with_blocks_to_text(self):
+        # A paragraph block produced by _text_to_blocks carries text under
+        # ["text"]["content"], not ["plain_text"], so this documents that the two
+        # helpers use the two distinct Notion shapes (write vs read).
+        blocks = _text_to_blocks("Roundtrip")
+        assert blocks[0]["type"] == "paragraph"
+
+
+# ---------------------------------------------------------------------------
+# _page_title
+# ---------------------------------------------------------------------------
+
+
+class TestPageTitle:
+    def test_extracts_title_property(self):
+        assert _page_title(_make_page(title="ADR-001")) == "ADR-001"
+
+    def test_untitled_when_no_title_property(self):
+        assert _page_title({"properties": {}}) == "Untitled"
+
+    def test_untitled_when_not_a_dict(self):
+        assert _page_title("nope") == "Untitled"
+
+
+# ---------------------------------------------------------------------------
+# _notion_error_msg
+# ---------------------------------------------------------------------------
+
+
+class TestNotionErrorMsg:
+    def test_401_auth_error(self):
+        assert "authentication failed" in _notion_error_msg(_make_api_error(401)).lower()
+
+    def test_403_permission_error(self):
+        assert "permission" in _notion_error_msg(_make_api_error(403)).lower()
+
+    def test_404_not_found(self):
+        assert "not found" in _notion_error_msg(_make_api_error(404)).lower()
+
+    def test_429_rate_limit(self):
+        assert "rate limit" in _notion_error_msg(_make_api_error(429)).lower()
+
+    def test_unknown_code(self):
+        assert "500" in _notion_error_msg(_make_api_error(500))
+
+
+# ---------------------------------------------------------------------------
+# notion_search_pages
+# ---------------------------------------------------------------------------
+
+
+class TestNotionSearchPages:
+    def test_happy_path_returns_titles_and_urls(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.search.return_value = {"results": [_make_page("111", "Architecture Overview")]}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_search_pages.invoke({"query": "architecture"})
+
+        assert "Architecture Overview" in result
+        assert "111" in result
+        assert "notion.so" in result
+
+    def test_no_results_returns_message(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.search.return_value = {"results": []}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_search_pages.invoke({"query": "missing topic"})
+
+        assert "No Notion pages found" in result
+
+    def test_filters_to_pages(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.search.return_value = {"results": []}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        notion_search_pages.invoke({"query": "test"})
+
+        kwargs = mock_client.search.call_args.kwargs
+        assert kwargs["filter"] == {"property": "object", "value": "page"}
+
+    def test_http_error_401(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.search.side_effect = _make_api_error(401)
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_search_pages.invoke({"query": "test"})
+
+        assert "authentication failed" in result.lower()
+
+    def test_missing_config_returns_message(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: None)
+
+        result = notion_search_pages.invoke({"query": "test"})
+
+        assert result == _MISSING_CONFIG_MSG
+
+
+# ---------------------------------------------------------------------------
+# notion_read_page
+# ---------------------------------------------------------------------------
+
+
+class TestNotionReadPage:
+    def test_happy_path(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.pages.retrieve.return_value = _make_page("999", "ADR-001")
+        mock_client.blocks.children.list.return_value = {"results": [_para_block("We chose PostgreSQL.")]}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_read_page.invoke({"page_id": "999"})
+
+        assert "ADR-001" in result
+        assert "PostgreSQL" in result
+
+    def test_empty_page_id_returns_error(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: MagicMock())
+
+        result = notion_read_page.invoke({"page_id": ""})
+
+        assert "Error" in result
+
+    def test_truncates_long_content(self, monkeypatch):
+        long_text = "x" * 9000
+        mock_client = MagicMock()
+        mock_client.pages.retrieve.return_value = _make_page("1", "Big")
+        mock_client.blocks.children.list.return_value = {"results": [_para_block(long_text)]}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_read_page.invoke({"page_id": "1"})
+
+        assert "Truncated" in result
+
+    def test_http_error_404(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.pages.retrieve.side_effect = _make_api_error(404)
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_read_page.invoke({"page_id": "999"})
+
+        assert "not found" in result.lower()
+
+    def test_missing_config(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: None)
+        assert notion_read_page.invoke({"page_id": "1"}) == _MISSING_CONFIG_MSG
+
+
+# ---------------------------------------------------------------------------
+# notion_read_database
+# ---------------------------------------------------------------------------
+
+
+class TestNotionReadDatabase:
+    def test_happy_path_lists_entries(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.data_sources.query.return_value = {"results": [_make_page("1", "Runbook"), _make_page("2", "Spec")]}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_read_database.invoke({"database_id": "db1"})
+
+        assert "Runbook" in result
+        assert "Spec" in result
+
+    def test_falls_back_to_database_data_source(self, monkeypatch):
+        # First query (id as data source) 404s → resolve via databases.retrieve.
+        mock_client = MagicMock()
+        mock_client.data_sources.query.side_effect = [
+            _make_api_error(404),
+            {"results": [_make_page("1", "Runbook")]},
+        ]
+        mock_client.databases.retrieve.return_value = {"data_sources": [{"id": "ds1"}]}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_read_database.invoke({"database_id": "db1"})
+
+        assert "Runbook" in result
+        mock_client.databases.retrieve.assert_called_once()
+
+    def test_empty_database(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.data_sources.query.return_value = {"results": []}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_read_database.invoke({"database_id": "db1"})
+
+        assert "No entries" in result
+
+    def test_empty_id_returns_error(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: MagicMock())
+        assert "Error" in notion_read_database.invoke({"database_id": ""})
+
+    def test_missing_config(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: None)
+        assert notion_read_database.invoke({"database_id": "db1"}) == _MISSING_CONFIG_MSG
+
+
+# ---------------------------------------------------------------------------
+# notion_create_page
+# ---------------------------------------------------------------------------
+
+
+class TestNotionCreatePage:
+    def test_happy_path_uses_explicit_parent(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.pages.create.return_value = _make_page("new1", "Sprint Plan")
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_create_page.invoke({"title": "Sprint Plan", "body": "Goals", "parent_id": "parent99"})
+
+        assert "Created Notion page" in result
+        assert "Sprint Plan" in result
+        assert mock_client.pages.create.call_args.kwargs["parent"] == {"page_id": "parent99"}
+
+    def test_falls_back_to_env_root(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.pages.create.return_value = _make_page("new1", "Plan")
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+        monkeypatch.setenv("NOTION_ROOT_PAGE_ID", "envroot")
+
+        notion_create_page.invoke({"title": "Plan", "body": "x"})
+
+        assert mock_client.pages.create.call_args.kwargs["parent"] == {"page_id": "envroot"}
+
+    def test_no_parent_returns_error(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: MagicMock())
+        monkeypatch.delenv("NOTION_ROOT_PAGE_ID", raising=False)
+
+        result = notion_create_page.invoke({"title": "Plan", "body": "x"})
+
+        assert "Error" in result and "NOTION_ROOT_PAGE_ID" in result
+
+    def test_http_error_403(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.pages.create.side_effect = _make_api_error(403)
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_create_page.invoke({"title": "P", "body": "x", "parent_id": "p"})
+
+        assert "permission" in result.lower()
+
+    def test_missing_config(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: None)
+        assert notion_create_page.invoke({"title": "P", "body": "x"}) == _MISSING_CONFIG_MSG
+
+
+# ---------------------------------------------------------------------------
+# notion_update_page
+# ---------------------------------------------------------------------------
+
+
+class TestNotionUpdatePage:
+    def test_appends_body_blocks(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.pages.retrieve.return_value = _make_page("p1", "Log")
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_update_page.invoke({"page_id": "p1", "body": "New entry"})
+
+        mock_client.blocks.children.append.assert_called_once()
+        assert "Updated Notion page" in result
+
+    def test_renames_when_title_given(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.pages.retrieve.return_value = _make_page("p1", "Renamed")
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        notion_update_page.invoke({"page_id": "p1", "body": "x", "title": "Renamed"})
+
+        mock_client.pages.update.assert_called_once()
+
+    def test_empty_page_id_returns_error(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: MagicMock())
+        assert "Error" in notion_update_page.invoke({"page_id": "", "body": "x"})
+
+    def test_http_error_404(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.blocks.children.append.side_effect = _make_api_error(404)
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        result = notion_update_page.invoke({"page_id": "p1", "body": "x"})
+
+        assert "not found" in result.lower()
+
+    def test_missing_config(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: None)
+        assert notion_update_page.invoke({"page_id": "p1", "body": "x"}) == _MISSING_CONFIG_MSG
+
+
+# ---------------------------------------------------------------------------
+# notion_recent_pages (standup helper)
+# ---------------------------------------------------------------------------
+
+
+class TestNotionRecentPages:
+    def test_returns_normalized_items(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.search.return_value = {
+            "results": [
+                {
+                    "id": "p1",
+                    "last_edited_time": "2999-01-01T10:00:00.000Z",
+                    "last_edited_by": {"id": "u1"},
+                    "properties": {"Name": {"type": "title", "title": [{"plain_text": "Recent Doc"}]}},
+                }
+            ]
+        }
+        mock_client.users.retrieve.return_value = {"name": "Alice"}
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        # Page is future-dated (2999), so any positive look-back keeps it.
+        items = notion_recent_pages(days=1)
+
+        assert len(items) == 1
+        assert items[0]["kind"] == "page"
+        assert items[0]["title"] == "Recent Doc"
+        assert items[0]["author"] == "Alice"
+        assert items[0]["key"] == "p1"
+
+    def test_filters_out_old_pages(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.search.return_value = {
+            "results": [{"id": "old", "last_edited_time": "2000-01-01T00:00:00.000Z", "properties": {}}]
+        }
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        assert notion_recent_pages(days=1) == []
+
+    def test_unconfigured_returns_empty(self, monkeypatch):
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: None)
+        assert notion_recent_pages(days=1) == []
+
+    def test_auth_error_raises_standup_source_error(self, monkeypatch):
+        import pytest
+
+        from scrum_agent.standup.errors import StandupSourceError
+
+        mock_client = MagicMock()
+        mock_client.search.side_effect = _make_api_error(403)
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        with pytest.raises(StandupSourceError):
+            notion_recent_pages(days=1)
+
+    def test_other_error_returns_empty(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.search.side_effect = _make_api_error(500)
+        monkeypatch.setattr("scrum_agent.tools.notion._make_notion_client", lambda: mock_client)
+
+        assert notion_recent_pages(days=1) == []
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_all_notion_tools_registered(self):
+        names = {t.name for t in get_tools()}
+        assert {
+            "notion_search_pages",
+            "notion_read_page",
+            "notion_read_database",
+            "notion_create_page",
+            "notion_update_page",
+        } <= names

--- a/uv.lock
+++ b/uv.lock
@@ -1076,6 +1076,18 @@ wheels = [
 ]
 
 [[package]]
+name = "notion-client"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/e3/4ac01384e86e2c381c21b87a0fefcdfe6d65577ae3153fad27e7e96c5d9c/notion_client-3.1.0.tar.gz", hash = "sha256:516e31326f855ec34559289b57be4e27ad656062f51f594c8f4ee3a608ee333d", size = 38781, upload-time = "2026-05-12T08:54:44.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/08/12645b24044301cb0d7908ec068c55c0d5724f39372891a1a27d630fdf50/notion_client-3.1.0-py2.py3-none-any.whl", hash = "sha256:7e3935f4dbc11231d8ad1fe404112e278501520342eaa35f86456f0df44a8aca", size = 23092, upload-time = "2026-05-12T08:54:43.135Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1973,6 +1985,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
+    { name = "notion-client" },
     { name = "prompt-toolkit" },
     { name = "pygithub" },
     { name = "python-dotenv" },
@@ -2036,6 +2049,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'openai'" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
+    { name = "notion-client" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "prompt-toolkit" },
     { name = "pygithub" },


### PR DESCRIPTION
## What & why

Mirrors the existing **Confluence** integration for **Notion**, so teams whose docs live in Notion get the same experience — usable everywhere Confluence is: **analysis**, **planning**, and **standup**.

Confluence was cheap to add because it reuses Jira's Atlassian auth (just a space-key field on the Jira form). **Notion is independent** — its own integration token, no shared auth, no "space key" — so it gets its own optional **"Docs / Notion"** step in the setup wizard with live token verification.

## What's included

**Tools** (`src/scrum_agent/tools/notion.py`) — 5 `@tool`s + a standup helper, via the `notion-client` SDK:
| Tool | Risk |
|------|------|
| `notion_search_pages` | Low |
| `notion_read_page` (blocks → text) | Low |
| `notion_read_database` (2025 data-sources API) | Low |
| `notion_create_page` | High (confirmation) |
| `notion_update_page` (appends blocks; optional rename) | High (confirmation) |
| `notion_recent_pages()` — standup activity feed | — |

**Wiring**
- `config.py`: `get_notion_token()` / `get_notion_root_page_id()`
- Registered in `get_tools()`; writes gated behind `_HIGH_RISK_TOOLS`
- **Analysis**: `_fetch_notion_context()` + `_extract_notion_page_ids()` (keyword search + Notion-URL extraction from SCRUM.md) → `## Notion Documentation` section in the analyzer prompt; `notion_context` threaded through `ScrumState` + session serialization
- **Standup**: `SOURCE_NOTION` fan-out branch (gated by `NOTION_ROOT_PAGE_ID`)
- **TUI**: dedicated "Docs / Notion" wizard step + `_verify_notion` + Settings display

**Deps/docs**: `notion-client`, `.env.example`, README, CLAUDE.md, TODO.md

## Tests
- Unit: `test_tools_notion.py` (all tools + helpers + error paths), `test_provider_verify_notion.py`, plus Notion cases in config/collector/analyzer-prompt tests
- Contract: `test_notion_contract.py` + hand-crafted VCR cassettes
- Updated the hardcoded tool-count/name assertions (32 → 37)

`ruff check` clean; touched suites pass. Two `tests/test_session.py` failures are **pre-existing and unrelated** (a `UserStory.epic_id` bug in `_editor.py`, present on `main` before this branch).

## Note
`notion_read_database` uses Notion's 2025 data-sources API because `databases.query` was removed in `notion-client` 3.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)