### PR TITLE
fix: use analysis header on analysis-mode status screens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "2.4.0"
+version = "2.4.1"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -2571,6 +2571,7 @@ def select_mode(
                             height=h,
                             subtitle="Board required",
                             hint="Press any key to go back.",
+                            mode="analysis",
                         )
                     )
                     while True:
@@ -2755,6 +2756,7 @@ def select_mode(
                                             width=w,
                                             height=h,
                                             subtitle="Team profile exported",
+                                            mode="analysis",
                                         )
                                     )
                                     _et = time.monotonic()
@@ -2917,6 +2919,7 @@ def select_mode(
                                                         width=w,
                                                         height=h,
                                                         subtitle="Team profile exported",
+                                                        mode="analysis",
                                                     )
                                                 )
                                                 _et = time.monotonic()
@@ -3355,6 +3358,7 @@ def select_mode(
                                                 width=w,
                                                 height=h,
                                                 subtitle="Team profile exported",
+                                                mode="analysis",
                                             )
                                         )
                                         _et = time.monotonic()
@@ -3408,6 +3412,7 @@ def select_mode(
                                     height=h,
                                     subtitle="Analysis failed",
                                     hint="Press any key to continue.",
+                                    mode="analysis",
                                 )
                             )
                             while True:


### PR DESCRIPTION
## Problem

Going to **Analysis** mode and landing on certain status/error screens showed the blue **Planning** ASCII header instead of the green **Analysis** one.

## Root cause

The wordmark helpers `analysis_title()` / `planning_title()` are correct. The bug was at the call sites: `_build_project_export_success_screen(...)` picks its title from a `mode` parameter that **defaults to `"planning"`**:

```python
title = analysis_title() if mode == "analysis" else planning_title()
```

Five calls inside the dedicated Team Analysis route (`src/scrum_agent/ui/mode_select/__init__.py`, lines ~2551–3523) omitted `mode="analysis"`, so they fell back to the blue Planning header.

## Fix

Add `mode="analysis"` to the five affected calls, matching the already-correct call at line 494:

| Screen (`subtitle=`) | Fixed |
|----------------------|-------|
| `"Board required"` (shown when entering Analysis with no tracker configured) | ✅ |
| `"Team profile exported"` (×3) | ✅ |
| `"Analysis failed"` | ✅ |

The similar calls in the Planning route's "calibrate planning with a team analysis" sub-flow are intentionally left unchanged — the blue Planning header is correct there.

## Verification

- `make lint` — clean
- `make test` — 3388 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)