### PR TITLE
fix: animate (shimmer) the planning and analysis page titles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "2.4.0"
+version = "2.4.1"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -2571,6 +2571,7 @@ def select_mode(
                             height=h,
                             subtitle="Board required",
                             hint="Press any key to go back.",
+                            mode="analysis",
                         )
                     )
                     while True:
@@ -2756,6 +2757,7 @@ def select_mode(
                                             width=w,
                                             height=h,
                                             subtitle="Team profile exported",
+                                            mode="analysis",
                                         )
                                     )
                                     _et = time.monotonic()
@@ -2920,6 +2922,7 @@ def select_mode(
                                                         width=w,
                                                         height=h,
                                                         subtitle="Team profile exported",
+                                                        mode="analysis",
                                                     )
                                                 )
                                                 _et = time.monotonic()
@@ -3361,6 +3364,7 @@ def select_mode(
                                                 width=w,
                                                 height=h,
                                                 subtitle="Team profile exported",
+                                                mode="analysis",
                                             )
                                         )
                                         _et = time.monotonic()
@@ -3414,6 +3418,7 @@ def select_mode(
                                     height=h,
                                     subtitle="Analysis failed",
                                     hint="Press any key to continue.",
+                                    mode="analysis",
                                 )
                             )
                             while True:

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -2710,6 +2710,7 @@ def select_mode(
                     _ana_del_popup_flash = 0.0
                     _ana_del_pending = False
                     _ana_prev = time.monotonic()
+                    _ana_anim0 = _ana_prev  # shimmer title clock
 
                     while True:
                         key = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
@@ -3141,6 +3142,7 @@ def select_mode(
                                 delete_popup_pulse=_ana_del_popup_pulse,
                                 delete_popup_flash=_ana_del_popup_flash,
                                 mode="analysis",
+                                shimmer_tick=_now - _ana_anim0,
                             )
                         )
 
@@ -3701,6 +3703,7 @@ def select_mode(
                         card_fade=1.0,
                         jira_enabled=_jira_ok,
                         azdevops_enabled=_azdevops_ok,
+                        shimmer_tick=dt_r,
                     )
                 )
                 time.sleep(_FRAME_TIME)
@@ -3775,6 +3778,7 @@ def select_mode(
                 _team_popup_msg = ""  # dynamic staleness message
 
                 prev_tick = time.monotonic()
+                _list_anim0 = prev_tick  # shimmer title clock
 
                 while True:
                     key = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
@@ -4400,6 +4404,7 @@ def select_mode(
                             team_popup_message=_team_popup_msg,
                             jira_enabled=_jira_ok,
                             azdevops_enabled=_azdevops_ok,
+                            shimmer_tick=now - _list_anim0,
                         )
                     )
 

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -2862,6 +2862,7 @@ def select_mode(
                                     _scr = 0
                                     _esel = 1  # default to "Next" on page 1
                                     _vp = 1  # current page
+                                    _ta_anim0 = time.monotonic()  # shimmer title clock
                                     while True:
                                         # Page-specific actions
                                         if _vp == 1:
@@ -2881,6 +2882,7 @@ def select_mode(
                                                 export_sel=_esel,
                                                 examples=_stored_ex,
                                                 page=_vp,
+                                                shimmer_tick=time.monotonic() - _ta_anim0,
                                             )
                                         )
                                         kk = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
@@ -3291,6 +3293,7 @@ def select_mode(
                             _ta_export_sel = 1  # default to "Next"
                             _ta_examples = _ta_examples_box[0] or {}
                             _ta_sprint_names = _ta_sprint_names_box[0]
+                            _ta_anim0 = time.monotonic()  # shimmer title clock
                             while True:
                                 if _ta_page == 1:
                                     _ta_actions = ["Export", "Next"]
@@ -3311,6 +3314,7 @@ def select_mode(
                                         sprint_names=_ta_sprint_names,
                                         team_name=_ta_team_name,
                                         page=_ta_page,
+                                        shimmer_tick=time.monotonic() - _ta_anim0,
                                     )
                                 )
                                 kk = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
@@ -4581,6 +4585,7 @@ def select_mode(
                                 if time.monotonic() - _exp_t0 > 1.5 and k:
                                     break
 
+                        _ta_anim0 = time.monotonic()  # shimmer title clock
                         while True:
                             # Page-specific actions
                             if _ta_page == 1:
@@ -4603,6 +4608,7 @@ def select_mode(
                                     sprint_names=_ta_sprint_names,
                                     team_name=_ta_team_name,
                                     page=_ta_page,
+                                    shimmer_tick=time.monotonic() - _ta_anim0,
                                 )
                             )
 

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -2559,22 +2559,25 @@ def select_mode(
                 _board_configured = _jira_ok or _azdevops_ok
 
                 if not _board_configured:
-                    # No board configured — show message and return to mode select
-                    w, h = console.size
-                    live.update(
-                        _build_project_export_success_screen(
-                            "No board configured.\n\n"
-                            "Set JIRA_BASE_URL + JIRA_API_TOKEN\n"
-                            "or AZURE_DEVOPS_ORG_URL + AZURE_DEVOPS_TOKEN\n"
-                            "in your .env file.",
-                            width=w,
-                            height=h,
-                            subtitle="Board required",
-                            hint="Press any key to go back.",
-                            mode="analysis",
-                        )
-                    )
+                    # No board configured — show message and return to mode select.
+                    # Re-render each frame so the ANALYSIS title keeps shimmering.
+                    _br_anim0 = time.monotonic()  # shimmer title clock
                     while True:
+                        w, h = console.size
+                        live.update(
+                            _build_project_export_success_screen(
+                                "No board configured.\n\n"
+                                "Set JIRA_BASE_URL + JIRA_API_TOKEN\n"
+                                "or AZURE_DEVOPS_ORG_URL + AZURE_DEVOPS_TOKEN\n"
+                                "in your .env file.",
+                                width=w,
+                                height=h,
+                                subtitle="Board required",
+                                hint="Press any key to go back.",
+                                mode="analysis",
+                                shimmer_tick=time.monotonic() - _br_anim0,
+                            )
+                        )
                         k = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
                         if k:
                             break
@@ -2680,6 +2683,7 @@ def select_mode(
                             profiles=_profiles_for_analysis,
                             new_analysis_labels=_ana_labels,
                             mode="analysis",
+                            shimmer_tick=dt_r,
                         )
                     )
                     time.sleep(_FRAME_TIME)

--- a/src/scrum_agent/ui/mode_select/screens/_project_list_screen.py
+++ b/src/scrum_agent/ui/mode_select/screens/_project_list_screen.py
@@ -301,13 +301,15 @@ def _build_project_list_screen(
     profile_submenu_visible: float = 0.0,
     profile_exp_fade: float = 0.0,
     mode: str = "planning",
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build the project list screen with title pinned at top.
 
     mode="planning": Shows "Your projects" section + optional Team Analysis.
     mode="analysis": Shows only profile cards + analysis buttons (no projects).
+    shimmer_tick: if set, animates the title's travelling highlight.
     """
-    title = analysis_title() if mode == "analysis" else planning_title()
+    title = analysis_title(shimmer_tick) if mode == "analysis" else planning_title(shimmer_tick)
 
     sub_color = lerp_color(card_opacity, BLACK_RGB, (100, 100, 100))
     if mode == "analysis":

--- a/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
@@ -2967,19 +2967,21 @@ def _build_project_export_success_screen(
     subtitle: str = "Plan exported",
     hint: str = "Press any key to continue.",
     mode: str = "planning",
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build the project export success/status screen.
 
     Shown after exporting a project's plan as Markdown and HTML,
     or during/after Jira sync operations. subtitle and hint can
     be customised for different contexts (e.g. loading states).
+    shimmer_tick: if set, animates the title's travelling highlight.
     """
     if mode == "analysis":
         from scrum_agent.ui.shared._components import analysis_title
 
-        title = analysis_title()
+        title = analysis_title(shimmer_tick)
     else:
-        title = planning_title()
+        title = planning_title(shimmer_tick)
 
     body: list = [
         Text(_PAD + subtitle, style="bold bright_green", justify="left"),

--- a/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
@@ -156,6 +156,7 @@ def _build_team_analysis_screen(
     sprint_names: list[str] | None = None,
     team_name: str = "",
     page: int = 1,
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build the team analysis results screen.
 
@@ -1832,7 +1833,7 @@ def _build_team_analysis_screen(
     # ── Layout matching planning mode ──────────────────────────────────
     from scrum_agent.ui.shared._components import analysis_title
 
-    title = analysis_title()
+    title = analysis_title(shimmer_tick)
 
     # Page-specific action buttons
     _page_labels = ["Velocity", "Patterns", "Insights"]

--- a/src/scrum_agent/ui/session/_utils.py
+++ b/src/scrum_agent/ui/session/_utils.py
@@ -332,6 +332,7 @@ def _invoke_with_animation(
                         width=w,
                         height=h,
                         border_override=loading_border_color(tick),
+                        shimmer_tick=tick,
                     )
                 )
             else:
@@ -341,6 +342,7 @@ def _invoke_with_animation(
                         width=w,
                         height=h,
                         border_override=loading_border_color(tick),
+                        shimmer_tick=tick,
                     )
                 )
         else:
@@ -357,6 +359,7 @@ def _invoke_with_animation(
                     tick=tick,
                     step=step,
                     total=total,
+                    shimmer_tick=tick,
                 )
             )
         time.sleep(FRAME_TIME_30FPS)

--- a/src/scrum_agent/ui/session/editor/_editor.py
+++ b/src/scrum_agent/ui/session/editor/_editor.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import re
+import time
 
 from rich.console import Console
 from rich.live import Live
@@ -302,16 +303,18 @@ def _render_editor(
     height: int = 24,
     story_id: str = "",
     fades: dict[int, float] | None = None,
+    shimmer_tick: float | None = None,
 ) -> tuple:
     """Render the story editor screen as a Rich Panel.
 
     Complex renderer with DoD button grid and AC markers — story-specific.
+    shimmer_tick: if set, animates the title's travelling highlight.
     """
     import rich.box
     from rich.console import Group
     from rich.panel import Panel
 
-    title = planning_title()
+    title = planning_title(shimmer_tick)
     sub = Text(justify="left")
     sub.append(PAD + (f"Editing {story_id}" if story_id else "Editing story"), style="dim")
     sub.append("  |  ", style="dim")
@@ -546,6 +549,7 @@ def edit_story(
         target_idx = idx + (direction * bpr)
         return all_dod[target_idx] if 0 <= target_idx < len(all_dod) else None
 
+    _ed_anim0 = time.monotonic()  # shimmer title clock
     while True:
         try:
             key = _key(timeout=0.05)
@@ -700,6 +704,14 @@ def edit_story(
         _step_fades()
         w, h = console.size
         panel, scroll_offset = _render_editor(
-            buffer, cursor_row, cursor_col, scroll_offset, width=w, height=h, story_id=story.id, fades=btn_fades
+            buffer,
+            cursor_row,
+            cursor_col,
+            scroll_offset,
+            width=w,
+            height=h,
+            story_id=story.id,
+            fades=btn_fades,
+            shimmer_tick=time.monotonic() - _ed_anim0,
         )
         live.update(panel)

--- a/src/scrum_agent/ui/session/editor/_editor_artifacts.py
+++ b/src/scrum_agent/ui/session/editor/_editor_artifacts.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import re
+import time
 
 from rich.console import Console
 from rich.live import Live
@@ -97,8 +98,19 @@ def edit_task(
     cursor_row, cursor_col = _find_first_editable(buffer, _task_editable_start)
     display_id = story_id or (task_list[0].story_id if task_list else "")
 
+    _ed_anim0 = time.monotonic()  # shimmer title clock
+
     def _render(buf, cr, cc, so, w, h):
-        return render_editor_panel(buf, cr, cc, so, width=w, height=h, editor_label=f"tasks for {display_id}")
+        return render_editor_panel(
+            buf,
+            cr,
+            cc,
+            so,
+            width=w,
+            height=h,
+            editor_label=f"tasks for {display_id}",
+            shimmer_tick=time.monotonic() - _ed_anim0,
+        )
 
     result = edit_buffer_loop(
         live,
@@ -180,8 +192,19 @@ def edit_sprint(
     buffer = text.split("\n")
     cursor_row, cursor_col = _find_first_editable(buffer, _sprint_editable_start)
 
+    _ed_anim0 = time.monotonic()  # shimmer title clock
+
     def _render(buf, cr, cc, so, w, h):
-        return render_editor_panel(buf, cr, cc, so, width=w, height=h, editor_label=sprint.name)
+        return render_editor_panel(
+            buf,
+            cr,
+            cc,
+            so,
+            width=w,
+            height=h,
+            editor_label=sprint.name,
+            shimmer_tick=time.monotonic() - _ed_anim0,
+        )
 
     result = edit_buffer_loop(
         live,
@@ -332,8 +355,19 @@ def edit_analysis(
     buffer = text.split("\n")
     cursor_row, cursor_col = _find_first_editable(buffer, _analysis_editable_start)
 
+    _ed_anim0 = time.monotonic()  # shimmer title clock
+
     def _render(buf, cr, cc, so, w, h):
-        return render_editor_panel(buf, cr, cc, so, width=w, height=h, editor_label=analysis.project_name)
+        return render_editor_panel(
+            buf,
+            cr,
+            cc,
+            so,
+            width=w,
+            height=h,
+            editor_label=analysis.project_name,
+            shimmer_tick=time.monotonic() - _ed_anim0,
+        )
 
     result = edit_buffer_loop(
         live,
@@ -424,8 +458,19 @@ def edit_feature(
     buffer = text.split("\n")
     cursor_row, cursor_col = _find_first_editable(buffer, _feature_editable_start)
 
+    _ed_anim0 = time.monotonic()  # shimmer title clock
+
     def _render(buf, cr, cc, so, w, h):
-        return render_editor_panel(buf, cr, cc, so, width=w, height=h, editor_label="Features")
+        return render_editor_panel(
+            buf,
+            cr,
+            cc,
+            so,
+            width=w,
+            height=h,
+            editor_label="Features",
+            shimmer_tick=time.monotonic() - _ed_anim0,
+        )
 
     result = edit_buffer_loop(
         live,

--- a/src/scrum_agent/ui/session/editor/_editor_core.py
+++ b/src/scrum_agent/ui/session/editor/_editor_core.py
@@ -169,13 +169,15 @@ def render_editor_panel(
     height: int = 24,
     editor_label: str = "",
     title_override=None,
+    shimmer_tick: float | None = None,
 ) -> tuple[Panel, int]:
     """Render a generic editor screen as a Rich Panel.
 
     Shows buffer lines with field-label highlighting, cursor, and scroll.
     Used by all non-story editors (task, sprint, analysis, feature).
+    shimmer_tick: if set (and no title_override), animates the title highlight.
     """
-    title = title_override if title_override is not None else planning_title()
+    title = title_override if title_override is not None else planning_title(shimmer_tick)
 
     sub = Text(justify="left")
     sub.append(PAD + (f"Editing {editor_label}" if editor_label else "Editing"), style="dim")

--- a/src/scrum_agent/ui/session/phases/_phases.py
+++ b/src/scrum_agent/ui/session/phases/_phases.py
@@ -141,6 +141,7 @@ def _pipeline_choice_screen(
     _amber = "\033[38;2;200;160;60m"
     _white = "\033[97m"
     _accent = "\033[38;2;70;100;180m"
+    _ch_anim0 = time.monotonic()  # shimmer title clock
 
     def _render_choices():
         w, _ = console.size
@@ -183,6 +184,7 @@ def _pipeline_choice_screen(
             step=step,
             total=total,
             actions=["Select"],
+            shimmer_tick=time.monotonic() - _ch_anim0,
         )
 
     live.update(_render_choices())
@@ -434,6 +436,7 @@ def _handle_tracker_sync(
                     tick=tick,
                     step=step,
                     total=total,
+                    shimmer_tick=tick,
                 )
             )
             time.sleep(FRAME_TIME_30FPS)
@@ -790,6 +793,7 @@ def _phase_pipeline(
                                         tick=_tick,
                                         step=1,
                                         total=6,
+                                        shimmer_tick=_tick,
                                     )
                                 )
                                 time.sleep(1 / 30)
@@ -853,6 +857,7 @@ def _phase_pipeline(
 
                 logger.info("Epic review: showing project-level epic")
 
+                _epv_anim0 = time.monotonic()  # shimmer title clock
                 while True:
                     w, h = console.size
                     live.update(
@@ -868,6 +873,7 @@ def _phase_pipeline(
                             actions=_ep_actions,
                             step=1,
                             total=6,
+                            shimmer_tick=time.monotonic() - _epv_anim0,
                         )
                     )
                     key = _key()
@@ -911,6 +917,7 @@ def _phase_pipeline(
                             )
                             _ep_buf = _features_to_text([_ep_feat]).split("\n")
                             _ep_cr, _ep_cc = _find_first_editable(_ep_buf, _feature_editable_start)
+                            _ep_anim0 = time.monotonic()  # shimmer title clock
 
                             def _ep_render(buf, cr, cc, so, rw, rh):
                                 return render_editor_panel(
@@ -921,6 +928,7 @@ def _phase_pipeline(
                                     width=rw,
                                     height=rh,
                                     editor_label="epic",
+                                    shimmer_tick=time.monotonic() - _ep_anim0,
                                 )
 
                             _ep_edited = edit_buffer_loop(
@@ -1031,6 +1039,7 @@ def _phase_pipeline(
                             tick=tick,
                             step=step,
                             total=total,
+                            shimmer_tick=tick,
                         )
                     )
                     time.sleep(FRAME_TIME_30FPS)
@@ -1215,6 +1224,7 @@ def _phase_pipeline(
             )
         )
 
+        _pl_anim0 = time.monotonic()  # shimmer title clock
         while True:
             key = _key()
 
@@ -1536,6 +1546,7 @@ def _phase_pipeline(
                     sticky_headers=sticky_headers,
                     actions=actions,
                     warning_text=cap_warning_text if is_sprint_stage else "",
+                    shimmer_tick=time.monotonic() - _pl_anim0,
                 )
             )
 
@@ -1573,6 +1584,7 @@ def _phase_chat(
     w, h = console.size
     live.update(_build_chat_screen(messages, input_value, scroll_offset, width=w, height=h))
 
+    _chat_anim0 = time.monotonic()  # shimmer title clock
     while True:
         key = _key()
 
@@ -1627,6 +1639,7 @@ def _phase_chat(
                         height=h,
                         processing=True,
                         tick=tick,
+                        shimmer_tick=tick,
                     )
                 )
                 time.sleep(FRAME_TIME_30FPS)
@@ -1660,4 +1673,13 @@ def _phase_chat(
             continue
 
         w, h = console.size
-        live.update(_build_chat_screen(messages, input_value, scroll_offset, width=w, height=h))
+        live.update(
+            _build_chat_screen(
+                messages,
+                input_value,
+                scroll_offset,
+                width=w,
+                height=h,
+                shimmer_tick=time.monotonic() - _chat_anim0,
+            )
+        )

--- a/src/scrum_agent/ui/session/phases/_phases_intake.py
+++ b/src/scrum_agent/ui/session/phases/_phases_intake.py
@@ -98,6 +98,7 @@ def _phase_description_input(
             cursor_col = len(vl)
         input_lines[cursor_row] += tail
 
+    _anim0 = time.monotonic()  # shimmer title clock
     while True:
         key = _key()
 
@@ -202,7 +203,16 @@ def _phase_description_input(
             continue
 
         w, h = console.size
-        live.update(_build_description_screen(input_lines, cursor_row, cursor_col, width=w, height=h))
+        live.update(
+            _build_description_screen(
+                input_lines,
+                cursor_row,
+                cursor_col,
+                width=w,
+                height=h,
+                shimmer_tick=time.monotonic() - _anim0,
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -484,6 +494,7 @@ def _question_input_loop(
     selected_choices: set[int] = set()  # for multi-select mode
     scroll_offset = 0
     use_accordion = questionnaire is not None
+    _anim0 = time.monotonic()  # shimmer title clock
 
     def _render():
         w, h = console.size
@@ -502,6 +513,7 @@ def _question_input_loop(
                 width=w,
                 height=h,
                 cursor_pos=cursor_pos,
+                shimmer_tick=time.monotonic() - _anim0,
                 edit_hint=(
                     "Space toggle \u00b7 Enter submit"
                     if multi_select
@@ -519,6 +531,7 @@ def _question_input_loop(
             selected_choice=selected_choice,
             width=w,
             height=h,
+            shimmer_tick=time.monotonic() - _anim0,
         )
 
     live.update(_render())
@@ -597,6 +610,8 @@ def _question_input_loop(
             selected_choice = (selected_choice - 1) % len(choices)
         elif key in ("down", "scroll_down") and choices:
             selected_choice = (selected_choice + 1) % len(choices)
+        elif key == "":
+            pass  # idle timeout — fall through to re-render so the title shimmer stays live
         elif choices:
             # Choice questions are arrow-key only — no typing
             continue

--- a/src/scrum_agent/ui/session/phases/_phases_review.py
+++ b/src/scrum_agent/ui/session/phases/_phases_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 
 from langchain_core.messages import HumanMessage
 from rich.console import Console
@@ -91,6 +92,7 @@ def _phase_intake_review(
             )
         )
 
+        _anim0 = time.monotonic()  # shimmer title clock
         while True:
             key = _key()
 
@@ -157,6 +159,7 @@ def _phase_intake_review(
                     height=h,
                     status_msg=status_msg,
                     btn_fades=btn_fades,
+                    shimmer_tick=time.monotonic() - _anim0,
                 )
             )
 
@@ -288,6 +291,7 @@ def _get_edit_input(live: Live, console: Console, _key, prompt: str) -> str | No
     w, h = console.size
     live.update(_build_edit_prompt_screen(prompt, input_value, width=w, height=h))
 
+    _anim0 = time.monotonic()  # shimmer title clock
     while True:
         key = _key()
         if key == "esc":
@@ -314,4 +318,6 @@ def _get_edit_input(live: Live, console: Console, _key, prompt: str) -> str | No
             continue
 
         w, h = console.size
-        live.update(_build_edit_prompt_screen(prompt, input_value, width=w, height=h))
+        live.update(
+            _build_edit_prompt_screen(prompt, input_value, width=w, height=h, shimmer_tick=time.monotonic() - _anim0)
+        )

--- a/src/scrum_agent/ui/session/screens/_accordion.py
+++ b/src/scrum_agent/ui/session/screens/_accordion.py
@@ -404,6 +404,7 @@ def _build_accordion_question_screen(
     border_override: str = "",
     edit_hint: str = "",
     cursor_pos: int = -1,
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build the accordion-style intake question screen.
 
@@ -414,8 +415,10 @@ def _build_accordion_question_screen(
     The viewport auto-scrolls to keep the active question roughly centered.
     Items at the bottom edge of the viewport recess left and truncate for
     a depth/fade-away effect.
+
+    shimmer_tick: if set, animates the title's travelling highlight.
     """
-    title = _planning_title()
+    title = _planning_title(shimmer_tick)
 
     # Subtitle: phase label + progress + edit hint (inline)
     sub = Text(_PAD, justify="left")

--- a/src/scrum_agent/ui/session/screens/_screens.py
+++ b/src/scrum_agent/ui/session/screens/_screens.py
@@ -105,12 +105,14 @@ def _build_action_bar(
 # ---------------------------------------------------------------------------
 
 
-def _planning_title() -> Text:
+def _planning_title(shimmer_tick: float | None = None) -> Text:
     """Return the Planning ASCII title styled with the brand colour.
 
     Delegates to shared planning_title() — previously a local duplicate.
+    Pass ``shimmer_tick`` (a monotonic elapsed clock) to animate the travelling
+    highlight; ``None`` (default) renders the solid static title.
     """
-    return planning_title()
+    return planning_title(shimmer_tick)
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +129,7 @@ def _build_summary_screen(
     height: int = 24,
     status_msg: str = "",
     btn_fades: list[float] | None = None,
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build the scrollable intake summary screen with Accept/Edit/Export action bar.
 
@@ -134,8 +137,9 @@ def _build_summary_screen(
     scroll_offset: first visible line index.
     menu_selected: 0=Accept, 1=Edit, 2=Export.
     status_msg: optional status message below the action bar.
+    shimmer_tick: if set, animates the title's travelling highlight.
     """
-    title = _planning_title()
+    title = _planning_title(shimmer_tick)
     sub = Text(_PAD + "Review your answers", style="dim", justify="left")
 
     inner_h = height - 4

--- a/src/scrum_agent/ui/session/screens/_screens_input.py
+++ b/src/scrum_agent/ui/session/screens/_screens_input.py
@@ -48,12 +48,14 @@ def _voice_hint() -> str:
 # ---------------------------------------------------------------------------
 
 
-def _planning_title() -> Text:
+def _planning_title(shimmer_tick: float | None = None) -> Text:
     """Return the Planning ASCII title styled with the brand colour.
 
     Delegates to shared planning_title() — previously a local duplicate.
+    Pass ``shimmer_tick`` (a monotonic elapsed clock) to animate the travelling
+    highlight; ``None`` (default) renders the solid static title.
     """
-    return planning_title()
+    return planning_title(shimmer_tick)
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +72,7 @@ def _build_description_screen(
     height: int = 24,
     border_override: str = "",
     status_line: str = "",
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build the multi-line project description input screen.
 
@@ -78,8 +81,9 @@ def _build_description_screen(
     border_override: if set, overrides the input box border colour (for green pulse).
     status_line: if set, replaces the submit hint with this text (e.g. the
         inline voice-recording indicator) so the user stays on this screen.
+    shimmer_tick: if set, animates the title's travelling highlight.
     """
-    title = _planning_title()
+    title = _planning_title(shimmer_tick)
     sub = Text(_PAD + "Tell me about your project", style="dim", justify="left")
 
     # Hint + example — mirrors the REPL opener so users know what to type
@@ -236,6 +240,7 @@ def _build_question_screen(
     height: int = 24,
     border_override: str = "",
     status_line: str = "",
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build a single intake question screen.
 
@@ -245,8 +250,9 @@ def _build_question_screen(
     progress: e.g. "Q3 of 26" or "2 remaining" — shown in subtitle.
     phase_label: e.g. "Phase 1: Project Context" — shown above question.
     preamble_lines: dim context lines (extraction summary, remaining count).
+    shimmer_tick: if set, animates the title's travelling highlight.
     """
-    title = _planning_title()
+    title = _planning_title(shimmer_tick)
 
     # Phase title in bright white, progress counter in dim
     sub = Text(_PAD, justify="left")

--- a/src/scrum_agent/ui/session/screens/_screens_pipeline.py
+++ b/src/scrum_agent/ui/session/screens/_screens_pipeline.py
@@ -53,6 +53,7 @@ def _build_pipeline_screen(
     popup_selected: int = 0,
     popup_t: float = 0.0,
     popup_pulse: float = 0.0,
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build the pipeline stage screen (processing + result).
 
@@ -68,7 +69,7 @@ def _build_pipeline_screen(
     """
     if actions is None:
         actions = ["Accept", "Edit", "Export"]
-    title = _planning_title()
+    title = _planning_title(shimmer_tick)
 
     # Subtitle: stage label + inline progress bar
     sub = Text(_PAD, justify="left")
@@ -380,14 +381,16 @@ def _build_chat_screen(
     height: int = 24,
     processing: bool = False,
     tick: float = 0.0,
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build the post-pipeline chat screen.
 
     messages: list of (role, text) tuples — role is "user" or "ai".
+    shimmer_tick: if set, animates the title's travelling highlight.
     """
     from scrum_agent.ui.shared._animations import loading_border_color
 
-    title = _planning_title()
+    title = _planning_title(shimmer_tick)
     sub = Text(_PAD + "Plan complete \u2014 ask questions or type 'export' to save", style="dim", justify="left")
 
     inner_h = height - 4
@@ -486,9 +489,10 @@ def _build_edit_prompt_screen(
     *,
     width: int = 80,
     height: int = 24,
+    shimmer_tick: float | None = None,
 ) -> Panel:
     """Build a screen prompting for edit feedback (used by both intake and pipeline edits)."""
-    title = _planning_title()
+    title = _planning_title(shimmer_tick)
     sub = Text(_PAD + "What changes would you like?", style="dim", justify="left")
 
     body: list = []


### PR DESCRIPTION
## Problem

The **Analysis** results screen and the **Planning** session screens render their ASCII title statically, while Retro / Reporting / Standup animate a travelling "shimmer" highlight. (Standup was already correct; this PR does not touch it.)

## Root cause

The shimmer only animates when a title builder is passed a live `shimmer_tick` (a monotonic elapsed clock) each frame — `build_ascii_title` renders a solid colour when `shimmer_tick is None`. The analysis and planning builders called `analysis_title()` / `_planning_title()` with **no tick**, so the highlight never moved even though their loops already re-render every frame.

## Fix

Thread an optional `shimmer_tick: float | None = None` (default `None` → static, so **snapshots are unchanged**) through:

- **Analysis**: `_build_team_analysis_screen`, fed from its 3 result render loops.
- **Planning**: every screen builder — description input, intake question + accordion, review summary, pipeline review, chat, edit prompt, and the story / task / sprint / feature / analysis editors — each fed a per-frame `time.monotonic()` clock from its driving loop.
- **Processing screens** reuse their existing spinner `tick`, so the title keeps shimmering during LLM calls (no freeze-then-resume).

One small loop fix: choice-type intake questions now re-render on the idle timeout (previously `elif choices: continue` skipped the redraw), so the shimmer stays live while a choice question is on screen.

Left intentionally static: transient one-shot confirmation/dismiss screens (e.g. "Epic created") that render once and wait for a keypress.

## Verification

- `make lint` — clean
- `make test` — 3388 passed, 7 skipped; **19 snapshots unchanged** (confirms static default preserves existing output)
- Manual: in Analysis results and each Planning screen, the title's highlight now sweeps like Retro/Reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)