### PR TITLE
fix: make focus music actually play — switch backend from cliamp to ffplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,14 @@ recording ends, so it never bleeds into your dictation. The on/off state and sel
 remembered between runs. Under the hood, playback runs as a headless `cliamp --daemon` process that
 is stopped automatically when you exit.
 
+> **Troubleshooting — the equalizer animates but there's no sound.** The `cliamp` binary is on your
+> `PATH` but crashes on launch. The usual cause on macOS is a Homebrew bottle that links against
+> shared libraries which aren't installed, e.g. `dyld: Library not loaded: …/libFLAC.14.dylib` or
+> `…/libvorbisenc.2.dylib`. Run `cliamp --version` in a terminal to see the exact missing library,
+> then install it (`brew install flac libvorbis`) or `brew reinstall cliamp` to pull all of cliamp's
+> dependencies. The status bar detects a daemon that exits on its own and reverts to
+> `♪ cliamp exited — run \`cliamp\` to check it works` instead of showing a phantom "playing" state.
+
 <details>
 <summary>💻 In-session commands</summary>
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ yeaboi --non-interactive --description @project-brief.txt --output html --team-s
 
 📊 **Usage Dashboard** — Track token consumption per session, per provider, and lifetime totals with a dedicated usage page
 
-🎵 **Focus Music** — Optional background music via [cliamp](https://github.com/bjarneo/cliamp): `Ctrl+P` play/pause, `Ctrl+O` to switch channel, from any screen. Auto-pauses while you dictate a voice note
+🎵 **Focus Music** — Optional background music via [`ffplay`](https://ffmpeg.org/ffplay.html) (ffmpeg): `Ctrl+P` play/pause, `Ctrl+O` to switch channel, from any screen. Auto-pauses while you dictate a voice note
 
 ---
 
@@ -610,13 +610,15 @@ yeaboi [OPTIONS]
 |------|-------------|
 | `--export-questionnaire [PATH]` | Export a blank questionnaire template as Markdown |
 
-### 🎵 Music (cliamp)
+### 🎵 Music (ffplay)
 
 Play focus music while you plan. This is an **optional** integration with
-[cliamp](https://github.com/bjarneo/cliamp), a standalone terminal music player — install it
-separately (`brew install bjarneo/cliamp/cliamp`, or `go install github.com/bjarneo/cliamp@latest`).
-If the `cliamp` binary isn't on your `PATH`, the feature is disabled — the status bar shows a dim
-`♪ music: brew install bjarneo/cliamp/cliamp` hint and the controls are no-ops until you install it.
+[`ffplay`](https://ffmpeg.org/ffplay.html), the headless player bundled with **ffmpeg** — install it
+separately (`brew install ffmpeg`, or your platform's package manager). ffplay is used because
+background music has to play *headlessly* alongside our own full-screen TUI: interactive terminal
+players refuse to start without a controlling terminal, whereas `ffplay -nodisp` plays a stream with
+no UI of its own. If the `ffplay` binary isn't on your `PATH`, the feature is disabled — the status
+bar shows a dim `♪ music: brew install ffmpeg` hint and the controls are no-ops until you install it.
 
 Once installed, a compact player status appears on the bottom border of **every** screen, and two
 control chords work app-wide — even while typing in a text field:
@@ -628,16 +630,17 @@ control chords work app-wide — even while typing in a text field:
 
 Music **auto-pauses while you record a voice note** (double-tap Space) and resumes when the
 recording ends, so it never bleeds into your dictation. The on/off state and selected channel are
-remembered between runs. Under the hood, playback runs as a headless `cliamp --daemon` process that
-is stopped automatically when you exit.
+remembered between runs. Under the hood, playback runs as a headless `ffplay -nodisp` process (one
+per stream); pause/resume suspend and continue it with `SIGSTOP`/`SIGCONT`, and it is stopped
+automatically when you exit.
 
-> **Troubleshooting — the equalizer animates but there's no sound.** The `cliamp` binary is on your
-> `PATH` but crashes on launch. The usual cause on macOS is a Homebrew bottle that links against
-> shared libraries which aren't installed, e.g. `dyld: Library not loaded: …/libFLAC.14.dylib` or
-> `…/libvorbisenc.2.dylib`. Run `cliamp --version` in a terminal to see the exact missing library,
-> then install it (`brew install flac libvorbis`) or `brew reinstall cliamp` to pull all of cliamp's
-> dependencies. The status bar detects a daemon that exits on its own and reverts to
-> `♪ cliamp exited — run \`cliamp\` to check it works` instead of showing a phantom "playing" state.
+> **Troubleshooting — the equalizer animates but there's no sound.** The equalizer is a light
+> animation that only means "a player was launched"; it is not driven by the audio itself. If you
+> hear nothing, the `ffplay` process likely exited on its own (a stream URL that's down, or a codec
+> the build can't decode). The status bar detects a player that exits unexpectedly and reverts to
+> `♪ music stopped — stream unavailable, ^P to retry` instead of showing a phantom "playing" state —
+> press `Ctrl+P` to retry, or `Ctrl+O` to switch to a different stream. Confirm your ffmpeg build can
+> play a stream directly with `ffplay -nodisp https://ice1.somafm.com/groovesalad-128-mp3`.
 
 <details>
 <summary>💻 In-session commands</summary>

--- a/TODO.md
+++ b/TODO.md
@@ -236,7 +236,8 @@ Comprehensive task list for building the project. Check items off as they're com
 - [x] Music tip added to the rotating welcome-screen tips
 - [x] Persist on/off + channel preference; stop daemon on exit
 - [x] Unit tests (`test_music.py`, `test_music_bar.py`, voice-hook tests) + README section
-- [x] Detect a cliamp daemon that dies on its own (missing dylib / bad stream / no audio device) — revert to a truthful "stopped" state with a diagnosable status-bar notice instead of a phantom equalizer; README troubleshooting note
+- [x] Detect a player process that dies on its own (bad stream / codec / no audio device) — revert to a truthful "stopped" state with a diagnosable status-bar notice instead of a phantom equalizer; README troubleshooting note
+- [x] Switch backend from cliamp to `ffplay` (ffmpeg) — cliamp can't run headless (needs a TTY, no `--daemon`/IPC), so it never actually played audio. `ffplay -nodisp` plays streams headlessly; pause/resume via `SIGSTOP`/`SIGCONT`. Updated availability check, status bar, tips, README to ffmpeg
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -236,6 +236,7 @@ Comprehensive task list for building the project. Check items off as they're com
 - [x] Music tip added to the rotating welcome-screen tips
 - [x] Persist on/off + channel preference; stop daemon on exit
 - [x] Unit tests (`test_music.py`, `test_music_bar.py`, voice-hook tests) + README section
+- [x] Detect a cliamp daemon that dies on its own (missing dylib / bad stream / no audio device) — revert to a truthful "stopped" state with a diagnosable status-bar notice instead of a phantom equalizer; README troubleshooting note
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "2.4.1"
+version = "2.4.2"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/music.py
+++ b/src/scrum_agent/music.py
@@ -1,45 +1,60 @@
-"""Background music via cliamp — optional, auto-detected terminal music player.
+"""Background music via ffplay — optional, auto-detected headless stream player.
 
 This module lets users play focus music while planning. It shells out to
-**cliamp** (https://github.com/bjarneo/cliamp), a standalone Winamp-inspired Go
-terminal music player, and is modelled directly on :mod:`scrum_agent.voice`: an
-optional, provider-agnostic helper that talks to an external binary.
+**ffplay** (ffmpeg's bundled player), and is modelled directly on
+:mod:`scrum_agent.voice`: an optional, provider-agnostic helper that talks to an
+external binary.
 
-# See README: "Music (cliamp)" — like voice input, background music does NOT go
+# See README: "Music (ffplay)" — like voice input, background music does NOT go
 # through the LangGraph agent or the get_llm() provider factory. It is a pure
 # terminal-UX helper.
 
 Design notes / architectural decisions:
-- **Optional and auto-detected.** cliamp is a Go binary, not a Python package, so
-  we never import or bundle it. :func:`is_music_available` just checks
-  ``shutil.which("cliamp")`` — cheap enough to call on every screen render,
+- **Why ffplay, not a TUI player.** Background music has to play *headlessly*
+  alongside our own full-screen TUI. Interactive terminal players (e.g. cliamp,
+  which this module originally targeted) refuse to start without a controlling TTY
+  and would fight us for the terminal. ``ffplay -nodisp`` has no UI of its own and
+  reads a stream URL directly, so it plays in the background and never touches the
+  terminal. ffmpeg is ubiquitous and frequently already installed.
+- **Optional and auto-detected.** ffplay is a binary, not a Python package, so we
+  never import or bundle it. :func:`is_music_available` just checks
+  ``shutil.which("ffplay")`` — cheap enough to call on every screen render,
   mirroring :func:`scrum_agent.voice.is_voice_available`. If the binary is absent
   every entry point below is a graceful no-op.
-- **Daemon + IPC.** cliamp exposes a headless daemon mode
-  (``cliamp --daemon <url> --auto-play``) that plays without its own TUI while
-  listening on a Unix socket, plus short-lived IPC commands (``cliamp pause`` /
-  ``cliamp play`` / ``cliamp stop``) that control the running daemon. We keep a
-  handle to the daemon subprocess; transport controls are separate one-shot runs.
-- **Channels = radio streams.** cliamp can play a stream URL directly, so a
+- **One long-lived process per stream.** We keep a handle to a single ffplay
+  subprocess playing the current channel. ffplay exposes no IPC, so transport is
+  done on the process itself: pause/resume suspend and continue it with
+  ``SIGSTOP`` / ``SIGCONT`` (a genuine pause of audio output), and switching
+  channel or stopping terminates and respawns it.
+- **Channels = radio streams.** ffplay plays a stream URL directly, so a
   "channel" is just an entry in :data:`CHANNELS`. Switching channel respawns the
-  daemon with the next stream URL — the robust, documented way to change a radio
-  station headlessly (IPC has no "load URL" verb).
-- **Never raises into the TUI.** Every subprocess call is wrapped; a missing or
-  broken cliamp logs a warning and leaves music off. Music must never break
-  planning.
+  player on the next stream URL.
+- **Never raises into the TUI.** Every subprocess/signal call is wrapped; a
+  missing or broken ffplay logs a warning and leaves music off. Music must never
+  break planning.
 """
 
 from __future__ import annotations
 
 import atexit
 import logging
+import os
 import shutil
+import signal
 import subprocess
 
 logger = logging.getLogger(__name__)
 
+# The headless player we drive. ffplay ships with ffmpeg and, with -nodisp, plays
+# a stream URL with no window and no terminal of its own.
+_PLAYER = "ffplay"
+
+# SIGSTOP/SIGCONT give us a true pause without any player-side IPC. They are
+# POSIX-only; on a platform without them (Windows) pause degrades to stop.
+_CAN_SUSPEND = hasattr(signal, "SIGSTOP") and hasattr(signal, "SIGCONT")
+
 # Built-in "channels": stable public internet-radio streams suited to focus work.
-# Kept intentionally small; cliamp plays each URL directly in daemon mode.
+# Kept intentionally small; ffplay plays each URL directly.
 CHANNELS: tuple[dict[str, str], ...] = (
     {"name": "Lofi", "url": "https://ice1.somafm.com/groovesalad-128-mp3"},
     {"name": "Jazz", "url": "https://ice1.somafm.com/sonicuniverse-128-mp3"},
@@ -47,9 +62,15 @@ CHANNELS: tuple[dict[str, str], ...] = (
     {"name": "Ambient", "url": "https://ice1.somafm.com/dronezone-128-mp3"},
 )
 
-# How long to wait on a one-shot IPC control command before giving up. Kept short
-# so a wedged cliamp can never stall the render loop.
-_CTL_TIMEOUT = 3.0
+
+def _player_command(url: str) -> list[str]:
+    """Return the ffplay argv for headless playback of ``url``.
+
+    ``-nodisp`` suppresses the video/SDL window (the key to running headlessly),
+    ``-autoexit`` ends the process when the stream does, and ``-loglevel quiet``
+    ``-nostats`` silence ffplay's banner/progress so nothing leaks onto our TUI.
+    """
+    return [_PLAYER, "-nodisp", "-autoexit", "-loglevel", "quiet", "-nostats", url]
 
 
 class _State:
@@ -59,14 +80,14 @@ class _State:
         # "stopped" (no audio), "playing", or "paused".
         self.status: str = "stopped"
         self.channel_idx: int = 0
-        # Handle to the running ``cliamp --daemon`` subprocess, or None.
+        # Handle to the running ``ffplay`` subprocess, or None.
         self.daemon: subprocess.Popen | None = None
         # True while playback is suspended for a voice recording, so we only auto
         # resume music that *we* paused (not music the user paused themselves).
         self._paused_for_voice: bool = False
         self._initialised: bool = False
-        # Last user-relevant failure (e.g. cliamp crashed at startup), surfaced by
-        # the status bar so a silent daemon death doesn't masquerade as playback.
+        # Last user-relevant failure (e.g. the player exited on its own), surfaced
+        # by the status bar so a silent process death doesn't masquerade as playback.
         self.last_error: str = ""
 
 
@@ -91,12 +112,13 @@ def _init_state() -> None:
 def is_music_available() -> tuple[bool, str]:
     """Return (available, reason) describing whether background music can be used.
 
-    Music needs the optional ``cliamp`` binary on PATH. ``reason`` is empty when
-    available, otherwise a short human-readable install hint for the UI. Mirrors
-    :func:`scrum_agent.voice.is_voice_available` so callers/tests feel familiar.
+    Music needs the optional ``ffplay`` binary (part of ffmpeg) on PATH. ``reason``
+    is empty when available, otherwise a short human-readable install hint for the
+    UI. Mirrors :func:`scrum_agent.voice.is_voice_available` so callers/tests feel
+    familiar.
     """
-    if shutil.which("cliamp") is None:
-        return False, "Install cliamp to enable music (brew install cliamp)"
+    if shutil.which(_PLAYER) is None:
+        return False, "Install ffmpeg to enable music (brew install ffmpeg)"
     return True, ""
 
 
@@ -104,24 +126,24 @@ def is_music_available() -> tuple[bool, str]:
 
 
 def _reconcile_status() -> None:
-    """Fall back to a truthful "stopped" state when the daemon has died on its own.
+    """Fall back to a truthful "stopped" state when the player has died on its own.
 
-    ``subprocess.Popen`` only reports that the *spawn* succeeded — not that cliamp
-    keeps running. cliamp can exit immediately (a missing shared library, an
-    unreachable stream URL, no audio device) while :func:`_start_channel` has
-    already optimistically set the status to "playing". Because we discard stderr,
-    that death is otherwise invisible and the status bar animates a phantom
-    equalizer with no audio. This is called from every read below, so a crash is
-    reflected within roughly one render frame — the "verify shortly after launch"
-    check, done lazily instead of blocking the toggle.
+    ``subprocess.Popen`` only reports that the *spawn* succeeded — not that ffplay
+    keeps running. ffplay can exit on its own (an unreachable/failed stream URL, a
+    codec/audio-device problem) while :func:`_start_channel` has already
+    optimistically set the status to "playing". Because we discard stderr, that
+    death is otherwise invisible and the status bar animates a phantom equalizer
+    with no audio. This is called from every read below, so a crash is reflected
+    within roughly one render frame — the "verify shortly after launch" check, done
+    lazily instead of blocking the toggle.
     """
     if _state.status in ("playing", "paused") and _state.daemon is not None and _state.daemon.poll() is not None:
         rc = _state.daemon.returncode
         _state.daemon = None
         _state.status = "stopped"
         _state._paused_for_voice = False
-        _state.last_error = "cliamp exited — run `cliamp` to check it works"
-        logger.warning("Music daemon exited on its own (rc=%s); reverting to stopped", rc)
+        _state.last_error = "music stopped — stream unavailable, ^P to retry"
+        logger.warning("Music player exited on its own (rc=%s); reverting to stopped", rc)
 
 
 def status() -> str:
@@ -138,9 +160,9 @@ def is_playing() -> bool:
 def last_error() -> str:
     """Return the last user-relevant music failure message, or "" if none.
 
-    Set when a spawned cliamp daemon dies unexpectedly (see :func:`_reconcile_status`)
+    Set when a spawned ffplay process dies unexpectedly (see :func:`_reconcile_status`)
     and cleared on the next successful start. Read by the status bar to explain why
-    music isn't playing despite cliamp being installed.
+    music isn't playing despite ffplay being installed.
     """
     return _state.last_error
 
@@ -154,34 +176,32 @@ def current_channel_name() -> str:
 # ── Subprocess helpers ────────────────────────────────────────────────────────
 
 
-def _control(*args: str) -> bool:
-    """Run a one-shot ``cliamp`` IPC command (play/pause/stop). Never raises.
+def _signal_daemon(sig: int) -> bool:
+    """Send ``sig`` to the running player process. Never raises.
 
-    Returns True on a clean exit, False on any failure. Failures are logged and
-    swallowed so a broken cliamp can't disrupt the TUI.
+    Used for pause (``SIGSTOP``) and resume (``SIGCONT``) — ffplay has no IPC, so
+    transport is done on the process itself. Returns True when the signal was
+    delivered to a live player, False otherwise (no player, dead player, or an
+    OS-level failure). Failures are logged and swallowed so the TUI is never
+    disrupted.
     """
+    if not (_CAN_SUSPEND and _daemon_alive()):
+        return False
     try:
-        subprocess.run(
-            ["cliamp", *args],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            stdin=subprocess.DEVNULL,
-            timeout=_CTL_TIMEOUT,
-            check=False,
-        )
+        os.kill(_state.daemon.pid, sig)
         return True
     except Exception:  # noqa: BLE001 - music is best-effort; surface as a warning only
-        logger.warning("cliamp control command failed: %s", " ".join(args), exc_info=True)
+        logger.warning("Failed to signal music player (sig=%s)", sig, exc_info=True)
         return False
 
 
 def _daemon_alive() -> bool:
-    """Return True if the cliamp daemon subprocess is running."""
+    """Return True if the player subprocess is running."""
     return _state.daemon is not None and _state.daemon.poll() is None
 
 
 def _stop_daemon() -> None:
-    """Terminate the running cliamp daemon (if any) and clear the handle."""
+    """Terminate the running player (if any) and clear the handle."""
     if _state.daemon is None:
         return
     try:
@@ -199,17 +219,17 @@ def _stop_daemon() -> None:
 
 
 def _start_channel() -> bool:
-    """Spawn a fresh cliamp daemon playing the currently selected channel.
+    """Spawn a fresh ffplay process playing the currently selected channel.
 
-    Any existing daemon is torn down first so we never leave an orphan or play two
-    streams at once. Returns True when the daemon was spawned.
+    Any existing player is torn down first so we never leave an orphan or play two
+    streams at once. Returns True when the player was spawned.
     """
     _init_state()
     _stop_daemon()
     channel = CHANNELS[_state.channel_idx]
     try:
         _state.daemon = subprocess.Popen(
-            ["cliamp", "--daemon", channel["url"], "--auto-play"],
+            _player_command(channel["url"]),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
@@ -219,7 +239,7 @@ def _start_channel() -> bool:
         logger.info("Music playing channel %s", channel["name"])
         return True
     except Exception:  # noqa: BLE001 - music is best-effort
-        logger.warning("Failed to start music daemon for %s", channel["name"], exc_info=True)
+        logger.warning("Failed to start music player for %s", channel["name"], exc_info=True)
         _state.daemon = None
         _state.status = "stopped"
         return False
@@ -246,11 +266,17 @@ def toggle() -> None:
         return
     _init_state()
     if _state.status == "playing":
-        if _control("pause"):
+        if _signal_daemon(signal.SIGSTOP if _CAN_SUSPEND else 0):
             _state.status = "paused"
             logger.info("Music paused")
+        else:
+            # No POSIX suspend (e.g. Windows) — stop the player so "pause" still
+            # silences audio rather than doing nothing.
+            _stop_daemon()
+            _state.status = "stopped"
+            logger.info("Music stopped (suspend unavailable)")
     elif _state.status == "paused" and _daemon_alive():
-        if _control("play"):
+        if _signal_daemon(signal.SIGCONT):
             _state.status = "playing"
             logger.info("Music resumed")
     else:
@@ -281,7 +307,7 @@ def cycle_channel() -> None:
 def pause_for_voice() -> None:
     """Pause playback while a voice note is recorded; remember to resume it."""
     if _state.status == "playing":
-        _state._paused_for_voice = _control("pause")
+        _state._paused_for_voice = _signal_daemon(signal.SIGSTOP) if _CAN_SUSPEND else False
         if _state._paused_for_voice:
             _state.status = "paused"
             logger.info("Music paused for voice recording")
@@ -291,7 +317,7 @@ def resume_after_voice() -> None:
     """Resume playback that :func:`pause_for_voice` suspended."""
     if _state._paused_for_voice:
         _state._paused_for_voice = False
-        if _daemon_alive() and _control("play"):
+        if _signal_daemon(signal.SIGCONT):
             _state.status = "playing"
             logger.info("Music resumed after voice recording")
 

--- a/src/scrum_agent/music.py
+++ b/src/scrum_agent/music.py
@@ -65,6 +65,9 @@ class _State:
         # resume music that *we* paused (not music the user paused themselves).
         self._paused_for_voice: bool = False
         self._initialised: bool = False
+        # Last user-relevant failure (e.g. cliamp crashed at startup), surfaced by
+        # the status bar so a silent daemon death doesn't masquerade as playback.
+        self.last_error: str = ""
 
 
 _state = _State()
@@ -100,14 +103,46 @@ def is_music_available() -> tuple[bool, str]:
 # ── Introspection (read by the status bar) ────────────────────────────────────
 
 
+def _reconcile_status() -> None:
+    """Fall back to a truthful "stopped" state when the daemon has died on its own.
+
+    ``subprocess.Popen`` only reports that the *spawn* succeeded — not that cliamp
+    keeps running. cliamp can exit immediately (a missing shared library, an
+    unreachable stream URL, no audio device) while :func:`_start_channel` has
+    already optimistically set the status to "playing". Because we discard stderr,
+    that death is otherwise invisible and the status bar animates a phantom
+    equalizer with no audio. This is called from every read below, so a crash is
+    reflected within roughly one render frame — the "verify shortly after launch"
+    check, done lazily instead of blocking the toggle.
+    """
+    if _state.status in ("playing", "paused") and _state.daemon is not None and _state.daemon.poll() is not None:
+        rc = _state.daemon.returncode
+        _state.daemon = None
+        _state.status = "stopped"
+        _state._paused_for_voice = False
+        _state.last_error = "cliamp exited — run `cliamp` to check it works"
+        logger.warning("Music daemon exited on its own (rc=%s); reverting to stopped", rc)
+
+
 def status() -> str:
     """Return the current player status: "stopped", "playing", or "paused"."""
+    _reconcile_status()
     return _state.status
 
 
 def is_playing() -> bool:
     """Return True when audio is actively playing (not paused/stopped)."""
-    return _state.status == "playing"
+    return status() == "playing"
+
+
+def last_error() -> str:
+    """Return the last user-relevant music failure message, or "" if none.
+
+    Set when a spawned cliamp daemon dies unexpectedly (see :func:`_reconcile_status`)
+    and cleared on the next successful start. Read by the status bar to explain why
+    music isn't playing despite cliamp being installed.
+    """
+    return _state.last_error
 
 
 def current_channel_name() -> str:
@@ -180,6 +215,7 @@ def _start_channel() -> bool:
             stdin=subprocess.DEVNULL,
         )
         _state.status = "playing"
+        _state.last_error = ""  # a fresh start clears any prior crash notice
         logger.info("Music playing channel %s", channel["name"])
         return True
     except Exception:  # noqa: BLE001 - music is best-effort

--- a/src/scrum_agent/ui/shared/_input.py
+++ b/src/scrum_agent/ui/shared/_input.py
@@ -240,7 +240,7 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
         # with no per-loop changes, and works even inside text fields because these
         # control bytes are never printable text. The action mutates music state and
         # nudges the status bar; we return "" (idle) so loops just re-render.
-        # # See README: "Music (cliamp)"
+        # # See README: "Music (ffplay)"
         if ch in ("\x10", "\x0f"):
             from scrum_agent import music
 

--- a/src/scrum_agent/ui/shared/_music_bar.py
+++ b/src/scrum_agent/ui/shared/_music_bar.py
@@ -1,6 +1,6 @@
 """Persistent music status bar — rendered on every screen's bottom border.
 
-# See README: "Music (cliamp)" and "TUI system" — this is the whole-app view for
+# See README: "Music (ffplay)" and "TUI system" — this is the whole-app view for
 # the optional background-music feature in :mod:`scrum_agent.music`.
 
 Two chokepoints let a single, always-visible music indicator cover the entire app
@@ -60,21 +60,21 @@ def build_music_subtitle(theme: Theme = PLANNING_THEME) -> Text:
     """Return the compact music status line for a Panel's bottom border.
 
     Shows the player state plus the two control-chord hints, e.g.
-    ``♪ Lofi · playing   ^P pause · ^O channel``. When cliamp isn't installed it
+    ``♪ Lofi · playing   ^P pause · ^O channel``. When ffplay isn't installed it
     shows a dim, one-line install hint instead so the feature stays discoverable;
-    when a spawned cliamp died on its own it shows a dim crash notice in place of
+    when a spawned player died on its own it shows a dim crash notice in place of
     ``off`` (see :func:`scrum_agent.music.last_error`).
     Styled with the shared Theme palette (no hardcoded RGB), matching the rest of
     the TUI.
     """
     available, _reason = music.is_music_available()
     if not available:
-        return Text("♪ music: brew install bjarneo/cliamp/cliamp ", style=theme.dim, justify="right")
+        return Text("♪ music: brew install ffmpeg ", style=theme.dim, justify="right")
     status = music.status()
     line = Text(justify="right")
     if status == "stopped":
         # A crashed daemon reverts to "stopped" (see music._reconcile_status); show
-        # why rather than a bare "off" so a silently-broken cliamp is diagnosable.
+        # why rather than a bare "off" so a silently-broken player is diagnosable.
         err = music.last_error()
         line.append(f"♪ {err} " if err else "♪ off ", style=theme.dim if err else theme.muted)
         toggle_hint = "^P play"
@@ -129,7 +129,7 @@ class MusicLive(Live):
             self._stamped = False
             return
         # Always stamp — build_music_subtitle() renders a dim install hint when
-        # cliamp is unavailable, so the bar stays present (and discoverable).
+        # ffplay is unavailable, so the bar stays present (and discoverable).
         renderable.subtitle = build_music_subtitle()
         renderable.subtitle_align = "right"
         renderable._music_stamped = True

--- a/src/scrum_agent/ui/shared/_music_bar.py
+++ b/src/scrum_agent/ui/shared/_music_bar.py
@@ -61,7 +61,9 @@ def build_music_subtitle(theme: Theme = PLANNING_THEME) -> Text:
 
     Shows the player state plus the two control-chord hints, e.g.
     ``♪ Lofi · playing   ^P pause · ^O channel``. When cliamp isn't installed it
-    shows a dim, one-line install hint instead so the feature stays discoverable.
+    shows a dim, one-line install hint instead so the feature stays discoverable;
+    when a spawned cliamp died on its own it shows a dim crash notice in place of
+    ``off`` (see :func:`scrum_agent.music.last_error`).
     Styled with the shared Theme palette (no hardcoded RGB), matching the rest of
     the TUI.
     """
@@ -71,7 +73,10 @@ def build_music_subtitle(theme: Theme = PLANNING_THEME) -> Text:
     status = music.status()
     line = Text(justify="right")
     if status == "stopped":
-        line.append("♪ off ", style=theme.muted)
+        # A crashed daemon reverts to "stopped" (see music._reconcile_status); show
+        # why rather than a bare "off" so a silently-broken cliamp is diagnosable.
+        err = music.last_error()
+        line.append(f"♪ {err} " if err else "♪ off ", style=theme.dim if err else theme.muted)
         toggle_hint = "^P play"
     else:
         line.append("♪ ", style=theme.accent)

--- a/src/scrum_agent/ui/shared/_tips.py
+++ b/src/scrum_agent/ui/shared/_tips.py
@@ -43,7 +43,7 @@ def get_tips() -> tuple[str, ...]:
     """Return the ordered tips shown on the welcome screen.
 
     The first entry is the voice tip and the last is the music tip; both adapt to
-    whether their optional dependency is installed (dictation extra / the cliamp
+    whether their optional dependency is installed (dictation extra / the ffplay
     binary), showing an install hint otherwise. The middle entries are static
     product tips. Memoised because availability is fixed for the life of the
     process.
@@ -61,7 +61,7 @@ def get_tips() -> tuple[str, ...]:
     music_tip = (
         "\U0001f3b5 Tip: press Ctrl+P for focus music · Ctrl+O to switch channel"
         if music_available
-        else "\U0001f3b5 Tip: play focus music while you plan — brew install bjarneo/cliamp/cliamp"
+        else "\U0001f3b5 Tip: play focus music while you plan — brew install ffmpeg"
     )
     return (voice_tip, *_GENERAL_TIPS, music_tip)
 

--- a/src/scrum_agent/ui/shared/_voice_input.py
+++ b/src/scrum_agent/ui/shared/_voice_input.py
@@ -120,7 +120,7 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
 
     # Silence any background music so it doesn't bleed into the recording. Resumed
     # the moment recording stops (below), including on the mic-failure path.
-    # # See README: "Music (cliamp)"
+    # # See README: "Music (ffplay)"
     from scrum_agent import music
 
     music.pause_for_voice()

--- a/tests/unit/test_music.py
+++ b/tests/unit/test_music.py
@@ -1,9 +1,13 @@
-"""Tests for the cliamp background-music controller (scrum_agent/music.py).
+"""Tests for the ffplay background-music controller (scrum_agent/music.py).
 
-Everything is mocked at the subprocess boundary so no real ``cliamp`` binary,
-audio device, or config file is touched. The controller must never raise into the
-TUI, so failure paths are asserted to degrade quietly.
+Everything is mocked at the subprocess/signal boundary so no real ``ffplay``
+binary, audio device, or config file is touched. Playback is one long-lived
+process; transport (pause/resume) is done with ``SIGSTOP`` / ``SIGCONT`` on it.
+The controller must never raise into the TUI, so failure paths are asserted to
+degrade quietly.
 """
+
+import signal
 
 import pytest
 
@@ -11,8 +15,9 @@ from scrum_agent import music
 
 
 class _FakePopen:
-    def __init__(self, args):
+    def __init__(self, args, pid=4242):
         self.args = args
+        self.pid = pid
         self._alive = True
         self.terminated = False
         self.killed = False
@@ -35,33 +40,28 @@ class _FakePopen:
         self.returncode = 0
 
     def die(self, code=1):
-        """Simulate cliamp exiting on its own (e.g. a missing shared library)."""
+        """Simulate the player exiting on its own (e.g. a failed stream)."""
         self._alive = False
         self.returncode = code
 
 
 @pytest.fixture
 def mock_music(monkeypatch):
-    """Reset state and mock cliamp so it 'exists' and every call succeeds."""
+    """Reset state and mock ffplay so it 'exists' and every call succeeds."""
     music._state = music._State()
     music._state._initialised = True  # skip config load; use default channel 0
-    calls = {"run": [], "popen": []}
-
-    def fake_run(args, **kwargs):
-        calls["run"].append(args)
-
-        class _Result:
-            returncode = 0
-
-        return _Result()
+    calls = {"popen": [], "kill": []}
 
     def fake_popen(args, **kwargs):
         calls["popen"].append(args)
         return _FakePopen(args)
 
-    monkeypatch.setattr(music.subprocess, "run", fake_run)
+    def fake_kill(pid, sig):
+        calls["kill"].append((pid, sig))
+
     monkeypatch.setattr(music.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(music.shutil, "which", lambda name: "/usr/bin/cliamp")
+    monkeypatch.setattr(music.os, "kill", fake_kill)
+    monkeypatch.setattr(music.shutil, "which", lambda name: "/usr/bin/ffplay")
     monkeypatch.setattr(music, "_nudge", lambda: None)
     monkeypatch.setattr(music, "_persist_enabled", lambda enabled: None)
     monkeypatch.setattr(music, "_persist_channel", lambda idx: None)
@@ -72,7 +72,7 @@ def mock_music(monkeypatch):
 
 
 def test_available_when_binary_present(monkeypatch):
-    monkeypatch.setattr(music.shutil, "which", lambda name: "/usr/bin/cliamp")
+    monkeypatch.setattr(music.shutil, "which", lambda name: "/usr/bin/ffplay")
     ok, reason = music.is_music_available()
     assert ok is True
     assert reason == ""
@@ -99,16 +99,17 @@ def test_unavailable_toggle_is_noop(monkeypatch):
 def test_toggle_starts_when_stopped(mock_music):
     music.toggle()
     assert music.status() == "playing"
-    assert mock_music["popen"], "a daemon should be spawned"
+    assert mock_music["popen"], "a player should be spawned"
     args = mock_music["popen"][0]
-    assert args[0] == "cliamp" and "--daemon" in args and "--auto-play" in args
+    assert args[0] == music._PLAYER and "-nodisp" in args
+    assert args[-1] == music.CHANNELS[0]["url"]  # the selected channel's stream
 
 
 def test_toggle_pauses_when_playing(mock_music):
     music.toggle()  # stopped -> playing
     music.toggle()  # playing -> paused
     assert music.status() == "paused"
-    assert ["cliamp", "pause"] in mock_music["run"]
+    assert any(sig == signal.SIGSTOP for _pid, sig in mock_music["kill"])
 
 
 def test_toggle_resumes_when_paused(mock_music):
@@ -116,7 +117,7 @@ def test_toggle_resumes_when_paused(mock_music):
     music.toggle()  # -> paused
     music.toggle()  # -> playing
     assert music.status() == "playing"
-    assert ["cliamp", "play"] in mock_music["run"]
+    assert any(sig == signal.SIGCONT for _pid, sig in mock_music["kill"])
 
 
 # ── Channel switching ─────────────────────────────────────────────────────────
@@ -131,11 +132,11 @@ def test_cycle_channel_wraps_when_stopped(mock_music):
 
 
 def test_cycle_channel_respawns_when_playing(mock_music):
-    music.toggle()  # playing, one daemon spawned
+    music.toggle()  # playing, one player spawned
     name_before = music.current_channel_name()
     music.cycle_channel()
     assert music.status() == "playing"
-    assert len(mock_music["popen"]) == 2, "daemon respawns on the new stream"
+    assert len(mock_music["popen"]) == 2, "player respawns on the new stream"
     assert music.current_channel_name() != name_before
 
 
@@ -159,7 +160,7 @@ def test_voice_hooks_noop_when_stopped(mock_music):
     music.pause_for_voice()
     music.resume_after_voice()
     assert music.status() == "stopped"
-    assert not mock_music["run"], "nothing to pause/resume when stopped"
+    assert not mock_music["kill"], "nothing to pause/resume when stopped"
 
 
 def test_resume_only_resumes_music_we_paused(mock_music):
@@ -173,15 +174,16 @@ def test_resume_only_resumes_music_we_paused(mock_music):
 # ── Robustness ────────────────────────────────────────────────────────────────
 
 
-def test_control_failure_is_graceful(mock_music, monkeypatch):
+def test_pause_signal_failure_falls_back_to_stop(mock_music, monkeypatch):
     music.toggle()  # playing
 
-    def boom(*args, **kwargs):
-        raise OSError("cliamp exploded")
+    def boom(pid, sig):
+        raise OSError("no such process")
 
-    monkeypatch.setattr(music.subprocess, "run", boom)
-    music.toggle()  # attempts pause; run raises -> _control returns False, no raise
-    assert music.status() == "playing"  # pause didn't take, but the app survives
+    monkeypatch.setattr(music.os, "kill", boom)
+    music.toggle()  # attempts pause; SIGSTOP raises -> _signal_daemon False, no raise
+    # Suspend failed, so "pause" degrades to a clean stop rather than doing nothing.
+    assert music.status() == "stopped"
 
 
 def test_shutdown_terminates_daemon(mock_music):
@@ -198,7 +200,7 @@ def test_shutdown_terminates_daemon(mock_music):
 
 def test_crashed_daemon_reverts_to_stopped(mock_music):
     music.toggle()  # playing
-    music._state.daemon.die()  # cliamp exits on its own (e.g. missing dylib)
+    music._state.daemon.die()  # ffplay exits on its own (e.g. a failed stream)
     # status() reconciles: the phantom "playing" collapses to a truthful "stopped".
     assert music.status() == "stopped"
     assert music.is_playing() is False
@@ -210,7 +212,7 @@ def test_crashed_daemon_sets_last_error(mock_music):
     music.toggle()  # playing
     music._state.daemon.die()
     music.status()  # triggers reconciliation
-    assert "cliamp" in music.last_error()
+    assert music.last_error()  # a human-readable notice explaining why music stopped
 
 
 def test_last_error_cleared_on_successful_restart(mock_music):

--- a/tests/unit/test_music.py
+++ b/tests/unit/test_music.py
@@ -16,13 +16,15 @@ class _FakePopen:
         self._alive = True
         self.terminated = False
         self.killed = False
+        self.returncode = None
 
     def poll(self):
-        return None if self._alive else 0
+        return None if self._alive else self.returncode
 
     def terminate(self):
         self.terminated = True
         self._alive = False
+        self.returncode = 0
 
     def wait(self, timeout=None):
         return 0
@@ -30,6 +32,12 @@ class _FakePopen:
     def kill(self):
         self.killed = True
         self._alive = False
+        self.returncode = 0
+
+    def die(self, code=1):
+        """Simulate cliamp exiting on its own (e.g. a missing shared library)."""
+        self._alive = False
+        self.returncode = code
 
 
 @pytest.fixture
@@ -183,3 +191,47 @@ def test_shutdown_terminates_daemon(mock_music):
     assert daemon.terminated
     assert music._state.daemon is None
     assert music.status() == "stopped"
+
+
+# ── Daemon liveness reconciliation (crash detection) ──────────────────────────
+
+
+def test_crashed_daemon_reverts_to_stopped(mock_music):
+    music.toggle()  # playing
+    music._state.daemon.die()  # cliamp exits on its own (e.g. missing dylib)
+    # status() reconciles: the phantom "playing" collapses to a truthful "stopped".
+    assert music.status() == "stopped"
+    assert music.is_playing() is False
+    assert music._state.daemon is None
+
+
+def test_crashed_daemon_sets_last_error(mock_music):
+    assert music.last_error() == ""  # clean to start
+    music.toggle()  # playing
+    music._state.daemon.die()
+    music.status()  # triggers reconciliation
+    assert "cliamp" in music.last_error()
+
+
+def test_last_error_cleared_on_successful_restart(mock_music):
+    music.toggle()
+    music._state.daemon.die()
+    music.status()  # records the crash notice
+    assert music.last_error()
+    music.toggle()  # stopped -> playing again (daemon respawns cleanly)
+    assert music.status() == "playing"
+    assert music.last_error() == ""
+
+
+def test_live_daemon_is_not_reconciled(mock_music):
+    music.toggle()  # playing, daemon alive
+    assert music.status() == "playing"  # a healthy daemon stays playing
+    assert music.last_error() == ""
+
+
+def test_crashed_daemon_while_paused_reverts(mock_music):
+    music.toggle()  # playing
+    music.toggle()  # paused (daemon still alive)
+    music._state.daemon.die()
+    assert music.status() == "stopped"
+    assert music.last_error()

--- a/tests/unit/test_music_bar.py
+++ b/tests/unit/test_music_bar.py
@@ -54,12 +54,12 @@ def test_subtitle_when_paused():
 
 
 def test_subtitle_shows_crash_notice_when_stopped_with_error():
-    # A daemon that died on its own reverts to "stopped" but leaves a last_error;
-    # the bar shows it instead of a bare "off" so a broken cliamp is diagnosable.
+    # A player that died on its own reverts to "stopped" but leaves a last_error;
+    # the bar shows it instead of a bare "off" so a broken player is diagnosable.
     music._state.status = "stopped"
-    music._state.last_error = "cliamp exited — run `cliamp` to check it works"
+    music._state.last_error = "music stopped — stream unavailable, ^P to retry"
     text = build_music_subtitle().plain
-    assert "cliamp exited" in text
+    assert "stream unavailable" in text
     assert "off" not in text
     assert "^P play" in text
 
@@ -105,20 +105,20 @@ def test_ignores_non_panel_renderables():
 
 
 def test_install_hint_when_unavailable(monkeypatch):
-    monkeypatch.setattr(music, "is_music_available", lambda: (False, "no cliamp"))
+    monkeypatch.setattr(music, "is_music_available", lambda: (False, "no ffplay"))
     text = build_music_subtitle().plain
-    assert "brew install" in text and "cliamp" in text
+    assert "brew install" in text and "ffmpeg" in text
 
 
 def test_stamps_install_hint_when_unavailable(monkeypatch):
-    # The bar stays present (dim install hint) even without cliamp, so the
+    # The bar stays present (dim install hint) even without ffplay, so the
     # feature remains discoverable.
-    monkeypatch.setattr(music, "is_music_available", lambda: (False, "no cliamp"))
+    monkeypatch.setattr(music, "is_music_available", lambda: (False, "no ffplay"))
     ml = make_live(Text(""))
     panel = Panel(Text("body"))
     ml._stamp(panel)
     assert panel.subtitle is not None
-    assert "brew install" in panel.subtitle.plain and "cliamp" in panel.subtitle.plain
+    assert "brew install" in panel.subtitle.plain and "ffmpeg" in panel.subtitle.plain
     assert getattr(panel, "_music_stamped", False) is True
 
 

--- a/tests/unit/test_music_bar.py
+++ b/tests/unit/test_music_bar.py
@@ -53,6 +53,17 @@ def test_subtitle_when_paused():
     assert "^P play" in text
 
 
+def test_subtitle_shows_crash_notice_when_stopped_with_error():
+    # A daemon that died on its own reverts to "stopped" but leaves a last_error;
+    # the bar shows it instead of a bare "off" so a broken cliamp is diagnosable.
+    music._state.status = "stopped"
+    music._state.last_error = "cliamp exited — run `cliamp` to check it works"
+    text = build_music_subtitle().plain
+    assert "cliamp exited" in text
+    assert "off" not in text
+    assert "^P play" in text
+
+
 def test_eq_bars_shape():
     bars = _eq_bars(4)
     assert len(bars) == 4

--- a/tests/unit/test_tips.py
+++ b/tests/unit/test_tips.py
@@ -51,8 +51,8 @@ def test_music_tip_when_available(monkeypatch):
 def test_music_tip_when_unavailable(monkeypatch):
     _clear_cache()
     monkeypatch.setattr("scrum_agent.voice.is_voice_available", lambda: (True, ""))
-    monkeypatch.setattr("scrum_agent.music.is_music_available", lambda: (False, "no cliamp"))
-    assert any("brew install" in t and "cliamp" in t for t in get_tips())
+    monkeypatch.setattr("scrum_agent.music.is_music_available", lambda: (False, "no ffplay"))
+    assert any("brew install" in t and "ffmpeg" in t for t in get_tips())
     _clear_cache()
 
 


### PR DESCRIPTION
## Problem

The focus-music feature **never actually played audio**, on any machine.

1. **The cliamp API it targeted doesn't exist.** `music.py` drove `cliamp --daemon <url> --auto-play` plus IPC `cliamp pause`/`play`/`stop`. The real [cliamp](https://github.com/bjarneo/cliamp) has no `--daemon` flag and no IPC — every launch died instantly with `unknown flag: --daemon`.
2. **cliamp can't run headless at all.** Even without `--daemon` it refuses to start without a controlling terminal (`could not open a new TTY`) — it's a full-screen interactive TUI player and can't coexist with our own TUI.

So the on-screen equalizer was always a phantom: `_eq_bars()` is a clock-driven `sin()` animation gated only on a `playing` flag that meant "the process spawned", not "audio is playing". `subprocess.Popen` reports the spawn succeeded; stderr was discarded, so the immediate crash was invisible.

## Fix

Two commits:

**1. Truthful state (safety net).** `music.py` now reconciles a player that exits on its own back to a `stopped` state with a diagnosable status-bar notice (`last_error()`), instead of animating a phantom equalizer. This surfaces the failure instead of hiding it.

**2. Switch the backend to `ffplay` (ffmpeg).** ffplay plays a stream URL headlessly with `-nodisp` (no window, no terminal of its own), which is exactly what "background music under a full-screen TUI" needs. The public API (`toggle`/`cycle_channel`/`status`/voice-ducking), the status bar, and the `Ctrl+P`/`Ctrl+O` chords are unchanged.
   - Availability now checks for `ffplay`; install hint is `brew install ffmpeg`.
   - Transport: ffplay has no IPC, so pause/resume suspend/continue the process with `SIGSTOP`/`SIGCONT` (a genuine pause), degrading to stop where POSIX signals aren't available.
   - Updated status bar, welcome tips, `See README` comments, and the README section/troubleshooting note from cliamp → ffmpeg.

## Verification

- Ran the **real** (unmocked) module against a live stream: ffplay connects and **stays alive** (where cliamp died instantly), `SIGSTOP`/`SIGCONT` pause/resume work, `shutdown()` terminates cleanly. Audio confirmed playing.
- `make test` → 3394 passed, 7 skipped
- `make lint` → clean

## Note

Requires `ffmpeg` (for `ffplay`) on PATH; the feature is a graceful no-op with an install hint otherwise — same optional-dependency model as before, just a different, working binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)