### PR TITLE
Retro web: social reactions, real music library, working share-code gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "2.4.2"
+version = "2.5.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/retro/board.py
+++ b/src/scrum_agent/retro/board.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import deque
 from datetime import UTC, date, datetime
 from uuid import uuid4
 
@@ -100,6 +101,12 @@ class RetroBoard:
         self._lock = threading.Lock()
         # All guarded by _lock, same as _cards.
         self._reactions: dict[str, dict[str, set[str]]] = {}  # card_id -> emoji -> {pid, …}
+        # Recent reaction *events* — a small ring buffer the browser poll drains to
+        # animate each new reaction exactly once (floating emoji seen by everyone,
+        # the same broadcast-by-polling trick the shared timer uses). Add-only:
+        # un-reacting never animates. Each event is {"id": int, "emoji": str}.
+        self._reaction_events: deque[dict] = deque(maxlen=25)
+        self._reaction_seq = 0
         self._card_owner: dict[str, str] = {}  # card_id -> creator pid (edit/delete permission)
         self._presence: dict[str, dict] = {}  # pid -> {name, avatar, typing_grid, last_seen}
         self._timer: dict = {"running": False, "end_epoch": None, "duration": 0}
@@ -281,6 +288,9 @@ class RetroBoard:
             else:
                 pids.add(pid)
                 now_set = True
+                # Queue a broadcast event so every poller floats this emoji once.
+                self._reaction_events.append({"id": self._reaction_seq, "emoji": emoji})
+                self._reaction_seq += 1
             if not pids:  # keep the map tidy
                 by_emoji.pop(emoji, None)
             self._revision += 1
@@ -387,6 +397,7 @@ class RetroBoard:
                 "presence": presence,
                 "typing": typing,
                 "timer": self._timer_locked(),
+                "reaction_events": list(self._reaction_events),
             }
 
 

--- a/src/scrum_agent/retro/page.py
+++ b/src/scrum_agent/retro/page.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 
+from scrum_agent.music import CHANNELS
 from scrum_agent.retro.board import AVATARS, REACTION_EMOJIS, RETRO_GRID_LABELS, RETRO_GRIDS
 
 # Grid (key, label) pairs for the client, kept in server order.
@@ -217,6 +218,17 @@ header .spacer { flex:1; }
 .chip:hover { border-color:var(--accent); }
 .chip.mine { background:rgba(80,190,190,.18); border-color:var(--accent); }
 .chip span { color:var(--muted); font-size:12px; margin-left:3px; }
+.react-btn { background:transparent; border:1px solid var(--line); border-radius:999px;
+             padding:1px 8px; cursor:pointer; font:inherit; font-size:13px; line-height:1.5; color:var(--muted); }
+.react-btn:hover { border-color:var(--accent); color:var(--text); }
+.react-btn .plus { font-size:11px; margin-left:1px; }
+.rx-picker { position:fixed; z-index:31; background:var(--panel); border:1px solid var(--line);
+             border-radius:12px; padding:6px; display:flex; flex-wrap:wrap; gap:4px; max-width:220px;
+             box-shadow:0 8px 24px rgba(0,0,0,.4); }
+.rx-picker .pick { background:transparent; border:1px solid transparent; border-radius:8px;
+                   padding:3px 6px; cursor:pointer; font-size:20px; line-height:1; }
+.rx-picker .pick:hover { border-color:var(--accent); background:rgba(80,190,190,.14); }
+.rx-picker .pick.mine { border-color:var(--accent); background:rgba(80,190,190,.22); }
 .typing { color:var(--accent2); font-size:12px; min-height:16px; margin-top:6px; font-style:italic; }
 .add { margin-top:6px; }
 textarea { width:100%; background:var(--card); color:var(--text); border:1px solid var(--line);
@@ -245,6 +257,14 @@ textarea { width:100%; background:var(--card); color:var(--text); border:1px sol
 .qrwrap img { width:220px; height:220px; }
 .hidden { display:none !important; }
 #confetti { position:fixed; inset:0; pointer-events:none; z-index:30; }
+#rx-fx { position:fixed; inset:0; pointer-events:none; z-index:29; overflow:hidden; }
+.floater { position:absolute; bottom:8vh; opacity:0; will-change:transform,opacity;
+           animation:rxfloat 2.8s ease-out forwards; text-shadow:0 2px 6px rgba(0,0,0,.35); }
+@keyframes rxfloat {
+  0% { transform:translateY(0) scale(.6); opacity:0; }
+  15% { opacity:1; }
+  100% { transform:translateY(-64vh) scale(1.15); opacity:0; }
+}
 """
 
 
@@ -255,7 +275,7 @@ const AVATARS = __AVATARS__;
 const ADJS = __ADJS__;
 const NOUNS = __NOUNS__;
 
-let TOKEN = new URLSearchParams(location.search).get("token") || "";
+let TOKEN = new URLSearchParams(location.search).get("token") || sessionStorage.getItem("retro_token") || "";
 let PID = localStorage.getItem("retro_pid");
 if (!PID) { PID = (self.crypto && crypto.randomUUID) ? crypto.randomUUID() : "p" + Math.random().toString(36).slice(2); localStorage.setItem("retro_pid", PID); }
 let NAME = localStorage.getItem("retro_name") || "";
@@ -266,6 +286,8 @@ let TYPING_GRID = "", typingTimer = null;
 let TIMER = { running: false }, OFFSET = 0, firedFor = null;
 let EDITING = null;                          // card id being edited inline
 const MY_REACTIONS = {};                     // card_id -> Set(emoji) I reacted with
+let lastRxEvent = -1, seededRx = false;       // high-water mark of animated reaction events
+let RX_CARD = null;                           // card whose react-picker is open
 let DRAG_ID = null;
 
 function esc(s) { const d = document.createElement("div"); d.textContent = s == null ? "" : s; return d.innerHTML; }
@@ -287,9 +309,8 @@ async function submitCode() {
     if (!r.ok) { err.textContent = "That code didn't work — check the host's screen."; return; }
     const d = await r.json();
     TOKEN = d.token;
-    history.replaceState(null, "", "/?token=" + encodeURIComponent(TOKEN));
     document.getElementById("code-modal").classList.add("hidden");
-    afterToken();
+    afterToken();   // persists the token + strips it from the URL
   } catch (e) { err.textContent = "Could not reach the retro."; }
 }
 
@@ -342,13 +363,15 @@ function buildCols() {
 function onType(grid) { TYPING_GRID = grid; clearTimeout(typingTimer); typingTimer = setTimeout(() => { TYPING_GRID = ""; }, 2500); }
 
 function reactionBar(card) {
+  // Only emojis that already have a count show as chips; all the rest live behind
+  // the React button's picker, so cards stay uncluttered.
   const mine = MY_REACTIONS[card.id] || new Set();
   const rx = card.reactions || {};
-  return '<div class="rx">' + EMOJIS.map(e => {
-    const n = rx[e] || 0;
-    return '<button class="chip' + (mine.has(e) ? " mine" : "") + '" data-card="' + card.id + '" data-emoji="' + e + '">' +
-           e + (n ? '<span>' + n + '</span>' : "") + '</button>';
-  }).join("") + '</div>';
+  const chips = EMOJIS.filter(e => rx[e]).map(e =>
+    '<button class="chip' + (mine.has(e) ? " mine" : "") + '" data-card="' + card.id + '" data-emoji="' + e + '">' +
+    e + '<span>' + rx[e] + '</span></button>').join("");
+  return '<div class="rx">' + chips +
+    '<button class="react-btn" data-react="' + card.id + '" title="Add a reaction">😊<span class="plus">+</span></button></div>';
 }
 function cardHTML(card, avatarByName) {
   const isAI = card.origin === "ai";
@@ -382,6 +405,39 @@ async function react(cardId, emoji) {
     if (d.reacted) set.add(emoji); else set.delete(emoji);
     render(d.state);
   } catch (e) {}
+}
+/* React picker: a floating menu (survives the ~1.2s re-render) with every emoji. */
+function openReactPicker(cardId, btn) {
+  const p = document.getElementById("rx-picker");
+  if (RX_CARD === cardId && !p.classList.contains("hidden")) { closeReactPicker(); return; }
+  RX_CARD = cardId;
+  const mine = MY_REACTIONS[cardId] || new Set();
+  p.innerHTML = EMOJIS.map(e =>
+    '<button class="pick' + (mine.has(e) ? " mine" : "") + '" data-emoji="' + e + '">' + e + '</button>').join("");
+  p.querySelectorAll(".pick").forEach(b =>
+    b.onclick = () => { react(cardId, b.getAttribute("data-emoji")); closeReactPicker(); });
+  p.classList.remove("hidden");
+  const r = btn.getBoundingClientRect();
+  let left = Math.min(r.left, innerWidth - p.offsetWidth - 8);
+  let top = r.bottom + 6;
+  if (top + p.offsetHeight > innerHeight) top = r.top - p.offsetHeight - 6;
+  p.style.left = Math.max(8, left) + "px";
+  p.style.top = Math.max(8, top) + "px";
+}
+function closeReactPicker() { RX_CARD = null; document.getElementById("rx-picker").classList.add("hidden"); }
+/* Floating emoji: a reaction everyone sees rise up the screen (broadcast via poll). */
+function floatEmoji(emoji) {
+  const fx = document.getElementById("rx-fx");
+  if (!fx || fx.childElementCount > 60) return;   // guard against a flood
+  for (let i = 0; i < 3; i++) {
+    const s = document.createElement("span");
+    s.className = "floater"; s.textContent = emoji;
+    s.style.left = (8 + Math.random() * 84) + "vw";
+    s.style.animationDelay = (Math.random() * 0.4) + "s";
+    s.style.fontSize = (26 + Math.random() * 18) + "px";
+    s.addEventListener("animationend", () => s.remove());
+    fx.appendChild(s);
+  }
 }
 async function saveEdit(cardId) {
   const box = document.getElementById("edit-" + cardId);
@@ -434,6 +490,14 @@ setInterval(paintTimer, 250);
 function render(state) {
   if (!state) return;
   if (state.timer) { TIMER = state.timer; OFFSET = state.timer.now_epoch - Date.now() / 1000; }
+  // Float any reaction events we haven't shown yet. On the first render we only
+  // seed the high-water mark (no backlog burst for someone who just joined).
+  if (state.reaction_events) {
+    const maxId = state.reaction_events.reduce((m, e) => Math.max(m, e.id), lastRxEvent);
+    if (seededRx) state.reaction_events.forEach(e => { if (e.id > lastRxEvent) floatEmoji(e.emoji); });
+    seededRx = true;
+    lastRxEvent = maxId;
+  }
   const avatarByName = {};
   (state.presence || []).forEach(p => { if (p.avatar) avatarByName[p.name] = p.avatar; });
 
@@ -479,6 +543,7 @@ function renderRoom(state) {
 }
 function wireCards() {
   document.querySelectorAll(".chip").forEach(ch => ch.onclick = () => react(ch.getAttribute("data-card"), ch.getAttribute("data-emoji")));
+  document.querySelectorAll("[data-react]").forEach(b => b.onclick = e => { e.stopPropagation(); openReactPicker(b.getAttribute("data-react"), b); });
   document.querySelectorAll("[data-edit]").forEach(b => b.onclick = () => { EDITING = b.getAttribute("data-edit"); tick(); });
   document.querySelectorAll("[data-del]").forEach(b => b.onclick = () => deleteCard(b.getAttribute("data-del")));
   document.querySelectorAll("[data-save]").forEach(b => b.onclick = () => saveEdit(b.getAttribute("data-save")));
@@ -532,10 +597,11 @@ function togglePop(popId) {
   }
 }
 document.addEventListener("click", e => {
+  if (!e.target.closest("#rx-picker") && !e.target.closest("[data-react]")) closeReactPicker();
   if (e.target.closest(".pop") || e.target.closest(".tbtn") || e.target.closest(".room-btn")) return;
   closePops();
 });
-document.addEventListener("keydown", e => { if (e.key === "Escape") closePops(); });
+document.addEventListener("keydown", e => { if (e.key === "Escape") { closePops(); closeReactPicker(); } });
 
 /* ── Theme swatches ─────────────────────────────────────────── */
 const THEMES = ["midnight", "light", "solarized", "synthwave", "forest"];
@@ -559,97 +625,62 @@ function buildSwatches() {
 }
 function markSwatch() { document.querySelectorAll(".swatch").forEach(s => s.classList.toggle("sel", s.getAttribute("data-set-theme") === THEME)); }
 
-/* ── Web-Audio music (offline, generated) + visualizer ──────── */
+/* Populate the station dropdown from the injected channel library. */
+function buildChannels() {
+  const sel = document.getElementById("music-mood");
+  sel.innerHTML = Music.channels().map((c, i) => '<option value="' + i + '">' + esc(c.name) + "</option>").join("");
+}
+
+/* ── Internet-radio music (same library as the TUI) + visualizer ─────
+ * The TUI streams SomaFM/SRG MP3 URLs (scrum_agent.music.CHANNELS); we play
+ * the very same URLs with a plain <audio> element. We deliberately do NOT route
+ * the stream through Web Audio (createMediaElementSource) — a cross-origin
+ * stream without CORS headers would be silenced. So the visualizer is a light
+ * decorative animation gated on "is it playing", not real frequency data. */
+const CHANNELS = __MUSIC_CHANNELS__;
 const Music = (function () {
-  let ctx = null, master = null, analyser = null, nodes = [], loop = null, playing = false;
-  const NOTE = { C2:65.41, E2:82.41, G2:98, A2:110, D3:146.83, F3:174.61, G3:196, A3:220, C4:261.63, D4:293.66, E4:329.63, F4:349.23, G4:392, A4:440, B4:493.88, "C#4":277.18 };
-  const MOODS = {
-    calm:  { pad: [220, 277.18, 329.63], bpm: 0 },
-    lofi:  { pad: [220, 261.63, 329.63, 392], bpm: 72, beat: "lofi" },
-    focus: { pad: [261.63, 329.63, 392], bpm: 66, beat: "soft" },
-    hiphop:{ pad: [110, 164.81], bpm: 86, beat: "boombap", bass: [65.41, 65.41, 98, 82.41] },
-    jazz:  { pad: [261.63, 329.63, 392, 493.88], bpm: 120, beat: "swing", bass: [130.81, 146.83, 164.81, 196] },
-  };
-  let mood = "calm", volume = 0.35, step = 0;
-  function ensure() {
-    if (!ctx) { const AC = window.AudioContext || window.webkitAudioContext; ctx = new AC();
-      master = ctx.createGain(); master.gain.value = volume;
-      analyser = ctx.createAnalyser(); analyser.fftSize = 64;
-      master.connect(analyser); analyser.connect(ctx.destination); }
+  const audio = new Audio(); audio.preload = "none"; audio.crossOrigin = "anonymous";
+  let channel = 0, volume = 0.35, playing = false, vizRAF = null;
+  audio.volume = volume;
+  audio.addEventListener("playing", () => { playing = true; paintBtn(); });
+  audio.addEventListener("pause", () => { playing = false; paintBtn(); });
+  audio.addEventListener("error", () => { playing = false; paintBtn(); });
+  function paintBtn() {
+    document.getElementById("music-play").textContent = playing ? "⏸" : "▶";
+    document.getElementById("music-btn").classList.toggle("playing", playing);
+    document.getElementById("viz").classList.toggle("on", playing);
+    if (playing) drawViz();
   }
-  function tone(freq, t, dur, type, peak) {
-    const o = ctx.createOscillator(), g = ctx.createGain();
-    o.type = type || "sine"; o.frequency.value = freq;
-    g.gain.setValueAtTime(0.0001, t);
-    g.gain.exponentialRampToValueAtTime(peak || 0.3, t + 0.02);
-    g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
-    o.connect(g); g.connect(master); o.start(t); o.stop(t + dur + 0.05);
-  }
-  function noise(t, dur, peak) {
-    const n = ctx.createBufferSource(), buf = ctx.createBuffer(1, ctx.sampleRate * dur, ctx.sampleRate);
-    const data = buf.getChannelData(0); for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
-    n.buffer = buf; const g = ctx.createGain(), hp = ctx.createBiquadFilter(); hp.type = "highpass"; hp.frequency.value = 6000;
-    g.gain.setValueAtTime(peak || 0.2, t); g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
-    n.connect(hp); hp.connect(g); g.connect(master); n.start(t); n.stop(t + dur);
-  }
-  function kick(t) { const o = ctx.createOscillator(), g = ctx.createGain(); o.frequency.setValueAtTime(150, t); o.frequency.exponentialRampToValueAtTime(50, t + 0.12);
-    g.gain.setValueAtTime(0.6, t); g.gain.exponentialRampToValueAtTime(0.0001, t + 0.16); o.connect(g); g.connect(master); o.start(t); o.stop(t + 0.2); }
-  function snare(t) { noise(t, 0.18, 0.35); tone(180, t, 0.12, "triangle", 0.15); }
-  function tickStep() {
-    if (!playing) return;
-    const cfg = MOODS[mood]; const t = ctx.currentTime + 0.02; const beat = step % 4;
-    if (cfg.beat === "boombap") { if (beat === 0 || beat === 2) kick(t); if (beat === 1 || beat === 3) snare(t); noise(t, 0.05, 0.08); }
-    else if (cfg.beat === "swing") { noise(t, 0.04, 0.06); if (beat % 2 === 0) noise(t + (60 / cfg.bpm) * 0.66, 0.04, 0.05); if (beat === 0) kick(t); if (beat === 2) snare(t); }
-    else if (cfg.beat === "lofi") { if (beat === 0 || beat === 2) kick(t); if (beat === 2) snare(t); noise(t, 0.04, 0.05); }
-    else if (cfg.beat === "soft") { if (beat === 0) kick(t); }
-    if (cfg.bass) { tone(cfg.bass[step % cfg.bass.length], t, (60 / cfg.bpm) * 0.9, "sawtooth", 0.18); }
-    step++;
-  }
-  function startPad() {
-    const cfg = MOODS[mood];
-    const lp = ctx.createBiquadFilter(); lp.type = "lowpass"; lp.frequency.value = 1100; lp.connect(master);
-    const pad = ctx.createGain(); pad.gain.value = 0.14; pad.connect(lp);
-    cfg.pad.forEach((f, i) => { const o = ctx.createOscillator(); o.type = i % 2 ? "sine" : "triangle"; o.frequency.value = f; o.detune.value = (i - 1) * 4; o.connect(pad); o.start(); nodes.push(o); });
-    const lfo = ctx.createOscillator(), lg = ctx.createGain(); lfo.frequency.value = 0.08; lg.gain.value = 0.05; lfo.connect(lg); lg.connect(pad.gain); lfo.start(); nodes.push(lfo);
-    nodes.push(pad, lp, lg);
-  }
-  function play() {
-    ensure(); if (ctx.state === "suspended") ctx.resume();
-    stopNodes(); step = 0; playing = true; startPad();
-    const cfg = MOODS[mood];
-    if (cfg.bpm > 0) loop = setInterval(tickStep, 60000 / cfg.bpm);
-    document.getElementById("music-play").textContent = "⏸";
-    document.getElementById("music-btn").classList.add("playing");
-    document.getElementById("viz").classList.add("on");
-    drawViz();
-  }
-  function stopNodes() { if (loop) { clearInterval(loop); loop = null; } nodes.forEach(n => { try { n.stop && n.stop(); n.disconnect && n.disconnect(); } catch (e) {} }); nodes = []; }
-  function stop() {
-    playing = false; stopNodes();
-    document.getElementById("music-play").textContent = "▶";
-    document.getElementById("music-btn").classList.remove("playing");
-    document.getElementById("viz").classList.remove("on");
-  }
+  function load(i) { channel = ((i % CHANNELS.length) + CHANNELS.length) % CHANNELS.length; audio.src = CHANNELS[channel].url; }
+  function play() { if (!audio.src) load(channel); audio.play().catch(() => {}); }
+  function stop() { audio.pause(); }
   function drawViz() {
-    const cv = document.getElementById("viz"); if (!cv || !analyser) return;
-    const cx = cv.getContext("2d"), buf = new Uint8Array(analyser.frequencyBinCount);
+    const cv = document.getElementById("viz"); if (!cv) return;
+    const cx = cv.getContext("2d"), bars = 16, w = cv.width / bars;
+    let phase = 0;
+    if (vizRAF) cancelAnimationFrame(vizRAF);
     function frame() {
-      if (!playing) { cx.clearRect(0, 0, cv.width, cv.height); return; }
-      analyser.getByteFrequencyData(buf);
+      if (!playing) { cx.clearRect(0, 0, cv.width, cv.height); vizRAF = null; return; }
       cx.clearRect(0, 0, cv.width, cv.height);
-      const bars = 16, w = cv.width / bars;
       const col = getComputedStyle(document.documentElement).getPropertyValue("--accent") || "#50bebe";
       cx.fillStyle = col.trim() || "#50bebe";
-      for (let i = 0; i < bars; i++) { const v = buf[i] / 255; const h = Math.max(2, v * cv.height); cx.fillRect(i * w, cv.height - h, w - 1, h); }
-      requestAnimationFrame(frame);
+      phase += 0.18;
+      for (let i = 0; i < bars; i++) {
+        // Layered sines give a lively, music-like bounce without touching the stream.
+        const v = (Math.sin(phase + i * 0.7) + Math.sin(phase * 1.7 + i) + 2) / 4;
+        const h = Math.max(2, v * cv.height);
+        cx.fillRect(i * w, cv.height - h, w - 1, h);
+      }
+      vizRAF = requestAnimationFrame(frame);
     }
-    requestAnimationFrame(frame);
+    vizRAF = requestAnimationFrame(frame);
   }
   return {
     toggle() { playing ? stop() : play(); },
-    setVolume(v) { volume = v; if (master) master.gain.value = v; },
-    setMood(m) { mood = m; if (playing) play(); },
-    ctx() { ensure(); return ctx; }, out() { ensure(); return master; },
+    setVolume(v) { volume = v; audio.volume = v; },
+    setChannel(i) { const wasPlaying = playing || !audio.paused; load(i); if (wasPlaying) play(); },
+    playing() { return playing; },
+    channels() { return CHANNELS; },
   };
 })();
 
@@ -669,12 +700,16 @@ function confetti() {
 }
 function alarm() {
   try {
-    const ctx = Music.ctx(), out = Music.out(); const t0 = ctx.currentTime;
+    // Own short-lived Web-Audio context (music is now a plain <audio> element).
+    const AC = window.AudioContext || window.webkitAudioContext; const ctx = new AC();
+    if (ctx.state === "suspended") ctx.resume();
+    const t0 = ctx.currentTime;
     for (let k = 0; k < 4; k++) {
       [880, 1175].forEach(f => { const o = ctx.createOscillator(), g = ctx.createGain(); o.type = "square"; o.frequency.value = f;
         const t = t0 + k * 0.4; g.gain.setValueAtTime(0.0001, t); g.gain.exponentialRampToValueAtTime(0.25, t + 0.02); g.gain.exponentialRampToValueAtTime(0.0001, t + 0.3);
-        o.connect(g); g.connect(out); o.start(t); o.stop(t + 0.32); });
+        o.connect(g); g.connect(ctx.destination); o.start(t); o.stop(t + 0.32); });
     }
+    setTimeout(() => { try { ctx.close(); } catch (e) {} }, 2000);
   } catch (e) {}
 }
 
@@ -683,6 +718,7 @@ applyTheme(THEME);
 buildCols();
 buildAvatars();
 buildSwatches();
+buildChannels();
 paintTimer();
 document.getElementById("dice").addEventListener("click", () => { document.getElementById("name-in").value = randomName(); });
 document.getElementById("name-in").addEventListener("keydown", e => { if (e.key === "Enter") saveProfile(); });
@@ -697,7 +733,7 @@ document.getElementById("theme-btn").addEventListener("click", () => togglePop("
 document.getElementById("room-btn").addEventListener("click", () => togglePop("room-pop"));
 document.getElementById("music-play").addEventListener("click", () => Music.toggle());
 document.getElementById("music-vol").addEventListener("input", e => Music.setVolume(parseFloat(e.target.value)));
-document.getElementById("music-mood").addEventListener("change", e => Music.setMood(e.target.value));
+document.getElementById("music-mood").addEventListener("change", e => Music.setChannel(parseInt(e.target.value, 10)));
 document.querySelectorAll(".preset").forEach(b => b.addEventListener("click", () => { startTimer(parseInt(b.getAttribute("data-secs"), 10)); closePops(); }));
 document.getElementById("custom-go").addEventListener("click", () => { customTimer(); closePops(); });
 document.getElementById("timer-stop").addEventListener("click", () => { stopTimer(); closePops(); });
@@ -705,7 +741,9 @@ document.getElementById("invite-btn").addEventListener("click", toggleInvite);
 document.getElementById("invite-close").addEventListener("click", toggleInvite);
 
 function afterToken() {
-  // Token known: go straight in if we have a saved profile, else prompt for it.
+  // Token known: keep it in sessionStorage (per-tab, survives refresh) and strip
+  // it from the address bar, so copying the URL never leaks access to others.
+  if (TOKEN) { sessionStorage.setItem("retro_token", TOKEN); history.replaceState(null, "", "/"); }
   paintMe();
   if (NAME && localStorage.getItem("retro_avatar")) { JOINED = true; document.getElementById("modal").classList.add("hidden"); startLoop(); }
   else { openProfile(); }
@@ -728,6 +766,9 @@ def build_board_html() -> str:
         .replace("__AVATARS__", _lit(list(AVATARS)))
         .replace("__ADJS__", _lit(_ADJECTIVES))
         .replace("__NOUNS__", _lit(_NOUNS))
+        # Same internet-radio library the TUI uses (scrum_agent.music.CHANNELS),
+        # so the browser plays real streams instead of synthesized tones.
+        .replace("__MUSIC_CHANNELS__", _lit([{"name": c["name"], "url": c["url"]} for c in CHANNELS]))
     )
     return (
         '<!DOCTYPE html>\n<html lang="en">\n<head>\n'
@@ -756,9 +797,7 @@ def build_board_html() -> str:
         '<div id="music-pop" class="pop hidden"><div class="row">\n'
         '  <button class="playbtn" id="music-play">▶</button>\n'
         '  <input type="range" id="music-vol" min="0" max="1" step="0.05" value="0.35" title="Volume">\n'
-        '  <select id="music-mood" title="Mood"><option value="calm">Ambient</option>'
-        '<option value="lofi">Lo-fi</option><option value="focus">Focus</option>'
-        '<option value="hiphop">Hip-hop</option><option value="jazz">Jazz</option></select>\n'
+        '  <select id="music-mood" title="Station"></select>\n'
         "</div></div>\n"
         # Timer popover
         '<div id="timer-pop" class="pop hidden">\n'
@@ -785,6 +824,8 @@ def build_board_html() -> str:
         "</div>\n"
         '<div class="grids" id="grids"></div>\n'
         '<canvas id="confetti"></canvas>\n'
+        '<div id="rx-fx"></div>\n'
+        '<div id="rx-picker" class="rx-picker hidden"></div>\n'
         # Code-entry gate (shown when the URL has no token)
         '<div id="code-modal" class="overlay hidden"><div class="box">\n'
         "  <h2>Join a retro</h2>\n"
@@ -804,7 +845,7 @@ def build_board_html() -> str:
         # Invite popover (QR)
         '<div id="invite-modal" class="overlay hidden"><div class="box">\n'
         "  <h2>Invite the team</h2>\n"
-        '  <p class="muted">Scan to join instantly, or share the code from the host.</p>\n'
+        '  <p class="muted">Scan to open the retro, then enter the Share code from the host.</p>\n'
         '  <div class="qrwrap"><img id="invite-img" alt="join QR"></div>\n'
         '  <button class="primary" id="invite-close">Close</button>\n'
         "</div></div>\n"

--- a/src/scrum_agent/retro/page.py
+++ b/src/scrum_agent/retro/page.py
@@ -247,6 +247,9 @@ textarea { width:100%; background:var(--card); color:var(--text); border:1px sol
          border-radius:8px; padding:9px; font:inherit; }
 .dice { background:var(--panel); border:1px solid var(--line); border-radius:8px;
         padding:0 12px; cursor:pointer; font-size:18px; }
+.join-btn { background:var(--accent); color:var(--ink); border:0; border-radius:8px;
+            padding:0 20px; font:inherit; font-weight:700; cursor:pointer; white-space:nowrap; }
+.join-btn:hover { filter:brightness(1.1); }
 .avatars { display:flex; flex-wrap:wrap; gap:6px; margin:12px 0; }
 .av { font-size:22px; background:var(--card); border:1px solid var(--line); border-radius:10px;
       width:40px; height:40px; cursor:pointer; display:flex; align-items:center; justify-content:center; }
@@ -831,7 +834,7 @@ def build_board_html() -> str:
         "  <h2>Join a retro</h2>\n"
         '  <p class="muted">Enter the share code shown on the host\'s screen.</p>\n'
         '  <div class="namerow"><input id="code-in" class="field" placeholder="e.g. A3F9-1B2C" autofocus>'
-        '<button class="dice" id="code-join">Join</button></div>\n'
+        '<button class="join-btn" id="code-join">Join</button></div>\n'
         '  <p class="muted" id="code-err" style="color:#f85149"></p>\n'
         "</div></div>\n"
         # Profile modal (name + avatar; reused for rename)

--- a/src/scrum_agent/retro/server.py
+++ b/src/scrum_agent/retro/server.py
@@ -181,13 +181,15 @@ class _RetroHandler(BaseHTTPRequestHandler):
         self._send_json(404, {"error": "not found"})
 
     def _send_qr(self) -> None:
-        """Render a QR of ``scheme://<Host header>/?token=…`` as inline SVG.
+        """Render a QR of the token-free join URL (``scheme://<Host header>/``) as inline SVG.
 
         Using the request's Host header makes the QR correct for both LAN and the
-        Cloudflare tunnel automatically. Best-effort — 501 if segno is unavailable.
+        Cloudflare tunnel automatically. The QR is token-free so scanning it lands
+        on the code gate — a scan alone does not grant access; the visitor still
+        types the join code. Best-effort — 501 if segno is unavailable.
         """
         host = self.headers.get("Host") or f"{self.server.server_address[0]}:{self.server.server_address[1]}"  # type: ignore[attr-defined]
-        url = f"http://{host}/?token={self._token}"
+        url = f"http://{host}/"
         try:
             import io
 
@@ -322,8 +324,18 @@ class RetroServer:
 
     @property
     def url(self) -> str:
-        """The full clickable URL teammates open (carries the token)."""
+        """The host's private direct link (carries the token — do not share).
+
+        This is the host's own convenience link and the value logged on startup;
+        anyone opening it is let straight in. Teammates get :attr:`share_url`
+        instead and must enter the join code.
+        """
         return f"http://{self.ip}:{self.port}/?token={self.token}"
+
+    @property
+    def share_url(self) -> str:
+        """The token-free URL to hand out — recipients must type the join code."""
+        return f"http://{self.ip}:{self.port}/"
 
     @property
     def share_code(self) -> str:

--- a/src/scrum_agent/ui/mode_select/__init__.py
+++ b/src/scrum_agent/ui/mode_select/__init__.py
@@ -2257,7 +2257,9 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
                     remote["status"] = "Remote link failed — tunnel did not start (see logs)."
                     return
                 remote["tunnel"] = tunnel
-                remote["url"] = f"{public}/?token={server.token}"
+                # Token-free public URL: off-network teammates must still enter the
+                # join code (the token is never handed out in a shareable link).
+                remote["url"] = f"{public}/"
                 remote["active"] = True
                 remote["status"] = "Remote link ready — share the Remote URL with off-network teammates."
             except Exception as e:  # never let the worker crash anything
@@ -2292,7 +2294,8 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
         return {
             "session_name": session_name,
             "display_code": server.display_code,
-            "url": server.url,
+            "url": server.share_url,
+            "host_url": server.url,
             "public_url": remote["url"],
             "message": remote["status"] or message,
             "grids": board.cards_by_grid(),

--- a/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
+++ b/src/scrum_agent/ui/mode_select/screens/_screens_secondary.py
@@ -3840,7 +3840,8 @@ def _build_retro_screen(
     lives in the browser; here the grids stack vertically so narrow terminals and
     the shared scrollbar behave like every other page.
 
-    retro_data keys: session_name, display_code, url, message (transient status),
+    retro_data keys: session_name, display_code, url (token-free LAN share URL),
+    host_url (optional private token'd host link), message (transient status),
     grids (dict[grid_key -> list[RetroCard]]), public_url (optional remote tunnel
     URL), actions (optional button-label list).
 
@@ -3889,11 +3890,15 @@ def _build_retro_screen(
     _heading("Join this retro")
     _row("Share code", retro_data.get("display_code", "—"), f"bold {theme.accent_bright}")
     _row("LAN URL", retro_data.get("url", "—"), theme.value)
-    _line("Teammates on the same Wi-Fi open the LAN URL in a browser to add cards.", theme.muted)
+    _line("Teammates on the same Wi-Fi open the LAN URL, then enter the Share code above.", theme.muted)
     public_url = retro_data.get("public_url", "")
     if public_url:
         _row("Remote URL", public_url, f"bold {theme.accent_bright}")
-        _line("Off-network teammates open the Remote URL (public HTTPS link).", theme.muted)
+        _line("Off-network teammates open the Remote URL (public HTTPS link), then enter the code.", theme.muted)
+    host_url = retro_data.get("host_url", "")
+    if host_url:
+        _row("Host link (private)", host_url, theme.muted)
+        _line("For you only — this link skips the code. Don't share it.", theme.muted)
 
     # ── The four grids ────────────────────────────────────────────
     grids = retro_data.get("grids") or {}

--- a/tests/unit/test_retro_board.py
+++ b/tests/unit/test_retro_board.py
@@ -159,6 +159,43 @@ class TestReactions:
         assert dict(rep.cards[0].reactions) == {"👍": 1, "🔥": 1}
 
 
+class TestReactionEvents:
+    def test_add_queues_event_remove_does_not(self):
+        # Adding a reaction broadcasts an event; toggling it back off does not.
+        b = RetroBoard("s")
+        c = b.add_card(grid="went_well", text="ci", author="Sam")
+        b.toggle_reaction(c.id, "👍", "p1")  # add -> one event
+        events = b.state_snapshot()["reaction_events"]
+        assert events == [{"id": 0, "emoji": "👍"}]
+        b.toggle_reaction(c.id, "👍", "p1")  # remove -> no new event
+        assert b.state_snapshot()["reaction_events"] == [{"id": 0, "emoji": "👍"}]
+
+    def test_ids_are_monotonic_across_cards(self):
+        b = RetroBoard("s")
+        c = b.add_card(grid="went_well", text="a", author="x")
+        b.toggle_reaction(c.id, "👍", "p1")
+        b.toggle_reaction(c.id, "🔥", "p2")
+        ids = [e["id"] for e in b.state_snapshot()["reaction_events"]]
+        assert ids == [0, 1]
+
+    def test_rejected_reaction_queues_nothing(self):
+        b = RetroBoard("s")
+        c = b.add_card(grid="demos", text="x", author="a")
+        b.toggle_reaction(c.id, "🦖", "p1")  # unknown emoji
+        b.toggle_reaction("nope", "👍", "p1")  # missing card
+        assert b.state_snapshot()["reaction_events"] == []
+
+    def test_event_buffer_caps_at_25(self):
+        b = RetroBoard("s")
+        c = b.add_card(grid="went_well", text="a", author="x")
+        # 30 distinct reactors adding 👍 -> 30 add-events, buffer keeps the last 25.
+        for i in range(30):
+            b.toggle_reaction(c.id, "👍", f"p{i}")
+        events = b.state_snapshot()["reaction_events"]
+        assert len(events) == 25
+        assert events[0]["id"] == 5 and events[-1]["id"] == 29
+
+
 class TestPresenceAndTyping:
     def test_heartbeat_and_presence_list(self):
         b = RetroBoard("s")
@@ -221,7 +258,7 @@ class TestStateSnapshot:
         b.toggle_reaction(c.id, "👍", "p1")
         b.heartbeat("p1", name="Sam", avatar="🤠", typing_grid="went_well")
         snap = b.state_snapshot()
-        assert set(snap) == {"revision", "cards", "presence", "typing", "timer"}
+        assert set(snap) == {"revision", "cards", "presence", "typing", "timer", "reaction_events"}
         assert snap["cards"][0]["reactions"] == {"👍": 1}
         assert snap["presence"] and snap["typing"][0]["grid"] == "went_well"
 

--- a/tests/unit/test_retro_page.py
+++ b/tests/unit/test_retro_page.py
@@ -8,8 +8,11 @@ class TestBuildBoardHtml:
         html = build_board_html()
         assert "<!DOCTYPE html>" in html
         assert "<style>" in html and "<script>" in html
-        # No external resources (CSP-hostile) — no http(s) src/href, no CDN.
-        assert "http://" not in html and "https://" not in html
+        # No external code/style resources (CSP-hostile) — no external script/style/
+        # link tags, no CDN. The music streams (audio URLs in JS data) are the one
+        # deliberate exception, so we forbid resource *tags* rather than any URL.
+        assert 'src="http' not in html and 'href="http' not in html
+        assert "<link" not in html
         assert "cdn" not in html.lower()
 
     def test_token_free_page(self):
@@ -48,8 +51,9 @@ class TestBuildBoardHtml:
         assert "data-set-theme" in html and '[data-theme="synthwave"]' in html
         assert '"synthwave"' in html and "buildSwatches" in html
         assert 'id="theme-btn"' in html and 'id="theme-pop"' in html
-        # richer music moods
-        assert ">Hip-hop<" in html and ">Jazz<" in html and "boombap" in html
+        # internet-radio music: the TUI's SomaFM channels, played via <audio>
+        assert "setChannel" in html and "buildChannels" in html
+        assert '"Lofi"' in html and '"Jazz"' in html and "somafm" in html
         # visualizer + drag + edit/delete + confetti/alarm
         assert 'id="viz"' in html and "drawViz" in html
         assert 'draggable="true"' in html and "/api/card/move" in html
@@ -94,6 +98,30 @@ class TestBuildBoardHtml:
         for emoji in ("👍", "❤️", "🔥"):
             assert emoji in html
         assert "🤠" in html  # an avatar
+
+    def test_reaction_broadcast_and_react_button(self):
+        html = build_board_html()
+        # Collapsed reactions: a React button + a floating picker (not all chips).
+        assert "react-btn" in html and "rx-picker" in html and "openReactPicker" in html
+        # Floating-emoji broadcast overlay + the poll-driven event drain.
+        assert 'id="rx-fx"' in html and "function floatEmoji(" in html
+        assert "reaction_events" in html and "seededRx" in html
+
+    def test_music_uses_audio_element_not_synth(self):
+        html = build_board_html()
+        # Real streams via <audio>; the old synth mood engine is gone.
+        assert "new Audio()" in html and "Music.channels()" in html
+        assert "MOODS" not in html and "boombap" not in html
+        # The alarm no longer borrows the (removed) synth context.
+        assert "Music.ctx()" not in html and "Music.out()" not in html
+
+    def test_share_code_token_hardening(self):
+        html = build_board_html()
+        # Token is persisted per-tab and never re-written into the address bar,
+        # so copying the URL doesn't leak access.
+        assert 'sessionStorage.getItem("retro_token")' in html
+        assert 'sessionStorage.setItem("retro_token"' in html
+        assert '"/?token="' not in html  # never rebuild a token'd URL client-side
 
 
 class TestConfig:

--- a/tests/unit/test_retro_server.py
+++ b/tests/unit/test_retro_server.py
@@ -32,6 +32,19 @@ class TestShareCode:
         assert make_token() != make_token()
 
 
+class TestShareVsHostUrl:
+    def test_share_url_is_token_free(self):
+        # The shareable URL must NOT carry the token — recipients type the code.
+        srv = RetroServer(RetroBoard("s"), port=5288)
+        assert "token" not in srv.share_url
+        assert srv.share_url == f"http://{srv.ip}:{srv.port}/"
+
+    def test_host_url_still_carries_token(self):
+        # The host's private direct link keeps the token for one-click access.
+        srv = RetroServer(RetroBoard("s"), port=5289)
+        assert f"?token={srv.token}" in srv.url
+
+
 class TestLanIp:
     def test_returns_ipv4_string(self):
         ip = get_lan_ip()
@@ -121,7 +134,7 @@ class TestStateEndpoint:
         srv, b = running_server
         b.add_card(grid="went_well", text="ci", author="Sam")
         data = json.load(_get(f"http://127.0.0.1:{srv.port}/api/state?token={srv.token}"))
-        assert set(data) == {"revision", "cards", "presence", "typing", "timer"}
+        assert set(data) == {"revision", "cards", "presence", "typing", "timer", "reaction_events"}
 
     def test_state_forbidden_without_token(self, running_server):
         srv, _ = running_server


### PR DESCRIPTION
## Summary

Four improvements to the collaborative retro web board (`src/scrum_agent/retro/`), all requested for the browser interface.

### 1. Reactions broadcast to everyone (screen interaction, like the timer confetti)
- New **add-only reaction-event ring buffer** on `RetroBoard` (`reaction_events` in the state snapshot), drained by the existing ~1.2s poll — no WebSocket needed.
- Each reaction now **floats up every teammate's screen** (Instagram-hearts style) via a fixed `#rx-fx` overlay.
- Joiners seed the high-water mark and never see a backlog burst; un-reacting never animates.

### 2. React button instead of a cluttered card
- Cards show only the emojis that already have a count; a **React button** opens a floating picker with the full emoji set that survives the periodic re-render.

### 3. Web music uses the TUI's library
- The browser now plays the **same SomaFM internet-radio channels** the TUI uses (`scrum_agent.music.CHANNELS`) via an `<audio>` element, replacing the offline Web-Audio synth.
- The stream is **not** routed through Web Audio (a cross-origin stream without CORS can be silenced), so the visualizer is a light decorative animation and the timer alarm gets its own short-lived `AudioContext`.
- Trade-off: music now requires internet (previously fully offline). Confirmed with the requester.

### 4. Share code actually gates access
- Root cause: the shared LAN/Remote URLs and the QR embedded `?token=…`, so any link opened straight in.
- The shared **LAN URL, Remote URL, and QR are now token-free** — recipients must enter the join code the host sees. The host keeps a private token'd **Host link**.
- Hardening: the client persists the token in **sessionStorage** (per-tab, survives refresh) and **strips it from the address bar**, so copying the URL no longer leaks access.

## Testing
- `make test` — 3403 passed, 7 skipped.
- `make lint` — clean.
- New/updated unit tests in `test_retro_board.py` (reaction events + buffer cap), `test_retro_server.py` (`share_url` token-free / `url` token'd), `test_retro_page.py` (React button + `#rx-fx`, `<audio>` music vs synth, sessionStorage token hardening).
- Runtime-verified against a live server: token-free page serves the code gate, `/api/state` is 403 without a token, wrong join code → 403 / right code → token, a reaction produces a `reaction_events` entry, and all four TUI channels are injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)