### PR TITLE
Add Docs section to setup wizard (Notion + Confluence)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "2.5.0"
+version = "2.6.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/setup_wizard.py
+++ b/src/scrum_agent/setup_wizard.py
@@ -241,9 +241,13 @@ def run_setup_wizard(console: Console) -> bool:
     issue_tracking = result.get("issue_tracking", {})
     collected.update(issue_tracking)
 
-    # ── Notion (optional doc tool, collected in full-screen UI) ─────────
+    # ── Docs (optional, collected in full-screen UI) ────────────────────
+    # Notion has its own token; Confluence adds only CONFLUENCE_SPACE_KEY on top of
+    # the Jira Atlassian creds already merged from `issue_tracking` above.
     notion = result.get("notion", {})
     collected.update(notion)
+    confluence = result.get("confluence", {})
+    collected.update(confluence)
 
     # ── Bedrock: auto-detect model from OpenClaw if available ───────────────
     # OpenClaw's models.json has the exact Bedrock model ID (e.g.

--- a/src/scrum_agent/ui/provider_select/__init__.py
+++ b/src/scrum_agent/ui/provider_select/__init__.py
@@ -20,6 +20,7 @@ from rich.console import Console
 
 from scrum_agent.ui.provider_select._config import _save_progress  # noqa: F401
 from scrum_agent.ui.provider_select._constants import _PROVIDER_CARDS, _VC_OPTIONS
+from scrum_agent.ui.provider_select._phase_confluence import _run_confluence  # noqa: F401
 from scrum_agent.ui.provider_select._phase_issue_tracking import _run_issue_tracking  # noqa: F401
 from scrum_agent.ui.provider_select._phase_notion import _run_notion  # noqa: F401
 from scrum_agent.ui.provider_select._transitions import _transition_to_input  # noqa: F401
@@ -110,7 +111,8 @@ def select_provider(
     Organized as a step-based loop so Esc navigates back between steps:
     Step 0: LLM Provider selection + API key verification
     Step 1: Issue Tracking (Jira / Azure DevOps Boards / Skip)
-    Step 2: Docs / Notion (optional integration token)
+    Step 2: Docs — Notion (own token) then Confluence (shares Jira's Atlassian
+            auth, so only shown when Jira was configured). Both optional.
     Step 3: Version Control (GitHub PAT)
 
     Returns a dict compatible with setup_wizard._PROVIDERS values (with an
@@ -543,7 +545,7 @@ def select_provider(
                 continue
 
             # ══════════════════════════════════════════════════════════════
-            # Step 2: Docs / Notion (optional integration token)
+            # Step 2: Docs (Notion + Confluence, both optional)
             # ══════════════════════════════════════════════════════════════
             elif step == 2:
                 # Fade out the previous screen into the Notion form.
@@ -553,12 +555,28 @@ def select_provider(
                     time.sleep(FRAME_TIME_30FPS)
 
                 notion_result = _run_notion(console, read_key, existing_config, live)
-                if notion_result is not None:
-                    # Empty dict = user skipped (optional). Either way, record and advance.
-                    _issue_tracking_result["notion"] = notion_result
-                    step = 3
-                else:
+                if notion_result is None:
                     step = 1  # Esc → go back to issue tracking
+                    continue
+                # Empty dict = user skipped (optional). Either way, record.
+                _issue_tracking_result["notion"] = notion_result
+
+                # Confluence rides on Jira's Atlassian auth, so its sub-step is only
+                # offered when Jira was configured in the Issue Tracking step (the
+                # same "only when Jira configured" invariant Confluence has always
+                # had). If Jira was skipped or Azure DevOps was chosen, skip past.
+                _jira_creds = _issue_tracking_result.get("issue_tracking", {})
+                _jira_configured = all(_jira_creds.get(k) for k in ("JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"))
+                if _jira_configured:
+                    confluence_result = _run_confluence(
+                        console, read_key, existing_config, live, jira_creds=_jira_creds
+                    )
+                    if confluence_result is None:
+                        # Esc from Confluence → re-run the Docs step from the Notion picker.
+                        continue
+                    _issue_tracking_result["confluence"] = confluence_result
+
+                step = 3
                 continue
 
             # ══════════════════════════════════════════════════════════════

--- a/src/scrum_agent/ui/provider_select/_constants.py
+++ b/src/scrum_agent/ui/provider_select/_constants.py
@@ -142,13 +142,6 @@ _ISSUE_TRACKING_FIELDS: list[dict[str, Any]] = [
         "masked": False,
         "required": True,
     },
-    {
-        "env_var": "CONFLUENCE_SPACE_KEY",
-        "label": "Confluence Space Key",
-        "placeholder": "MYSPACE",
-        "masked": False,
-        "required": False,
-    },
 ]
 
 # Issue tracking fields — Azure DevOps Boards
@@ -190,10 +183,15 @@ _ISSUE_TRACKING_OPTIONS: list[dict[str, Any]] = [
     {"name": "Skip", "fields": []},
 ]
 
-# Notion doc-tool fields — a standalone wizard step (step 3). Unlike Confluence
-# (which rides on Jira's Atlassian auth), Notion has its own integration token and
-# no "space key"; the optional root page/database ID scopes page creation and the
-# standup activity feed. Both fields are optional so users without Notion skip past.
+# ── Docs step (Notion + Confluence) ──────────────────────────────────────────
+# Both doc tools live under the "Docs" progress chip (_STEPS[2]). Notion has its
+# own integration token; Confluence rides on Jira's Atlassian auth (JIRA_BASE_URL/
+# EMAIL/API_TOKEN — see tools/confluence.py) and only adds a space key, so its
+# sub-step is only offered when Jira was configured in the Issue Tracking step.
+
+# Notion doc-tool fields. Unlike Confluence, Notion has its own integration token
+# and no "space key"; the optional root page/database ID scopes page creation and
+# the standup activity feed. Both fields are optional so users without Notion skip past.
 _NOTION_FIELDS: list[dict[str, Any]] = [
     {
         "env_var": "NOTION_TOKEN",
@@ -206,6 +204,20 @@ _NOTION_FIELDS: list[dict[str, Any]] = [
         "env_var": "NOTION_ROOT_PAGE_ID",
         "label": "Root Page/Database ID (optional)",
         "placeholder": "",
+        "masked": False,
+        "required": False,
+    },
+]
+
+# Confluence fields — the Docs step's second sub-tool. Confluence reuses the Jira
+# Atlassian credentials (JIRA_BASE_URL/EMAIL/API_TOKEN) collected in the Issue
+# Tracking step, so the only field here is the space key. The sub-step is gated on
+# Jira being configured (see _phase_confluence / the wizard flow in __init__.py).
+_CONFLUENCE_FIELDS: list[dict[str, Any]] = [
+    {
+        "env_var": "CONFLUENCE_SPACE_KEY",
+        "label": "Confluence Space Key",
+        "placeholder": "MYSPACE",
         "masked": False,
         "required": False,
     },

--- a/src/scrum_agent/ui/provider_select/_phase_confluence.py
+++ b/src/scrum_agent/ui/provider_select/_phase_confluence.py
@@ -1,18 +1,20 @@
-"""Notion (Docs) phase of the provider selection wizard.
+"""Confluence (Docs) phase of the provider selection wizard.
 
-# See README: "Architecture" — this module handles the standalone Notion
-# credential step. Unlike Confluence (which rides on Jira's Atlassian auth in the
-# Issue Tracking form), Notion is an independent doc tool with its own integration
-# token, so it gets its own optional wizard step.
+# See README: "Architecture" — this module handles the Confluence sub-step of the
+# Docs wizard step. Unlike Notion (an independent doc tool with its own token),
+# Confluence rides on Jira's Atlassian auth (JIRA_BASE_URL/EMAIL/API_TOKEN — see
+# tools/confluence.py); the only extra credential is the space key. The wizard
+# therefore only runs this phase when Jira was configured in the Issue Tracking
+# step and passes those creds in for live verification.
 #
-# It reuses the generic multi-field form renderer (_build_issue_tracking_screen,
-# which accepts `fields=` and `subtitle=`) and the same pulsing verify/confirm
-# animation as the Jira/AzDO form — just with _NOTION_FIELDS and a live
-# _verify_notion check.
+# It reuses the generic multi-field form renderer (_build_issue_tracking_screen)
+# and the same pulsing verify/confirm animation as the Notion/Jira forms — just
+# with _CONFLUENCE_FIELDS and a live _verify_confluence check.
 """
 
 from __future__ import annotations
 
+import logging
 import math
 import sys
 import termios
@@ -23,8 +25,8 @@ from rich.console import Console
 from rich.live import Live
 
 from scrum_agent.ui.provider_select._config import _save_progress
-from scrum_agent.ui.provider_select._constants import _NOTION_FIELDS
-from scrum_agent.ui.provider_select._verification import _verify_notion
+from scrum_agent.ui.provider_select._constants import _CONFLUENCE_FIELDS
+from scrum_agent.ui.provider_select._verification import _verify_confluence
 from scrum_agent.ui.provider_select.screens._screens import (
     _ACCENT,
     _build_provider_row,
@@ -33,36 +35,48 @@ from scrum_agent.ui.provider_select.screens._screens import (
 from scrum_agent.ui.provider_select.screens._screens_vc import _build_issue_tracking_screen
 from scrum_agent.ui.shared._animations import FRAME_TIME_30FPS
 
-_TITLE = "Notion"
+logger = logging.getLogger(__name__)
+
+_TITLE = "Confluence"
 _SUBTITLE = "Docs"
+_DOCS_STEP = 2  # _STEPS[2] == "Docs"
 
 
-def _run_notion(
+def _run_confluence(
     console: Console,
     read_key,
     existing_config: dict[str, str] | None,
     live: Live,
+    *,
+    jira_creds: dict[str, str],
 ) -> dict[str, str] | None:
-    """Show the optional Notion credential form and verify the token.
+    """Show the optional Confluence space-key form and verify it.
 
-    Shows a Notion / Skip picker first (matching the Issue Tracking & Version
-    Control steps), then the credential form. Returns a dict of collected Notion
-    env vars, an empty dict when the user picks Skip (or submits an empty token),
-    or None when the user presses Esc to go back. Notion is optional — the step
-    never blocks users who don't use it.
+    Shows a Confluence / Skip picker first (matching the Notion & Issue Tracking
+    steps), then the space-key form. ``jira_creds`` supplies the shared Atlassian
+    credentials (JIRA_BASE_URL/EMAIL/API_TOKEN) used to verify the space. Returns a
+    dict of collected Confluence env vars, an empty dict when the user picks Skip
+    (or submits an empty space key), or None when the user presses Esc to go back.
+    Confluence is optional — the step never blocks users who don't use it.
     """
     import threading
 
     from rich.align import Align
     from rich.text import Text
 
-    fields = _NOTION_FIELDS
+    logger.info("Entering Confluence setup sub-step")
+
+    fields = _CONFLUENCE_FIELDS
     n = len(fields)
     _cfg = existing_config or {}
     values: dict[int, str] = {i: _cfg.get(field["env_var"], "") for i, field in enumerate(fields)}
     errors: dict[int, str] = {}
     verified: dict[int, bool] = {}
     selected = 0
+
+    base_url = jira_creds.get("JIRA_BASE_URL", "")
+    email = jira_creds.get("JIRA_EMAIL", "")
+    token = jira_creds.get("JIRA_API_TOKEN", "")
 
     def _drain() -> None:
         """Drain buffered stdin so a held key from the previous screen doesn't leak in."""
@@ -77,12 +91,12 @@ def _run_notion(
         finally:
             termios.tcsetattr(_drain_fd, termios.TCSADRAIN, _drain_old)
 
-    # --- Step 1: Notion / Skip picker (matches the Issue Tracking & Version
-    # Control steps, which both offer an explicit Skip rather than making the user
-    # guess that an empty submit skips the step). ---
-    def _run_notion_selection() -> str | None:
-        """Show the Notion / Skip picker. Returns "notion", "skip", or None (Esc)."""
-        cards = [{"name": "Notion", "color": _ACCENT}, {"name": "Skip", "color": _ACCENT}]
+    # --- Step 1: Confluence / Skip picker (matches the Notion & Issue Tracking
+    # steps, which both offer an explicit Skip rather than making the user guess
+    # that an empty submit skips the step). ---
+    def _run_confluence_selection() -> str | None:
+        """Show the Confluence / Skip picker. Returns "confluence", "skip", or None (Esc)."""
+        cards = [{"name": "Confluence", "color": _ACCENT}, {"name": "Skip", "color": _ACCENT}]
         pick = 0
 
         def _render_menu() -> None:
@@ -95,7 +109,7 @@ def _run_notion(
             live.update(
                 _build_screen_frame(
                     subtitle="Docs  ·  ↑↓ choose  ·  Enter select",
-                    step=2,
+                    step=_DOCS_STEP,
                     body_items=body,
                     body_height=body_h,
                     width=w,
@@ -113,15 +127,17 @@ def _run_notion(
             elif key in ("down", "scroll_down"):
                 pick = (pick + 1) % len(cards)
             elif key == "enter":
-                return "notion" if pick == 0 else "skip"
+                return "confluence" if pick == 0 else "skip"
             elif key == "esc":
                 return None
             _render_menu()
 
-    choice = _run_notion_selection()
+    choice = _run_confluence_selection()
     if choice is None:
+        logger.info("Confluence sub-step: user pressed Esc (back)")
         return None
     if choice == "skip":
+        logger.info("Confluence sub-step: skipped")
         return {}
 
     _drain()
@@ -137,7 +153,7 @@ def _run_notion(
                 fields=fields,
                 subtitle=_SUBTITLE,
                 title_text=_TITLE,
-                step=2,  # Docs chip (_STEPS[2]); shared form defaults to Issue Tracking
+                step=_DOCS_STEP,
                 **kw,
             )
         )
@@ -152,17 +168,18 @@ def _run_notion(
         elif key in ("down", "scroll_down"):
             selected = (selected + 1) % n
         elif key == "enter":
-            token = values.get(0, "").strip()
+            space_key = values.get(0, "").strip()
 
-            # Empty token → skip Notion entirely (it's optional).
-            if not token:
+            # Empty space key → skip Confluence entirely (it's optional).
+            if not space_key:
+                logger.info("Confluence sub-step: empty space key, skipping")
                 return {}
 
-            # Verify the token with a pulsing border while the API call runs.
+            # Verify the space with a pulsing border while the API call runs.
             verify_result: list[tuple[bool, str]] = []
 
             def _do_verify():
-                verify_result.append(_verify_notion(token))
+                verify_result.append(_verify_confluence(base_url, email, token, space_key))
 
             thread = threading.Thread(target=_do_verify, daemon=True)
             thread.start()
@@ -179,7 +196,7 @@ def _run_notion(
             ok, msg = verify_result[0]
 
             if ok:
-                # Green success flash, matching the Jira/VC verify animation.
+                # Green success flash, matching the Notion/Jira verify animation.
                 green_r, green_g, green_b = 80, 220, 120
                 for frame in range(10):
                     t = frame / 9
@@ -195,21 +212,23 @@ def _run_notion(
                 _render(verified={i: True for i in range(n)})
                 time.sleep(0.6)
 
-                notion_data = {}
+                confluence_data = {}
                 for i, field in enumerate(fields):
                     val = values.get(i, "").strip()
                     if val:
-                        notion_data[field["env_var"]] = val
-                _save_progress(notion_data)
-                return notion_data
+                        confluence_data[field["env_var"]] = val
+                _save_progress(confluence_data)
+                logger.info("Confluence sub-step: saved space key")
+                return confluence_data
 
-            # Verification failed — surface the error on the token field.
+            # Verification failed — surface the error on the space-key field.
             errors[0] = msg
             selected = 0
             _render(errors=errors)
             continue
 
         elif key == "esc":
+            logger.info("Confluence sub-step: user pressed Esc (back)")
             return None
         elif key == "clear":
             values[selected] = ""

--- a/src/scrum_agent/ui/provider_select/_phase_issue_tracking.py
+++ b/src/scrum_agent/ui/provider_select/_phase_issue_tracking.py
@@ -77,7 +77,7 @@ def _run_issue_tracking(
             w, h = console.size
             return _build_screen_frame(
                 subtitle="Issue tracking  ·  ↑↓ choose  ·  Enter select",
-                step=2,
+                step=1,
                 body_items=body,
                 body_height=body_h,
                 width=w,

--- a/src/scrum_agent/ui/provider_select/_verification.py
+++ b/src/scrum_agent/ui/provider_select/_verification.py
@@ -419,6 +419,42 @@ def _verify_jira(base_url: str, email: str, token: str) -> tuple[bool, str]:
         return False, f"Connection error: {e}"
 
 
+def _verify_confluence(base_url: str, email: str, token: str, space_key: str) -> tuple[bool, str]:
+    """Verify a Confluence space is reachable with the Jira Atlassian credentials.
+
+    Confluence Cloud shares the Atlassian account auth used for Jira (base URL +
+    email + API token — see tools/confluence.py); the space key is the only extra
+    input. Hits GET /wiki/rest/api/space/{key} — 200 confirms the space exists and
+    the credentials can read it. Mirrors _verify_jira's basic-auth pattern.
+    """
+    logger.info("Verifying Confluence space '%s'", space_key)
+    try:
+        import base64
+
+        import httpx
+
+        b64 = base64.b64encode(f"{email}:{token}".encode()).decode()
+        url = f"{base_url.rstrip('/')}/wiki/rest/api/space/{space_key}"
+        resp = httpx.get(
+            url,
+            headers={"Authorization": f"Basic {b64}", "Accept": "application/json"},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            logger.info("Confluence space '%s' verified", space_key)
+            return True, "Confluence verified"
+        if resp.status_code in (401, 403):
+            logger.warning("Confluence auth failed for space '%s' (%s)", space_key, resp.status_code)
+            return False, "Invalid Atlassian credentials"
+        if resp.status_code == 404:
+            logger.warning("Confluence space '%s' not found", space_key)
+            return False, f"Space '{space_key}' not found"
+        return False, f"Unexpected response: {resp.status_code}"
+    except Exception as e:
+        logger.warning("Confluence verification error for space '%s': %s", space_key, e)
+        return False, f"Connection error: {e}"
+
+
 def _verify_notion(token: str) -> tuple[bool, str]:
     """Verify a Notion integration token with a lightweight API call.
 

--- a/src/scrum_agent/ui/provider_select/screens/_screens.py
+++ b/src/scrum_agent/ui/provider_select/screens/_screens.py
@@ -23,7 +23,7 @@ from scrum_agent.ui.shared._wordmarks import get_shadow_wordmark
 # Rendering helpers
 # ---------------------------------------------------------------------------
 
-_STEPS = ["LLM Provider", "Issue Tracking", "Version Control"]
+_STEPS = ["LLM Provider", "Issue Tracking", "Docs", "Version Control"]
 
 # Brand blue accent — the same rgb the app's project cards / action buttons and
 # the setup intro wordmark use. Applied to the frame border, title, idle input

--- a/src/scrum_agent/ui/provider_select/screens/_screens_vc.py
+++ b/src/scrum_agent/ui/provider_select/screens/_screens_vc.py
@@ -63,7 +63,7 @@ def _build_vc_select_screen(
 
     return _build_screen_frame(
         subtitle="Version Control",
-        step=1,
+        step=3,
         body_items=body,
         body_height=body_h,
         width=width,
@@ -144,7 +144,7 @@ def _build_vc_input_screen(
 
     return _build_screen_frame(
         subtitle="Enter your PAT token",
-        step=1,
+        step=3,
         body_items=body,
         body_height=body_h,
         width=width,
@@ -237,6 +237,7 @@ def _build_issue_tracking_screen(
     fields: list[dict[str, Any]] | None = None,
     subtitle: str = "Issue tracking",
     title_text: str = "",
+    step: int = 1,
 ) -> Panel:
     """Build the issue tracking multi-field form screen with viewport scrolling.
 
@@ -246,6 +247,9 @@ def _build_issue_tracking_screen(
     fields: optional field definitions to use instead of the default Jira fields.
     subtitle: context line shown under the title (e.g. "Issue tracking", "Docs").
     title_text: tall ANSI-Shadow title (e.g. "Jira", "Notion"). Defaults to "Setup".
+    step: progress-bar step index into ``_STEPS``. This generic form renders both
+        the Issue Tracking step (1) and the Docs step (2, Notion/Confluence), so the
+        active chip is caller-driven rather than hardcoded. Defaults to 1.
     """
     errors = errors or {}
     verified = verified or {}
@@ -320,7 +324,7 @@ def _build_issue_tracking_screen(
 
     return _build_screen_frame(
         subtitle=subtitle,
-        step=2,
+        step=step,
         body_items=body,
         body_height=body_h,
         width=width,

--- a/tests/unit/test_provider_model_select.py
+++ b/tests/unit/test_provider_model_select.py
@@ -16,11 +16,17 @@ from rich.panel import Panel
 from scrum_agent.agent.llm import _PROVIDER_DEFAULTS
 from scrum_agent.setup_wizard import _PROVIDERS, run_setup_wizard
 from scrum_agent.ui.provider_select._constants import _PROVIDER_CARDS
-from scrum_agent.ui.provider_select._verification import _verify_model, fetch_available_models
+from scrum_agent.ui.provider_select._verification import (
+    _verify_confluence,
+    _verify_model,
+    fetch_available_models,
+)
 from scrum_agent.ui.provider_select.screens._screens import (
+    _STEPS,
     _build_model_input_screen,
     _build_model_loading_screen,
     _build_model_select_screen,
+    _build_progress,
     _build_screen_frame,
 )
 from scrum_agent.ui.provider_select.screens._screens_vc import _build_issue_tracking_screen
@@ -347,6 +353,16 @@ class TestIssueTrackingHint:
         )
         assert "Enter to verify" not in out
 
+    def test_docs_step_renders_docs_chip(self):
+        # The shared form is reused for the Docs step (Notion/Confluence); step=2
+        # must surface the "Docs" progress chip in the footer.
+        out = _render(
+            _build_issue_tracking_screen(
+                0, {0: ""}, width=100, height=30, title_text="Confluence", subtitle="Docs", step=2
+            )
+        )
+        assert "Docs" in out
+
 
 class TestNotionPicker:
     """The Notion step offers an explicit Notion / Skip picker (like Issue Tracking)."""
@@ -386,6 +402,127 @@ class TestNotionPicker:
         from scrum_agent.ui.provider_select._phase_notion import _run_notion
 
         assert _run_notion(_console(), _KeySequence(["esc"]), None, _FakeLive()) is None
+
+
+def _active_progress_label(step: int) -> str | None:
+    """Return the label of the chip _build_progress marks active for *step*.
+
+    The active chip is styled ``bold white on <accent>`` (see _build_progress);
+    the done chips use a green bg and future chips a dim grey bg, so the accent
+    background uniquely identifies the active step. This lets the test assert the
+    full step→chip mapping without depending on exact colour constants.
+    """
+    text = _build_progress(step)
+    for span in text.spans:
+        if "on rgb(70,100,180)" in str(span.style):
+            return text.plain[span.start : span.end].strip()
+    return None
+
+
+class TestProgressSteps:
+    """The setup wizard's progress bar has a dedicated 'Docs' chip, correctly indexed."""
+
+    def test_steps_order(self):
+        assert _STEPS == ["LLM Provider", "Issue Tracking", "Docs", "Version Control"]
+
+    @pytest.mark.parametrize(
+        "step,label",
+        [
+            (0, "LLM Provider"),
+            (1, "Issue Tracking"),
+            (2, "Docs"),
+            (3, "Version Control"),
+        ],
+    )
+    def test_active_chip_matches_step(self, step, label):
+        # Regression guard for the step re-indexing: the Notion/Confluence (Docs)
+        # step must highlight "Docs", not "Version Control" (the original bug).
+        assert _active_progress_label(step) == label
+
+
+class TestConfluenceVerify:
+    """_verify_confluence checks a space is reachable with the shared Jira Atlassian auth."""
+
+    def test_success(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200))
+        ok, msg = _verify_confluence("https://org.atlassian.net", "u@x.com", "tok", "SPACE")
+        assert ok is True
+        assert "verified" in msg.lower()
+
+    def test_bad_credentials(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(401))
+        ok, msg = _verify_confluence("https://org.atlassian.net", "u@x.com", "bad", "SPACE")
+        assert ok is False
+        assert "credentials" in msg.lower()
+
+    def test_space_not_found(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(404))
+        ok, msg = _verify_confluence("https://org.atlassian.net", "u@x.com", "tok", "NOPE")
+        assert ok is False
+        assert "NOPE" in msg
+
+    def test_connection_error(self, monkeypatch):
+        import httpx
+
+        def _boom(*a, **kw):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(httpx, "get", _boom)
+        ok, msg = _verify_confluence("https://org.atlassian.net", "u@x.com", "tok", "SPACE")
+        assert ok is False
+        assert "Connection error" in msg
+
+
+class TestConfluencePicker:
+    """The Docs step's Confluence sub-step offers an explicit Confluence / Skip picker."""
+
+    _JIRA = {
+        "JIRA_BASE_URL": "https://org.atlassian.net",
+        "JIRA_EMAIL": "u@x.com",
+        "JIRA_API_TOKEN": "tok",
+    }
+
+    def _patch_tty(self, monkeypatch):
+        import select as _select
+
+        from scrum_agent.ui.provider_select import _phase_confluence as pc
+
+        class _FakeStdin:
+            def fileno(self):
+                return 0
+
+            def read(self, n):
+                return ""
+
+        monkeypatch.setattr(pc.sys, "stdin", _FakeStdin())
+        monkeypatch.setattr(pc.termios, "tcgetattr", lambda fd: None)
+        monkeypatch.setattr(pc.termios, "tcsetattr", lambda fd, when, attrs: None)
+        monkeypatch.setattr(pc.tty, "setcbreak", lambda fd: None)
+        monkeypatch.setattr(_select, "select", lambda r, w, x, t: ([], [], []))
+
+    def test_skip_returns_empty_dict(self, monkeypatch):
+        self._patch_tty(monkeypatch)
+        from scrum_agent.ui.provider_select._phase_confluence import _run_confluence
+
+        live = _FakeLive()
+        # ↓ moves to "Skip", Enter selects it.
+        result = _run_confluence(_console(), _KeySequence(["down", "enter"]), None, live, jira_creds=self._JIRA)
+        assert result == {}
+        rendered = "".join(_render(f) for f in live.frames)
+        assert "█" in rendered and "choose" in rendered
+
+    def test_esc_on_picker_returns_none(self, monkeypatch):
+        self._patch_tty(monkeypatch)
+        from scrum_agent.ui.provider_select._phase_confluence import _run_confluence
+
+        result = _run_confluence(_console(), _KeySequence(["esc"]), None, _FakeLive(), jira_creds=self._JIRA)
+        assert result is None
 
 
 class TestShadowWordmarks:

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -30,15 +30,22 @@ def _mock_inputs(*values):
     return lambda *a, **kw: next(it)
 
 
-def _mock_select_provider(provider_key: str, *, api_key: str = "", issue_tracking: dict | None = None):
+def _mock_select_provider(
+    provider_key: str,
+    *,
+    api_key: str = "",
+    issue_tracking: dict | None = None,
+    confluence: dict | None = None,
+):
     """Return a mock select_provider that returns the provider dict.
 
     provider_key: "1" for Anthropic, "2" for OpenAI, "3" for Google, or None for cancel.
     api_key: optional API key — when set, the wizard skips inline key prompt.
-    issue_tracking: optional dict of Jira/Confluence env vars.
+    issue_tracking: optional dict of Jira env vars.
+    confluence: optional dict of Confluence env vars (collected in the Docs step).
 
     The full-screen select_provider returns a dict with optional keys:
-        api_key, vc_env_var, vc_token, issue_tracking
+        api_key, vc_env_var, vc_token, issue_tracking, notion, confluence
     This mock emulates that so the wizard doesn't need inline prompts.
     """
     if provider_key is None:
@@ -49,6 +56,8 @@ def _mock_select_provider(provider_key: str, *, api_key: str = "", issue_trackin
         p["api_key"] = api_key
     if issue_tracking:
         p["issue_tracking"] = issue_tracking
+    if confluence:
+        p["confluence"] = confluence
     return lambda *a, **kw: p
 
 
@@ -279,16 +288,25 @@ class TestRunSetupWizard:
         assert not any("Confluence" in c for c in calls)
 
     def test_confluence_saves_space_key(self, monkeypatch, tmp_path):
-        """Confluence vars are collected via select_provider's issue tracking phase."""
+        """Confluence is collected in the Docs step (separate from issue tracking).
+
+        The space key rides on the Jira Atlassian creds gathered in the Issue
+        Tracking step, but is returned under its own `confluence` result key.
+        """
         _patch_config_file(monkeypatch, tmp_path)
         issue_tracking = {
             "JIRA_BASE_URL": "https://org.atlassian.net",
             "JIRA_EMAIL": "user@example.com",
             "JIRA_API_TOKEN": "tok",
             "JIRA_PROJECT_KEY": "PROJ",
-            "CONFLUENCE_SPACE_KEY": "MYSPACE",
         }
-        _patch_provider(monkeypatch, "1", api_key="sk-ant-key", issue_tracking=issue_tracking)
+        _patch_provider(
+            monkeypatch,
+            "1",
+            api_key="sk-ant-key",
+            issue_tracking=issue_tracking,
+            confluence={"CONFLUENCE_SPACE_KEY": "MYSPACE"},
+        )
         console = _make_console()
         run_setup_wizard(console)
         content = (tmp_path / ".env").read_text()


### PR DESCRIPTION
## Problem

In the setup wizard (`scrum-agent --setup`), the bottom progress bar showed three chips — **LLM Provider · Issue Tracking · Version Control** — but the wizard has four steps. The optional **Notion** step passed `step=2`, which indexed into `_STEPS[2] = "Version Control"`, so the Notion screen highlighted **"Version Control"** (see reported screenshot). The Issue Tracking (`step=2`) and Version Control (`step=1`) chips were additionally swapped.

## Changes

- **New "Docs" chip.** `_STEPS` is now `["LLM Provider", "Issue Tracking", "Docs", "Version Control"]`, and every screen's `step=` argument is re-indexed so each step highlights its own chip. This also corrects the pre-existing Issue-Tracking/Version-Control swap.
- **Confluence moved into the Docs step.** Previously an optional field tacked onto the Jira form. A new `_phase_confluence` collects the space key and verifies it via a new `_verify_confluence` (reuses the Jira Atlassian creds — `JIRA_BASE_URL/EMAIL/API_TOKEN` — since Confluence has no independent auth). Notion keeps its own token.
- **Gate preserved.** The Confluence sub-step is only offered when Jira was configured in the Issue Tracking step, keeping the prior "only when Jira configured" invariant. No env-var changes (still `CONFLUENCE_SPACE_KEY`).

## Verification

- `make lint` clean; `make test` → **3415 passed, 7 skipped**.
- New tests: full step→chip mapping regression guard, `_verify_confluence` (200/401/404/error), Confluence picker skip/esc, and the relocated Confluence-saves-space-key flow.

Progress bar after the change (active chip per step):
```
step=0 -> LLM Provider     step=1 -> Issue Tracking
step=2 -> Docs             step=3 -> Version Control
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)