### PR TITLE
Setup wizard: connection hints, hint styling, and ←/→ section navigation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scrum-agent"
-version = "2.6.0"
+version = "2.7.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scrum_agent/ui/provider_select/__init__.py
+++ b/src/scrum_agent/ui/provider_select/__init__.py
@@ -20,6 +20,7 @@ from rich.console import Console
 
 from scrum_agent.ui.provider_select._config import _save_progress  # noqa: F401
 from scrum_agent.ui.provider_select._constants import _PROVIDER_CARDS, _VC_OPTIONS
+from scrum_agent.ui.provider_select._nav import StepNav, nav_for_key
 from scrum_agent.ui.provider_select._phase_confluence import _run_confluence  # noqa: F401
 from scrum_agent.ui.provider_select._phase_issue_tracking import _run_issue_tracking  # noqa: F401
 from scrum_agent.ui.provider_select._phase_notion import _run_notion  # noqa: F401
@@ -108,12 +109,19 @@ def select_provider(
 ) -> dict[str, str] | None:
     """Show full-screen provider selection, then API key input with verification.
 
-    Organized as a step-based loop so Esc navigates back between steps:
+    Organized as a step-based loop:
     Step 0: LLM Provider selection + API key verification
     Step 1: Issue Tracking (Jira / Azure DevOps Boards / Skip)
     Step 2: Docs — Notion (own token) then Confluence (shares Jira's Atlassian
             auth, so only shown when Jira was configured). Both optional.
     Step 3: Version Control (GitHub PAT)
+
+    Navigation: Enter advances / confirms and Esc steps back, as before. Step 0
+    (LLM) is a required gate — the returned config dict is seeded from the chosen
+    provider + key. Once past it, the section chips act as a tab bar: on any
+    section's picker, ← / → jump between Issue Tracking, Docs and Version Control
+    (and back to LLM) in any order, and F finishes the wizard from anywhere.
+    Choices are accumulated in a single dict so jumping around never loses them.
 
     Returns a dict compatible with setup_wizard._PROVIDERS values (with an
     added 'api_key' field), or None if the user cancelled.
@@ -137,6 +145,16 @@ def select_provider(
     vc = None
     vc_token = ""
     step = 0
+
+    # The single accumulator for everything the wizard collects. Seeded once the
+    # LLM step completes (see step 0) and then updated slice-by-slice by each
+    # section, so the user can visit Issue Tracking / Docs / Version Control in
+    # any order (← / → between chips) and finish (F) from anywhere without losing
+    # what earlier sections gathered. Returned to setup_wizard as the result.
+    _collected: dict[str, str] = {}
+    # Set when a StepNav jump lands us on a section, so that section skips its
+    # cinematic fade-in transition (which assumes we arrived from the prior step).
+    _via_nav = False
 
     w, h = console.size
     with make_live(
@@ -509,7 +527,24 @@ def select_provider(
                     )
 
                 if _step0_done:
+                    # Seed the accumulator from the LLM choice. setdefault keeps any
+                    # slices (issue_tracking/notion/confluence/vc) already gathered on
+                    # a prior visit, so re-doing the LLM step to change providers never
+                    # wipes the other sections' data.
+                    _collected.update(
+                        {
+                            "name": provider["full_name"],
+                            "env_var": provider["env_var"],
+                            "provider_val": provider["provider_val"],
+                            "prefix": provider["prefix"],
+                            "instructions": provider["instructions"],
+                            "api_key": api_key,
+                            "llm_model": llm_model,
+                        }
+                    )
+                    _collected.setdefault("issue_tracking", {})
                     step = 1
+                    _via_nav = False
                 # else: Esc pressed → loop restarts step 0
                 continue
 
@@ -517,11 +552,15 @@ def select_provider(
             # Step 1: Issue Tracking (Jira / Azure DevOps Boards / Skip)
             # ══════════════════════════════════════════════════════════════
             elif step == 1:
-                # Fade out LLM input, fade in issue tracking
-                for grey in FADE_OUT_LEVELS:
-                    w, h = console.size
-                    live.update(_build_input_screen(provider, api_key, width=w, height=h, input_fade=grey))
-                    time.sleep(FRAME_TIME_30FPS)
+                _arrived_nav = _via_nav
+                _via_nav = False
+                # Fade out LLM input, fade in issue tracking. Skipped when we
+                # arrived via a ←/→ jump (there's no LLM input to fade from).
+                if not _arrived_nav:
+                    for grey in FADE_OUT_LEVELS:
+                        w, h = console.size
+                        live.update(_build_input_screen(provider, api_key, width=w, height=h, input_fade=grey))
+                        time.sleep(FRAME_TIME_30FPS)
 
                 # vc/vc_token not known yet — pass placeholders
                 _dummy_vc = {"env_var": "", "name": ""}
@@ -537,8 +576,14 @@ def select_provider(
                     llm_model=llm_model,
                 )
 
-                if result is not None:
-                    _issue_tracking_result = result
+                if isinstance(result, StepNav):
+                    if result.finish:
+                        disable_bracketed_paste()
+                        return _collected
+                    step = result.target
+                    _via_nav = True
+                elif result is not None:
+                    _collected.update(result)
                     step = 2
                 else:
                     step = 0  # Esc → go back to LLM provider
@@ -548,33 +593,51 @@ def select_provider(
             # Step 2: Docs (Notion + Confluence, both optional)
             # ══════════════════════════════════════════════════════════════
             elif step == 2:
-                # Fade out the previous screen into the Notion form.
-                for grey in FADE_OUT_LEVELS:
-                    w, h = console.size
-                    live.update(_build_input_screen(provider, api_key, width=w, height=h, input_fade=grey))
-                    time.sleep(FRAME_TIME_30FPS)
+                _arrived_nav = _via_nav
+                _via_nav = False
+                # Fade out the previous screen into the Notion form. Skipped on a
+                # ←/→ jump (there's no prior input screen to fade from).
+                if not _arrived_nav:
+                    for grey in FADE_OUT_LEVELS:
+                        w, h = console.size
+                        live.update(_build_input_screen(provider, api_key, width=w, height=h, input_fade=grey))
+                        time.sleep(FRAME_TIME_30FPS)
 
                 notion_result = _run_notion(console, read_key, existing_config, live)
+                if isinstance(notion_result, StepNav):
+                    if notion_result.finish:
+                        disable_bracketed_paste()
+                        return _collected
+                    step = notion_result.target
+                    _via_nav = True
+                    continue
                 if notion_result is None:
                     step = 1  # Esc → go back to issue tracking
                     continue
                 # Empty dict = user skipped (optional). Either way, record.
-                _issue_tracking_result["notion"] = notion_result
+                _collected["notion"] = notion_result
 
                 # Confluence rides on Jira's Atlassian auth, so its sub-step is only
                 # offered when Jira was configured in the Issue Tracking step (the
                 # same "only when Jira configured" invariant Confluence has always
                 # had). If Jira was skipped or Azure DevOps was chosen, skip past.
-                _jira_creds = _issue_tracking_result.get("issue_tracking", {})
+                _jira_creds = _collected.get("issue_tracking", {})
                 _jira_configured = all(_jira_creds.get(k) for k in ("JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"))
                 if _jira_configured:
                     confluence_result = _run_confluence(
                         console, read_key, existing_config, live, jira_creds=_jira_creds
                     )
+                    if isinstance(confluence_result, StepNav):
+                        if confluence_result.finish:
+                            disable_bracketed_paste()
+                            return _collected
+                        step = confluence_result.target
+                        _via_nav = True
+                        continue
                     if confluence_result is None:
                         # Esc from Confluence → re-run the Docs step from the Notion picker.
                         continue
-                    _issue_tracking_result["confluence"] = confluence_result
+                    _collected["confluence"] = confluence_result
 
                 step = 3
                 continue
@@ -583,27 +646,37 @@ def select_provider(
             # Step 3: Version Control (GitHub PAT)
             # ══════════════════════════════════════════════════════════════
             elif step == 3:
+                _arrived_nav = _via_nav
+                _via_nav = False
                 vc_selected = 0
                 vc_n = len(_VC_OPTIONS)
                 vc_start = time.monotonic()
 
-                for grey in FADE_IN_LEVELS:
-                    w, h = console.size
-                    live.update(
-                        _build_vc_select_screen(
-                            vc_selected,
-                            width=w,
-                            height=h,
-                            fade_style=grey,
-                            fade_indices=list(range(vc_n)),
+                if not _arrived_nav:
+                    for grey in FADE_IN_LEVELS:
+                        w, h = console.size
+                        live.update(
+                            _build_vc_select_screen(
+                                vc_selected,
+                                width=w,
+                                height=h,
+                                fade_style=grey,
+                                fade_indices=list(range(vc_n)),
+                            )
                         )
-                    )
-                    time.sleep(FRAME_TIME_30FPS)
+                        time.sleep(FRAME_TIME_30FPS)
 
                 # VC selection loop
                 _step2_selected = False
+                _vc_nav: StepNav | None = None
                 while True:
                     key = read_key(timeout=FRAME_TIME_30FPS) if _supports_timeout else read_key()
+                    # Section navigation (←/→ between chips, F to finish) short-circuits
+                    # the picker just like the other sections.
+                    nav = nav_for_key(key, 3)
+                    if nav is not None:
+                        _vc_nav = nav
+                        break
                     if key in ("up", "scroll_up"):
                         vc_selected = (vc_selected - 1) % vc_n
                     elif key in ("down", "scroll_down"):
@@ -617,6 +690,14 @@ def select_provider(
                     tick = time.monotonic() - vc_start
                     live.update(_build_vc_select_screen(vc_selected, width=w, height=h, shimmer_tick=tick))
 
+                if _vc_nav is not None:
+                    if _vc_nav.finish:
+                        disable_bracketed_paste()
+                        return _collected
+                    step = _vc_nav.target
+                    _via_nav = True
+                    continue
+
                 if not _step2_selected:
                     step = 1
                     continue
@@ -625,10 +706,10 @@ def select_provider(
 
                 # Skip selected — no PAT needed, finish wizard
                 if not vc["env_var"]:
-                    _issue_tracking_result["vc_env_var"] = ""
-                    _issue_tracking_result["vc_token"] = ""
+                    _collected["vc_env_var"] = ""
+                    _collected["vc_token"] = ""
                     disable_bracketed_paste()
-                    return _issue_tracking_result
+                    return _collected
 
                 # Transition: pulse selected, fade others, crossfade to input
                 all_vc = list(range(vc_n))
@@ -800,10 +881,10 @@ def select_provider(
 
                 if _step2_done:
                     # Build final result — merge issue tracking data with VC
-                    _issue_tracking_result["vc_env_var"] = vc["env_var"]
-                    _issue_tracking_result["vc_token"] = vc_token
+                    _collected["vc_env_var"] = vc["env_var"]
+                    _collected["vc_token"] = vc_token
                     disable_bracketed_paste()
-                    return _issue_tracking_result
+                    return _collected
                 else:
                     step = 2  # Esc → go back to Notion
                     continue

--- a/src/scrum_agent/ui/provider_select/_constants.py
+++ b/src/scrum_agent/ui/provider_select/_constants.py
@@ -113,6 +113,8 @@ _VC_OPTIONS: list[dict[str, Any]] = [
 ]
 
 # Issue tracking fields — step 4 (Jira)
+# Each field carries a "hint": a one-line "where to get it" note shown under the
+# focused field, mirroring the LLM/GitHub steps' "Get yours at: …" line.
 _ISSUE_TRACKING_FIELDS: list[dict[str, Any]] = [
     {
         "env_var": "JIRA_BASE_URL",
@@ -120,6 +122,7 @@ _ISSUE_TRACKING_FIELDS: list[dict[str, Any]] = [
         "placeholder": "https://org.atlassian.net",
         "masked": False,
         "required": True,
+        "hint": "Your Atlassian site — https://<your-org>.atlassian.net",
     },
     {
         "env_var": "JIRA_EMAIL",
@@ -127,6 +130,7 @@ _ISSUE_TRACKING_FIELDS: list[dict[str, Any]] = [
         "placeholder": "you@company.com",
         "masked": False,
         "required": True,
+        "hint": "The email you sign in to Atlassian with",
     },
     {
         "env_var": "JIRA_API_TOKEN",
@@ -134,6 +138,7 @@ _ISSUE_TRACKING_FIELDS: list[dict[str, Any]] = [
         "placeholder": "",
         "masked": True,
         "required": True,
+        "hint": "Create at: id.atlassian.com/manage-profile/security/api-tokens",
     },
     {
         "env_var": "JIRA_PROJECT_KEY",
@@ -141,6 +146,7 @@ _ISSUE_TRACKING_FIELDS: list[dict[str, Any]] = [
         "placeholder": "MYPROJ",
         "masked": False,
         "required": True,
+        "hint": "The prefix on issue keys — e.g. MYPROJ in MYPROJ-123",
     },
 ]
 
@@ -152,6 +158,7 @@ _AZDEVOPS_TRACKING_FIELDS: list[dict[str, Any]] = [
         "placeholder": "https://dev.azure.com/myorg",
         "masked": False,
         "required": True,
+        "hint": "Your org — https://dev.azure.com/<your-org>",
     },
     {
         "env_var": "AZURE_DEVOPS_PROJECT",
@@ -159,6 +166,7 @@ _AZDEVOPS_TRACKING_FIELDS: list[dict[str, Any]] = [
         "placeholder": "MyProject",
         "masked": False,
         "required": True,
+        "hint": "The project name as it appears in the Azure DevOps URL",
     },
     {
         "env_var": "AZURE_DEVOPS_TOKEN",
@@ -166,6 +174,7 @@ _AZDEVOPS_TRACKING_FIELDS: list[dict[str, Any]] = [
         "placeholder": "",
         "masked": True,
         "required": True,
+        "hint": "Create at: dev.azure.com → User settings → Personal access tokens",
     },
     {
         "env_var": "AZURE_DEVOPS_TEAM",
@@ -173,6 +182,7 @@ _AZDEVOPS_TRACKING_FIELDS: list[dict[str, Any]] = [
         "placeholder": "MyProject Team",
         "masked": False,
         "required": False,
+        "hint": "Optional — defaults to '<Project> Team' if left blank",
     },
 ]
 
@@ -199,6 +209,7 @@ _NOTION_FIELDS: list[dict[str, Any]] = [
         "placeholder": "ntn_… / secret_…",
         "masked": True,
         "required": False,
+        "hint": "Create at: notion.so/my-integrations, then share your pages with it",
     },
     {
         "env_var": "NOTION_ROOT_PAGE_ID",
@@ -206,6 +217,7 @@ _NOTION_FIELDS: list[dict[str, Any]] = [
         "placeholder": "",
         "masked": False,
         "required": False,
+        "hint": "The 32-char id at the end of the page's Notion URL",
     },
 ]
 
@@ -220,5 +232,6 @@ _CONFLUENCE_FIELDS: list[dict[str, Any]] = [
         "placeholder": "MYSPACE",
         "masked": False,
         "required": False,
+        "hint": "The <KEY> in your space URL /wiki/spaces/<KEY> — reuses your Jira login",
     },
 ]

--- a/src/scrum_agent/ui/provider_select/_nav.py
+++ b/src/scrum_agent/ui/provider_select/_nav.py
@@ -1,0 +1,63 @@
+"""Section navigation for the setup wizard's step state machine.
+
+# See README: "Architecture" — the setup wizard (``select_provider``) is a step
+# state machine that, by default, runs LLM Provider → Issue Tracking → Docs →
+# Version Control in order. This module lets the user move between those sections
+# with the ← / → arrow keys (a "tab bar" over the progress chips) and finish from
+# anywhere with F, instead of only advancing linearly.
+#
+# The mechanism is a small sentinel: a phase's picker loop calls ``nav_for_key``
+# on each keypress and, when it returns a ``StepNav``, hands that back to the main
+# loop instead of a result dict. The main loop then jumps to ``target`` (or
+# returns the collected config when ``finish`` is set). The LLM step stays a
+# required gate — the master config dict is seeded from the provider + key — so
+# free movement is offered only once the LLM step is done.
+"""
+
+from __future__ import annotations
+
+# Step indices — mirror ``_STEPS`` in ``screens/_screens.py``.
+_STEP_LLM = 0
+_STEP_ISSUE_TRACKING = 1
+_STEP_DOCS = 2
+_STEP_VERSION_CONTROL = 3
+_LAST_STEP = _STEP_VERSION_CONTROL
+
+
+class StepNav:
+    """A phase returns this (instead of its result dict) when the user pressed a
+    section-switch key. ``target`` is the step index to jump to; ``finish`` is
+    True when the user asked to finish the wizard from the current section.
+    """
+
+    __slots__ = ("target", "finish")
+
+    def __init__(self, target: int | None = None, *, finish: bool = False):
+        self.target = target
+        self.finish = finish
+
+    def __eq__(self, other: object) -> bool:
+        # Value equality keeps the unit tests (and any de-dup) straightforward.
+        return isinstance(other, StepNav) and other.target == self.target and other.finish == self.finish
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid only
+        return f"StepNav(target={self.target}, finish={self.finish})"
+
+
+def nav_for_key(key: str, current_step: int) -> StepNav | None:
+    """Map a raw keypress to a section-navigation intent, or ``None``.
+
+    - ``F`` → finish the wizard from here (``StepNav(finish=True)``).
+    - ``←`` → previous chip, clamped so it never goes below ``_STEP_LLM``.
+    - ``→`` → next chip, clamped so it never goes past ``_LAST_STEP``.
+
+    Any other key (or an arrow at the clamp boundary) returns ``None`` so the
+    caller falls through to its own ↑/↓/Enter/Esc/typing handling.
+    """
+    if key in ("f", "F"):
+        return StepNav(finish=True)
+    if key == "left" and current_step > _STEP_LLM:
+        return StepNav(target=current_step - 1)
+    if key == "right" and current_step < _LAST_STEP:
+        return StepNav(target=current_step + 1)
+    return None

--- a/src/scrum_agent/ui/provider_select/_phase_confluence.py
+++ b/src/scrum_agent/ui/provider_select/_phase_confluence.py
@@ -26,6 +26,7 @@ from rich.live import Live
 
 from scrum_agent.ui.provider_select._config import _save_progress
 from scrum_agent.ui.provider_select._constants import _CONFLUENCE_FIELDS
+from scrum_agent.ui.provider_select._nav import StepNav, nav_for_key
 from scrum_agent.ui.provider_select._verification import _verify_confluence
 from scrum_agent.ui.provider_select.screens._screens import (
     _ACCENT,
@@ -49,7 +50,7 @@ def _run_confluence(
     live: Live,
     *,
     jira_creds: dict[str, str],
-) -> dict[str, str] | None:
+) -> dict[str, str] | StepNav | None:
     """Show the optional Confluence space-key form and verify it.
 
     Shows a Confluence / Skip picker first (matching the Notion & Issue Tracking
@@ -94,8 +95,8 @@ def _run_confluence(
     # --- Step 1: Confluence / Skip picker (matches the Notion & Issue Tracking
     # steps, which both offer an explicit Skip rather than making the user guess
     # that an empty submit skips the step). ---
-    def _run_confluence_selection() -> str | None:
-        """Show the Confluence / Skip picker. Returns "confluence", "skip", or None (Esc)."""
+    def _run_confluence_selection() -> str | StepNav | None:
+        """Show the Confluence / Skip picker. Returns "confluence"/"skip", a StepNav (←/→/F), or None (Esc)."""
         cards = [{"name": "Confluence", "color": _ACCENT}, {"name": "Skip", "color": _ACCENT}]
         pick = 0
 
@@ -108,7 +109,7 @@ def _run_confluence(
             w, h = console.size
             live.update(
                 _build_screen_frame(
-                    subtitle="Docs  ·  ↑↓ choose  ·  Enter select",
+                    subtitle="Docs · ↑↓ choose · Enter select · ←→ section · F finish",
                     step=_DOCS_STEP,
                     body_items=body,
                     body_height=body_h,
@@ -122,6 +123,11 @@ def _run_confluence(
         _render_menu()
         while True:
             key = read_key()
+            # Section navigation (←/→ between chips, F to finish) short-circuits
+            # the picker so the user can leave the Docs step without choosing.
+            nav = nav_for_key(key, _DOCS_STEP)
+            if nav is not None:
+                return nav
             if key in ("up", "scroll_up"):
                 pick = (pick - 1) % len(cards)
             elif key in ("down", "scroll_down"):
@@ -133,6 +139,9 @@ def _run_confluence(
             _render_menu()
 
     choice = _run_confluence_selection()
+    if isinstance(choice, StepNav):
+        logger.info("Confluence sub-step: section navigation (%r)", choice)
+        return choice
     if choice is None:
         logger.info("Confluence sub-step: user pressed Esc (back)")
         return None

--- a/src/scrum_agent/ui/provider_select/_phase_issue_tracking.py
+++ b/src/scrum_agent/ui/provider_select/_phase_issue_tracking.py
@@ -19,6 +19,7 @@ from rich.live import Live
 
 from scrum_agent.ui.provider_select._config import _save_progress
 from scrum_agent.ui.provider_select._constants import _ISSUE_TRACKING_OPTIONS
+from scrum_agent.ui.provider_select._nav import StepNav, nav_for_key
 from scrum_agent.ui.provider_select._verification import _verify_azdevops, _verify_jira
 from scrum_agent.ui.provider_select.screens._screens_vc import _build_issue_tracking_screen
 from scrum_agent.ui.shared._animations import FRAME_TIME_30FPS
@@ -36,7 +37,7 @@ def _run_issue_tracking(
     *,
     live: Live | None = None,
     llm_model: str = "",
-) -> dict[str, str] | None:
+) -> dict[str, str] | StepNav | None:
     """Run the issue tracking phase with provider selection.
 
     First shows a provider picker (Jira / Azure DevOps Boards / Skip),
@@ -59,8 +60,8 @@ def _run_issue_tracking(
     ]
     tracker_selected = 0
 
-    def _run_tracker_selection(_live: Live) -> int | None:
-        """Show tracker provider picker. Returns index or None on Esc."""
+    def _run_tracker_selection(_live: Live) -> int | StepNav | None:
+        """Show tracker provider picker. Returns index, a StepNav (←/→/F), or None on Esc."""
         nonlocal tracker_selected
         from rich.align import Align
         from rich.text import Text
@@ -76,7 +77,7 @@ def _run_issue_tracking(
             body_h = len(rows) * 3 - 1 if rows else 0
             w, h = console.size
             return _build_screen_frame(
-                subtitle="Issue tracking  ·  ↑↓ choose  ·  Enter select",
+                subtitle="Issue tracking · ↑↓ choose · Enter select · ←→ section · F finish",
                 step=1,
                 body_items=body,
                 body_height=body_h,
@@ -99,6 +100,11 @@ def _run_issue_tracking(
         _live.update(_render_tracker_menu())
         while True:
             key = read_key()
+            # Section navigation (←/→ between chips, F to finish) takes priority
+            # over the menu's own ↑/↓/Enter so the user can jump straight out.
+            nav = nav_for_key(key, 1)
+            if nav is not None:
+                return nav
             if key in ("up", "scroll_up"):
                 tracker_selected = (tracker_selected - 1) % len(tracker_options)
             elif key in ("down", "scroll_down"):
@@ -357,8 +363,10 @@ def _run_issue_tracking(
                 )
             )
 
-    def _run_full(_live: Live) -> dict[str, str] | None:
+    def _run_full(_live: Live) -> dict[str, str] | StepNav | None:
         tracker_idx = _run_tracker_selection(_live)
+        if isinstance(tracker_idx, StepNav):
+            return tracker_idx
         if tracker_idx is None:
             return None
         return _run_form(_live, tracker_idx)

--- a/src/scrum_agent/ui/provider_select/_phase_notion.py
+++ b/src/scrum_agent/ui/provider_select/_phase_notion.py
@@ -24,6 +24,7 @@ from rich.live import Live
 
 from scrum_agent.ui.provider_select._config import _save_progress
 from scrum_agent.ui.provider_select._constants import _NOTION_FIELDS
+from scrum_agent.ui.provider_select._nav import StepNav, nav_for_key
 from scrum_agent.ui.provider_select._verification import _verify_notion
 from scrum_agent.ui.provider_select.screens._screens import (
     _ACCENT,
@@ -42,7 +43,7 @@ def _run_notion(
     read_key,
     existing_config: dict[str, str] | None,
     live: Live,
-) -> dict[str, str] | None:
+) -> dict[str, str] | StepNav | None:
     """Show the optional Notion credential form and verify the token.
 
     Shows a Notion / Skip picker first (matching the Issue Tracking & Version
@@ -80,8 +81,8 @@ def _run_notion(
     # --- Step 1: Notion / Skip picker (matches the Issue Tracking & Version
     # Control steps, which both offer an explicit Skip rather than making the user
     # guess that an empty submit skips the step). ---
-    def _run_notion_selection() -> str | None:
-        """Show the Notion / Skip picker. Returns "notion", "skip", or None (Esc)."""
+    def _run_notion_selection() -> str | StepNav | None:
+        """Show the Notion / Skip picker. Returns "notion"/"skip", a StepNav (←/→/F), or None (Esc)."""
         cards = [{"name": "Notion", "color": _ACCENT}, {"name": "Skip", "color": _ACCENT}]
         pick = 0
 
@@ -94,7 +95,7 @@ def _run_notion(
             w, h = console.size
             live.update(
                 _build_screen_frame(
-                    subtitle="Docs  ·  ↑↓ choose  ·  Enter select",
+                    subtitle="Docs · ↑↓ choose · Enter select · ←→ section · F finish",
                     step=2,
                     body_items=body,
                     body_height=body_h,
@@ -108,6 +109,11 @@ def _run_notion(
         _render_menu()
         while True:
             key = read_key()
+            # Section navigation (←/→ between chips, F to finish) short-circuits
+            # the picker so the user can leave the Docs step without choosing.
+            nav = nav_for_key(key, 2)
+            if nav is not None:
+                return nav
             if key in ("up", "scroll_up"):
                 pick = (pick - 1) % len(cards)
             elif key in ("down", "scroll_down"):
@@ -119,6 +125,8 @@ def _run_notion(
             _render_menu()
 
     choice = _run_notion_selection()
+    if isinstance(choice, StepNav):
+        return choice
     if choice is None:
         return None
     if choice == "skip":

--- a/src/scrum_agent/ui/provider_select/screens/_screens_vc.py
+++ b/src/scrum_agent/ui/provider_select/screens/_screens_vc.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from rich.align import Align
@@ -21,6 +22,40 @@ from scrum_agent.ui.provider_select.screens._screens import (
     _build_provider_row,
     _build_screen_frame,
 )
+
+# Field-hint palette. The where-to-get-it line is styled as *help*, distinct from
+# the pure-dim keyboard footer and the red error line: an accent-blue info glyph,
+# soft blue-grey lead-in text, and a brighter/underlined URL so the eye lands on
+# the actionable part.
+_HINT_MUTED = "rgb(120,130,150)"
+_HINT_URL = "rgb(140,170,235)"
+
+# Matches the first URL / domain-path token in a hint (the actionable bit): a
+# full http(s) URL, or a lowercase domain (any 2+ letter TLD — .com, .so, .net…)
+# with an optional path. Bounded by whitespace/commas so trailing prose
+# ("…, then share …") isn't swallowed, and lowercase-only so uppercase prose like
+# "MYPROJ-123" never false-matches.
+_HINT_URL_RE = re.compile(r"https?://[^\s,]+|[a-z0-9][a-z0-9.-]*\.[a-z]{2,}(?:/[^\s,]*)?")
+
+
+def _build_hint_text(hint: str) -> Text:
+    """Render a where-to-get-it hint with an info glyph and emphasized URL.
+
+    The leading ``ⓘ`` glyph (accent blue) flags the line as help; the lead-in
+    prose is soft blue-grey; any URL/domain token is brightened + underlined so
+    the actionable part stands out. Hints without a URL render entirely in the
+    muted style. Pure rendering — returns a centered Rich ``Text``.
+    """
+    text = Text(justify="center")
+    text.append("ⓘ  ", style=_ACCENT)  # ⓘ info glyph
+    match = _HINT_URL_RE.search(hint)
+    if match:
+        text.append(hint[: match.start()], style=_HINT_MUTED)
+        text.append(match.group(0), style=f"{_HINT_URL} underline")
+        text.append(hint[match.end() :], style=_HINT_MUTED)
+    else:
+        text.append(hint, style=_HINT_MUTED)
+    return text
 
 
 def _build_vc_select_screen(
@@ -315,7 +350,7 @@ def _build_issue_tracking_screen(
         # (border_overrides) so those states read cleanly.
         hint = field.get("hint", "")
         if hint and is_active and not err and not border_overrides:
-            body.append(Text(hint, style="dim", justify="center"))
+            body.append(_build_hint_text(hint))
             body_h += 1
 
     # Keyboard hint — makes editing/clearing/skipping discoverable, matching the

--- a/src/scrum_agent/ui/provider_select/screens/_screens_vc.py
+++ b/src/scrum_agent/ui/provider_select/screens/_screens_vc.py
@@ -308,6 +308,16 @@ def _build_issue_tracking_screen(
             body.append(Text(f"  {err}", style="bright_red", justify="center"))
             body_h += 1
 
+        # Where-to-get-it hint for the focused field — mirrors the LLM and
+        # GitHub steps, which show a "Get yours at: …" line. Only the active
+        # field's hint is shown (keeps the stack uncluttered); it's suppressed
+        # while an error is on screen or the verify animation is running
+        # (border_overrides) so those states read cleanly.
+        hint = field.get("hint", "")
+        if hint and is_active and not err and not border_overrides:
+            body.append(Text(hint, style="dim", justify="center"))
+            body_h += 1
+
     # Keyboard hint — makes editing/clearing/skipping discoverable, matching the
     # LLM API-key screen. Hidden while verifying (border_overrides drives the
     # pulse + success flash) so the animation reads cleanly.

--- a/tests/unit/test_provider_model_select.py
+++ b/tests/unit/test_provider_model_select.py
@@ -22,6 +22,12 @@ from scrum_agent.ui.provider_select._constants import (
     _NOTION_FIELDS,
     _PROVIDER_CARDS,
 )
+from scrum_agent.ui.provider_select._nav import (
+    _LAST_STEP,
+    _STEP_LLM,
+    StepNav,
+    nav_for_key,
+)
 from scrum_agent.ui.provider_select._verification import (
     _verify_confluence,
     _verify_model,
@@ -454,6 +460,99 @@ class TestHintStyling:
         assert not any("underline" in str(s.style) for s in t.spans)
 
 
+class TestIssueTrackingPickerNav:
+    """The Issue Tracking picker also honours ←/→/F section navigation."""
+
+    _PROVIDER = {
+        "full_name": "Anthropic (Claude)",
+        "name": "Anthropic",
+        "env_var": "ANTHROPIC_API_KEY",
+        "provider_val": "anthropic",
+        "prefix": "sk-ant-",
+        "instructions": "x",
+    }
+
+    def _patch_tty(self, monkeypatch):
+        import select as _select
+
+        from scrum_agent.ui.provider_select import _phase_issue_tracking as it
+
+        class _FakeStdin:
+            def fileno(self):
+                return 0
+
+            def read(self, n):
+                return ""
+
+        monkeypatch.setattr(it.sys, "stdin", _FakeStdin())
+        monkeypatch.setattr(it.termios, "tcgetattr", lambda fd: None)
+        monkeypatch.setattr(it.termios, "tcsetattr", lambda fd, when, attrs: None)
+        monkeypatch.setattr(it.tty, "setcbreak", lambda fd: None)
+        monkeypatch.setattr(_select, "select", lambda r, w, x, t: ([], [], []))
+
+    def _run(self, monkeypatch, keys):
+        self._patch_tty(monkeypatch)
+        from scrum_agent.ui.provider_select._phase_issue_tracking import _run_issue_tracking
+
+        return _run_issue_tracking(
+            _console(),
+            _KeySequence(keys),
+            None,
+            self._PROVIDER,
+            "sk-ant-key",
+            {"env_var": "", "name": ""},
+            "",
+            live=_FakeLive(),
+            llm_model="claude-opus-4-8",
+        )
+
+    def test_right_arrow_navigates_to_docs(self, monkeypatch):
+        # Issue Tracking is step 1 → → jumps to Docs (step 2).
+        assert self._run(monkeypatch, ["right"]) == StepNav(target=2)
+
+    def test_left_arrow_navigates_to_llm(self, monkeypatch):
+        assert self._run(monkeypatch, ["left"]) == StepNav(target=0)
+
+    def test_f_finishes(self, monkeypatch):
+        assert self._run(monkeypatch, ["f"]) == StepNav(finish=True)
+
+    def test_esc_still_returns_none(self, monkeypatch):
+        assert self._run(monkeypatch, ["esc"]) is None
+
+
+class TestStepNav:
+    """`nav_for_key` maps ←/→/F to section jumps, clamped to the chip range."""
+
+    def test_f_finishes_from_any_step(self):
+        for step in range(4):
+            assert nav_for_key("f", step) == StepNav(finish=True)
+        # Upper-case F (some terminals) also finishes.
+        assert nav_for_key("F", 2) == StepNav(finish=True)
+
+    def test_left_goes_to_previous_chip(self):
+        assert nav_for_key("left", 1) == StepNav(target=0)
+        assert nav_for_key("left", 3) == StepNav(target=2)
+
+    def test_right_goes_to_next_chip(self):
+        assert nav_for_key("right", 0) == StepNav(target=1)
+        assert nav_for_key("right", 2) == StepNav(target=3)
+
+    def test_arrows_clamp_at_boundaries(self):
+        # ← at the first chip and → at the last chip do nothing (fall through).
+        assert nav_for_key("left", _STEP_LLM) is None
+        assert nav_for_key("right", _LAST_STEP) is None
+
+    def test_non_nav_keys_fall_through(self):
+        for key in ("up", "down", "enter", "esc", "a", "tab", "backspace"):
+            assert nav_for_key(key, 2) is None
+
+    def test_stepnav_equality_and_defaults(self):
+        assert StepNav(target=2) == StepNav(target=2)
+        assert StepNav(target=2) != StepNav(target=3)
+        assert StepNav(finish=True) != StepNav(target=None)
+        assert StepNav(target=1).finish is False
+
+
 class TestNotionPicker:
     """The Notion step offers an explicit Notion / Skip picker (like Issue Tracking)."""
 
@@ -492,6 +591,28 @@ class TestNotionPicker:
         from scrum_agent.ui.provider_select._phase_notion import _run_notion
 
         assert _run_notion(_console(), _KeySequence(["esc"]), None, _FakeLive()) is None
+
+    def test_right_arrow_navigates_to_version_control(self, monkeypatch):
+        # Docs is step 2 → → jumps to Version Control (step 3).
+        self._patch_tty(monkeypatch)
+        from scrum_agent.ui.provider_select._phase_notion import _run_notion
+
+        result = _run_notion(_console(), _KeySequence(["right"]), None, _FakeLive())
+        assert result == StepNav(target=3)
+
+    def test_left_arrow_navigates_to_issue_tracking(self, monkeypatch):
+        self._patch_tty(monkeypatch)
+        from scrum_agent.ui.provider_select._phase_notion import _run_notion
+
+        result = _run_notion(_console(), _KeySequence(["left"]), None, _FakeLive())
+        assert result == StepNav(target=1)
+
+    def test_f_finishes(self, monkeypatch):
+        self._patch_tty(monkeypatch)
+        from scrum_agent.ui.provider_select._phase_notion import _run_notion
+
+        result = _run_notion(_console(), _KeySequence(["f"]), None, _FakeLive())
+        assert result == StepNav(finish=True)
 
 
 def _active_progress_label(step: int) -> str | None:
@@ -613,6 +734,20 @@ class TestConfluencePicker:
 
         result = _run_confluence(_console(), _KeySequence(["esc"]), None, _FakeLive(), jira_creds=self._JIRA)
         assert result is None
+
+    def test_right_arrow_navigates_to_version_control(self, monkeypatch):
+        self._patch_tty(monkeypatch)
+        from scrum_agent.ui.provider_select._phase_confluence import _run_confluence
+
+        result = _run_confluence(_console(), _KeySequence(["right"]), None, _FakeLive(), jira_creds=self._JIRA)
+        assert result == StepNav(target=3)
+
+    def test_f_finishes(self, monkeypatch):
+        self._patch_tty(monkeypatch)
+        from scrum_agent.ui.provider_select._phase_confluence import _run_confluence
+
+        result = _run_confluence(_console(), _KeySequence(["f"]), None, _FakeLive(), jira_creds=self._JIRA)
+        assert result == StepNav(finish=True)
 
 
 class TestShadowWordmarks:

--- a/tests/unit/test_provider_model_select.py
+++ b/tests/unit/test_provider_model_select.py
@@ -35,7 +35,7 @@ from scrum_agent.ui.provider_select.screens._screens import (
     _build_progress,
     _build_screen_frame,
 )
-from scrum_agent.ui.provider_select.screens._screens_vc import _build_issue_tracking_screen
+from scrum_agent.ui.provider_select.screens._screens_vc import _build_hint_text, _build_issue_tracking_screen
 from scrum_agent.ui.shared._wordmarks import get_shadow_wordmark
 
 # ---------------------------------------------------------------------------
@@ -420,6 +420,38 @@ class TestConnectionFieldHints:
     def test_all_fields_have_hints(self, fields):
         for field in fields:
             assert field.get("hint"), f"{field['env_var']} is missing a where-to-get-it hint"
+
+
+class TestHintStyling:
+    """`_build_hint_text` renders the info glyph + emphasized URL treatment."""
+
+    def test_glyph_prefixes_the_line(self):
+        t = _build_hint_text("Create at: id.atlassian.com/x/api-tokens")
+        assert t.plain.startswith("ⓘ")
+
+    def test_url_is_emphasized_and_underlined(self):
+        t = _build_hint_text("Create at: id.atlassian.com/x/api-tokens")
+        # The URL token keeps its plain text intact...
+        assert "id.atlassian.com/x/api-tokens" in t.plain
+        # ...and is rendered underlined (emphasis) via a dedicated span.
+        assert any("underline" in str(s.style) for s in t.spans)
+
+    def test_https_url_emphasized(self):
+        t = _build_hint_text("Your org — https://dev.azure.com/<your-org>")
+        assert any("underline" in str(s.style) and "dev.azure.com" in t.plain[s.start : s.end] for s in t.spans)
+
+    def test_trailing_prose_not_swallowed_by_url(self):
+        # "notion.so/my-integrations, then share …" — the comma bounds the URL so
+        # the trailing instruction stays in the muted (non-underlined) style.
+        t = _build_hint_text("Create at: notion.so/my-integrations, then share your pages with it")
+        underlined = [t.plain[s.start : s.end] for s in t.spans if "underline" in str(s.style)]
+        assert underlined == ["notion.so/my-integrations"]
+
+    def test_no_url_renders_without_underline(self):
+        t = _build_hint_text("The email you sign in to Atlassian with")
+        assert "ⓘ" in t.plain
+        assert "Atlassian" in t.plain
+        assert not any("underline" in str(s.style) for s in t.spans)
 
 
 class TestNotionPicker:

--- a/tests/unit/test_provider_model_select.py
+++ b/tests/unit/test_provider_model_select.py
@@ -15,7 +15,13 @@ from rich.panel import Panel
 
 from scrum_agent.agent.llm import _PROVIDER_DEFAULTS
 from scrum_agent.setup_wizard import _PROVIDERS, run_setup_wizard
-from scrum_agent.ui.provider_select._constants import _PROVIDER_CARDS
+from scrum_agent.ui.provider_select._constants import (
+    _AZDEVOPS_TRACKING_FIELDS,
+    _CONFLUENCE_FIELDS,
+    _ISSUE_TRACKING_FIELDS,
+    _NOTION_FIELDS,
+    _PROVIDER_CARDS,
+)
 from scrum_agent.ui.provider_select._verification import (
     _verify_confluence,
     _verify_model,
@@ -362,6 +368,58 @@ class TestIssueTrackingHint:
             )
         )
         assert "Docs" in out
+
+    def test_active_field_shows_where_to_get_hint(self):
+        # The focused field surfaces its "where to get it" hint, like the LLM and
+        # GitHub steps. Field 2 = JIRA_API_TOKEN → the token-creation URL.
+        out = _render(
+            _build_issue_tracking_screen(2, {}, width=100, height=30, fields=_ISSUE_TRACKING_FIELDS, title_text="Jira")
+        )
+        assert "id.atlassian.com" in out
+
+    def test_where_to_get_hint_hidden_while_verifying(self):
+        # The verify pulse / success flash (border_overrides) should read cleanly —
+        # the where-to-get hint is suppressed just like the keyboard hint.
+        out = _render(
+            _build_issue_tracking_screen(
+                2,
+                {},
+                width=100,
+                height=30,
+                fields=_ISSUE_TRACKING_FIELDS,
+                title_text="Jira",
+                border_overrides={2: "rgb(1,1,1)"},
+            )
+        )
+        assert "id.atlassian.com" not in out
+
+    def test_error_replaces_where_to_get_hint(self):
+        # A validation error on the active field takes the slot instead of the hint.
+        out = _render(
+            _build_issue_tracking_screen(
+                2,
+                {},
+                width=100,
+                height=30,
+                fields=_ISSUE_TRACKING_FIELDS,
+                title_text="Jira",
+                errors={2: "Invalid token"},
+            )
+        )
+        assert "Invalid token" in out
+        assert "id.atlassian.com" not in out
+
+
+class TestConnectionFieldHints:
+    """Every connection field carries a non-empty 'where to get it' hint."""
+
+    @pytest.mark.parametrize(
+        "fields",
+        [_ISSUE_TRACKING_FIELDS, _AZDEVOPS_TRACKING_FIELDS, _NOTION_FIELDS, _CONFLUENCE_FIELDS],
+    )
+    def test_all_fields_have_hints(self, fields):
+        for field in fields:
+            assert field.get("hint"), f"{field['env_var']} is missing a where-to-get-it hint"
 
 
 class TestNotionPicker:


### PR DESCRIPTION
Three related improvements to the `scrum-agent --setup` wizard.

## 1. Where-to-get-it hints on connection fields
The LLM-provider and GitHub steps already showed a "Get yours at: …" line, but the Jira / Azure DevOps and Notion / Confluence forms rendered bare input boxes. Each field now carries a per-field hint (the token-creation URL, integration page, space-key location, etc.), shown under the **active** field only — suppressed while an error or the verify animation is on screen.

## 2. Polished hint styling
The hint was flat `dim` text. It now gets a branded help treatment via `_build_hint_text`: an accent-blue `ⓘ` glyph, soft blue-grey lead-in, and the URL/action brightened + underlined so the eye lands on the actionable part. URL detection handles `https://…` and domain-paths (incl. `notion.so`), stopping at commas so trailing prose stays muted; prose-only hints render fully muted.

## 3. ←/→ section navigation + F to finish
The wizard ran LLM → Issue Tracking → Docs → Version Control strictly in order. The progress chips are now a **tab bar**: from any section's picker, ←/→ jump between Issue Tracking, Docs and Version Control (and back to LLM), and **F** finishes from anywhere.

- **LLM stays a required gate** — the result config is seeded from the chosen provider + key.
- That seeding now happens once, into a single persistent `_collected` dict each section updates slice-by-slice, so jumping around never loses earlier choices.
- New `_nav.StepNav` + `nav_for_key` map ←/→/F, intercepted in every phase picker (not in text-entry forms, so typing `f` still types). Section jumps skip the fade transition so movement stays snappy.

## Tests
- Full suite green: **3442 passed, 7 skipped**; `make lint` + format clean.
- Added coverage for: every connection field having a hint; the glyph + URL-underline styling (incl. `https`, comma-bounding, no-URL cases); and `nav_for_key` mapping/clamping plus each picker returning the correct `StepNav` on ←/→/F while Esc/skip behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)