### PR TITLE
make voice install hint install-method-aware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.8.0"
+version = "2.8.1"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/setup_wizard.py
+++ b/src/yeaboi/setup_wizard.py
@@ -273,15 +273,16 @@ def run_setup_wizard(console: Console) -> bool:
     # new users discover they can dictate answers instead of typing. Skipped
     # entirely when the user has switched tips off.
     from yeaboi.config import is_tips_enabled
-    from yeaboi.voice import is_voice_available
+    from yeaboi.voice import is_voice_available, voice_install_command
 
     if is_tips_enabled():
         if is_voice_available():
             console.print("[dim]🎤 Voice input is ready — double-tap Space in any text field to dictate.[/dim]")
         else:
+            cmd = voice_install_command()
             console.print(
                 "[dim]🎤 Tip: enable voice input to dictate answers — "
-                "run [/dim][cyan]uv sync --extra voice[/cyan][dim] (works offline, any LLM provider).[/dim]"
+                f"run [/dim][cyan]{cmd}[/cyan][dim] (works offline, any LLM provider).[/dim]"
             )
 
     logger.info("Setup wizard completed successfully")

--- a/src/yeaboi/ui/session/screens/_screens_input.py
+++ b/src/yeaboi/ui/session/screens/_screens_input.py
@@ -32,7 +32,7 @@ def _voice_hint() -> str:
     hint too (the double-tap Space shortcut still works regardless).
     """
     from yeaboi.config import is_tips_enabled
-    from yeaboi.voice import is_voice_available
+    from yeaboi.voice import is_voice_available, voice_install_command
 
     if not is_tips_enabled():
         return ""
@@ -40,7 +40,7 @@ def _voice_hint() -> str:
     available, _reason = is_voice_available()
     if available:
         return " · \U0001f3a4 double-tap Space to speak"
-    return " · \U0001f3a4 dictate: uv sync --extra voice"
+    return f" · \U0001f3a4 dictate: {voice_install_command()}"
 
 
 # ---------------------------------------------------------------------------

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -49,13 +49,13 @@ def get_tips() -> tuple[str, ...]:
     process.
     """
     from yeaboi.music import is_music_available
-    from yeaboi.voice import is_voice_available
+    from yeaboi.voice import is_voice_available, voice_install_command
 
     available, _reason = is_voice_available()
     voice_tip = (
         "\U0001f3a4 Tip: double-tap Space in any text field to dictate"
         if available
-        else "\U0001f3a4 Tip: enable dictation with — uv sync --extra voice"
+        else f"\U0001f3a4 Tip: enable dictation with — {voice_install_command()}"
     )
     music_available, _music_reason = is_music_available()
     music_tip = (

--- a/src/yeaboi/ui/shared/_voice_input.py
+++ b/src/yeaboi/ui/shared/_voice_input.py
@@ -101,7 +101,7 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
     background thread while animating, and returns the transcript. Returns None
     on cancel, no speech, or error (errors are logged and shown briefly).
     """
-    from yeaboi.voice import Recorder, is_model_loaded, is_voice_available, transcribe
+    from yeaboi.voice import Recorder, is_model_loaded, is_voice_available, transcribe, voice_install_command
 
     def _paint(status: str, tick: float) -> None:
         if render_status is not None:
@@ -183,7 +183,7 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
 
     if error[0] is not None:
         logger.warning("Transcription failed", exc_info=error[0])
-        _flash(live, console, _key, "Transcription failed — see logs (try: uv sync --extra voice)", _ERR_BORDER)
+        _flash(live, console, _key, f"Transcription failed — see logs (try: {voice_install_command()})", _ERR_BORDER)
         return None
 
     text = result[0] or ""

--- a/src/yeaboi/voice.py
+++ b/src/yeaboi/voice.py
@@ -16,8 +16,10 @@ Design notes / architectural decisions:
 - **Lazy imports.** Both heavy dependencies (`sounddevice` for mic capture and
   `faster_whisper` for transcription) are imported *inside* functions, mirroring
   the optional-provider pattern in `agent/llm.py`. Importing this module never
-  fails; the deps are only needed when voice is actually used. Install with:
-  ``uv sync --extra voice``. The sounddevice wheels bundle PortAudio on macOS
+  fails; the deps are only needed when voice is actually used. The install
+  command is install-method-aware — see :func:`voice_install_command` (a source
+  checkout uses ``uv sync --extra voice``; PyPI users get the matching
+  ``uv tool``/``pipx``/``pip`` form). The sounddevice wheels bundle PortAudio on macOS
   and Windows (nothing else to install); on Linux the wheel is pure-Python and
   needs the system library too (e.g. ``sudo apt install libportaudio2``).
 - **Cheap availability probe.** :func:`is_voice_available` uses
@@ -37,6 +39,9 @@ from __future__ import annotations
 import importlib.util
 import io
 import logging
+import os
+import pathlib
+import sys
 import wave
 
 from yeaboi.config import get_voice_model
@@ -52,6 +57,32 @@ _SAMPLE_WIDTH_BYTES = 2  # int16
 # Loaded WhisperModel instances keyed by size (e.g. "base"). Populated lazily on
 # first transcription so the (potentially large) model download happens once.
 _MODEL_CACHE: dict = {}
+
+
+def voice_install_command() -> str:
+    """Return the install command that will actually work for *this* install.
+
+    The voice deps live in the ``voice`` extra, but *how* to add an extra depends
+    on how yeaboi was installed. A source checkout uses ``uv sync``; PyPI users
+    (uv tool / pipx / pip) must reinstall the distribution with the extra. There
+    is no single command that fits all, so detect and branch. Detection is
+    path-based (not ``importlib.metadata``) because the legacy install may be
+    registered under the old distribution name ``scrum-agent``; the package name
+    in the returned command is pinned to ``yeaboi`` — the canonical distribution
+    that actually publishes the extra.
+    """
+    # Source checkout (incl. editable / `make install`): pyproject at the repo
+    # root two levels above this package. `uv sync --extra voice` is valid there.
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    if (repo_root / "pyproject.toml").exists() and (repo_root / "src" / "yeaboi").is_dir():
+        return "uv sync --extra voice"
+
+    exe = sys.executable.replace("\\", "/")
+    if "/uv/tools/" in exe:
+        return "uv tool install 'yeaboi[voice]'"
+    if "pipx" in exe or os.environ.get("PIPX_HOME") or os.environ.get("PIPX_BIN_DIR"):
+        return "pipx install 'yeaboi[voice]'"
+    return "pip install 'yeaboi[voice]'"
 
 
 def _installed(module_name: str) -> bool:
@@ -75,9 +106,10 @@ def is_voice_available() -> tuple[bool, str]:
     available, otherwise a short human-readable explanation for the UI.
     """
     if not _installed("sounddevice"):
-        return False, "Install voice extra: uv sync --extra voice (Linux also: apt install libportaudio2)"
+        # Linux wheels need the system PortAudio lib too.
+        return False, f"Install voice extra: {voice_install_command()} (Linux also: apt install libportaudio2)"
     if not _installed("faster_whisper"):
-        return False, "Install voice extra: uv sync --extra voice"
+        return False, f"Install voice extra: {voice_install_command()}"
     return True, ""
 
 

--- a/tests/unit/test_tips.py
+++ b/tests/unit/test_tips.py
@@ -8,6 +8,7 @@ from yeaboi.ui.shared._tips import (
     tip_brightness,
     tip_count,
 )
+from yeaboi.voice import voice_install_command
 
 
 def _clear_cache():
@@ -36,7 +37,9 @@ def test_voice_tip_when_unavailable(monkeypatch):
     _clear_cache()
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (False, "reason"))
     voice_tip = get_tips()[0]
-    assert "uv sync --extra voice" in voice_tip
+    # Tip shows the install-method-aware command (not a hardcoded `uv sync`).
+    assert "enable dictation" in voice_tip
+    assert voice_install_command() in voice_tip
     _clear_cache()
 
 

--- a/tests/unit/test_tips_ui.py
+++ b/tests/unit/test_tips_ui.py
@@ -4,6 +4,7 @@ from rich.panel import Panel
 
 from yeaboi.ui.mode_select.screens._screens import _build_mode_screen
 from yeaboi.ui.session.screens._screens_input import _voice_hint
+from yeaboi.voice import voice_install_command
 
 
 def test_voice_hint_empty_when_tips_disabled(monkeypatch):
@@ -22,7 +23,9 @@ def test_voice_hint_shows_install_when_unavailable(monkeypatch):
     monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (False, "x"))
     hint = _voice_hint()
-    assert "uv sync --extra voice" in hint
+    # Hint shows the install-method-aware command (not a hardcoded `uv sync`).
+    assert "dictate:" in hint
+    assert voice_install_command() in hint
 
 
 def test_mode_screen_renders_with_tips_on(monkeypatch):

--- a/tests/unit/test_voice.py
+++ b/tests/unit/test_voice.py
@@ -166,6 +166,47 @@ class TestVoiceModel:
 # ---------------------------------------------------------------------------
 
 
+class TestVoiceInstallCommand:
+    """The install hint must match how yeaboi was actually installed."""
+
+    def _no_source_checkout(self, monkeypatch):
+        # Force the source-checkout branch to miss so path-based detection runs.
+        # (When the tests run from a checkout, pyproject.toml exists at the repo
+        # root and would otherwise short-circuit to `uv sync`.)
+        monkeypatch.setattr(voice.pathlib.Path, "exists", lambda self: False)
+
+    def test_source_checkout(self, monkeypatch):
+        # pyproject.toml + src/yeaboi both present -> source checkout.
+        monkeypatch.setattr(voice.pathlib.Path, "exists", lambda self: True)
+        monkeypatch.setattr(voice.pathlib.Path, "is_dir", lambda self: True)
+        assert voice.voice_install_command() == "uv sync --extra voice"
+
+    def test_uv_tool_install(self, monkeypatch):
+        self._no_source_checkout(monkeypatch)
+        monkeypatch.setattr(voice.sys, "executable", "/home/u/.local/share/uv/tools/yeaboi/bin/python")
+        assert voice.voice_install_command() == "uv tool install 'yeaboi[voice]'"
+
+    def test_pipx_by_path(self, monkeypatch):
+        self._no_source_checkout(monkeypatch)
+        monkeypatch.delenv("PIPX_HOME", raising=False)
+        monkeypatch.delenv("PIPX_BIN_DIR", raising=False)
+        monkeypatch.setattr(voice.sys, "executable", "/home/u/.local/pipx/venvs/yeaboi/bin/python")
+        assert voice.voice_install_command() == "pipx install 'yeaboi[voice]'"
+
+    def test_pipx_by_env(self, monkeypatch):
+        self._no_source_checkout(monkeypatch)
+        monkeypatch.setattr(voice.sys, "executable", "/usr/bin/python3")
+        monkeypatch.setenv("PIPX_HOME", "/home/u/.local/pipx")
+        assert voice.voice_install_command() == "pipx install 'yeaboi[voice]'"
+
+    def test_pip_fallback(self, monkeypatch):
+        self._no_source_checkout(monkeypatch)
+        monkeypatch.delenv("PIPX_HOME", raising=False)
+        monkeypatch.delenv("PIPX_BIN_DIR", raising=False)
+        monkeypatch.setattr(voice.sys, "executable", "/usr/bin/python3")
+        assert voice.voice_install_command() == "pip install 'yeaboi[voice]'"
+
+
 class TestIsVoiceAvailable:
     def test_missing_sounddevice(self, _inject):
         _inject(sounddevice=False, faster_whisper_captured={})


### PR DESCRIPTION
## Problem

The `🎤 dictate: uv sync --extra voice` hint is **hardcoded in 5 places**, but `uv sync` only works in a source checkout. Every PyPI user (uv tool / pipx / pip) who follows it hits:

```
error: No `pyproject.toml` found in current directory or any parent directory
```

(Found while enabling voice on a `uv tool` install — the command sent me nowhere.)

## Fix

Add `voice_install_command()` in `voice.py` that detects how yeaboi was installed and returns the command that actually works:

| Install method | Command shown |
|----------------|---------------|
| source checkout / editable | `uv sync --extra voice` |
| uv tool | `uv tool install 'yeaboi[voice]'` |
| pipx | `pipx install 'yeaboi[voice]'` |
| pip (fallback) | `pip install 'yeaboi[voice]'` |

Detection is path-based (not `importlib.metadata`) so it's robust even when the legacy `scrum-agent` distribution name is installed; the command always names the canonical `yeaboi` package (the only one that publishes the `voice` extra).

Routed all 5 hardcoded sites through the helper:
- the two `is_voice_available()` reason strings (`voice.py`)
- the inline dictate hint (`_screens_input.py`)
- the welcome-screen tip (`_tips.py`)
- the setup-wizard tip (`setup_wizard.py`)
- the transcription-failure flash (`_voice_input.py`)

## Tests

- New `TestVoiceInstallCommand` — one case per branch (source / uv tool / pipx by path / pipx by env / pip fallback).
- Made the two existing `uv sync`-literal assertions branch-robust.
- `make test` → 3447 passed, 7 skipped · `make lint` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)