### PR TITLE
fix(tui): make scrolling smooth and stop the view tearing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.8.1"
+version = "2.8.2"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -1235,7 +1235,12 @@ def main(argv: list[str] | None = None) -> None:
         # the app instead of the terminal's own scrollback buffer.
         import atexit
 
-        from yeaboi.ui.shared._input import disable_mouse_tracking, enable_mouse_tracking
+        from yeaboi.ui.shared._input import (
+            disable_mouse_tracking,
+            enable_mouse_tracking,
+            enter_raw_mode,
+            exit_raw_mode,
+        )
 
         def _terminal_cleanup() -> None:
             """Safety net — ensure terminal is restored even on unhandled crash."""
@@ -1243,8 +1248,15 @@ def main(argv: list[str] | None = None) -> None:
                 disable_mouse_tracking()
             except Exception:
                 pass
+            try:
+                exit_raw_mode()
+            except Exception:
+                pass
 
         atexit.register(_terminal_cleanup)
+        # Hold cbreak+no-echo for the whole TUI so mouse-report bytes arriving
+        # between key reads can't echo as garbage during a fast wheel scroll.
+        enter_raw_mode()
         enable_mouse_tracking()
         _tui_error: Exception | None = None
         try:
@@ -1257,6 +1269,7 @@ def main(argv: list[str] | None = None) -> None:
             mode_result = None
         finally:
             disable_mouse_tracking()
+            exit_raw_mode()
             # Stop any background music daemon so it doesn't outlive the app.
             from yeaboi import music
 

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -2859,9 +2859,7 @@ def select_mode(
                             _ana_del_pending = False
 
                         if key in ("up", "scroll_up", "down", "scroll_down"):
-                            _delta = coalesce_steps(
-                                key, read_key, down=("down", "scroll_down"), up=("up", "scroll_up")
-                            )
+                            _delta = coalesce_steps(key, read_key, down=("down", "scroll_down"), up=("up", "scroll_up"))
                             if not _delta:
                                 continue
                             _ana_selected = (_ana_selected + _delta) % _ana_n
@@ -4069,9 +4067,7 @@ def select_mode(
                     # ── Normal project list mode ───────────────────────────────
                     elif key in ("up", "scroll_up", "down", "scroll_down"):
                         # Coalesce a fast wheel/held-key burst into one net move.
-                        _delta = coalesce_steps(
-                            key, read_key, down=("down", "scroll_down"), up=("up", "scroll_up")
-                        )
+                        _delta = coalesce_steps(key, read_key, down=("down", "scroll_down"), up=("up", "scroll_up"))
                         if not _delta:
                             continue
                         proj_selected = (proj_selected + _delta) % proj_n

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -64,6 +64,7 @@ from yeaboi.ui.shared._animations import (
 )
 from yeaboi.ui.shared._input import read_key as _read_key
 from yeaboi.ui.shared._music_bar import make_live
+from yeaboi.ui.shared._scroll import SCROLL_KEYS, coalesce_scroll, coalesce_steps
 from yeaboi.ui.splash import play_wordmark_intro
 
 logger = logging.getLogger(__name__)
@@ -156,7 +157,9 @@ def _run_preview_flow(
         _build_sample_tasks_screen,
     )
 
-    _rk = lambda: read_key(timeout=frame_time) if supports_timeout else read_key()  # noqa: E731
+    # Accepts an optional timeout so coalesce_scroll() can poll non-blocking
+    # (timeout=0.0); a bare _rk() keeps the original per-frame/blocking behaviour.
+    _rk = lambda timeout=(frame_time if supports_timeout else None): read_key(timeout=timeout)  # noqa: E731
 
     # ── Inline editor helpers for dict-based artifacts ────────────
     def _dict_editable_start(line: str) -> int | None:
@@ -526,16 +529,21 @@ def _run_preview_flow(
     _stories = (resume_state or {}).get("sample_stories")
     _tasks = (resume_state or {}).get("sample_tasks")
 
+    # Scroll geometry published by each page's screen builder; reused across the
+    # sequential pages (repopulated on every render before any key is handled).
+    _scroll_meta: dict = {}
+
     # ── Page 1: Instructions ──────────────────────────────────────
     logger.info("Preview: entering Instructions page")
     if last_page not in ("epic", "stories", "tasks", "sprint"):
         scroll, sel = 0, 0
         while True:
             k = _rk()
-            if k in ("up", "scroll_up"):
-                scroll = max(0, scroll - 1)
-            elif k in ("down", "scroll_down"):
-                scroll += 1
+            if k in SCROLL_KEYS:
+                _ns = coalesce_scroll(scroll, k, _scroll_meta, _rk)
+                if _ns == scroll:
+                    continue
+                scroll = _ns
             elif k == "left":
                 sel = max(0, sel - 1)
             elif k == "right":
@@ -588,6 +596,7 @@ def _run_preview_flow(
                 _build_instructions_review_screen(
                     _instr,
                     scroll_offset=scroll,
+                    scroll_meta=_scroll_meta,
                     width=w,
                     height=h,
                     action_sel=sel,
@@ -619,10 +628,11 @@ def _run_preview_flow(
         scroll, sel = 0, 0
         while True:
             k = _rk()
-            if k in ("up", "scroll_up"):
-                scroll = max(0, scroll - 1)
-            elif k in ("down", "scroll_down"):
-                scroll += 1
+            if k in SCROLL_KEYS:
+                _ns = coalesce_scroll(scroll, k, _scroll_meta, _rk)
+                if _ns == scroll:
+                    continue
+                scroll = _ns
             elif k == "left":
                 sel = max(0, sel - 1)
             elif k == "right":
@@ -650,6 +660,7 @@ def _run_preview_flow(
                 _build_sample_epic_screen(
                     _epic,
                     scroll_offset=scroll,
+                    scroll_meta=_scroll_meta,
                     width=w,
                     height=h,
                     action_sel=sel,
@@ -682,10 +693,11 @@ def _run_preview_flow(
         scroll, sel = 0, 0
         while True:
             k = _rk()
-            if k in ("up", "scroll_up"):
-                scroll = max(0, scroll - 1)
-            elif k in ("down", "scroll_down"):
-                scroll += 1
+            if k in SCROLL_KEYS:
+                _ns = coalesce_scroll(scroll, k, _scroll_meta, _rk)
+                if _ns == scroll:
+                    continue
+                scroll = _ns
             elif k == "left":
                 sel = max(0, sel - 1)
             elif k == "right":
@@ -725,6 +737,7 @@ def _run_preview_flow(
                 _build_sample_stories_screen(
                     _stories,
                     scroll_offset=scroll,
+                    scroll_meta=_scroll_meta,
                     width=w,
                     height=h,
                     action_sel=sel,
@@ -758,10 +771,11 @@ def _run_preview_flow(
         scroll, sel = 0, 0
         while True:
             k = _rk()
-            if k in ("up", "scroll_up"):
-                scroll = max(0, scroll - 1)
-            elif k in ("down", "scroll_down"):
-                scroll += 1
+            if k in SCROLL_KEYS:
+                _ns = coalesce_scroll(scroll, k, _scroll_meta, _rk)
+                if _ns == scroll:
+                    continue
+                scroll = _ns
             elif k == "left":
                 sel = max(0, sel - 1)
             elif k == "right":
@@ -816,6 +830,7 @@ def _run_preview_flow(
                 _build_sample_tasks_screen(
                     _tasks,
                     scroll_offset=scroll,
+                    scroll_meta=_scroll_meta,
                     width=w,
                     height=h,
                     action_sel=sel,
@@ -912,12 +927,14 @@ def _run_sprint_review(
     }
     scroll = 0
     sel = 0
+    _scroll_meta: dict = {}
     while True:
         k = read_key(timeout=frame_time) if supports_timeout else read_key()
-        if k in ("up", "scroll_up"):
-            scroll = max(0, scroll - 1)
-        elif k in ("down", "scroll_down"):
-            scroll += 1
+        if k in SCROLL_KEYS:
+            _ns = coalesce_scroll(scroll, k, _scroll_meta, read_key)
+            if _ns == scroll:
+                continue
+            scroll = _ns
         elif k == "left":
             sel = max(0, sel - 1)
         elif k == "right":
@@ -939,6 +956,7 @@ def _run_sprint_review(
                 sprint,
                 sample_stories,
                 scroll_offset=scroll,
+                scroll_meta=_scroll_meta,
                 width=w,
                 height=h,
                 action_sel=sel,
@@ -1410,6 +1428,7 @@ def _run_standup_page(console: Console, live, read_key, frame_time: float, suppo
 
     data = _collect_standup_data()
     scroll, sel = 0, 0
+    _scroll_meta: dict = {}
     n_buttons = 5  # Generate, My Update, Configure, Export, Back
     anim_start = time.monotonic()  # shimmer title + typewriter subtitle clock
 
@@ -1422,6 +1441,7 @@ def _run_standup_page(console: Console, live, read_key, frame_time: float, suppo
             _build_standup_screen(
                 data,
                 scroll_offset=scroll,
+                scroll_meta=_scroll_meta,
                 width=w,
                 height=max(10, h - 1),
                 action_sel=sel,
@@ -1433,10 +1453,11 @@ def _run_standup_page(console: Console, live, read_key, frame_time: float, suppo
     _render()
     while True:
         k = read_key(timeout=frame_time) if supports_timeout else read_key()
-        if k in ("up", "scroll_up"):
-            scroll = max(0, scroll - 1)
-        elif k in ("down", "scroll_down"):
-            scroll += 1
+        if k in SCROLL_KEYS:
+            _ns = coalesce_scroll(scroll, k, _scroll_meta, read_key)
+            if _ns == scroll:
+                continue
+            scroll = _ns
         elif k == "left":
             sel = max(0, sel - 1)
         elif k == "right":
@@ -1662,6 +1683,7 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
         "view": "roster",
         "selected": 0,
         "scroll": 0,
+        "scroll_meta": {},
         "sel": 0,
         "message": "",
         "detail_lines": [],
@@ -1701,6 +1723,7 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
             _build_performance_screen(
                 _data(),
                 scroll_offset=state["scroll"],
+                scroll_meta=state["scroll_meta"],
                 width=w,
                 height=max(10, h - 1),
                 action_sel=state["sel"],
@@ -1798,10 +1821,11 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
             elif k in ("esc", "q"):
                 break
         else:  # detail view
-            if k in ("up", "scroll_up"):
-                state["scroll"] = max(0, state["scroll"] - 1)
-            elif k in ("down", "scroll_down"):
-                state["scroll"] += 1
+            if k in SCROLL_KEYS:
+                _ns = coalesce_scroll(state["scroll"], k, state["scroll_meta"], read_key)
+                if _ns == state["scroll"]:
+                    continue  # at a boundary — don't repaint (avoids title-shimmer flicker)
+                state["scroll"] = _ns
             elif k == "left":
                 state["sel"] = max(0, state["sel"] - 1)
             elif k == "right":
@@ -1884,6 +1908,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
         "view": "picker",
         "selected": 0,  # period index
         "scroll": 0,
+        "scroll_meta": {},
         "sel": 0,  # action button index
         "message": "",
         "theme": "midnight",
@@ -1933,6 +1958,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
             _build_reporting_screen(
                 _data(),
                 scroll_offset=state["scroll"],
+                scroll_meta=state["scroll_meta"],
                 width=w,
                 height=max(10, h - 1),
                 action_sel=state["sel"],
@@ -2103,10 +2129,11 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
                 state["view"] = "picker"
                 state["sel"], state["scroll"], state["message"] = 0, 0, ""
         else:  # detail view
-            if k in ("up", "scroll_up"):
-                state["scroll"] = max(0, state["scroll"] - 1)
-            elif k in ("down", "scroll_down"):
-                state["scroll"] += 1
+            if k in SCROLL_KEYS:
+                _ns = coalesce_scroll(state["scroll"], k, state["scroll_meta"], read_key)
+                if _ns == state["scroll"]:
+                    continue  # at a boundary — don't repaint (avoids title-shimmer flicker)
+                state["scroll"] = _ns
             elif k == "left":
                 state["sel"] = max(0, state["sel"] - 1)
             elif k == "right":
@@ -2167,6 +2194,7 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_retro_screen
 
     anim_start = time.monotonic()  # shimmer title + typewriter subtitle clock
+    _scroll_meta: dict = {}  # scroll geometry published by _build_retro_screen
 
     def _render(data: dict, scroll: int, sel: int) -> None:
         w, h = console.size
@@ -2176,6 +2204,7 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
             _build_retro_screen(
                 data,
                 scroll_offset=scroll,
+                scroll_meta=_scroll_meta,
                 width=w,
                 height=max(10, h - 1),
                 action_sel=sel,
@@ -2308,10 +2337,11 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
         _render(_data(), scroll, sel)
         while True:
             k = read_key(timeout=frame_time) if supports_timeout else read_key()
-            if k in ("up", "scroll_up"):
-                scroll = max(0, scroll - 1)
-            elif k in ("down", "scroll_down"):
-                scroll += 1
+            if k in SCROLL_KEYS:
+                _ns = coalesce_scroll(scroll, k, _scroll_meta, read_key)
+                if _ns == scroll:
+                    continue
+                scroll = _ns
             elif k == "left":
                 sel = max(0, sel - 1)
             elif k == "right":
@@ -2445,12 +2475,20 @@ def select_mode(
             while True:
                 key = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
 
-                if key in ("up", "left", "scroll_up"):
-                    selected = (selected - 1) % n
-                    select_time = time.monotonic()
-                elif key in ("down", "right", "scroll_down"):
-                    selected = (selected + 1) % n
-                    select_time = time.monotonic()
+                if key in ("up", "left", "scroll_up", "down", "right", "scroll_down"):
+                    # Coalesce a fast wheel/held-key burst into one net move + one
+                    # repaint, so the animated mode carousel doesn't stutter.
+                    _delta = coalesce_steps(
+                        key,
+                        read_key,
+                        down=("down", "right", "scroll_down"),
+                        up=("up", "left", "scroll_up"),
+                    )
+                    if _delta:
+                        selected = (selected + _delta) % n
+                        select_time = time.monotonic()
+                    else:
+                        continue  # net-zero burst — nothing moved, skip the repaint
                 elif key == "enter":
                     mode = _MODE_CARDS[selected]
                     if mode["available"]:
@@ -2820,18 +2858,13 @@ def select_mode(
                             _ana_del_popup_name = ""
                             _ana_del_pending = False
 
-                        if key in ("up", "scroll_up"):
-                            _ana_selected = (_ana_selected - 1) % _ana_n
-                            _ana_focus = 0
-                            _ana_action_btns = 0.0
-                            _is_profile = _ana_selected < len(_profiles_for_analysis)
-                            _ana_action_btns_target = 2.0 if _is_profile else 0.0
-                            _ana_del_fade = 0.0
-                            _ana_exp_fade = 0.0
-                            _ana_export_submenu = False
-                            _ana_sub_visible_target = 0.0
-                        elif key in ("down", "scroll_down"):
-                            _ana_selected = (_ana_selected + 1) % _ana_n
+                        if key in ("up", "scroll_up", "down", "scroll_down"):
+                            _delta = coalesce_steps(
+                                key, read_key, down=("down", "scroll_down"), up=("up", "scroll_up")
+                            )
+                            if not _delta:
+                                continue
+                            _ana_selected = (_ana_selected + _delta) % _ana_n
                             _ana_focus = 0
                             _ana_action_btns = 0.0
                             _is_profile = _ana_selected < len(_profiles_for_analysis)
@@ -2870,6 +2903,7 @@ def select_mode(
                                     )
 
                                     _scr = 0
+                                    _scr_meta: dict = {}
                                     _esel = 1  # default to "Next" on page 1
                                     _vp = 1  # current page
                                     _ta_anim0 = time.monotonic()  # shimmer title clock
@@ -2887,6 +2921,7 @@ def select_mode(
                                             _build_team_analysis_screen(
                                                 _full,
                                                 scroll_offset=_scr,
+                                                scroll_meta=_scr_meta,
                                                 width=w,
                                                 height=h,
                                                 export_sel=_esel,
@@ -2896,10 +2931,8 @@ def select_mode(
                                             )
                                         )
                                         kk = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
-                                        if kk in ("up", "scroll_up"):
-                                            _scr = max(0, _scr - 1)
-                                        elif kk in ("down", "scroll_down"):
-                                            _scr += 1
+                                        if kk in SCROLL_KEYS:
+                                            _scr = coalesce_scroll(_scr, kk, _scr_meta, read_key)
                                         elif kk == "left":
                                             _esel = max(0, _esel - 1)
                                         elif kk == "right":
@@ -3301,6 +3334,7 @@ def select_mode(
                             )
 
                             _ta_scroll = 0
+                            _ta_scroll_meta: dict = {}
                             _ta_page = 1
                             _ta_export_sel = 1  # default to "Next"
                             _ta_examples = _ta_examples_box[0] or {}
@@ -3319,6 +3353,7 @@ def select_mode(
                                     _build_team_analysis_screen(
                                         _ta_profile,
                                         scroll_offset=_ta_scroll,
+                                        scroll_meta=_ta_scroll_meta,
                                         width=w,
                                         height=h,
                                         export_sel=_ta_export_sel,
@@ -3330,10 +3365,8 @@ def select_mode(
                                     )
                                 )
                                 kk = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
-                                if kk in ("up", "scroll_up"):
-                                    _ta_scroll = max(0, _ta_scroll - 1)
-                                elif kk in ("down", "scroll_down"):
-                                    _ta_scroll += 1
+                                if kk in SCROLL_KEYS:
+                                    _ta_scroll = coalesce_scroll(_ta_scroll, kk, _ta_scroll_meta, read_key)
                                 elif kk == "left":
                                     _ta_export_sel = max(0, _ta_export_sel - 1)
                                 elif kk == "right":
@@ -3583,12 +3616,14 @@ def select_mode(
 
                 _usage_data = _collect_usage_data()
                 _u_scroll, _u_sel = 0, 0
+                _u_scroll_meta: dict = {}
                 _u_anim_start = time.monotonic()  # shimmer title + typewriter subtitle
                 w, h = console.size
                 live.update(
                     _build_usage_screen(
                         _usage_data,
                         scroll_offset=_u_scroll,
+                        scroll_meta=_u_scroll_meta,
                         width=w,
                         height=h,
                         action_sel=_u_sel,
@@ -3598,10 +3633,11 @@ def select_mode(
                 )
                 while True:
                     k = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
-                    if k in ("up", "scroll_up"):
-                        _u_scroll = max(0, _u_scroll - 1)
-                    elif k in ("down", "scroll_down"):
-                        _u_scroll += 1
+                    if k in SCROLL_KEYS:
+                        _ns = coalesce_scroll(_u_scroll, k, _u_scroll_meta, read_key)
+                        if _ns == _u_scroll:
+                            continue
+                        _u_scroll = _ns
                     elif k in ("enter", " ", "esc", "q"):
                         break
                     w, h = console.size
@@ -3610,6 +3646,7 @@ def select_mode(
                         _build_usage_screen(
                             _usage_data,
                             scroll_offset=_u_scroll,
+                            scroll_meta=_u_scroll_meta,
                             width=w,
                             height=h,
                             action_sel=_u_sel,
@@ -3629,12 +3666,14 @@ def select_mode(
 
                 _settings_data = _collect_settings_data()
                 _s_scroll, _s_sel = 0, 0
+                _s_scroll_meta: dict = {}
                 _s_anim_start = time.monotonic()  # shimmer title + typewriter subtitle
                 w, h = console.size
                 live.update(
                     _build_settings_screen(
                         _settings_data,
                         scroll_offset=_s_scroll,
+                        scroll_meta=_s_scroll_meta,
                         width=w,
                         height=h,
                         action_sel=_s_sel,
@@ -3644,10 +3683,11 @@ def select_mode(
                 )
                 while True:
                     sk = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
-                    if sk in ("up", "scroll_up"):
-                        _s_scroll = max(0, _s_scroll - 1)
-                    elif sk in ("down", "scroll_down"):
-                        _s_scroll += 1
+                    if sk in SCROLL_KEYS:
+                        _ns = coalesce_scroll(_s_scroll, sk, _s_scroll_meta, read_key)
+                        if _ns == _s_scroll:
+                            continue
+                        _s_scroll = _ns
                     elif sk == "left":
                         _s_sel = max(0, _s_sel - 1)
                     elif sk == "right":
@@ -3679,6 +3719,7 @@ def select_mode(
                         _build_settings_screen(
                             _settings_data,
                             scroll_offset=_s_scroll,
+                            scroll_meta=_s_scroll_meta,
                             width=w,
                             height=h,
                             action_sel=_s_sel,
@@ -4026,17 +4067,14 @@ def select_mode(
                             delete_popup_target = 0.0
 
                     # ── Normal project list mode ───────────────────────────────
-                    elif key in ("up", "scroll_up"):
-                        proj_selected = (proj_selected - 1) % proj_n
-                        focus = 0
-                        del_fade_target = 0.0
-                        exp_fade_target = 0.0
-                        card_fade = 0.0
-                        card_fade_target = 1.0
-                        action_btns_visible = 0.0
-                        action_btns_visible_target = 2.0 if _is_project_row() else 0.0
-                    elif key in ("down", "scroll_down"):
-                        proj_selected = (proj_selected + 1) % proj_n
+                    elif key in ("up", "scroll_up", "down", "scroll_down"):
+                        # Coalesce a fast wheel/held-key burst into one net move.
+                        _delta = coalesce_steps(
+                            key, read_key, down=("down", "scroll_down"), up=("up", "scroll_up")
+                        )
+                        if not _delta:
+                            continue
+                        proj_selected = (proj_selected + _delta) % proj_n
                         focus = 0
                         del_fade_target = 0.0
                         exp_fade_target = 0.0
@@ -4565,6 +4603,7 @@ def select_mode(
                         )
 
                         _ta_scroll = 0
+                        _ta_scroll_meta: dict = {}
                         _ta_page = 1
                         _ta_export_sel = 1  # default to "Next" on page 1
 
@@ -4618,6 +4657,7 @@ def select_mode(
                                 _build_team_analysis_screen(
                                     _ta_profile,
                                     scroll_offset=_ta_scroll,
+                                    scroll_meta=_ta_scroll_meta,
                                     width=w,
                                     height=h,
                                     export_sel=_ta_export_sel,
@@ -4631,10 +4671,8 @@ def select_mode(
 
                             key = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
 
-                            if key in ("up", "scroll_up"):
-                                _ta_scroll = max(0, _ta_scroll - 1)
-                            elif key in ("down", "scroll_down"):
-                                _ta_scroll += 1
+                            if key in SCROLL_KEYS:
+                                _ta_scroll = coalesce_scroll(_ta_scroll, key, _ta_scroll_meta, read_key)
                             elif key == "left":
                                 _ta_export_sel = max(0, _ta_export_sel - 1)
                             elif key == "right":
@@ -4707,11 +4745,16 @@ def select_mode(
                 while True:
                     key = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
 
-                    if key in ("up", "left", "scroll_up"):
-                        intake_selected = (intake_selected - 1) % intake_n
-                        intake_start = time.monotonic()
-                    elif key in ("down", "right", "scroll_down"):
-                        intake_selected = (intake_selected + 1) % intake_n
+                    if key in ("up", "left", "scroll_up", "down", "right", "scroll_down"):
+                        _delta = coalesce_steps(
+                            key,
+                            read_key,
+                            down=("down", "right", "scroll_down"),
+                            up=("up", "left", "scroll_up"),
+                        )
+                        if not _delta:
+                            continue
+                        intake_selected = (intake_selected + _delta) % intake_n
                         intake_start = time.monotonic()
                     elif key == "enter":
                         chosen_intake = _INTAKE_CARDS[intake_selected]["key"]
@@ -4849,11 +4892,16 @@ def select_mode(
                 while True:
                     key = read_key(timeout=_FRAME_TIME) if _supports_timeout else read_key()
 
-                    if key in ("up", "left", "scroll_up"):
-                        offline_selected = (offline_selected - 1) % offline_n
-                        offline_start = time.monotonic()
-                    elif key in ("down", "right", "scroll_down"):
-                        offline_selected = (offline_selected + 1) % offline_n
+                    if key in ("up", "left", "scroll_up", "down", "right", "scroll_down"):
+                        _delta = coalesce_steps(
+                            key,
+                            read_key,
+                            down=("down", "right", "scroll_down"),
+                            up=("up", "left", "scroll_up"),
+                        )
+                        if not _delta:
+                            continue
+                        offline_selected = (offline_selected + _delta) % offline_n
                         offline_start = time.monotonic()
                     elif key == "enter":
                         break  # → Phase 5b (export or import)

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -24,6 +24,7 @@ from yeaboi.ui.shared._components import (
     calc_viewport,
     planning_title,
 )
+from yeaboi.ui.shared._scroll import publish_geometry
 
 # ---------------------------------------------------------------------------
 # Shared analysis review screen builder (mirrors planning mode layout)
@@ -37,6 +38,7 @@ def _build_analysis_review_screen(
     *,
     stage_index: int = 0,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -79,6 +81,7 @@ def _build_analysis_review_screen(
     else:
         max_scroll = 0
     actual_scroll = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
 
     # Collect visible items
     visible: list = []
@@ -149,6 +152,7 @@ def _build_team_analysis_screen(
     profile,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     export_sel: int = 2,
@@ -1849,6 +1853,7 @@ def _build_team_analysis_screen(
 
     max_scroll = max(0, _rendered_lines - body_h)
     actual_scroll = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, body_h)
 
     _vis_items: list = []
     _vis_h = 0
@@ -1910,6 +1915,7 @@ def _build_instructions_review_screen(
     instructions_text: str,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -2050,6 +2056,7 @@ def _build_instructions_review_screen(
         body_lines,
         stage_index=0,
         scroll_offset=scroll_offset,
+        scroll_meta=scroll_meta,
         width=width,
         height=height,
         action_sel=action_sel,
@@ -2062,6 +2069,7 @@ def _build_sample_epic_screen(
     epic: dict,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -2189,6 +2197,7 @@ def _build_sample_epic_screen(
         body_lines,
         stage_index=1,
         scroll_offset=scroll_offset,
+        scroll_meta=scroll_meta,
         width=width,
         height=height,
         action_sel=action_sel,
@@ -2200,6 +2209,7 @@ def _build_sample_stories_screen(
     stories: list[dict],
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -2323,6 +2333,7 @@ def _build_sample_stories_screen(
         body_lines,
         stage_index=2,
         scroll_offset=scroll_offset,
+        scroll_meta=scroll_meta,
         width=width,
         height=height,
         action_sel=action_sel,
@@ -2334,6 +2345,7 @@ def _build_sample_tasks_screen(
     tasks: list[dict],
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -2464,6 +2476,7 @@ def _build_sample_tasks_screen(
         body_lines,
         stage_index=3,
         scroll_offset=scroll_offset,
+        scroll_meta=scroll_meta,
         width=width,
         height=height,
         action_sel=action_sel,
@@ -2476,6 +2489,7 @@ def _build_sample_sprint_screen(
     stories: list[dict],
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -2596,6 +2610,7 @@ def _build_sample_sprint_screen(
         body_lines,
         stage_index=4,
         scroll_offset=scroll_offset,
+        scroll_meta=scroll_meta,
         width=width,
         height=height,
         action_sel=action_sel,
@@ -3029,6 +3044,7 @@ def _build_usage_screen(
     usage_data: dict,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -3141,6 +3157,7 @@ def _build_usage_screen(
     total_lines = len(body_lines)
     max_scroll = max(0, total_lines - viewport_h)
     actual_scroll = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
     visible = body_lines[actual_scroll : actual_scroll + viewport_h]
 
     _sb_text = build_scrollbar(viewport_h, total_lines, actual_scroll, max_scroll, always_show=True)
@@ -3195,6 +3212,7 @@ def _build_standup_screen(
     standup_data: dict,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -3331,6 +3349,7 @@ def _build_standup_screen(
     total_lines = len(body_lines)
     max_scroll = max(0, total_lines - viewport_h)
     actual_scroll = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
     visible = body_lines[actual_scroll : actual_scroll + viewport_h]
 
     _sb_text = build_scrollbar(viewport_h, total_lines, actual_scroll, max_scroll, always_show=True)
@@ -3413,6 +3432,7 @@ def _build_performance_screen(
     performance_data: dict,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -3546,6 +3566,7 @@ def _build_performance_screen(
     total_lines = len(body_lines)
     max_scroll = max(0, total_lines - viewport_h)
     actual_scroll = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
     visible = body_lines[actual_scroll : actual_scroll + viewport_h]
 
     _sb_text = build_scrollbar(viewport_h, total_lines, actual_scroll, max_scroll, always_show=True)
@@ -3591,6 +3612,7 @@ def _build_reporting_screen(
     reporting_data: dict,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -3781,6 +3803,7 @@ def _build_reporting_screen(
     total_lines = len(body_lines)
     max_scroll = max(0, total_lines - viewport_h)
     actual_scroll = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
     visible = body_lines[actual_scroll : actual_scroll + viewport_h]
 
     _sb_text = build_scrollbar(viewport_h, total_lines, actual_scroll, max_scroll, always_show=True)
@@ -3825,6 +3848,7 @@ def _build_retro_screen(
     retro_data: dict,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -3925,6 +3949,7 @@ def _build_retro_screen(
     total_lines = len(body_lines)
     max_scroll = max(0, total_lines - viewport_h)
     actual_scroll = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
     visible = body_lines[actual_scroll : actual_scroll + viewport_h]
 
     _sb_text = build_scrollbar(viewport_h, total_lines, actual_scroll, max_scroll, always_show=True)
@@ -4205,6 +4230,7 @@ def _build_settings_screen(
     config_data: dict,
     *,
     scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
     width: int = 80,
     height: int = 24,
     action_sel: int = 0,
@@ -4323,6 +4349,7 @@ def _build_settings_screen(
     total_lines = len(body_lines)
     max_scroll = max(0, total_lines - viewport_h)
     actual_scroll = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
     visible = body_lines[actual_scroll : actual_scroll + viewport_h]
 
     _sb_text = build_scrollbar(viewport_h, total_lines, actual_scroll, max_scroll, always_show=True)

--- a/src/yeaboi/ui/session/phases/_phases.py
+++ b/src/yeaboi/ui/session/phases/_phases.py
@@ -41,8 +41,14 @@ from yeaboi.ui.session.phases._phases_review import (  # noqa: F401
 )
 from yeaboi.ui.session.screens._screens_pipeline import _build_chat_screen, _build_pipeline_screen
 from yeaboi.ui.shared._animations import FRAME_TIME_30FPS
+from yeaboi.ui.shared._scroll import SCROLL_KEYS, coalesce_scroll
 
 logger = logging.getLogger(__name__)
+
+# Sentinel scroll offset meaning "pin to the last line". Any screen builder
+# clamps it down to its real maximum for display and publishes that maximum via
+# scroll_meta, which the loop then adopts. Larger than any realistic line count.
+_SCROLL_BOTTOM = 1_000_000_000
 
 # ---------------------------------------------------------------------------
 # Story-level auto-scroll helper
@@ -827,6 +833,7 @@ def _phase_pipeline(
 
                 _ep_lines = _render_to_lines(console, _ep_renderable, _rw)
                 _ep_scroll, _ep_sel = 0, 0
+                _ep_scroll_meta: dict = {}
                 _ep_actions = ["Accept", "Edit", "Export"]
 
                 # Add tracker sync buttons (dynamic based on configured boards)
@@ -874,16 +881,15 @@ def _phase_pipeline(
                             step=1,
                             total=6,
                             shimmer_tick=time.monotonic() - _epv_anim0,
+                            scroll_meta=_ep_scroll_meta,
                         )
                     )
                     key = _key()
                     if key in ("esc", "q"):
                         logger.info("Epic review: user pressed Esc — exiting planning")
                         return graph_state
-                    elif key in ("up", "scroll_up"):
-                        _ep_scroll = max(0, _ep_scroll - 1)
-                    elif key in ("down", "scroll_down"):
-                        _ep_scroll += 1
+                    elif key in SCROLL_KEYS:
+                        _ep_scroll = coalesce_scroll(_ep_scroll, key, _ep_scroll_meta, _key)
                     elif key == "left":
                         _ep_sel = max(0, _ep_sel - 1)
                     elif key == "right":
@@ -1161,6 +1167,7 @@ def _phase_pipeline(
         scroll_offset = 0
         menu_selected = 0
         status_msg = ""
+        _scroll_meta: dict = {}  # geometry published by _build_pipeline_screen
 
         # Action buttons differ by stage:
         # story_writer/task_decomposer/sprint_planner: Accept | Edit | Regenerate | Export [| Jira]
@@ -1221,6 +1228,7 @@ def _phase_pipeline(
                 sticky_headers=sticky_headers,
                 actions=actions,
                 warning_text=cap_warning_text if is_sprint_stage else "",
+                scroll_meta=_scroll_meta,
             )
         )
 
@@ -1230,17 +1238,12 @@ def _phase_pipeline(
 
             if key == "esc":
                 return None
-            elif key in ("up", "scroll_up"):
-                scroll_offset = max(0, scroll_offset - 1)
+            elif key in SCROLL_KEYS:
+                _ns = coalesce_scroll(scroll_offset, key, _scroll_meta, _key)
+                if _ns == scroll_offset:
+                    continue  # boundary — skip the repaint so the title shimmer stays put
+                scroll_offset = _ns
                 # Track which story is closest to viewport center (for Edit action)
-                if is_story_stage and story_panel_ranges:
-                    _, viewport_h = console.size
-                    vp_h = max(3, viewport_h - 14)
-                    new_sel = _story_index_at_scroll(story_panel_ranges, scroll_offset, vp_h)
-                    if new_sel != selected_story:
-                        selected_story = new_sel
-            elif key in ("down", "scroll_down"):
-                scroll_offset += 1
                 if is_story_stage and story_panel_ranges:
                     _, viewport_h = console.size
                     vp_h = max(3, viewport_h - 14)
@@ -1493,6 +1496,7 @@ def _phase_pipeline(
                             sticky_headers=sticky_headers,
                             actions=actions,
                             warning_text=cap_warning_text if is_sprint_stage else "",
+                            scroll_meta=_scroll_meta,
                         )
                     )
                 elif action in ("Jira", "Azure DevOps"):
@@ -1547,6 +1551,7 @@ def _phase_pipeline(
                     actions=actions,
                     warning_text=cap_warning_text if is_sprint_stage else "",
                     shimmer_tick=time.monotonic() - _pl_anim0,
+                    scroll_meta=_scroll_meta,
                 )
             )
 
@@ -1580,9 +1585,18 @@ def _phase_chat(
     messages: list[tuple[str, str]] = []
     input_value = ""
     scroll_offset = 0
+    _chat_scroll_meta: dict = {}
+    # Follow the newest message until the user scrolls up; new messages re-pin to
+    # the bottom only while following. Manual scroll keys break the follow.
+    _chat_follow = True
+
+    def _chat_bottom() -> int:
+        return _chat_scroll_meta.get("max_offset", 0)
 
     w, h = console.size
-    live.update(_build_chat_screen(messages, input_value, scroll_offset, width=w, height=h))
+    live.update(
+        _build_chat_screen(messages, input_value, scroll_offset, width=w, height=h, scroll_meta=_chat_scroll_meta)
+    )
 
     _chat_anim0 = time.monotonic()  # shimmer title clock
     while True:
@@ -1601,9 +1615,17 @@ def _phase_chat(
                 _export_checkpoint(console, graph_state, stage="complete")
                 messages.append(("ai", "Plan exported successfully."))
                 input_value = ""
-                scroll_offset = max(0, len(messages) * 2 - 5)
+                # Pin to the newest line: request past-the-end, the builder clamps
+                # for display AND publishes the true bottom, which we then adopt.
+                scroll_offset = _SCROLL_BOTTOM
                 w, h = console.size
-                live.update(_build_chat_screen(messages, input_value, scroll_offset, width=w, height=h))
+                live.update(
+                    _build_chat_screen(
+                        messages, input_value, scroll_offset, width=w, height=h, scroll_meta=_chat_scroll_meta
+                    )
+                )
+                scroll_offset = _chat_bottom()
+                _chat_follow = True
                 continue
 
             if text.lower() in {"exit", "quit"}:
@@ -1640,6 +1662,7 @@ def _phase_chat(
                         processing=True,
                         tick=tick,
                         shimmer_tick=tick,
+                        scroll_meta=_chat_scroll_meta,
                     )
                 )
                 time.sleep(FRAME_TIME_30FPS)
@@ -1657,8 +1680,25 @@ def _phase_chat(
                 logger.error("Chat graph invoke failed: %s", result_box[1])
                 messages.append(("ai", f"Error: {result_box[1]}"))
 
-            scroll_offset = max(0, len(messages) * 2 - 5)
+            # New reply — pin to the bottom (adopted after the render below).
+            scroll_offset = _SCROLL_BOTTOM
+            _chat_follow = True
 
+        elif key in ("up", "scroll_up", "pageup", "home"):
+            _ns = coalesce_scroll(scroll_offset, key, _chat_scroll_meta, _key)
+            if _ns == scroll_offset:
+                continue  # already at the top — skip the repaint (no shimmer flicker)
+            # Any upward scroll stops following the newest message.
+            _chat_follow = False
+            scroll_offset = _ns
+        elif key in ("down", "scroll_down", "pagedown", "end"):
+            _ns = coalesce_scroll(scroll_offset, key, _chat_scroll_meta, _key)
+            if _ns == scroll_offset:
+                continue  # already at the bottom — skip the repaint
+            scroll_offset = _ns
+            # Re-pin to follow mode once the user scrolls back to the bottom.
+            if scroll_offset >= _chat_scroll_meta.get("max_offset", 0):
+                _chat_follow = True
         elif key == "backspace":
             input_value = input_value[:-1]
         elif key == "clear":
@@ -1681,5 +1721,10 @@ def _phase_chat(
                 width=w,
                 height=h,
                 shimmer_tick=time.monotonic() - _chat_anim0,
+                scroll_meta=_chat_scroll_meta,
             )
         )
+        # Adopt the builder's clamped bottom when following or when we requested
+        # past-the-end, so the loop counter matches what's displayed.
+        if _chat_follow or scroll_offset == _SCROLL_BOTTOM:
+            scroll_offset = _chat_bottom()

--- a/src/yeaboi/ui/session/phases/_phases_review.py
+++ b/src/yeaboi/ui/session/phases/_phases_review.py
@@ -16,6 +16,7 @@ from yeaboi.ui.session._utils import _invoke_with_animation, _render_to_lines, _
 from yeaboi.ui.session.screens._accordion import _build_accordion_question_screen
 from yeaboi.ui.session.screens._screens import _build_summary_screen
 from yeaboi.ui.session.screens._screens_pipeline import _build_edit_prompt_screen
+from yeaboi.ui.shared._scroll import SCROLL_KEYS, coalesce_scroll
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,9 @@ def _phase_intake_review(
         scroll_offset = 0
         menu_selected = 0  # 0=Accept, 1=Edit, 2=Export
         status_msg = ""
+        # The screen builder publishes its true scroll geometry here each render;
+        # coalesce_scroll() below clamps to it so the offset never runs past the end.
+        _scroll_meta: dict = {}
 
         # Button fade animation state — mirrors project dashboard pattern.
         # Each button has a current fade (0.0–1.0) and a target.
@@ -89,6 +93,7 @@ def _phase_intake_review(
                 width=w,
                 height=h,
                 btn_fades=btn_fades,
+                scroll_meta=_scroll_meta,
             )
         )
 
@@ -98,10 +103,11 @@ def _phase_intake_review(
 
             if key == "esc":
                 return None
-            elif key in ("up", "scroll_up"):
-                scroll_offset = max(0, scroll_offset - 1)
-            elif key in ("down", "scroll_down"):
-                scroll_offset += 1
+            elif key in SCROLL_KEYS:
+                _ns = coalesce_scroll(scroll_offset, key, _scroll_meta, _key)
+                if _ns == scroll_offset:
+                    continue  # boundary — skip the repaint so the title shimmer stays put
+                scroll_offset = _ns
             elif key == "left":
                 menu_selected = (menu_selected - 1) % 3
                 btn_targets = [1.0 if i == menu_selected else 0.0 for i in range(3)]
@@ -160,6 +166,7 @@ def _phase_intake_review(
                     status_msg=status_msg,
                     btn_fades=btn_fades,
                     shimmer_tick=time.monotonic() - _anim0,
+                    scroll_meta=_scroll_meta,
                 )
             )
 

--- a/src/yeaboi/ui/session/screens/_screens.py
+++ b/src/yeaboi/ui/session/screens/_screens.py
@@ -15,6 +15,7 @@ from rich.text import Text
 from yeaboi.ui.shared._animations import lerp_color as _shared_lerp_color
 from yeaboi.ui.shared._animations import scrollbar_column
 from yeaboi.ui.shared._components import PAD, planning_title
+from yeaboi.ui.shared._scroll import publish_geometry
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -130,6 +131,7 @@ def _build_summary_screen(
     status_msg: str = "",
     btn_fades: list[float] | None = None,
     shimmer_tick: float | None = None,
+    scroll_meta: dict | None = None,
 ) -> Panel:
     """Build the scrollable intake summary screen with Accept/Edit/Export action bar.
 
@@ -150,6 +152,7 @@ def _build_summary_screen(
     # Clamp scroll offset
     max_scroll = max(0, len(summary_lines) - viewport_h)
     scroll_offset = max(0, min(scroll_offset, max_scroll))
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
 
     body: list = []
 

--- a/src/yeaboi/ui/session/screens/_screens_pipeline.py
+++ b/src/yeaboi/ui/session/screens/_screens_pipeline.py
@@ -18,6 +18,7 @@ from yeaboi.ui.session._utils import _pad_left, _wrap_text
 from yeaboi.ui.session.screens._screens import _build_action_bar, _planning_title
 from yeaboi.ui.shared._animations import scrollbar_column
 from yeaboi.ui.shared._components import PAD
+from yeaboi.ui.shared._scroll import publish_geometry
 
 _PAD = PAD
 
@@ -54,6 +55,7 @@ def _build_pipeline_screen(
     popup_t: float = 0.0,
     popup_pulse: float = 0.0,
     shimmer_tick: float | None = None,
+    scroll_meta: dict | None = None,
 ) -> Panel:
     """Build the pipeline stage screen (processing + result).
 
@@ -129,6 +131,9 @@ def _build_pipeline_screen(
         effective_h = viewport_h - 2 if has_sticky_headers else viewport_h
         max_scroll = max(0, len(content_lines) - effective_h)
         scroll_offset = max(0, min(scroll_offset, max_scroll))
+        # Hand the real geometry back to the scroll loop so its counter clamps to
+        # exactly what's displayed (see yeaboi.ui.shared._scroll.publish_geometry).
+        publish_geometry(scroll_meta, max_scroll, effective_h)
         has_above = scroll_offset > 0
 
         # Determine sticky header — find the most recent group header above viewport.
@@ -382,6 +387,7 @@ def _build_chat_screen(
     processing: bool = False,
     tick: float = 0.0,
     shimmer_tick: float | None = None,
+    scroll_meta: dict | None = None,
 ) -> Panel:
     """Build the post-pipeline chat screen.
 
@@ -412,6 +418,9 @@ def _build_chat_screen(
 
     max_scroll = max(0, len(msg_lines) - viewport_h)
     scroll_offset = max(0, min(scroll_offset, max_scroll))
+    # Hand the real geometry (msg_lines is built here, not in the loop) back so
+    # the chat loop can clamp/jump-to-bottom exactly. See _scroll.publish_geometry.
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
     has_above = scroll_offset > 0
     has_below = scroll_offset + viewport_h < len(msg_lines)
 

--- a/src/yeaboi/ui/shared/__init__.py
+++ b/src/yeaboi/ui/shared/__init__.py
@@ -41,3 +41,13 @@ from yeaboi.ui.shared._input import (  # noqa: F401
     enable_mouse_tracking,
     read_key,
 )
+from yeaboi.ui.shared._scroll import (  # noqa: F401
+    SCROLL_KEYS,
+    WHEEL_STEP,
+    apply_scroll,
+    clamp_scroll,
+    coalesce_scroll,
+    coalesce_steps,
+    max_scroll,
+    publish_geometry,
+)

--- a/src/yeaboi/ui/shared/_input.py
+++ b/src/yeaboi/ui/shared/_input.py
@@ -13,11 +13,26 @@ import sys
 import termios
 import tty
 
+# Keys read ahead while coalescing a fast scroll burst but not consumed (a
+# non-scroll key drained past the end of the burst) are stashed here and returned
+# by the next read_key() call, so no keypress is ever lost. Single-threaded input,
+# so a plain module list is safe. See coalesce_scroll() in _scroll.py.
+_pushback: list[str] = []
+
+
+def push_back_key(key: str) -> None:
+    """Return a key to the front of the input stream (LIFO with the buffer)."""
+    _pushback.append(key)
+
 
 def read_key(stdin=None, timeout: float | None = None) -> str:
     """Read a single keypress from the terminal in raw mode.
 
     If timeout is given, returns "" if no key is pressed within that time.
+
+    A key stashed by push_back_key() is returned first (immediately, ignoring
+    timeout) — this is how a coalesced scroll burst hands back the non-scroll key
+    that ended it.
 
     Returns standardised key names:
       - "up", "down", "left", "right" — arrow keys
@@ -32,6 +47,9 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
     invisible to select(), causing escape-sequence detection to fail.
     """
     import select as _select
+
+    if _pushback:
+        return _pushback.pop()
 
     fd = (stdin or sys.stdin).fileno()
     old_settings = termios.tcgetattr(fd)
@@ -108,6 +126,8 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
                 # CSI u (kitty keyboard protocol): \x1b[13;2u = Shift+Enter
                 if ch3 == "1":
                     rest = _read_available(0.05)
+                    if rest == "~":
+                        return "home"  # \x1b[1~ — Home on vt-style terminals
                     if rest.startswith("3;2u"):
                         return "alt+enter"
                     if rest.startswith(";2D"):
@@ -138,6 +158,22 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
                         rest = _read_available(0.05)
                         if rest.startswith("2~"):
                             return "word_delete"
+                    _read_available()
+                    return ""
+                # Page / Home / End as CSI-tilde sequences (vt-style, used by
+                # many terminals for the navigation cluster). Scroll loops handle
+                # these via apply_scroll(). \x1b[5~ PageUp, \x1b[6~ PageDown,
+                # \x1b[1~/\x1b[7~ Home, \x1b[4~/\x1b[8~ End.
+                if ch3 in ("5", "6", "4", "7", "8"):
+                    ch4 = _read1()
+                    if ch4 == "~":
+                        return {
+                            "5": "pageup",
+                            "6": "pagedown",
+                            "4": "end",
+                            "7": "home",
+                            "8": "end",
+                        }[ch3]
                     _read_available()
                     return ""
                 if ch3 == "H":
@@ -256,6 +292,50 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
         return ch
     finally:
         termios.tcsetattr(fd, termios.TCSANOW, old_settings)
+
+
+# Terminal settings saved by enter_raw_mode(), restored by exit_raw_mode().
+_saved_term_settings = None
+
+
+def enter_raw_mode(stdin=None) -> None:
+    """Hold the terminal in cbreak + no-echo for the whole full-screen TUI.
+
+    read_key() flips to cbreak per call but restores the *prior* settings in its
+    finally, so between keypresses the terminal reverts to cooked + echo. During
+    a fast mouse-wheel scroll, mouse-tracking report bytes (``\\x1b[<64;…M``)
+    arrive in that between-reads window, get echoed to the screen as garbage, and
+    tear the view — and the terminal (e.g. iTerm2) flags "mouse reporting left
+    on". Holding cbreak for the entire session closes that window: read_key's
+    per-call save/restore now captures and restores cbreak, so echo stays off the
+    whole time. Idempotent-safe; a no-op if the fd isn't a real terminal.
+    """
+    global _saved_term_settings
+    try:
+        fd = (stdin or sys.stdin).fileno()
+        _saved_term_settings = termios.tcgetattr(fd)
+        tty.setcbreak(fd)  # disables ICANON + ECHO
+        # Mirror read_key: drop IXON/IEXTEN so Ctrl+S / Ctrl+O reach the app.
+        m = termios.tcgetattr(fd)
+        m[0] &= ~termios.IXON
+        m[3] &= ~termios.IEXTEN
+        termios.tcsetattr(fd, termios.TCSANOW, m)
+    except Exception:  # noqa: BLE001 - not a tty (pipe, redirect, CI); leave as-is
+        _saved_term_settings = None
+
+
+def exit_raw_mode(stdin=None) -> None:
+    """Restore the terminal mode saved by :func:`enter_raw_mode`."""
+    global _saved_term_settings
+    if _saved_term_settings is None:
+        return
+    try:
+        fd = (stdin or sys.stdin).fileno()
+        termios.tcsetattr(fd, termios.TCSANOW, _saved_term_settings)
+    except Exception:  # noqa: BLE001
+        pass
+    finally:
+        _saved_term_settings = None
 
 
 def enable_bracketed_paste() -> None:

--- a/src/yeaboi/ui/shared/_music_bar.py
+++ b/src/yeaboi/ui/shared/_music_bar.py
@@ -98,6 +98,15 @@ class MusicLive(Live):
     """A Rich ``Live`` that stamps the music status onto every Panel it renders."""
 
     def __init__(self, *args, **kwargs) -> None:
+        # Default vertical_overflow to "crop". The TUI is a hand-rolled scroller:
+        # every screen builds a Panel sized to the terminal height and does its
+        # own line-slicing. If a Panel ever renders even one row too tall (small
+        # terminal, an ASCII title whose height differs from the assumed
+        # constant, or line-wrapping), Rich's default "ellipsis" overflow pushes
+        # the real terminal into scrolling and corrupts the frame — the "breaks
+        # the view" symptom. "crop" silently trims the overflow instead of
+        # scrolling; unlike "ellipsis" it also avoids a stray "…" on the last row.
+        kwargs.setdefault("vertical_overflow", "crop")
         super().__init__(*args, **kwargs)
         self._last_renderable = None
         self._stamped = False

--- a/src/yeaboi/ui/shared/_scroll.py
+++ b/src/yeaboi/ui/shared/_scroll.py
@@ -1,0 +1,191 @@
+"""Shared scroll-offset helpers for the full-screen TUI.
+
+# See README: "Architecture" — the TUI is a hand-rolled scroller on rich.Live.
+# Each screen renders content to text lines and slices lines[offset:offset+h].
+
+Historically every scroll loop tracked its own offset and let the *screen
+builder* clamp for display only (``max(0, min(offset, max_scroll))``). The
+clamped value was thrown away, so the loop's counter kept growing past the end
+— then scrolling back up wasted N dead keypresses with no visible movement (the
+"impossible to scroll sometimes" bug).
+
+The fix: the builder is the single source of truth for how far a screen can
+scroll (line-based screens use ``max_scroll(total, viewport)``; variable-height
+screens compute their own ``max_scroll``). It hands that back to the loop via
+``publish_geometry`` into a shared ``scroll_meta`` dict, and the loop advances
+its offset with ``apply_scroll`` using those exact bounds — so the loop counter
+and the on-screen position can never diverge.
+"""
+
+from __future__ import annotations
+
+# One wheel notch moves this many lines. Arrow keys still move one line at a
+# time; the wheel is accelerated because each notch is a discrete "chunk" of
+# intent and one-line-per-notch feels sluggish on long content.
+WHEEL_STEP = 3
+
+# Every key that apply_scroll() acts on. Scroll loops branch on `k in SCROLL_KEYS`
+# so a single membership test routes all scrolling (arrows, wheel, page, home/end)
+# through one handler instead of a per-key elif chain.
+SCROLL_KEYS = (
+    "up",
+    "down",
+    "scroll_up",
+    "scroll_down",
+    "pageup",
+    "pagedown",
+    "home",
+    "end",
+)
+
+
+def max_scroll(total_lines: int, viewport_h: int) -> int:
+    """Largest valid offset for a line-based screen so the last line is reachable.
+
+    The single definition of this arithmetic for screens that scroll a flat list
+    of lines. Variable-height screens (item cards) compute their own maximum and
+    pass it straight to :func:`publish_geometry`.
+    """
+    return max(0, total_lines - viewport_h)
+
+
+def clamp_scroll(offset: int, total_lines: int, viewport_h: int) -> int:
+    """Clamp an offset into ``[0, max_scroll(total_lines, viewport_h)]``."""
+    return max(0, min(offset, max_scroll(total_lines, viewport_h)))
+
+
+def coalesce_scroll(offset: int, first_key: str, meta: dict, read_key_fn) -> int:
+    """Apply ``first_key`` then fold in every already-buffered scroll key.
+
+    A fast wheel flick or a held arrow key delivers a *burst* of scroll events.
+    Processing them one-per-loop-iteration — each followed by a repaint — lets the
+    terminal input buffer back up faster than it drains, which splits escape
+    sequences and tears the view ("fast scroll breaks it, slow scroll is fine").
+
+    This drains the burst in one shot: it keeps reading non-blocking
+    (``timeout=0``) and applies each scroll key to ``offset``, stopping at the
+    first non-scroll key — which it pushes back via :func:`_input.push_back_key`
+    so the caller's next ``read_key`` still sees it (no lost keypress). The caller
+    then repaints once for the whole burst.
+
+    Falls back to a single ``apply_scroll`` when ``read_key_fn`` can't poll
+    non-blocking (e.g. a test stub that ignores ``timeout``).
+    """
+    mo = meta.get("max_offset", 0)
+    vh = meta.get("viewport_h", 1)
+    offset = apply_scroll(offset, first_key, mo, vh)
+    for _ in range(4096):  # safety bound against a misbehaving reader
+        try:
+            nxt = read_key_fn(timeout=0.0)
+        except TypeError:
+            break  # reader doesn't support a timeout — can't drain, that's fine
+        if nxt in SCROLL_KEYS:
+            offset = apply_scroll(offset, nxt, mo, vh)
+        elif nxt == "":
+            break  # input drained
+        else:
+            from yeaboi.ui.shared._input import push_back_key
+
+            push_back_key(nxt)  # a real key ended the burst — hand it back
+            break
+    return offset
+
+
+def coalesce_steps(first_key: str, read_key_fn, *, down, up) -> int:
+    """Drain a burst of one-step navigation keys; return the net step (+down / -up).
+
+    The offset-based :func:`coalesce_scroll` is for content viewports; this is its
+    sibling for **selection carousels** (menus that do ``sel = (sel ± 1) % n``). A
+    fast wheel flick or held arrow otherwise fires one selection change + one
+    repaint per event, and on an animated screen (ASCII art, shimmer, description
+    reveal that restarts each move) that stutters. This folds the whole burst into
+    a single net movement so the caller repaints once.
+
+    ``down`` / ``up`` are the key-name collections that step forward / back by one.
+    A key in neither ends the burst and is pushed back via
+    :func:`_input.push_back_key` so the caller's next ``read_key`` still sees it.
+    Falls back to just ``first_key`` when ``read_key_fn`` can't poll non-blocking.
+    """
+    delta = 1 if first_key in down else (-1 if first_key in up else 0)
+    for _ in range(4096):  # safety bound
+        try:
+            nxt = read_key_fn(timeout=0.0)
+        except TypeError:
+            break
+        if nxt in down:
+            delta += 1
+        elif nxt in up:
+            delta -= 1
+        elif nxt == "":
+            break
+        else:
+            from yeaboi.ui.shared._input import push_back_key
+
+            push_back_key(nxt)
+            break
+    return delta
+
+
+def publish_geometry(meta: dict | None, max_offset: int, viewport_h: int) -> None:
+    """Screen builder → scroll loop hand-off of the true scroll geometry.
+
+    A scroll loop passes an empty dict as its screen builder's ``scroll_meta``.
+    The builder — which alone knows its real geometry (viewport reduced by sticky
+    headers / warning banners, or content it wraps internally) — calls this once
+    it has computed the maximum offset and viewport height, so the loop's next
+    :func:`apply_scroll` clamps to exactly what is on screen. The loop counter can
+    never run past the last displayed line again.
+
+    ``max_offset`` is the largest valid scroll offset (a line count for flat
+    screens, an item/line index for variable-height ones). No-op when ``meta`` is
+    None — builders are also called outside scroll loops.
+    """
+    if meta is None:
+        return
+    meta["max_offset"] = max(0, max_offset)
+    meta["viewport_h"] = max(1, viewport_h)
+
+
+def apply_scroll(
+    offset: int,
+    key: str,
+    max_offset: int,
+    viewport_h: int,
+    *,
+    page: int | None = None,
+    wheel_step: int = WHEEL_STEP,
+) -> int:
+    """Return the new, clamped scroll offset after handling ``key``.
+
+    Recognised keys (names produced by ``read_key``):
+      - ``"up"`` / ``"down"`` — one line
+      - ``"scroll_up"`` / ``"scroll_down"`` — one wheel notch (``wheel_step`` lines)
+      - ``"pageup"`` / ``"pagedown"`` — one page (``page`` lines, default: a viewport)
+      - ``"home"`` / ``"end"`` — jump to the top / bottom
+
+    Any other key returns ``offset`` unchanged. The result is always clamped into
+    ``[0, max_offset]``, so callers assign it straight back to their offset
+    variable and never track a separate maximum. Pass ``max_offset`` /
+    ``viewport_h`` from the ``scroll_meta`` the paired screen builder published.
+    """
+    max_offset = max(0, max_offset)
+    page_step = page if page is not None else max(1, viewport_h - 1)
+
+    if key == "up":
+        offset -= 1
+    elif key == "down":
+        offset += 1
+    elif key == "scroll_up":
+        offset -= wheel_step
+    elif key == "scroll_down":
+        offset += wheel_step
+    elif key == "pageup":
+        offset -= page_step
+    elif key == "pagedown":
+        offset += page_step
+    elif key == "home":
+        offset = 0
+    elif key == "end":
+        offset = max_offset
+
+    return max(0, min(offset, max_offset))

--- a/tests/unit/test_input_raw_mode.py
+++ b/tests/unit/test_input_raw_mode.py
@@ -1,0 +1,103 @@
+"""Regression tests for TUI terminal raw-mode handling (ui/shared/_input.py).
+
+The "fast scroll breaks the view" bug: read_key() flips to cbreak per call and
+restores the prior (cooked + echo) mode in its finally, so between keypresses the
+terminal echoes any incoming bytes. During a fast mouse-wheel scroll, mouse-report
+bytes arriving in that window get echoed as on-screen garbage. enter_raw_mode()
+holds cbreak + no-echo for the whole session so that can't happen.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import sys
+import termios
+
+import pytest
+
+from yeaboi.ui.shared import _input
+from yeaboi.ui.shared._input import enter_raw_mode, exit_raw_mode
+
+
+def _echoed_bytes(fd_holder) -> int:
+    """Write mouse-report bytes to a pty master; count what the slave echoes back."""
+    master, slave = fd_holder
+    payload = b"\x1b[<64;10;20M" * 5
+    os.write(master, payload)
+    echoed = b""
+    for _ in range(50):
+        r, _, _ = select.select([master], [], [], 0.05)
+        if not r:
+            break
+        try:
+            echoed += os.read(master, 4096)
+        except OSError:
+            break
+    return len(echoed)
+
+
+@pytest.fixture
+def pty_pair(monkeypatch):
+    master, slave = os.openpty()
+    # Start in a normal cooked + echo mode, like a fresh shell.
+    m = termios.tcgetattr(slave)
+    m[3] |= termios.ICANON | termios.ECHO
+    termios.tcsetattr(slave, termios.TCSANOW, m)
+
+    class _Stdin:
+        def fileno(self):
+            return slave
+
+    monkeypatch.setattr(sys, "stdin", _Stdin())
+    yield (master, slave)
+    os.close(master)
+    os.close(slave)
+
+
+def test_cooked_mode_echoes_mouse_bytes(pty_pair):
+    # Baseline: without raw mode the terminal echoes mouse bytes (the bug).
+    assert _echoed_bytes(pty_pair) > 0
+
+
+def test_enter_raw_mode_suppresses_mouse_echo(pty_pair):
+    enter_raw_mode()
+    try:
+        assert _echoed_bytes(pty_pair) == 0
+    finally:
+        exit_raw_mode()
+
+
+def test_exit_raw_mode_restores_echo_and_canonical(pty_pair):
+    _, slave = pty_pair
+    # Cooked mode has ECHO + ICANON on; enter_raw_mode clears them.
+    assert termios.tcgetattr(slave)[3] & (termios.ECHO | termios.ICANON)
+    enter_raw_mode()
+    assert not (termios.tcgetattr(slave)[3] & (termios.ECHO | termios.ICANON))
+    exit_raw_mode()
+    # Restored — the meaningful line-discipline flags are back (ignoring the
+    # driver's volatile PENDIN status bit, which isn't a real setting).
+    assert termios.tcgetattr(slave)[3] & (termios.ECHO | termios.ICANON)
+
+
+def test_exit_without_enter_is_noop():
+    _input._saved_term_settings = None
+    exit_raw_mode()  # must not raise
+
+
+def test_enter_raw_mode_on_non_tty_is_safe(monkeypatch):
+    # A pipe fd is not a terminal — enter_raw_mode must swallow the error.
+    r, w = os.pipe()
+
+    class _Stdin:
+        def fileno(self):
+            return r
+
+    monkeypatch.setattr(sys, "stdin", _Stdin())
+    try:
+        enter_raw_mode()
+        assert _input._saved_term_settings is None
+        exit_raw_mode()  # no-op, must not raise
+    finally:
+        os.close(r)
+        os.close(w)

--- a/tests/unit/test_scroll.py
+++ b/tests/unit/test_scroll.py
@@ -146,11 +146,13 @@ class TestCoalesceScroll:
         # A reader that pops from `queue` when polled non-blocking; "" when empty.
         def read(timeout=None):
             return queue.pop(0) if queue else ""
+
         return read
 
     def test_applies_first_key_plus_buffered_burst(self):
         # first_key + 4 buffered scroll_downs, wheel_step 3 → 5*3 = 15, clamped to 80.
         from yeaboi.ui.shared._scroll import coalesce_scroll
+
         q = ["scroll_down", "scroll_down", "scroll_down", "scroll_down"]
         out = coalesce_scroll(0, "scroll_down", {"max_offset": 80, "viewport_h": 20}, self._reader(q))
         assert out == 15
@@ -159,6 +161,7 @@ class TestCoalesceScroll:
     def test_stops_and_pushes_back_non_scroll_key(self):
         from yeaboi.ui.shared import _input
         from yeaboi.ui.shared._scroll import coalesce_scroll
+
         _input._pushback.clear()
         q = ["scroll_down", "enter"]
         out = coalesce_scroll(0, "scroll_down", {"max_offset": 80, "viewport_h": 20}, self._reader(q))
@@ -170,16 +173,20 @@ class TestCoalesceScroll:
 
     def test_stops_when_input_drained(self):
         from yeaboi.ui.shared._scroll import coalesce_scroll
+
         out = coalesce_scroll(10, "up", {"max_offset": 80, "viewport_h": 20}, self._reader([]))
         assert out == 9  # just the first key; nothing buffered
 
     def test_falls_back_to_single_apply_without_timeout_support(self):
         # A no-arg reader (like the test stubs) → TypeError → single apply, no drain.
         from yeaboi.ui.shared._scroll import coalesce_scroll
+
         calls = {"n": 0}
+
         def noarg_reader():
             calls["n"] += 1
             return "scroll_down"
+
         out = coalesce_scroll(0, "scroll_down", {"max_offset": 80, "viewport_h": 20}, noarg_reader)
         assert out == 3  # single wheel step
         assert calls["n"] == 0  # reader never successfully polled
@@ -187,6 +194,7 @@ class TestCoalesceScroll:
     def test_boundary_burst_is_noop(self):
         # Bursting down at the bottom stays put (so the caller can skip the repaint).
         from yeaboi.ui.shared._scroll import coalesce_scroll
+
         q = ["scroll_down", "scroll_down"]
         out = coalesce_scroll(80, "scroll_down", {"max_offset": 80, "viewport_h": 20}, self._reader(q))
         assert out == 80
@@ -201,26 +209,31 @@ class TestCoalesceSteps:
     def _reader(self, queue):
         def read(timeout=None):
             return queue.pop(0) if queue else ""
+
         return read
 
     def test_single_key_no_buffer(self):
         from yeaboi.ui.shared._scroll import coalesce_steps
+
         assert coalesce_steps("scroll_down", self._reader([]), down=self.DOWN, up=self.UP) == 1
         assert coalesce_steps("scroll_up", self._reader([]), down=self.DOWN, up=self.UP) == -1
 
     def test_sums_a_same_direction_burst(self):
         from yeaboi.ui.shared._scroll import coalesce_steps
+
         q = ["scroll_down", "scroll_down", "scroll_down"]  # + first = 4
         assert coalesce_steps("scroll_down", self._reader(q), down=self.DOWN, up=self.UP) == 4
 
     def test_mixed_directions_net_out(self):
         from yeaboi.ui.shared._scroll import coalesce_steps
+
         q = ["scroll_up", "scroll_up"]  # first down(+1) then two up(-2) = -1
         assert coalesce_steps("scroll_down", self._reader(q), down=self.DOWN, up=self.UP) == -1
 
     def test_pushes_back_non_nav_key(self):
         from yeaboi.ui.shared import _input
         from yeaboi.ui.shared._scroll import coalesce_steps
+
         _input._pushback.clear()
         q = ["scroll_down", "enter"]
         out = coalesce_steps("scroll_down", self._reader(q), down=self.DOWN, up=self.UP)
@@ -230,4 +243,5 @@ class TestCoalesceSteps:
 
     def test_no_timeout_reader_falls_back_to_first_key(self):
         from yeaboi.ui.shared._scroll import coalesce_steps
+
         assert coalesce_steps("scroll_down", lambda: "scroll_down", down=self.DOWN, up=self.UP) == 1

--- a/tests/unit/test_scroll.py
+++ b/tests/unit/test_scroll.py
@@ -1,0 +1,233 @@
+"""Unit tests for the shared TUI scroll helpers (yeaboi.ui.shared._scroll).
+
+These guard the fix for the "impossible to scroll sometimes" bug: the loop's
+offset must always stay clamped to what the screen builder can display, so
+scrolling back up moves on the first keypress instead of burning dead presses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from yeaboi.ui.shared._scroll import (
+    SCROLL_KEYS,
+    WHEEL_STEP,
+    apply_scroll,
+    clamp_scroll,
+    max_scroll,
+    publish_geometry,
+)
+
+
+class TestMaxScroll:
+    def test_content_taller_than_viewport(self):
+        assert max_scroll(total_lines=100, viewport_h=20) == 80
+
+    def test_content_fits_returns_zero(self):
+        assert max_scroll(total_lines=10, viewport_h=20) == 0
+
+    def test_exact_fit_returns_zero(self):
+        assert max_scroll(total_lines=20, viewport_h=20) == 0
+
+    def test_never_negative(self):
+        assert max_scroll(total_lines=0, viewport_h=5) == 0
+
+
+class TestClampScroll:
+    def test_clamps_to_max(self):
+        assert clamp_scroll(999, total_lines=100, viewport_h=20) == 80
+
+    def test_clamps_negative_to_zero(self):
+        assert clamp_scroll(-5, total_lines=100, viewport_h=20) == 0
+
+    def test_within_range_unchanged(self):
+        assert clamp_scroll(40, total_lines=100, viewport_h=20) == 40
+
+
+class TestApplyScroll:
+    # max_offset=80 (e.g. 100 lines, 20-row viewport)
+    MAX = 80
+    VH = 20
+
+    def test_down_moves_one_line(self):
+        assert apply_scroll(0, "down", self.MAX, self.VH) == 1
+
+    def test_up_moves_one_line(self):
+        assert apply_scroll(5, "up", self.MAX, self.VH) == 4
+
+    def test_wheel_uses_wheel_step(self):
+        assert apply_scroll(0, "scroll_down", self.MAX, self.VH) == WHEEL_STEP
+        assert apply_scroll(10, "scroll_up", self.MAX, self.VH) == 10 - WHEEL_STEP
+
+    def test_up_clamps_at_top(self):
+        # The dead-counter regression guard: from the top, "up" stays at 0
+        # (never goes negative and never needs "catch-up" presses).
+        assert apply_scroll(0, "up", self.MAX, self.VH) == 0
+
+    def test_down_clamps_at_bottom(self):
+        assert apply_scroll(self.MAX, "down", self.MAX, self.VH) == self.MAX
+
+    def test_scroll_down_clamps_at_bottom(self):
+        assert apply_scroll(self.MAX - 1, "scroll_down", self.MAX, self.VH) == self.MAX
+
+    def test_home_jumps_to_top(self):
+        assert apply_scroll(50, "home", self.MAX, self.VH) == 0
+
+    def test_end_jumps_to_bottom(self):
+        assert apply_scroll(0, "end", self.MAX, self.VH) == self.MAX
+
+    def test_pagedown_moves_a_viewport(self):
+        # Default page = viewport_h - 1 so one line of overlap is kept.
+        assert apply_scroll(0, "pagedown", self.MAX, self.VH) == self.VH - 1
+
+    def test_pageup_moves_a_viewport(self):
+        assert apply_scroll(40, "pageup", self.MAX, self.VH) == 40 - (self.VH - 1)
+
+    def test_custom_page_size(self):
+        assert apply_scroll(0, "pagedown", self.MAX, self.VH, page=5) == 5
+
+    def test_custom_wheel_step(self):
+        assert apply_scroll(0, "scroll_down", self.MAX, self.VH, wheel_step=1) == 1
+
+    def test_unknown_key_is_noop(self):
+        assert apply_scroll(42, "enter", self.MAX, self.VH) == 42
+        assert apply_scroll(42, "left", self.MAX, self.VH) == 42
+
+    def test_negative_max_offset_treated_as_zero(self):
+        # When content fits (max_offset would be 0/negative) every scroll stays at 0.
+        assert apply_scroll(0, "down", -3, self.VH) == 0
+        assert apply_scroll(5, "end", 0, self.VH) == 0
+
+    @pytest.mark.parametrize("key", SCROLL_KEYS)
+    def test_all_scroll_keys_stay_in_bounds(self, key):
+        # Every recognised key, from any starting offset, lands within [0, max].
+        for start in (-10, 0, 40, self.MAX, 999):
+            result = apply_scroll(start, key, self.MAX, self.VH)
+            assert 0 <= result <= self.MAX
+
+    def test_scroll_down_then_up_is_responsive(self):
+        # Regression: over-scroll must not inflate a hidden counter. Drive to the
+        # bottom with the wheel, then a single "up" must actually move up.
+        offset = 0
+        for _ in range(1000):  # spam the wheel far past the end
+            offset = apply_scroll(offset, "scroll_down", self.MAX, self.VH)
+        assert offset == self.MAX
+        assert apply_scroll(offset, "up", self.MAX, self.VH) == self.MAX - 1
+
+
+class TestPublishGeometry:
+    def test_populates_meta(self):
+        meta: dict = {}
+        publish_geometry(meta, max_offset=80, viewport_h=20)
+        assert meta == {"max_offset": 80, "viewport_h": 20}
+
+    def test_none_meta_is_noop(self):
+        # Builders are also called outside scroll loops (meta=None) — must not raise.
+        assert publish_geometry(None, max_offset=80, viewport_h=20) is None
+
+    def test_negative_values_floored(self):
+        meta: dict = {}
+        publish_geometry(meta, max_offset=-5, viewport_h=0)
+        assert meta["max_offset"] == 0
+        assert meta["viewport_h"] == 1
+
+    def test_meta_drives_apply_scroll(self):
+        # The loop's real usage: builder publishes, loop clamps against it.
+        meta: dict = {}
+        publish_geometry(meta, max_offset=30, viewport_h=10)
+        offset = apply_scroll(999, "down", meta["max_offset"], meta["viewport_h"])
+        assert offset == 30
+
+
+class TestCoalesceScroll:
+    """coalesce_scroll drains a burst of scroll keys into one offset update."""
+
+    def _reader(self, queue):
+        # A reader that pops from `queue` when polled non-blocking; "" when empty.
+        def read(timeout=None):
+            return queue.pop(0) if queue else ""
+        return read
+
+    def test_applies_first_key_plus_buffered_burst(self):
+        # first_key + 4 buffered scroll_downs, wheel_step 3 → 5*3 = 15, clamped to 80.
+        from yeaboi.ui.shared._scroll import coalesce_scroll
+        q = ["scroll_down", "scroll_down", "scroll_down", "scroll_down"]
+        out = coalesce_scroll(0, "scroll_down", {"max_offset": 80, "viewport_h": 20}, self._reader(q))
+        assert out == 15
+        assert q == []  # whole burst consumed
+
+    def test_stops_and_pushes_back_non_scroll_key(self):
+        from yeaboi.ui.shared import _input
+        from yeaboi.ui.shared._scroll import coalesce_scroll
+        _input._pushback.clear()
+        q = ["scroll_down", "enter"]
+        out = coalesce_scroll(0, "scroll_down", {"max_offset": 80, "viewport_h": 20}, self._reader(q))
+        assert out == 6  # two scroll_downs (first + one buffered) * 3
+        assert _input._pushback == ["enter"]  # non-scroll key handed back
+        # The next read_key() returns the pushed-back key (ignores real stdin).
+        assert _input.read_key() == "enter"
+        assert _input._pushback == []
+
+    def test_stops_when_input_drained(self):
+        from yeaboi.ui.shared._scroll import coalesce_scroll
+        out = coalesce_scroll(10, "up", {"max_offset": 80, "viewport_h": 20}, self._reader([]))
+        assert out == 9  # just the first key; nothing buffered
+
+    def test_falls_back_to_single_apply_without_timeout_support(self):
+        # A no-arg reader (like the test stubs) → TypeError → single apply, no drain.
+        from yeaboi.ui.shared._scroll import coalesce_scroll
+        calls = {"n": 0}
+        def noarg_reader():
+            calls["n"] += 1
+            return "scroll_down"
+        out = coalesce_scroll(0, "scroll_down", {"max_offset": 80, "viewport_h": 20}, noarg_reader)
+        assert out == 3  # single wheel step
+        assert calls["n"] == 0  # reader never successfully polled
+
+    def test_boundary_burst_is_noop(self):
+        # Bursting down at the bottom stays put (so the caller can skip the repaint).
+        from yeaboi.ui.shared._scroll import coalesce_scroll
+        q = ["scroll_down", "scroll_down"]
+        out = coalesce_scroll(80, "scroll_down", {"max_offset": 80, "viewport_h": 20}, self._reader(q))
+        assert out == 80
+
+
+class TestCoalesceSteps:
+    """coalesce_steps folds a nav burst into one net step for selection carousels."""
+
+    DOWN = ("down", "right", "scroll_down")
+    UP = ("up", "left", "scroll_up")
+
+    def _reader(self, queue):
+        def read(timeout=None):
+            return queue.pop(0) if queue else ""
+        return read
+
+    def test_single_key_no_buffer(self):
+        from yeaboi.ui.shared._scroll import coalesce_steps
+        assert coalesce_steps("scroll_down", self._reader([]), down=self.DOWN, up=self.UP) == 1
+        assert coalesce_steps("scroll_up", self._reader([]), down=self.DOWN, up=self.UP) == -1
+
+    def test_sums_a_same_direction_burst(self):
+        from yeaboi.ui.shared._scroll import coalesce_steps
+        q = ["scroll_down", "scroll_down", "scroll_down"]  # + first = 4
+        assert coalesce_steps("scroll_down", self._reader(q), down=self.DOWN, up=self.UP) == 4
+
+    def test_mixed_directions_net_out(self):
+        from yeaboi.ui.shared._scroll import coalesce_steps
+        q = ["scroll_up", "scroll_up"]  # first down(+1) then two up(-2) = -1
+        assert coalesce_steps("scroll_down", self._reader(q), down=self.DOWN, up=self.UP) == -1
+
+    def test_pushes_back_non_nav_key(self):
+        from yeaboi.ui.shared import _input
+        from yeaboi.ui.shared._scroll import coalesce_steps
+        _input._pushback.clear()
+        q = ["scroll_down", "enter"]
+        out = coalesce_steps("scroll_down", self._reader(q), down=self.DOWN, up=self.UP)
+        assert out == 2
+        assert _input._pushback == ["enter"]
+        assert _input.read_key() == "enter"
+
+    def test_no_timeout_reader_falls_back_to_first_key(self):
+        from yeaboi.ui.shared._scroll import coalesce_steps
+        assert coalesce_steps("scroll_down", lambda: "scroll_down", down=self.DOWN, up=self.UP) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -2481,7 +2481,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.8.0"
+version = "2.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Problem

The full-screen TUI scroll UX was broken: scrolling "broke the view", felt impossible/stuck at boundaries, shimmered, and a fast wheel-flick tore the screen (iTerm2 even flagged *"mouse reporting was left on… an app misbehaved"*).

## Root causes fixed

1. **Dead-counter bug** ("impossible to scroll sometimes") — every scroll loop incremented an *unbounded* offset and relied on the screen builder to clamp for display only. Over-scrolling inflated the counter, so scrolling back up wasted dead keypresses. Builders now **publish their true geometry** (`publish_geometry`) and loops clamp via `apply_scroll`.

2. **View tears / garbage on fast scroll** (the big one) — `read_key` switched to cbreak *per call* and restored the terminal's **cooked + echo** mode in its `finally`, so mouse-report bytes arriving *between* reads got **echoed to the screen as garbage** (and stuck iTerm2's mouse-reporting state). `enter_raw_mode`/`exit_raw_mode` now hold **cbreak + no-echo for the whole TUI session** (wired into `cli.py` with `atexit` + `finally` cleanup). Proven in a pty: 5 mouse events → **65 bytes echoed** before, **0 after**.

3. **Boundary shimmer** — a no-op scroll still repainted, advancing the title-shimmer animation. Loops now **skip the repaint** when the offset doesn't change.

4. **Fast-scroll flooding** — `coalesce_scroll` drains a wheel/key-repeat **burst into one** offset update + one repaint; `coalesce_steps` does the same for **selection carousels** (main menu, intake pickers, project/analysis lists).

Plus: `vertical_overflow="crop"` on the app `Live`, **PageUp/PageDown/Home/End** parsing in `read_key`, a faster wheel step, and de-duplicated viewport math — all centralized in a new `src/yeaboi/ui/shared/_scroll.py`.

## Tests

- New `tests/unit/test_scroll.py` — clamping, page/home/end, wheel step, burst coalescing, carousel steps, key push-back.
- New `tests/unit/test_input_raw_mode.py` — raw-mode echo suppression proven via a pty.
- Full suite green: **3496 passed, 7 skipped**; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)