### PR TITLE
fix(analysis): save each preview step the moment it generates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.8.2"
+version = "2.8.3"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -528,6 +528,7 @@ def _run_preview_flow(
     _epic = (resume_state or {}).get("sample_epic")
     _stories = (resume_state or {}).get("sample_stories")
     _tasks = (resume_state or {}).get("sample_tasks")
+    _sprint = (resume_state or {}).get("sample_sprint")
 
     # Scroll geometry published by each page's screen builder; reused across the
     # sequential pages (repopulated on every render before any key is handled).
@@ -623,6 +624,10 @@ def _run_preview_flow(
         if result is not None:
             _epic = result
         logger.info("Preview: sample epic generated: %s", _epic.get("title", "?"))
+        # Persist the moment generation completes — not only on the Accept/next
+        # keypress — so quitting here still leaves a resumable session (matches the
+        # Accept-handler save dict below).
+        _save_ana({"instructions": _instr, "sample_epic": _epic, "last_page": "epic"}, "epic")
 
     if last_page not in ("stories", "tasks", "sprint"):
         scroll, sel = 0, 0
@@ -688,6 +693,16 @@ def _run_preview_flow(
         if result is not None:
             _stories = result
         logger.info("Preview: %d sample stories generated", len(_stories))
+        # Persist on generation (see Epic page) so a mid-flow quit stays resumable.
+        _save_ana(
+            {
+                "instructions": _instr,
+                "sample_epic": _epic,
+                "sample_stories": _stories,
+                "last_page": "stories",
+            },
+            "stories",
+        )
 
     if last_page not in ("tasks", "sprint"):
         scroll, sel = 0, 0
@@ -766,6 +781,17 @@ def _run_preview_flow(
         if result is not None:
             _tasks = result
         logger.info("Preview: %d sample tasks generated", len(_tasks))
+        # Persist on generation (see Epic page) so a mid-flow quit stays resumable.
+        _save_ana(
+            {
+                "instructions": _instr,
+                "sample_epic": _epic,
+                "sample_stories": _stories,
+                "sample_tasks": _tasks,
+                "last_page": "tasks",
+            },
+            "tasks",
+        )
 
     if last_page != "sprint":
         scroll, sel = 0, 0
@@ -843,19 +869,24 @@ def _run_preview_flow(
         "Preview: entering Sprint page (%.1fs elapsed)",
         time.monotonic() - _flow_start,
     )
-    _run_sprint_review(
+    _finished = _run_sprint_review(
         live,
         console,
         read_key,
         frame_time,
         supports_timeout,
         _instr,
+        _epic,
         _stories,
         _tasks,
         ta_examples,
+        resume_sprint=_sprint,
     )
-    # Clear session so next run starts fresh (not resuming from sprint)
-    _save_ana({"last_page": "complete"}, "complete")
+    # Only mark the session complete (non-resumable) when the user actually
+    # finished the Sprint page. On a quit, _run_sprint_review has already saved
+    # the sprint with last_page="sprint", so the analysis resumes straight here.
+    if _finished:
+        _save_ana({"last_page": "complete"}, "complete")
     logger.info(
         "Preview flow completed in %.1fs",
         time.monotonic() - _flow_start,
@@ -869,11 +900,17 @@ def _run_sprint_review(
     frame_time,
     supports_timeout,
     instr_text,
+    sample_epic,
     sample_stories,
     sample_tasks,
     ta_examples,
+    resume_sprint=None,
 ):
-    """Run the sample sprint review loop (extracted to reduce nesting depth)."""
+    """Run the sample sprint review loop (extracted to reduce nesting depth).
+
+    Returns True if the user finished the page (chose "Done"), False if they quit
+    (Esc). The caller uses this to decide whether to mark the session complete.
+    """
     logger.info("Sprint review: generating sample sprint via LLM")
     import threading as _threading
 
@@ -882,6 +919,21 @@ def _run_sprint_review(
         _build_analysis_progress_screen,
         _build_sample_sprint_screen,
     )
+
+    def _save_sprint(sprint_obj: dict) -> None:
+        # Persist the sprint the moment it is generated (see the Epic page), with
+        # last_page="sprint" so a quit here resumes to this page without a re-run.
+        _save_ana(
+            {
+                "instructions": instr_text,
+                "sample_epic": sample_epic,
+                "sample_stories": sample_stories,
+                "sample_tasks": sample_tasks,
+                "sample_sprint": sprint_obj,
+                "last_page": "sprint",
+            },
+            "sprint",
+        )
 
     def _regen_sprint():
         result_box: list = [None, None]
@@ -916,15 +968,20 @@ def _run_sprint_review(
             return None
         return result_box[0]
 
-    sprint = _regen_sprint() or {
-        "sprint_name": "Sprint 1",
-        "velocity_target": 20,
-        "stories_included": [s.get("id", "") for s in sample_stories],
-        "total_points": sum(s.get("story_points", 0) for s in sample_stories),
-        "capacity_notes": "Fallback — generation failed.",
-        "risks": [],
-        "rationale": "Fallback sprint plan.",
-    }
+    if resume_sprint:
+        # Resumed session — reuse the saved sprint, skip the (expensive) LLM call.
+        sprint = resume_sprint
+    else:
+        sprint = _regen_sprint() or {
+            "sprint_name": "Sprint 1",
+            "velocity_target": 20,
+            "stories_included": [s.get("id", "") for s in sample_stories],
+            "total_points": sum(s.get("story_points", 0) for s in sample_stories),
+            "capacity_notes": "Fallback — generation failed.",
+            "risks": [],
+            "rationale": "Fallback sprint plan.",
+        }
+        _save_sprint(sprint)
     scroll = 0
     sel = 0
     _scroll_meta: dict = {}
@@ -941,15 +998,16 @@ def _run_sprint_review(
             sel = min(2, sel + 1)
         elif k in ("enter", " "):
             if sel == 0:
-                break  # Done
+                return True  # Done — caller marks the session complete
             elif sel == 1:
                 result = _regen_sprint()
                 if result is not None:
                     sprint = result
+                    _save_sprint(sprint)
             elif sel == 2:
                 pass  # Export (handled at report level)
         elif k in ("esc", "q"):
-            break
+            return False  # Quit — keep last_page="sprint" so it stays resumable
         w, h = console.size
         live.update(
             _build_sample_sprint_screen(

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -3368,9 +3368,10 @@ def select_mode(
                                 from dataclasses import replace as _dc_replace
 
                                 _ta_profile = _dc_replace(_ta_profile, team_name=_ta_team_name)
-                            db_dir = Path.home() / ".scrum-agent"
-                            db_dir.mkdir(parents=True, exist_ok=True)
-                            with TeamProfileStore(db_dir / "sessions.db") as store:
+                            # Save to the same DB every list/resume path reads from
+                            # (_ana_dbp = ~/.yeaboi/data/sessions.db) so a just-finished
+                            # analysis is visible immediately, not only after a restart.
+                            with TeamProfileStore(_ana_dbp) as store:
                                 store.save(_ta_profile, examples=_ta_examples_box[0])
                             try:
                                 from yeaboi.team_profile_exporter import write_analysis_log
@@ -4630,12 +4631,12 @@ def select_mode(
 
                             _ta_profile = _dc_replace(_ta_profile, team_name=_ta_team_name)
 
-                        # Save the fresh profile
-                        db_dir = Path.home() / ".scrum-agent"
-                        db_dir.mkdir(parents=True, exist_ok=True)
-                        with TeamProfileStore(db_dir / "sessions.db") as store:
+                        # Save the fresh profile to the same DB every list/resume path
+                        # reads from (_ana_dbp = ~/.yeaboi/data/sessions.db) so it's
+                        # visible immediately, not only after a restart.
+                        with TeamProfileStore(_ana_dbp) as store:
                             store.save(_ta_profile, examples=_ta_examples_box[0])
-                        logger.info("Profile saved to %s/sessions.db", db_dir)
+                        logger.info("Profile saved to %s", _ana_dbp)
 
                         # Write structured analysis log to ~/.scrum-agent/logs/
                         try:

--- a/tests/unit/test_analysis_sessions.py
+++ b/tests/unit/test_analysis_sessions.py
@@ -291,3 +291,67 @@ class TestMigrationV3ToV4:
             # None should show up as analysis sessions
             analysis = store.list_analysis_sessions()
             assert len(analysis) == 0
+
+
+# ---------------------------------------------------------------------------
+# Resume contract — save-on-generation persists each step, resumable until
+# the flow is marked complete. Backs the immediate-save behaviour in
+# ui/mode_select/__init__.py (_save_ana / _load_ana_session).
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisResumeContract:
+    def test_sample_artifacts_round_trip(self, store: SessionStore):
+        """Every preview artifact (incl. the sprint) survives save/load verbatim."""
+        sid = make_session_id()
+        store.create_session(sid, project_name="Platform", mode="analysis")
+        state = {
+            "messages": [],
+            "instructions": "Team velocity is 23.5",
+            "sample_epic": {"title": "Checkout revamp"},
+            "sample_stories": [{"id": "S1", "story_points": 3}],
+            "sample_tasks": [{"id": "T1"}],
+            "sample_sprint": {"sprint_name": "Sprint 1", "total_points": 3},
+            "last_page": "sprint",
+        }
+        store.save_state(sid, state)
+
+        loaded = store.load_state(sid)
+        assert loaded is not None
+        assert loaded["last_page"] == "sprint"
+        assert loaded["sample_epic"] == {"title": "Checkout revamp"}
+        assert loaded["sample_sprint"] == {"sprint_name": "Sprint 1", "total_points": 3}
+
+    def test_load_ana_session_resumes_incomplete(self, tmp_path: Path, monkeypatch):
+        """A session saved mid-flow (last_page != complete) is returned for resume."""
+        from yeaboi.ui import mode_select
+
+        db = tmp_path / "sessions.db"
+        monkeypatch.setattr(mode_select, "_ana_dbp", db)
+        monkeypatch.setattr(mode_select, "_ana_sid", "")
+
+        sid = make_session_id()
+        with SessionStore(db) as store:
+            store.create_session(sid, project_name="Platform", mode="analysis")
+            store.save_state(sid, {"messages": [], "sample_epic": {"title": "E"}, "last_page": "epic"})
+
+        resumed = mode_select._load_ana_session("Platform")
+        assert resumed is not None
+        assert resumed["last_page"] == "epic"
+        # The resume target is latched so subsequent _save_ana calls hit the same row.
+        assert mode_select._ana_sid == sid
+
+    def test_load_ana_session_skips_complete(self, tmp_path: Path, monkeypatch):
+        """A finished session (last_page == complete) is not offered for resume."""
+        from yeaboi.ui import mode_select
+
+        db = tmp_path / "sessions.db"
+        monkeypatch.setattr(mode_select, "_ana_dbp", db)
+        monkeypatch.setattr(mode_select, "_ana_sid", "")
+
+        sid = make_session_id()
+        with SessionStore(db) as store:
+            store.create_session(sid, project_name="Platform", mode="analysis")
+            store.save_state(sid, {"messages": [], "last_page": "complete"})
+
+        assert mode_select._load_ana_session("Platform") is None


### PR DESCRIPTION
## Problem

Two related issues meant a team analysis wasn't reliably saved/resumable:

1. **Preview step-through not saved on generation.** In analysis mode's preview (Instructions → Epic → Stories → Tasks → Sprint), each step's sample artifact is generated by an LLM call *at the top of its page*, but the resumable session was only persisted on the **"next"/Accept** keypress. Quitting after a step generated but before advancing lost the work; the Sprint step was never saved at all, and quitting it wrote `last_page="complete"` (marking the analysis non-resumable).

2. **Finished profile saved to the wrong DB.** Both post-analysis profile saves hardcoded `~/.scrum-agent/sessions.db` (the pre-rebrand legacy DB), while every profile list/resume path reads from `_ana_dbp` = `~/.yeaboi/data/sessions.db`. A just-finished analysis therefore landed in the legacy DB and only became visible after the next launch (when `get_db_path()` merges legacy→active) — so it looked like the analysis wasn't saved on completion.

## Fix

**Save each preview step the moment it generates** (`_run_preview_flow`):
- Epic / Stories / Tasks — added a `_save_ana(...)` call immediately after each generator returns, reusing the exact state dict the Accept handlers already build. These sit inside `if not _<artifact>:`, so a resumed artifact is never redundantly re-saved and normal forward navigation is unchanged — only a *quit* becomes recoverable.
- Sprint — `_run_sprint_review` now saves the sprint on generation (and regenerate) with `last_page="sprint"`, reuses a `resume_sprint` instead of re-calling the LLM, and returns a "finished" flag so the caller only writes the terminal `complete` marker when the user actually chose **Done** (not on quit).

**Save the finished profile to the active DB** — both save sites now use `_ana_dbp` (`~/.yeaboi/data/sessions.db`) instead of the hardcoded legacy path, so a finished analysis is immediately listable and resumable without a restart.

## Behavior change to note

Quitting the Sprint page no longer marks the analysis complete — it now resumes straight back to the saved Sprint page.

## Verification

- New regression test `TestAnalysisResumeContract` in `tests/unit/test_analysis_sessions.py`: asserts all four sample artifacts (incl. the new `sample_sprint`) round-trip through the store, that `_load_ana_session` returns a mid-flow session for resume and latches `_ana_sid`, and that a `complete` session is not offered for resume.
- `make test` → **3499 passed, 7 skipped**. `ruff check` + `ruff format --check` clean.
- Full `_run_preview_flow` is an interactive Rich TUI loop, so the tests assert the persistence contract; the end-to-end resume path is best confirmed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)