### PR TITLE
Fix Patterns-page button cropping + add ticket-generation confirmation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.9.1"
+version = "2.10.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -128,6 +128,49 @@ def _save_ana(state: dict, node: str) -> None:
         logger.debug("Analysis session save failed", exc_info=True)
 
 
+def _confirm_ticket_generation(
+    live,
+    console,
+    read_key,
+    frame_time,
+    supports_timeout,
+    *,
+    subtitle: str = "",
+) -> bool:
+    """Ask the user whether to generate sample tickets from the team analysis.
+
+    Renders a dedicated confirmation screen (separating "analyse the team/board"
+    from "create sample tickets") and drives a thin frame loop. Returns True if
+    the user chooses to generate, False if they decline (Not now / Esc).
+    """
+    from yeaboi.ui.mode_select.screens._screens_secondary import _build_generate_confirm_screen
+
+    logger.info("Analysis: showing ticket-generation confirmation")
+    sel = 0  # 0 = Generate tickets, 1 = Not now
+    while True:
+        w, h = console.size
+        live.update(
+            _build_generate_confirm_screen(
+                width=w,
+                height=h,
+                action_sel=sel,
+                subtitle=subtitle,
+            )
+        )
+        k = read_key(timeout=frame_time) if supports_timeout else read_key()
+        if k == "left":
+            sel = max(0, sel - 1)
+        elif k == "right":
+            sel = min(1, sel + 1)
+        elif k in ("enter", " "):
+            proceed = sel == 0
+            logger.info("Analysis: ticket generation %s", "confirmed" if proceed else "declined")
+            return proceed
+        elif k in ("esc", "q"):
+            logger.info("Analysis: ticket generation declined (esc)")
+            return False
+
+
 def _run_preview_flow(
     live,
     console,
@@ -3041,17 +3084,33 @@ def select_mode(
                                                     _si_resume = _load_ana_session(
                                                         _full.project_key if _full else "",
                                                     )
-                                                    _run_preview_flow(
+                                                    # Skip the confirmation when resuming a
+                                                    # ticket session already mid-generation —
+                                                    # the user confirmed on the first pass.
+                                                    _resuming = bool(_si_resume) and _si_resume.get(
+                                                        "last_page"
+                                                    ) in ("epic", "stories", "tasks", "sprint")
+                                                    if _resuming or _confirm_ticket_generation(
                                                         live,
                                                         console,
                                                         read_key,
                                                         _FRAME_TIME,
                                                         _supports_timeout,
-                                                        _si_text,
-                                                        _full,
-                                                        _stored_ex,
-                                                        resume_state=_si_resume,
-                                                    )
+                                                        subtitle=f"{_full.source}/{_full.project_key}"
+                                                        if _full
+                                                        else "",
+                                                    ):
+                                                        _run_preview_flow(
+                                                            live,
+                                                            console,
+                                                            read_key,
+                                                            _FRAME_TIME,
+                                                            _supports_timeout,
+                                                            _si_text,
+                                                            _full,
+                                                            _stored_ex,
+                                                            resume_state=_si_resume,
+                                                        )
                                                 break
                                         elif kk in ("esc", "q"):
                                             break
@@ -3472,37 +3531,49 @@ def select_mode(
                                     elif _act == "Continue":
                                         global _ana_sid  # noqa: PLW0603
 
-                                        from yeaboi.agent.nodes import _format_team_calibration
-                                        from yeaboi.sessions import SessionStore as _AStore
-                                        from yeaboi.sessions import make_session_id
+                                        # Ask before generating tickets — separate the
+                                        # team/board analysis from ticket creation.
+                                        if _confirm_ticket_generation(
+                                            live,
+                                            console,
+                                            read_key,
+                                            _FRAME_TIME,
+                                            _supports_timeout,
+                                            subtitle=f"{_ta_profile.source}/{_ta_profile.project_key}"
+                                            if _ta_profile
+                                            else "",
+                                        ):
+                                            from yeaboi.agent.nodes import _format_team_calibration
+                                            from yeaboi.sessions import SessionStore as _AStore
+                                            from yeaboi.sessions import make_session_id
 
-                                        _ana_sid = make_session_id()
-                                        try:
-                                            with _AStore(_ana_dbp) as _as:
-                                                _as.create_session(
-                                                    _ana_sid,
-                                                    _ta_profile.project_key if _ta_profile else "",
-                                                    mode="analysis",
-                                                )
-                                        except Exception:
-                                            pass
+                                            _ana_sid = make_session_id()
+                                            try:
+                                                with _AStore(_ana_dbp) as _as:
+                                                    _as.create_session(
+                                                        _ana_sid,
+                                                        _ta_profile.project_key if _ta_profile else "",
+                                                        mode="analysis",
+                                                    )
+                                            except Exception:
+                                                pass
 
-                                        _instr_text = _format_team_calibration(
-                                            _ta_profile,
-                                            examples=_ta_examples,
-                                        )
-                                        if _instr_text.strip():
-                                            _run_preview_flow(
-                                                live,
-                                                console,
-                                                read_key,
-                                                _FRAME_TIME,
-                                                _supports_timeout,
-                                                _instr_text,
+                                            _instr_text = _format_team_calibration(
                                                 _ta_profile,
-                                                _ta_examples,
-                                                resume_state=None,
+                                                examples=_ta_examples,
                                             )
+                                            if _instr_text.strip():
+                                                _run_preview_flow(
+                                                    live,
+                                                    console,
+                                                    read_key,
+                                                    _FRAME_TIME,
+                                                    _supports_timeout,
+                                                    _instr_text,
+                                                    _ta_profile,
+                                                    _ta_examples,
+                                                    resume_state=None,
+                                                )
                                         break
                                 elif kk in ("esc", "q"):
                                     break

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -3087,18 +3087,19 @@ def select_mode(
                                                     # Skip the confirmation when resuming a
                                                     # ticket session already mid-generation —
                                                     # the user confirmed on the first pass.
-                                                    _resuming = bool(_si_resume) and _si_resume.get(
-                                                        "last_page"
-                                                    ) in ("epic", "stories", "tasks", "sprint")
+                                                    _resuming = bool(_si_resume) and _si_resume.get("last_page") in (
+                                                        "epic",
+                                                        "stories",
+                                                        "tasks",
+                                                        "sprint",
+                                                    )
                                                     if _resuming or _confirm_ticket_generation(
                                                         live,
                                                         console,
                                                         read_key,
                                                         _FRAME_TIME,
                                                         _supports_timeout,
-                                                        subtitle=f"{_full.source}/{_full.project_key}"
-                                                        if _full
-                                                        else "",
+                                                        subtitle=f"{_full.source}/{_full.project_key}" if _full else "",
                                                     ):
                                                         _run_preview_flow(
                                                             live,

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -8,8 +8,10 @@
 
 from __future__ import annotations
 
+import io
+
 import rich.box
-from rich.console import Group
+from rich.console import Console, Group
 from rich.padding import Padding
 from rich.panel import Panel
 from rich.text import Text
@@ -25,6 +27,22 @@ from yeaboi.ui.shared._components import (
     planning_title,
 )
 from yeaboi.ui.shared._scroll import publish_geometry
+
+
+def _measure_render_height(renderable, width: int) -> int:
+    """Return the true number of terminal rows a renderable occupies at ``width``.
+
+    The analysis/profile screens pack a scrollable viewport by hand, estimating
+    each item's height so the packer knows when to stop and leave room for the
+    action buttons below. Plain ``Text`` items are one row, but a Rich table
+    with fixed-width columns wraps long cells onto several rows — a naive
+    ``row_count`` under-counts it, which lets the packer overfill the viewport
+    and push the buttons off the bottom of the fixed-height panel. Rendering to
+    an off-screen console and counting the produced lines gives the real height.
+    """
+    _con = Console(width=max(1, width), file=io.StringIO(), legacy_windows=False)
+    return len(_con.render_lines(renderable, pad=False))
+
 
 # ---------------------------------------------------------------------------
 # Shared analysis review screen builder (mirrors planning mode layout)
@@ -148,6 +166,72 @@ def _build_analysis_review_screen(
 _PAD = PAD  # alias for backward compatibility within this module
 
 
+def _build_generate_confirm_screen(
+    *,
+    width: int = 80,
+    height: int = 24,
+    action_sel: int = 0,
+    subtitle: str = "",
+) -> Panel:
+    """Confirmation screen shown between team/board analysis and ticket generation.
+
+    Separates the two concerns: the user has just analysed the team/board and is
+    now explicitly asked whether they want yeaboi to draft a sample epic/stories/
+    tasks/sprint (which runs the LLM) — rather than the app assuming they do.
+
+    Delegates to ``_build_analysis_review_screen`` so the layout (title, progress
+    dots, viewport, action buttons) stays identical to the rest of analysis mode.
+    """
+    c_label = "bold white"
+    c_body = "rgb(180,180,200)"
+    c_bullet = "rgb(100,180,100)"
+    c_muted = "rgb(120,120,140)"
+
+    def _bullet(text: str) -> Text:
+        t = Text(_PAD + "  ", justify="left")
+        t.append("• ", style=c_bullet)
+        t.append(text, style=c_body)
+        return t
+
+    # The question leads the body so it stays above the fold even on short
+    # terminals, where the viewport shows only a few rows. The action buttons
+    # below are always visible; the explanation and bullets follow.
+    body_lines: list = [
+        Text(""),
+        Text(
+            _PAD + "Analysis complete — generate sample tickets now?",
+            style=c_label,
+            justify="left",
+        ),
+        Text(""),
+        Text(
+            _PAD + "yeaboi can draft a sample set, calibrated to these patterns:",
+            style=c_body,
+            justify="left",
+        ),
+        _bullet("a sample epic"),
+        _bullet("sample user stories"),
+        _bullet("sample tasks"),
+        _bullet("a sample sprint plan"),
+        Text(""),
+        Text(
+            _PAD + "This runs the LLM. You can edit, regenerate, or export each step.",
+            style=c_muted,
+            justify="left",
+        ),
+    ]
+
+    return _build_analysis_review_screen(
+        body_lines,
+        stage_index=0,
+        width=width,
+        height=height,
+        action_sel=action_sel,
+        actions=["Generate tickets", "Not now"],
+        subtitle=subtitle,
+    )
+
+
 def _build_team_analysis_screen(
     profile,
     *,
@@ -203,6 +287,18 @@ def _build_team_analysis_screen(
         lines.append(item)
         _item_heights.append(rendered_h)
         _rendered_lines += rendered_h
+
+    def _add_table(table) -> None:
+        """Append a table with its wrapped height measured (not naive row count).
+
+        Fixed-width columns wrap long cells onto multiple rows; measuring at the
+        body column width (panel interior minus the 1-col scrollbar) keeps the
+        viewport packer honest so the action buttons stay on screen. Measured
+        only on the active page — inactive pages are dropped by ``_add`` anyway.
+        """
+        padded = Padding(table, (0, 0, 0, len(_PAD) + 2))
+        rendered_h = _measure_render_height(padded, max(10, width - 7)) if _active else 1
+        _add(padded, rendered_h=rendered_h)
 
     def _heading(text: str) -> None:
         _add(Text(""))
@@ -471,7 +567,7 @@ def _build_team_analysis_screen(
 
             sp_table.add_row(*row_cells)
 
-        _add(Padding(sp_table, (0, 0, 0, len(_PAD) + 2)), rendered_h=sp_table.row_count + 1)
+        _add_table(sp_table)
 
         # Analysis of incomplete sprints
         incomplete_sprints = [
@@ -741,7 +837,7 @@ def _build_team_analysis_screen(
                 Text(focus[:14], style=c_dim),
                 Text(str(ps), style=ps_sty),
             )
-        _add(Padding(mt, (0, 0, 0, len(_PAD) + 2)), rendered_h=len(_contrib[:10]) + 1)
+        _add_table(mt)
 
         # Insights
         if len(_contrib) >= 3:
@@ -1047,7 +1143,7 @@ def _build_team_analysis_screen(
                 ex_text,
             )
 
-        _add(Padding(dod_table, (0, 0, 0, len(_PAD) + 2)), rendered_h=dod_table.row_count + 1)
+        _add_table(dod_table)
 
         if dod.common_checklist_items:
             _add(Text(""))
@@ -1142,7 +1238,7 @@ def _build_team_analysis_screen(
                 Text(sig, style=c_muted),
                 Text(item.get("recommendation", "")[:55], style=c_dim),
             )
-        _add(Padding(pdod_table, (0, 0, 0, len(_PAD) + 2)), rendered_h=len(proposed_dod["items"]) + 1)
+        _add_table(pdod_table)
 
         # DoD ordering (typical sequence)
         dod_ordering = proposed_dod.get("ordering", [])
@@ -1790,7 +1886,7 @@ def _build_team_analysis_screen(
                 ct_text,
             )
 
-        _add(Padding(repo_table, (0, 0, 0, len(_PAD) + 2)), rendered_h=repo_table.row_count + 1)
+        _add_table(repo_table)
 
         # Spillover-prone repos
         spill_repos = repos.get("spillover_repos", [])

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -72,6 +72,9 @@ _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
     "Jira": ("rgb(70,100,180)", "rgb(100,140,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
     "Azure DevOps": ("rgb(70,100,180)", "rgb(100,140,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
     "Configure": ("rgb(160,160,180)", "rgb(200,200,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
+    # Analysis-mode ticket-generation confirmation screen.
+    "Generate tickets": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),
+    "Not now": ("rgb(100,100,120)", "rgb(140,140,160)", "rgb(40,40,50)", "rgb(50,50,60)"),
     "Generate": ("rgb(180,80,160)", "rgb(220,120,200)", "rgb(50,40,50)", "rgb(60,50,60)"),
     "My Update": ("rgb(180,80,160)", "rgb(220,120,200)", "rgb(50,40,50)", "rgb(60,50,60)"),
     "Generate Action Items": ("rgb(50,170,170)", "rgb(90,220,220)", "rgb(40,52,52)", "rgb(50,62,62)"),

--- a/tests/unit/test_analysis_screens.py
+++ b/tests/unit/test_analysis_screens.py
@@ -26,6 +26,7 @@ from rich.text import Text
 from yeaboi.ui.mode_select.screens._screens_secondary import (
     _build_analysis_progress_screen,
     _build_analysis_review_screen,
+    _build_generate_confirm_screen,
     _build_instructions_review_screen,
     _build_sample_epic_screen,
     _build_sample_sprint_screen,
@@ -828,3 +829,165 @@ class TestBuildTeamAnalysisScreenExtended:
     def test_mid_scroll(self, profile):
         result = _build_team_analysis_screen(profile, scroll_offset=10, width=80, height=30)
         assert isinstance(result, Panel)
+
+    # Wrapping tables (DoD + Proposed DoD) previously reported a naive row_count
+    # as their height. When cells wrapped onto multiple rows the viewport packer
+    # over-filled the fixed-height panel and Rich cropped the action buttons off
+    # the bottom (Patterns page showed no buttons). Heights are now measured, so
+    # the buttons must survive even with a tall, heavily-wrapping Proposed DoD.
+    _DOD_HEAVY_EXAMPLES = {
+        "dod_testing": [{"issue_key": "PSOT-791", "summary": "Phase 9: Entra App Registration flow"}],
+        "dod_pr": [{"issue_key": "PSOT-851", "summary": "WIZ - Create an automated repo scanner"}],
+        "dod_review": [{"issue_key": "PSOT-880", "summary": "Complete DAST API Scan Implementation"}],
+        "dod_deploy": [{"issue_key": "PSOT-880", "summary": "Complete DAST API Scan Implementation"}],
+        "proposed_dod": {
+            "summary": "7 of 9 practices are well-established. The team has a clear definition of done.",
+            "health": "strong",
+            "items": [
+                {
+                    "practice": f"Practice number {i} updated",
+                    "status": "established",
+                    "signals": f"{90 - i * 8}% mentioned in stories · 6% have subtasks",
+                    "recommendation": "Consistently done. Include as a required DoD step.",
+                }
+                for i in range(8)
+            ],
+        },
+    }
+
+    @staticmethod
+    def _render_cropped(panel: Panel, width: int, height: int) -> str:
+        """Render exactly like the TUI: a fixed-height panel on a sized console.
+
+        The panel's ``height`` crops overflowing content, so this reproduces the
+        real button-cropping behaviour that a height-less render would hide.
+        """
+        buf = StringIO()
+        console = Console(file=buf, width=width, height=height, force_terminal=False, highlight=False)
+        console.print(panel)
+        return buf.getvalue()
+
+    def test_patterns_page_buttons_visible_with_wrapping_tables(self, profile):
+        """Page 2 action buttons must stay on screen even when tables wrap a lot."""
+        for scroll in (0, 9999):  # top of page and clamped-to-bottom
+            panel = _build_team_analysis_screen(
+                profile,
+                examples=self._DOD_HEAVY_EXAMPLES,
+                page=2,
+                width=120,
+                height=44,
+                scroll_offset=scroll,
+            )
+            output = self._render_cropped(panel, width=120, height=44)
+            assert "Back" in output, f"Back button cropped at scroll={scroll}"
+            assert "Next" in output, f"Next button cropped at scroll={scroll}"
+
+
+# ---------------------------------------------------------------------------
+# Confirmation screen: _build_generate_confirm_screen
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGenerateConfirmScreen:
+    """The gate shown between team/board analysis and sample-ticket generation."""
+
+    def test_returns_panel(self):
+        result = _build_generate_confirm_screen(width=80, height=24)
+        assert isinstance(result, Panel)
+
+    def test_renders_prompt_and_buttons(self):
+        output = _render(_build_generate_confirm_screen(width=100, height=30), width=100)
+        assert "generate sample tickets now?" in output
+        assert "Generate tickets" in output
+        assert "Not now" in output
+
+    def test_both_action_selections(self):
+        """Either button may be highlighted without crashing."""
+        for sel in (0, 1):
+            result = _build_generate_confirm_screen(width=100, height=30, action_sel=sel)
+            assert isinstance(result, Panel)
+
+    def test_subtitle_rendered(self):
+        output = _render(_build_generate_confirm_screen(width=100, height=30, subtitle="jira/PROJ"), width=100)
+        assert "jira/PROJ" in output
+
+    def test_narrow_terminal(self):
+        assert isinstance(_build_generate_confirm_screen(width=40, height=24), Panel)
+
+    def test_short_terminal(self):
+        assert isinstance(_build_generate_confirm_screen(width=80, height=14), Panel)
+
+    def test_buttons_registered(self):
+        """New button labels must have colours registered (CLAUDE.md convention)."""
+        from yeaboi.ui.shared._components import _BTN_COLORS
+
+        assert "Generate tickets" in _BTN_COLORS
+        assert "Not now" in _BTN_COLORS
+
+
+class TestConfirmTicketGeneration:
+    """The driver loop gating analysis → ticket generation (key handling)."""
+
+    class _FakeConsole:
+        size = (100, 30)
+
+    class _FakeLive:
+        def __init__(self):
+            self.frames = 0
+
+        def update(self, _panel):
+            self.frames += 1
+
+    @staticmethod
+    def _run(keys):
+        """Drive _confirm_ticket_generation with a scripted key sequence."""
+        from yeaboi.ui.mode_select import _confirm_ticket_generation
+
+        it = iter(keys)
+
+        def _read_key(timeout=None):
+            return next(it)
+
+        live = TestConfirmTicketGeneration._FakeLive()
+        result = _confirm_ticket_generation(
+            live,
+            TestConfirmTicketGeneration._FakeConsole(),
+            _read_key,
+            0.05,
+            True,
+            subtitle="jira/PROJ",
+        )
+        return result, live
+
+    def test_enter_on_generate_confirms(self):
+        result, live = self._run(["enter"])
+        assert result is True
+        assert live.frames >= 1  # rendered at least once before the keypress
+
+    def test_right_then_enter_declines(self):
+        # Move to "Not now" (sel=1), then confirm the selection.
+        result, _ = self._run(["right", "enter"])
+        assert result is False
+
+    def test_right_left_enter_confirms(self):
+        # Navigate to Not now and back to Generate, then Enter.
+        result, _ = self._run(["right", "left", "enter"])
+        assert result is True
+
+    def test_esc_declines(self):
+        result, _ = self._run(["esc"])
+        assert result is False
+
+    def test_space_selects_current(self):
+        result, _ = self._run([" "])
+        assert result is True
+
+    def test_left_clamps_at_zero(self):
+        # Pressing left at sel=0 stays on Generate.
+        result, _ = self._run(["left", "left", "enter"])
+        assert result is True
+
+    def test_right_clamps_at_one(self):
+        # Pressing right past the last button stays on Not now.
+        result, _ = self._run(["right", "right", "enter"])
+        assert result is False

--- a/uv.lock
+++ b/uv.lock
@@ -2481,7 +2481,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.9.0"
+version = "2.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
Two related Analysis-mode changes.

## 1. Fix: cropped action buttons on the Patterns page

**Symptom:** On Analysis → **Patterns**, scrolling to the bottom showed no `Back`/`Next` buttons.

**Cause:** The team-analysis screen (`_build_team_analysis_screen`) hand-packs a scrollable viewport, estimating each item's height so it can stop and leave room for the buttons below. The panel is a **fixed height**, so overflow gets cropped — and the buttons render last. The **Definition of Done** and **Proposed Definition of Done** tables use fixed-width columns whose cells wrap onto 2–3 rows, but the height estimate used a naive `row_count + 1` (e.g. a 7-item table estimated at 6 rows actually renders 11–13). The undercount overfilled the viewport and pushed the buttons past the panel's bottom edge.

**Fix:** Measure the true wrapped height by rendering to an off-screen `Console` (`_measure_render_height`) via a new `_add_table` helper, applied to all five `Padding(table)` additions in that screen. Also fixes scrolling never reaching the true bottom (the same undercount shrank `max_scroll`).

## 2. Feature: confirmation before sample-ticket generation

**Before:** Pressing **Continue** on the analysis results dropped the user straight into `_run_preview_flow` (Instructions → Epic → Stories → Tasks → Sprint), firing LLM calls — the app assumed they wanted tickets.

**Now:** A dedicated screen separates *analyzing the team/board* from *creating sample tickets*:
- `_build_generate_confirm_screen` — reuses the shared analysis layout; leads with "Analysis complete — generate sample tickets now?" and shows **Generate tickets** / **Not now**.
- `_confirm_ticket_generation` — thin driver loop (←/→ navigate, Enter/Space select, Esc decline) gating both `Continue` handlers in `select_mode`.
- **Decline** (Not now / Esc) → returns to the analysis home, **no LLM call**.
- **Resume-safe:** a profile with an in-progress ticket session (`last_page` in epic/stories/tasks/sprint) skips the prompt — the user already confirmed.
- Registered `Generate tickets` / `Not now` button colors in `_BTN_COLORS`.

The planning-mode pre-intake analysis loop (Continue → intake) is untouched.

## Tests
- Button-crop regression test: renders page 2 with heavily-wrapping tables at a fixed panel height and asserts the buttons survive (verified non-vacuous — fails under the old naive height).
- 14 new tests for the confirmation screen builder (prompt/buttons/subtitle, narrow & short terminals, button-registry) and the driver's key handling (Enter/Space/Esc, navigation, clamping).
- `make lint` clean; full suite **3531 passed, 7 skipped**.

## Verification
`make run` → Analysis → analyze/open a board → page to Insights → **Continue**: the confirmation screen appears. **Not now**/Esc returns home with no generation; **Generate tickets** proceeds into the existing flow. The Patterns page now shows its buttons at full scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)