### PR TITLE
add make wt-* targets for parallel worktree claude sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ ENV/
 .env.local
 .env.*.local
 
+# Git worktrees (make wt-new / wt-open)
+.claude/worktrees/
+
 # IDE
 .vscode/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 UV := $(or $(shell command -v uv 2>/dev/null),$(HOME)/.local/bin/uv)
 
-.PHONY: install dev test test-fast test-v test-all lint format run run-dry clean env pre-commit graph eval contract record smoke-test snapshot-update budget-report bump-patch bump-minor bump-major build publish help
+# Editor CLI used by `make wt-open` to open each worktree in a new window.
+# Override for forks of VS Code (e.g. `CODE=cursor make wt-open NAME=my-feature`).
+CODE ?= code
+
+.PHONY: install dev test test-fast test-v test-all lint format run run-dry clean env pre-commit graph eval contract record smoke-test snapshot-update budget-report bump-patch bump-minor bump-major build publish help wt-new wt-open wt-list wt-rm wt-rm-all
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -78,6 +82,37 @@ build: ## Build sdist + wheel into dist/
 
 publish: ## Publish to PyPI (use GitHub Actions for production releases)
 	$(UV) publish
+
+# --- Worktrees — parallel Claude sessions, one per task (NAME= required) ------
+
+# Guard NAME= for every wt-* target without duplicating the message.
+define need-name
+	@test -n "$(NAME)" || { echo "usage: make $@ NAME=<slug>  (e.g. NAME=standup-fix)"; exit 1; }
+endef
+
+wt-new: ## Create worktree .claude/worktrees/NAME (branch + .env + venv)
+	$(need-name)
+	bash scripts/wt.sh "$(NAME)"
+
+wt-open: ## Create worktree (if needed) + open a NEW VS Code window with claude auto-running
+	$(need-name)
+	CODE="$(CODE)" bash scripts/wt.sh "$(NAME)" open
+
+wt-list: ## List worktrees (branch, clean/dirty, path)
+	@bash scripts/wt-list.sh
+
+wt-rm: ## Remove worktree dir + branch
+	$(need-name)
+	bash scripts/wt.sh "$(NAME)" rm
+
+wt-rm-all: ## Remove ALL worktrees under .claude/worktrees/ (prompts to confirm)
+	@read -r -p "Remove ALL .claude/worktrees/* worktrees and their branches? [y/N] " ans; \
+	  if [ "$$ans" = "y" ] || [ "$$ans" = "Y" ]; then \
+	    for w in $$(git worktree list --porcelain | awk '/^worktree /{print $$2}' | grep "/.claude/worktrees/" || true); do \
+	      name="$$(basename "$$w")"; echo "[wt-rm-all] removing $$name"; bash scripts/wt.sh "$$name" rm || true; \
+	    done; \
+	    git worktree prune; echo "[wt-rm-all] done."; \
+	  else echo "[wt-rm-all] aborted"; fi
 
 clean: ## Remove build artifacts and caches
 	rm -rf .venv build dist .pytest_cache .ruff_cache *.egg-info src/*.egg-info

--- a/scripts/wt-list.sh
+++ b/scripts/wt-list.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# scripts/wt-list.sh — list every git worktree with branch, clean/dirty status,
+# and path. Backs `make wt-list`. The main checkout is included, marked (main).
+
+set -euo pipefail
+
+# Colours only when stdout is a terminal — `make wt-list | grep …` stays clean.
+if [ -t 1 ]; then
+  GREEN=$'\033[32m'; YELLOW=$'\033[33m'; DIM=$'\033[2m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+  GREEN=""; YELLOW=""; DIM=""; BOLD=""; RESET=""
+fi
+
+MAIN_ROOT="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+
+printf "%s%-24s  %-7s  %s%s\n" "$BOLD" "BRANCH" "STATUS" "PATH" "$RESET"
+printf "%s%-24s  %-7s  %s%s\n" "$DIM" "------" "------" "----" "$RESET"
+
+# `git worktree list --porcelain` stanzas:
+#   worktree <abs-path>
+#   HEAD <sha>
+#   branch refs/heads/<name>     (or `detached`)
+git worktree list --porcelain | awk '
+  /^worktree /  { wt=$2 }
+  /^branch /    { print wt "\t" $2 }
+  /^detached$/  { print wt "\t(detached)" }
+' | while IFS=$'\t' read -r wt branch; do
+  short_branch="${branch#refs/heads/}"
+  [ "$wt" = "$MAIN_ROOT" ] && short_branch="$short_branch (main)"
+  if [ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]; then
+    status_cell="${YELLOW}dirty${RESET}  "
+  else
+    status_cell="${GREEN}clean${RESET}  "
+  fi
+  printf "%-24s  %s  %s\n" "$short_branch" "$status_cell" "$wt"
+done

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/wt.sh <name> [open|rm] — git-worktree lifecycle for parallel Claude sessions.
+#
+#   bash scripts/wt.sh my-feature        -> create .claude/worktrees/my-feature + provision
+#   bash scripts/wt.sh my-feature open   -> create (if needed) + open a new VS Code window
+#                                           (claude auto-starts in the integrated terminal)
+#   bash scripts/wt.sh my-feature rm     -> remove worktree dir + git branch
+#
+# Provisioning per worktree: copy the main checkout's .env, create a uv venv with
+# the package installed editable (same as `make install`), and write .vscode/
+# auto-launch files so opening the folder starts a claude session.
+#
+# Backs `make wt-new` / `make wt-open` / `make wt-rm`. Editor CLI comes from
+# $CODE (default: code) — e.g. `CODE=cursor make wt-open NAME=my-feature`.
+
+set -euo pipefail
+
+NAME="${1:?usage: wt.sh <name> [open|rm]}"
+ACTION="${2:-create}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+# Always operate against the MAIN checkout, even when invoked from inside a
+# worktree (the main worktree is the first `git worktree list` entry).
+ROOT="$(git -C "$ROOT" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+TARGET="$ROOT/.claude/worktrees/$NAME"
+
+# Same uv fallback as the Makefile's UV := $(or ...) resolution.
+UV="$(command -v uv 2>/dev/null || echo "$HOME/.local/bin/uv")"
+
+if [ "$ACTION" = "rm" ]; then
+  git -C "$ROOT" worktree remove --force "$TARGET" 2>/dev/null || true
+  rm -rf "$TARGET"
+  git -C "$ROOT" worktree prune
+  git -C "$ROOT" branch -D "$NAME" 2>/dev/null || true
+  echo "[wt] removed worktree '$NAME' (dir + branch)"
+  exit 0
+fi
+
+if [ ! -d "$TARGET" ]; then
+  mkdir -p "$ROOT/.claude/worktrees"
+  # New branch by default; reuse the branch if it already exists.
+  if git -C "$ROOT" show-ref --verify --quiet "refs/heads/$NAME"; then
+    git -C "$ROOT" worktree add "$TARGET" "$NAME"
+  else
+    git -C "$ROOT" worktree add "$TARGET" -b "$NAME"
+  fi
+
+  # --- .env: carry API keys over from the main checkout ------------------------
+  if [ -f "$ROOT/.env" ]; then
+    cp "$ROOT/.env" "$TARGET/.env"
+    echo "[wt] copied .env from main checkout"
+  else
+    echo "[wt] note: no $ROOT/.env — run \`make env\` in the main checkout, then re-create this worktree"
+  fi
+
+  # --- venv: editable install so make test / make run work immediately --------
+  echo "[wt] creating venv + installing deps (uv)…"
+  (cd "$TARGET" && "$UV" venv >/dev/null && "$UV" pip install -q -e ".[dev]")
+
+  # --- .vscode/: auto-launch claude in the integrated terminal on folder open --
+  # `runOn: folderOpen` + workspace-scoped `task.allowAutomaticTasks: on` skips
+  # VS Code's "allow automatic tasks?" prompt. The Workspace Trust prompt is
+  # unavoidable on first open of any folder; trust once and it sticks.
+  mkdir -p "$TARGET/.vscode"
+  cat > "$TARGET/.vscode/settings.json" <<'EOF'
+{
+  "task.allowAutomaticTasks": "on"
+}
+EOF
+  # Add --dangerously-skip-permissions to the command for unattended fan-out runs.
+  cat > "$TARGET/.vscode/tasks.json" <<'EOF'
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "claude",
+      "type": "shell",
+      "command": "claude",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new",
+        "focus": true,
+        "clear": true,
+        "showReuseMessage": false
+      },
+      "runOptions": { "runOn": "folderOpen" },
+      "problemMatcher": []
+    }
+  ]
+}
+EOF
+fi
+
+echo "[wt] worktree ready: $TARGET"
+
+if [ "$ACTION" = "open" ]; then
+  CODE="${CODE:-code}"
+  if ! command -v "$CODE" >/dev/null 2>&1; then
+    echo "[wt] '$CODE' CLI not found on PATH." >&2
+    echo "     In VS Code: Cmd-Shift-P → \"Shell Command: Install 'code' command in PATH\"" >&2
+    echo "     Or override the editor: CODE=cursor make wt-open NAME=$NAME" >&2
+    exit 1
+  fi
+  "$CODE" -n "$TARGET"
+  echo "[wt] opened $NAME in $CODE; claude auto-starts in the integrated terminal"
+fi

--- a/uv.lock
+++ b/uv.lock
@@ -2481,7 +2481,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.9.1"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

Adds worktree lifecycle targets to the Makefile so multiple Claude Code sessions can work on the repo in parallel, each in an isolated checkout:

| Target | What it does |
|--------|--------------|
| `make wt-new NAME=x` | Create `.claude/worktrees/x` + branch `x`, copy `.env` from the main checkout, build a uv venv (`uv pip install -e ".[dev]"`), write `.vscode/` auto-launch files |
| `make wt-open NAME=x` | Create if needed + open a **new VS Code window**; `claude` auto-starts in the integrated terminal via a `runOn: folderOpen` task |
| `make wt-list` | Table of all worktrees: branch, clean/dirty (coloured when TTY), path |
| `make wt-rm NAME=x` | Remove worktree dir + branch |
| `make wt-rm-all` | Confirm prompt, then remove everything under `.claude/worktrees/` |

- Editor CLI overridable: `CODE=cursor make wt-open NAME=x`
- `need-name` guard prints usage and exits 1 when `NAME=` is missing
- `.claude/worktrees/` added to `.gitignore` (worktrees are full checkouts nested in the repo)
- Also syncs the stale `uv.lock` own-package version stamp (2.9.1 → 2.10.0, left over from the last release bump)

No Python source changes — implementation is two shell scripts (`scripts/wt.sh`, `scripts/wt-list.sh`) plus Makefile/.gitignore wiring, adapted from a reference worktree setup.

## Test plan

- [x] `make wt-new NAME=test-wt` — worktree created with `.env` note, own `.venv` (yeaboi importable), `.vscode/{settings,tasks}.json`, clean status on branch `test-wt`
- [x] `make test-fast` inside the worktree passes using the worktree's own venv (2977 passed)
- [x] `make wt-list` shows main + worktrees with clean/dirty status
- [x] `make wt-new` / `wt-rm` / `wt-open` without `NAME=` → usage error, exit 1
- [x] `wt-open` with a missing editor CLI → friendly install/override hints, exit 1
- [x] `make wt-rm NAME=test-wt` — dir + branch removed, `git worktree list` clean
- [x] `make wt-rm-all` — `n` aborts; `y` removes all worktrees + branches, then prunes
- [x] `make test` (3538 passed) and `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)