### PR TITLE
make wt-new open the worktree in VS Code with claude auto-running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,11 @@ define need-name
 	@test -n "$(NAME)" || { echo "usage: make $@ NAME=<slug>  (e.g. NAME=standup-fix)"; exit 1; }
 endef
 
-wt-new: ## Create worktree .claude/worktrees/NAME (branch + .env + venv)
+wt-new: ## Create worktree .claude/worktrees/NAME (branch + .env + venv) + open in VS Code with claude auto-running
 	$(need-name)
-	bash scripts/wt.sh "$(NAME)"
+	CODE="$(CODE)" bash scripts/wt.sh "$(NAME)" open
 
-wt-open: ## Create worktree (if needed) + open a NEW VS Code window with claude auto-running
+wt-open: ## Open worktree in a NEW VS Code window with claude auto-running (creates it first if needed)
 	$(need-name)
 	CODE="$(CODE)" bash scripts/wt.sh "$(NAME)" open
 


### PR DESCRIPTION
## Summary

Follow-up to #50. `make wt-new NAME=x` created the worktree but stopped there — opening the VS Code window (and the auto-started claude session) required a second `make wt-open` call. The intended flow is one command per parallel session, so `wt-new` now performs the same create-if-needed + open action as `wt-open`.

- `wt-new` — create + open (the everyday command)
- `wt-open` — re-open a window on an existing worktree (still creates if needed)

Makefile-only change; `scripts/wt.sh` already supported the `open` action.

## Test plan

- [x] `make -n wt-new NAME=x` shows `CODE="code" bash scripts/wt.sh "x" open`
- [x] `make wt-open NAME=analytics` on an existing worktree opens a new VS Code window with claude auto-running (same code path `wt-new` now uses)
- [x] `NAME=` guard unchanged (usage error, exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)