### PR TITLE
add step 2 agentic workflow: permissions, verify hooks, slash commands, headless worktrees, pr automation

### DIFF
--- a/.claude/commands/babysit-prs.md
+++ b/.claude/commands/babysit-prs.md
@@ -1,0 +1,17 @@
+---
+description: Check all open PRs, surface CI failures, and spawn fix agents for red ones
+---
+
+Babysit the open pull requests so finished work doesn't pile up. Arguments (optional): $ARGUMENTS — `fix` to auto-spawn fix agents, otherwise report-only.
+
+1. **Survey** — `gh pr list --state open` then `gh pr checks <number>` for each. Build a table: PR, branch, CI status (green/red/pending), review status, mergeable.
+
+2. **Green PRs** — list them as ready to merge. Do NOT merge anything yourself unless the PR carries the `auto-merge` label (then `gh pr merge --auto --squash` is allowed).
+
+3. **Red PRs** — for each failing PR, fetch the failing run's log (`gh run view <run-id> --log-failed`) and summarize the root cause in one line.
+   - If `fix` was passed: for each red PR, spawn a background fix agent (Agent tool, worktree isolation) whose prompt contains the branch name, the failure summary, and the failing log excerpt. Instruct it to check out that branch, reproduce with `make test` / `make lint`, fix, and push to the same branch. Track the agents and report when they finish.
+   - Otherwise: just report the failures with their causes.
+
+4. **Stale PRs** — flag PRs behind `main` by many commits or inactive for days; suggest `/sync-main` on their worktree.
+
+5. **Report** — end with a compact status table and the list of actions taken or recommended.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,27 @@
+---
+description: Verify (independent review + full tests), commit, push, and open a PR for the current branch
+---
+
+Ship the current feature branch. Arguments (optional): $ARGUMENTS — may include `auto-merge` to enable auto-merge for low-risk changes (docs/chores/small fixes only).
+
+Follow these steps **in order**. If any step fails, stop, report what failed, and fix it before continuing. Never skip the verification steps.
+
+1. **Sanity check** — run `git branch --show-current`. If on `main`, stop: create a feature branch first.
+
+2. **Independent verification (fresh context, no author bias)** — spawn a review agent via the Agent tool. Give it ONLY: (a) the output of `git diff main...HEAD`, (b) a one-paragraph description of what this branch was supposed to do — NOT this conversation's history. Instruct it to check:
+   - Does the diff actually accomplish the stated task? Any spec gaps?
+   - CLAUDE.md conventions: three-pillar observability (logging, log directory, tests), TUI component standards (shared components, themes, no hardcoded colours), frozen-dataclass fields have defaults, paths come from `paths.py`.
+   - Obvious correctness bugs.
+   Resolve every finding the reviewer confirms before proceeding (fix it, or explain in the PR body why it's intentionally not addressed).
+
+3. **Full test gate** — run `make test` and `make lint`. Both must pass (CLAUDE.md REQUIRED: Verification). `make test-fast` is not enough at ship time.
+
+4. **Commit** — stage the relevant changes and commit using repo conventions: lowercase imperative message (e.g. "add streaming output"), ending with the Co-Authored-By trailer from CLAUDE.md's Git Conventions.
+
+5. **Push + PR** — `git push -u origin <branch>`, then `gh pr create` against `main` with:
+   - Title: same style as the commit message.
+   - Body: a Summary section (what and why), a Test plan section (what was run), and the standard "🤖 Generated with Claude Code" footer.
+
+6. **Auto-merge (only if `auto-merge` was passed)** — confirm the change is genuinely low-risk (docs, chore, small fix; no `src/yeaboi/agent/`, schema, or workflow changes), then run `gh pr merge --auto --squash`. If it is not low-risk, say so and skip this step.
+
+7. **Report** — output the PR URL and a one-line status.

--- a/.claude/commands/sync-main.md
+++ b/.claude/commands/sync-main.md
@@ -1,0 +1,13 @@
+---
+description: Rebase the current worktree branch on latest main and re-verify
+---
+
+Bring the current feature branch up to date with `main`.
+
+1. Run `git branch --show-current`. If on `main`, just run `git pull --ff-only` and stop.
+2. `git fetch origin main`.
+3. If the working tree is dirty, stash first (`git stash push -u -m "sync-main autostash"`) and remember to pop at the end.
+4. `git rebase origin/main`. If conflicts arise, resolve them: prefer `main`'s version for files this branch didn't intentionally change; for genuine overlaps, merge both intents and explain what you did.
+5. Pop the stash if one was created (resolve any conflicts the same way).
+6. Run `make test-fast` and `make lint` to confirm the branch still works on top of the new base. If either fails, fix before finishing.
+7. Report: how many commits the branch was behind, any conflicts resolved, and the verification result.

--- a/.claude/commands/wt.md
+++ b/.claude/commands/wt.md
@@ -1,0 +1,14 @@
+---
+description: Manage git worktrees for parallel development (new/list/rm/headless)
+---
+
+Worktree operations for parallel feature development. Arguments: $ARGUMENTS
+
+Parse the arguments and run the matching operation via the existing tooling (never reimplement it):
+
+- `list` (or no arguments) — run `bash scripts/wt-list.sh` and, for each worktree, also check `gh pr list --head <branch>` to note whether it has an open PR. Present a compact table: name, branch, clean/dirty, PR status.
+- `new <name>` — run `bash scripts/wt.sh <name> open` (creates `.claude/worktrees/<name>` with branch, `.env`, venv, pre-commit hooks, then opens VS Code with a claude session).
+- `headless <name>` — run `bash scripts/wt.sh <name> headless` (same provisioning, no VS Code window; prints the path). Use this when the feature will be driven by a background agent from this session instead of a human-attended window.
+- `rm <name>` — first check the worktree is clean (`git -C .claude/worktrees/<name> status --porcelain` from the main checkout) and has no unmerged work; warn and ask before removing anything dirty. Then run `bash scripts/wt.sh <name> rm`.
+
+Worktrees live under `<main checkout>/.claude/worktrees/`. If the current directory is itself a worktree, the scripts already resolve the main checkout — just run them from here.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,60 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make test)",
+      "Bash(make test-fast)",
+      "Bash(make test-v)",
+      "Bash(make test-all)",
+      "Bash(make lint)",
+      "Bash(make format)",
+      "Bash(make run-dry)",
+      "Bash(make pre-commit)",
+      "Bash(make budget-report)",
+      "Bash(make wt-list)",
+      "Bash(uv run pytest:*)",
+      "Bash(uv run ruff:*)",
+      "Bash(uv sync:*)",
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff)",
+      "Bash(git diff:*)",
+      "Bash(git log)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch)",
+      "Bash(git branch -a)",
+      "Bash(git branch -vv)",
+      "Bash(git worktree list)",
+      "Bash(git worktree list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/claude-hooks/format-file.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/claude-hooks/verify-stop.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,64 @@
+# Async Claude code + security review on every PR.
+#
+# Deliberately NON-BLOCKING: this workflow is not a required check — ci.yml
+# remains the merge gate. The old per-PR review was removed for being slow;
+# this one can never block a merge, only add review comments when it lands.
+# Skips drafts and the auto-version bot's `chore: bump version` pushes.
+
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: |
+      github.event.pull_request.draft == false &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Read the diff with `gh pr diff ${{ github.event.pull_request.number }}` and the PR
+            description with `gh pr view ${{ github.event.pull_request.number }}`. Then review for:
+
+            1. **Correctness** — real bugs only: logic errors, broken edge cases, state
+               serialization issues (frozen dataclass fields without defaults break --resume),
+               concurrency problems in the retro/standup servers.
+            2. **Repo conventions (CLAUDE.md)** — three-pillar observability (logging via
+               logging_setup, paths from paths.py, tests for every new function), TUI component
+               standards (shared components from ui/shared/_components.py, theme colours not
+               hardcoded RGB), parse → fallback → format pattern in generation code, prompts
+               separated in prompts/.
+            3. **Security** — injected/unescaped untrusted input (LAN retro cards, tracker
+               ticket text), secrets or tokens logged or committed, unsafe subprocess/network
+               use, missing auth on new server endpoints.
+
+            Post the result as a single PR review comment via
+            `gh pr comment ${{ github.event.pull_request.number }} --body "..."`:
+            a short verdict line, then only findings that matter (file:line, what, why).
+            If there are no significant findings, post one line saying the review passed.
+            Do not comment on style that ruff already enforces. Do not request changes on
+            nitpicks. This review is advisory — never attempt to approve, merge, or block.
+          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh run view:*),Read,Grep,Glob"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened, assigned, labeled]
   pull_request_review:
     types: [submitted]
 
@@ -16,7 +16,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && github.event.action != 'labeled' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,3 +47,44 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
+
+  # Issue-to-PR: adding the `claude-implement` label to an issue kicks off an
+  # implementation run that opens a PR. The PR then flows through ci.yml,
+  # claude-review.yml, and auto-version.yml like any human-authored branch.
+  implement:
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'claude-implement'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Implement issue
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Implement GitHub issue #${{ github.event.issue.number }} in ${{ github.repository }}.
+
+            1. Read the issue with `gh issue view ${{ github.event.issue.number }}` (including comments).
+            2. Create a branch named `feature/issue-${{ github.event.issue.number }}-<short-slug>` off main.
+            3. Implement the change following CLAUDE.md conventions (observability pillars,
+               TUI component standards, frozen-dataclass defaults, tests for every new function).
+            4. Verify: `make test` and `make lint` must both pass before you commit.
+            5. Commit (lowercase imperative message + the Co-Authored-By trailer from CLAUDE.md),
+               push the branch, and open a PR against main whose body summarizes the change,
+               lists what was verified, and closes the issue (`Closes #${{ github.event.issue.number }}`).
+            6. Comment on the issue with a link to the PR.
+
+            If the issue is too ambiguous to implement safely, do NOT guess: comment on the
+            issue with the specific questions that need answering, and stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,29 @@ agg docs/demo.cast docs/demo.gif --theme github-dark       # convert to GIF
 rm docs/demo.cast                                           # clean up source
 ```
 
+## Parallel Development (worktrees)
+
+Each feature gets its own git worktree under `<main checkout>/.claude/worktrees/<name>` with its own branch, `.env`, uv venv, and pre-commit hooks. Never develop two features in one checkout.
+
+```bash
+make wt-new NAME=my-feature       # create worktree + open VS Code with claude auto-running
+make wt-headless NAME=my-feature  # create worktree WITHOUT VS Code (for background-agent work)
+make wt-list                      # list worktrees (branch, clean/dirty, path)
+make wt-rm NAME=my-feature        # remove worktree dir + branch
+```
+
+Slash commands (in `.claude/commands/`): `/wt` (worktree ops from inside a session), `/sync-main` (rebase on latest main + re-verify), `/ship` (independent review → full tests → commit → push → PR), `/babysit-prs` (survey open PRs, spawn fix agents for red CI).
+
+### Verification loop
+
+- **Every turn (automatic)**: a Stop hook runs `make lint` + `make test-fast` whenever a turn ends with dirty `.py` files, and a PostToolUse hook ruff-formats every edited `.py` file. Hook scripts live in `scripts/claude-hooks/`; wiring is in `.claude/settings.json`.
+- **At ship time (`/ship`)**: an independent fresh-context agent reviews the diff against the task (spec-fit + CLAUDE.md conventions), then the full `make test` + `make lint` gate runs before commit/push/PR.
+- **In CI**: `claude-review.yml` posts an async code + security review on every PR (non-blocking; `ci.yml` remains the merge gate).
+
+### Orchestration conventions
+
+When driving multiple features at once, work as an **orchestrator**: one main session, one background agent per feature, each in its own worktree (`make wt-headless`). The orchestrator kicks off agents, tracks them, reviews **final diffs** (not intermediate steps), and runs `/ship` per feature when green. Use `make test-fast` in the inner loop; the full `make test` runs at ship time.
+
 ## Code Style
 
 - Python 3.11+, ruff for linting/formatting (line-length 120)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ UV := $(or $(shell command -v uv 2>/dev/null),$(HOME)/.local/bin/uv)
 # Override for forks of VS Code (e.g. `CODE=cursor make wt-open NAME=my-feature`).
 CODE ?= code
 
-.PHONY: install dev test test-fast test-v test-all lint format security run run-dry clean env pre-commit graph eval contract record smoke-test snapshot-update budget-report bump-patch bump-minor bump-major build publish help wt-new wt-open wt-list wt-rm wt-rm-all
+.PHONY: install dev test test-fast test-v test-all lint format security run run-dry clean env pre-commit graph eval contract record smoke-test snapshot-update budget-report bump-patch bump-minor bump-major build publish help wt-new wt-open wt-headless wt-list wt-rm wt-rm-all
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -104,6 +104,10 @@ wt-new: ## Create worktree .claude/worktrees/NAME (branch + .env + venv) + open 
 wt-open: ## Open worktree in a NEW VS Code window with claude auto-running (creates it first if needed)
 	$(need-name)
 	CODE="$(CODE)" bash scripts/wt.sh "$(NAME)" open
+
+wt-headless: ## Create worktree WITHOUT VS Code auto-launch (driven by background agents instead)
+	$(need-name)
+	bash scripts/wt.sh "$(NAME)" headless
 
 wt-list: ## List worktrees (branch, clean/dirty, path)
 	@bash scripts/wt-list.sh

--- a/scripts/claude-hooks/format-file.sh
+++ b/scripts/claude-hooks/format-file.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook (Edit|Write): auto-format the touched Python file
+# with ruff so every edit lands pre-formatted and lint round-trips disappear.
+#
+# Receives the hook payload as JSON on stdin; extracts tool_input.file_path.
+# Best-effort by design: non-.py files, missing files, and ruff errors all
+# exit 0 — formatting must never block the session.
+
+set -uo pipefail
+
+file_path="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("tool_input", {}).get("file_path", ""))' 2>/dev/null)"
+
+[ -n "${file_path}" ] || exit 0
+case "${file_path}" in
+  *.py) ;;
+  *) exit 0 ;;
+esac
+[ -f "${file_path}" ] || exit 0
+
+# Same uv fallback as the Makefile; plain ruff if uv is absent.
+if command -v uv >/dev/null 2>&1; then
+  RUFF="uv run ruff"
+elif [ -x "${HOME}/.local/bin/uv" ]; then
+  RUFF="${HOME}/.local/bin/uv run ruff"
+else
+  RUFF="ruff"
+fi
+
+${RUFF} format -q "${file_path}" 2>/dev/null || true
+${RUFF} check -q --fix "${file_path}" 2>/dev/null || true
+exit 0

--- a/scripts/claude-hooks/verify-stop.sh
+++ b/scripts/claude-hooks/verify-stop.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Claude Code Stop hook: enforce CLAUDE.md's "REQUIRED: Verification" as a
+# mechanism instead of a request. When a turn ends with uncommitted Python
+# changes, run `make lint` + `make test-fast`; a failure exits 2, which feeds
+# the output back to Claude so it fixes the problem before handing work off.
+#
+# Deliberately same-session and deterministic-only (fast loop). Judgment
+# review by an independent session happens at ship time (/ship) and in CI
+# (claude-review.yml), not on every stop.
+
+set -uo pipefail
+
+input="$(cat)"
+
+# Claude is already continuing because this hook blocked once this turn.
+# Don't block again — prevents infinite loops when the failure needs the
+# user (e.g. a broken environment rather than the change itself).
+if printf '%s' "${input}" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true'; then
+  exit 0
+fi
+
+# Fast exit for conversational turns: only verify when .py files are dirty.
+if ! git status --porcelain 2>/dev/null | grep -qE '\.py$'; then
+  exit 0
+fi
+
+if ! out="$(make lint 2>&1)"; then
+  {
+    echo "Stop-hook verification failed: make lint. Fix before finishing (CLAUDE.md REQUIRED: Verification):"
+    printf '%s\n' "${out}" | tail -50
+  } >&2
+  exit 2
+fi
+
+if ! out="$(make test-fast 2>&1)"; then
+  {
+    echo "Stop-hook verification failed: make test-fast. Fix before finishing (CLAUDE.md REQUIRED: Verification):"
+    printf '%s\n' "${out}" | tail -50
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -1,21 +1,25 @@
 #!/usr/bin/env bash
-# scripts/wt.sh <name> [open|rm] — git-worktree lifecycle for parallel Claude sessions.
+# scripts/wt.sh <name> [open|headless|rm] — git-worktree lifecycle for parallel Claude sessions.
 #
-#   bash scripts/wt.sh my-feature        -> create .claude/worktrees/my-feature + provision
-#   bash scripts/wt.sh my-feature open   -> create (if needed) + open a new VS Code window
-#                                           (claude auto-starts in the integrated terminal)
-#   bash scripts/wt.sh my-feature rm     -> remove worktree dir + git branch
+#   bash scripts/wt.sh my-feature          -> create .claude/worktrees/my-feature + provision
+#   bash scripts/wt.sh my-feature open     -> create (if needed) + open a new VS Code window
+#                                             (claude auto-starts in the integrated terminal)
+#   bash scripts/wt.sh my-feature headless -> create + provision WITHOUT VS Code auto-launch;
+#                                             for worktrees driven by background agents from
+#                                             an orchestrating Claude session
+#   bash scripts/wt.sh my-feature rm       -> remove worktree dir + git branch
 #
 # Provisioning per worktree: copy the main checkout's .env, create a uv venv with
-# the package installed editable (same as `make install`), and write .vscode/
-# auto-launch files so opening the folder starts a claude session.
+# the package installed editable (same as `make install`), install pre-commit
+# hooks, and (except for headless) write .vscode/ auto-launch files so opening
+# the folder starts a claude session.
 #
-# Backs `make wt-new` / `make wt-open` / `make wt-rm`. Editor CLI comes from
-# $CODE (default: code) — e.g. `CODE=cursor make wt-open NAME=my-feature`.
+# Backs `make wt-new` / `make wt-open` / `make wt-headless` / `make wt-rm`.
+# Editor CLI comes from $CODE (default: code) — e.g. `CODE=cursor make wt-open NAME=my-feature`.
 
 set -euo pipefail
 
-NAME="${1:?usage: wt.sh <name> [open|rm]}"
+NAME="${1:?usage: wt.sh <name> [open|headless|rm]}"
 ACTION="${2:-create}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,10 +62,21 @@ if [ ! -d "$TARGET" ]; then
   echo "[wt] creating venv + installing deps (uv)…"
   (cd "$TARGET" && "$UV" venv >/dev/null && "$UV" pip install -q -e ".[dev]")
 
+  # --- pre-commit: ruff/gitleaks/unit-test hooks guaranteed in every worktree --
+  # (hooks land in the shared .git/hooks, so this is idempotent across worktrees)
+  if (cd "$TARGET" && "$UV" run pre-commit install >/dev/null 2>&1); then
+    echo "[wt] pre-commit hooks installed"
+  else
+    echo "[wt] note: pre-commit install failed — run \`make pre-commit\` in the worktree"
+  fi
+
   # --- .vscode/: auto-launch claude in the integrated terminal on folder open --
   # `runOn: folderOpen` + workspace-scoped `task.allowAutomaticTasks: on` skips
   # VS Code's "allow automatic tasks?" prompt. The Workspace Trust prompt is
   # unavoidable on first open of any folder; trust once and it sticks.
+  # Skipped for headless worktrees — those are driven by background agents,
+  # not a human-attended editor window.
+  if [ "$ACTION" != "headless" ]; then
   mkdir -p "$TARGET/.vscode"
   cat > "$TARGET/.vscode/settings.json" <<'EOF'
 {
@@ -90,9 +105,13 @@ EOF
   ]
 }
 EOF
+  fi
 fi
 
 echo "[wt] worktree ready: $TARGET"
+if [ "$ACTION" = "headless" ]; then
+  echo "[wt] headless — no VS Code auto-launch; drive it with a background agent from your orchestrating session"
+fi
 
 if [ "$ACTION" = "open" ]; then
   CODE="${CODE:-code}"

--- a/uv.lock
+++ b/uv.lock
@@ -2886,7 +2886,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.16.0"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

Moves the repo from manual parallel worktrees to Step 2 "Parallel" of the AI adoption ladder (Boris Cherny's *Steps of AI Adoption*): agents self-verify before handing off, safe commands never block on permission prompts, review shifts to final diffs, and automated code + security review runs on every PR.

- **`.claude/settings.json`** (new, checked in) — pre-approved safe commands (`make test*/lint/format`, `uv run pytest/ruff`, read-only `git`/`gh`); write ops stay prompted. Two hooks: PostToolUse ruff-formats every edited `.py`; Stop hook runs `make lint` + `make test-fast` when a turn ends with dirty `.py` files and feeds failures back (`scripts/claude-hooks/`).
- **Slash commands** — `/ship` (independent fresh-context review → full `make test` gate → commit → PR), `/wt` (worktree ops), `/sync-main` (rebase + re-verify), `/babysit-prs` (survey open PRs, spawn fix agents for red CI).
- **Headless worktrees** — `make wt-headless NAME=x` provisions a worktree without VS Code auto-launch, for features driven by background agents from one orchestrating session. Worktree provisioning now also installs pre-commit hooks.
- **`claude-review.yml`** (new) — async, non-blocking Claude code + security review on every non-draft PR. `ci.yml` remains the only merge gate, so slow reviews can never block (why the old auto-review was removed).
- **`claude.yml`** — a `claude-implement` label on an issue now kicks off an implementation run that opens a PR (flows through ci/review/auto-version like any branch).
- **CLAUDE.md** — new "Parallel Development (worktrees)" section documenting the workflow, verification loop, and orchestration conventions.

## Test plan

- `make test` — 4213 passed, 0 failed; `make lint` clean
- Hook smoke tests: format hook reformats a messy `.py`; Stop hook exits 0 on clean tree / `stop_hook_active`, exits 2 with feedback on a lint-broken dirty file
- `wt.sh <name> headless` end-to-end: venv + pre-commit installed, no `.vscode`, cleanly removed with `wt.sh <name> rm`
- Both workflow YAMLs validated; settings.json validated
- Note for after merge: `claude-review.yml` and the `claude-implement` trigger need the existing `CLAUDE_CODE_OAUTH_TOKEN` secret (already used by `claude.yml`) — no new secrets required

🤖 Generated with [Claude Code](https://claude.com/claude-code)