### PR TITLE
fix: claude review silently dropped on version-bumped PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,9 +9,17 @@
 #
 # Because workflow_run loses the PR context, the PR is resolved from the CI
 # run's head SHA, and the old trigger filters are reimplemented there: skip
-# drafts, Dependabot PRs (dependabot-auto.yml owns those), and the
-# auto-version bot's `chore: bump version` pushes (re-reviewing the same diff
-# plus a version line wastes tokens — the original review already posted).
+# drafts and Dependabot PRs (dependabot-auto.yml owns those).
+#
+# We deliberately do NOT skip the auto-version bot's `chore: bump version`
+# commit. auto-version pushes that commit to the PR branch, which fires a fresh
+# CI run; ci.yml's own `cancel-in-progress` concurrency then cancels the
+# in-flight CI run on the pre-bump commit. A cancelled run isn't `success`, so
+# its workflow_run never fires — meaning the bump commit is usually the ONLY CI
+# run that reaches `success` on a feature PR. Skipping it dropped the review
+# entirely. Reviewing it is correct anyway: `gh pr diff` shows the whole PR
+# (feature changes + the one version line), and the per-branch
+# `cancel-in-progress` below guarantees exactly one review, on the final head.
 
 name: Claude Review
 
@@ -28,8 +36,7 @@ jobs:
   review:
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      !startsWith(github.event.workflow_run.head_commit.message, 'chore: bump version')
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

Claude review comments stopped appearing on normal feature PRs. Root cause is a race between two workflows, not a broken review:

1. PR opens → CI run **A** starts on your commit.
2. `auto-version.yml` classifies the diff and pushes `chore: bump version…` to the branch.
3. That push fires CI run **B** — and `ci.yml` has `concurrency: cancel-in-progress` keyed by branch, so it **cancels run A mid-flight**. A cancelled run isn't `success`, so its `workflow_run` never fires the review.
4. CI run **B** (the bump commit) passes and fires `workflow_run` — but `claude-review.yml` **explicitly skipped `chore: bump version` commits**.

Net: on any PR that touches `src/` (→ gets a version bump), the *only* CI run that reaches `success` is the bump commit, and we skipped it → **no review ever posts**. PRs with no `src/` change (e.g. #70) still got reviewed, which is why it looked intermittent.

## Fix

Remove the `chore: bump version` skip from the job condition. Reviewing the bump commit is correct anyway — `gh pr diff` shows the entire PR (feature changes + the one version line) — and the review workflow's own per-branch `cancel-in-progress` guarantees exactly one review, on the final PR head.

Workflow-YAML-only change; `check yaml` passed and the file parses. No Python touched.

## Known minor edge

If the pre-bump CI *does* finish before the bump lands (rare — the full suite is slower than auto-version), both runs could post a review. Harmless and uncommon; far better than zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)