### PR TITLE
add local llm mode (ollama) — free, keyless, cloud-grade reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
 # LLM Provider
-# Options: anthropic (default), openai, google
-# Install additional providers: uv sync --extra openai   or   uv sync --extra google
+# Options: anthropic (default), openai, google, bedrock, ollama
+# Install additional providers: uv sync --extra openai / --extra google / --extra bedrock / --extra ollama
 LLM_PROVIDER=anthropic
 # Optional: override the default model for the selected provider
-# Anthropic default: claude-sonnet-4-20250514
+# Anthropic default: claude-sonnet-4-6
 # OpenAI default:    gpt-4o
-# Google default:    gemini-2.0-flash
+# Google default:    gemini-2.5-flash
+# Bedrock default:   us.anthropic.claude-sonnet-4-6-v1:0
+# Ollama default:    qwen3:8b
 LLM_MODEL=
 
 # Anthropic (required when LLM_PROVIDER=anthropic)
@@ -16,6 +18,14 @@ OPENAI_API_KEY=your-openai-api-key
 
 # Google AI (required when LLM_PROVIDER=google)
 GOOGLE_API_KEY=your-google-api-key
+
+# Ollama (local, no API key — free & private; see README "Local Mode (Ollama)")
+# Install Ollama from https://ollama.com, then: ollama pull qwen3:8b
+# Base URL of the local Ollama server (default shown)
+OLLAMA_BASE_URL=http://localhost:11434
+# Context window requested from the model (default 16384 — the server's own
+# 2-4k default silently truncates yeaboi's larger planning prompts)
+OLLAMA_NUM_CTX=16384
 
 # LangSmith (optional — enables tracing for development)
 LANGSMITH_TRACING=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,12 +369,13 @@ Tool modules are imported **inside** `get_tools()`, not at module level. This is
 
 ## LLM Provider Conventions
 
-`agent/llm.py` provides `get_llm()` — a factory supporting Anthropic (default), OpenAI, Google, and AWS Bedrock:
+`agent/llm.py` provides `get_llm()` — a factory supporting Anthropic (default), OpenAI, Google, AWS Bedrock, and Ollama (local):
 - Each provider is **lazy-imported** inside an if-branch so the module works even if optional packages aren't installed
 - Provider selected via `LLM_PROVIDER` env var; model override via `LLM_MODEL`
-- Default models: `claude-sonnet-4-20250514` (Anthropic), `gpt-4o` (OpenAI), `gemini-2.0-flash` (Google), `us.anthropic.claude-sonnet-4-20250514-v1:0` (Bedrock)
-- Install optional providers: `uv sync --extra openai` / `--extra google` / `--extra bedrock`
+- Default models: `claude-sonnet-4-6` (Anthropic), `gpt-4o` (OpenAI), `gemini-2.5-flash` (Google), `us.anthropic.claude-sonnet-4-6-v1:0` (Bedrock), `qwen3:8b` (Ollama)
+- Install optional providers: `uv sync --extra openai` / `--extra google` / `--extra bedrock` / `--extra ollama`
 - **Bedrock** uses IAM credentials (no API key) — auto-detects AWS profile from `~/.aws/config` via `get_aws_profile()` in `config.py`. On Lightsail, uses `[profile assumed]` with `credential_source=Ec2InstanceMetadata`. The boto3 session is created with explicit profile + increased read timeout (300s) for cross-region inference profiles.
+- **Ollama** is the keyless local provider (README: "Local Mode (Ollama)") — `OLLAMA_BASE_URL` (default `http://localhost:11434`), `OLLAMA_NUM_CTX` (default 16384; the server's 2-4k default silently truncates the big planning prompts). Reliability layer: `get_llm(json_mode=True)` turns on ChatOllama's constrained JSON decoding (`format="json"`, no-op for cloud providers), and `invoke_json()` in `agent/llm.py` wraps every JSON-parsed call site (planning nodes, mode engines, team_learning) with a one-shot "your JSON was invalid, fix it" re-ask for **all** providers. `invoke_json` calls `track_usage()` internally — callers must not track again. Never pass `json_mode=True` on prose paths (conversational agent, llm_tools, guardrail classifier). Local failures surface via `_local_llm_hint()` in `nodes.py` — the single decision point (used by `_should_reraise_llm_error`, the TUI's `_classify_api_error`, and all 4 mode engines) mapping four cases to actionable hints: langchain-ollama not installed → "uv sync --extra ollama", model not pulled (404) → "ollama pull <model>", read timeout → "try a smaller model", server down → "ollama serve". Cloud connection blips keep the graceful fallback. Prose paths strip qwen3 `<think>` blocks via `strip_think_tags()`; chat history is trimmed to the context window by `_trim_history_for_local()` (cut at HumanMessage boundaries only, never splits tool-call pairs); `warn_if_context_overflow()` logs when a prompt likely exceeds `OLLAMA_NUM_CTX`. The setup wizard verifies the langchain-ollama package + server + pulled model, and offers an in-app model download (`pull_ollama_model()` in `ui/provider_select/_verification.py`, streamed `POST /api/pull`).
 
 ## State Schema Conventions
 
@@ -465,8 +466,10 @@ Rules:
 - `GOOGLE_API_KEY` — required when `LLM_PROVIDER=google`
 - `AWS_REGION` — required when `LLM_PROVIDER=bedrock` (auto-detected from `~/.aws/config` on Lightsail)
 - `AWS_PROFILE` — optional, auto-detected from `~/.aws/config` (looks for profiles with `credential_source` or `role_arn`)
-- `LLM_PROVIDER` — `anthropic` (default), `openai`, `google`, `bedrock`
+- `LLM_PROVIDER` — `anthropic` (default), `openai`, `google`, `bedrock`, `ollama`
 - `LLM_MODEL` — optional model override for the selected provider
+- `OLLAMA_BASE_URL` — optional, base URL of the local Ollama server (default `http://localhost:11434`); no API key needed when `LLM_PROVIDER=ollama`
+- `OLLAMA_NUM_CTX` — optional, context window requested from the Ollama model (default 16384)
 - `GITHUB_TOKEN`, `AZURE_DEVOPS_TOKEN` — optional, for repo context tools
 - `AZURE_DEVOPS_ORG_URL`, `AZURE_DEVOPS_PROJECT`, `AZURE_DEVOPS_TEAM` — optional, for Azure DevOps board sync
 - `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, `JIRA_PROJECT_KEY` — optional, for Jira integration

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ yeaboi --non-interactive --description @project-brief.txt --output html --team-s
 - [Quick Start](#-quick-start)
 - [Features](#-features)
 - [Getting Started](#-getting-started)
+- [Local Mode (Ollama)](#-local-mode-ollama)
 - [Deploy on AWS Lightsail](#-deploy-on-aws-lightsail-openclaw)
 - [CLI Reference](#%EF%B8%8F-cli-reference)
 - [Intake Modes](#-intake-modes)
@@ -125,7 +126,7 @@ yeaboi --non-interactive --description @project-brief.txt --output html --team-s
 
 📤 **5 Export Formats** — Markdown, HTML, JSON, Jira sync, Azure DevOps Boards sync
 
-🤖 **4 LLM Providers** — Claude (default), GPT, Gemini, AWS Bedrock
+🤖 **5 LLM Providers** — Claude (default), GPT, Gemini, AWS Bedrock, Ollama (local, free, no API key)
 
 💾 **Session Persistence** — SQLite-backed sessions that survive terminal restarts; resume with `--resume`
 
@@ -207,6 +208,60 @@ OPENAI_API_KEY=sk-...
 LLM_PROVIDER=google
 GOOGLE_API_KEY=AIza...
 ```
+
+#### Ollama — no API key needed (see [Local Mode](#-local-mode-ollama))
+
+```
+LLM_PROVIDER=ollama
+```
+
+## 🏠 Local Mode (Ollama)
+
+yeaboi runs **completely free, offline, and private** on a local model via [Ollama](https://ollama.com) — no API key, no cloud account, nothing leaves your machine.
+
+### Setup
+
+```bash
+# 1. Install the Ollama extra
+uv sync --extra ollama          # (or: pipx inject yeaboi langchain-ollama)
+
+# 2. Install Ollama and pull a model
+brew install ollama             # or download from https://ollama.com
+ollama serve                    # usually auto-starts on install
+ollama pull qwen3:8b
+
+# 3. Point yeaboi at it — or just pick "Ollama (Local)" in the setup wizard
+echo "LLM_PROVIDER=ollama" >> ~/.yeaboi/.env
+```
+
+The setup wizard's **Ollama (Local)** card pre-fills `http://localhost:11434`, verifies the server is running, and lists every model you've pulled (live from `/api/tags`). You don't even need step 2's `ollama pull` — pick any preset and the wizard offers to **download it for you** (press `P` on the "Model not pulled" notice) with live progress, straight from the Ollama server API.
+
+### Choosing a model
+
+All presets work — they differ in RAM appetite, download size, and how disciplined their JSON output is (which drives plan quality):
+
+| Model | Size | RAM | Trade-off |
+|-------|------|-----|-----------|
+| `qwen3:8b` (default) | ~5 GB | 16 GB | Best balance — strong JSON + tool calling |
+| `qwen3:14b` | ~9 GB | 24 GB+ | Noticeably better plans, heavier |
+| `qwen2.5:14b` | ~9 GB | 24 GB+ | Proven JSON discipline, slightly older |
+| `llama3.1:8b` | ~5 GB | 16 GB | Familiar name; weaker JSON → more fallback artifacts |
+
+Any other Ollama model works too (`Custom…` in the wizard) — prefer models advertised as good at JSON/tool-calling.
+
+### How reliability is achieved
+
+Local models are weaker than cloud models at emitting valid JSON, and every yeaboi pipeline stage parses JSON. Local mode stays reliable through three layers:
+
+1. **Constrained decoding** — on Ollama, JSON-producing calls run with `format="json"`, so the model *cannot* emit anything but syntactically valid JSON.
+2. **One-shot repair** — if a reply still fails to parse (e.g. truncation), yeaboi sends the exact parse error back and asks the model to fix it (`invoke_json()` — applied to every provider, cloud included).
+3. **Deterministic fallbacks** — as always, a failed generation degrades to a deterministic artifact instead of crashing.
+
+On top of that, chat history is automatically trimmed to fit the local context window (oldest turns first, never mid-exchange), and `<think>` reasoning blocks from thinking models like qwen3 are stripped before display.
+
+Config knobs: `OLLAMA_BASE_URL` (default `http://localhost:11434`), `OLLAMA_NUM_CTX` (default 16384 — yeaboi requests a bigger context than Ollama's 2-4k default because the planning prompts are large; lower it on low-RAM machines).
+
+**Limitations:** the post-planning conversational agent (Jira/Confluence writes via chat) depends on the model's tool-calling quality, which varies by model — planning itself never needs tool calling; a model that can't call tools automatically degrades to plain chat with a one-time notice. If something's wrong locally, yeaboi tells you exactly what instead of silently degrading: server down → "Start it with: ollama serve", model not pulled → "ollama pull <model>", package missing → "uv sync --extra ollama", model too slow → "try a smaller model".
 
 <details>
 <summary>🔍 LangSmith (optional tracing)</summary>
@@ -2022,7 +2077,7 @@ Every pipeline stage has an accept/edit/reject checkpoint. High-risk tool calls 
 
 ## 🤖 Multi-Provider LLM Support
 
-The agent supports four LLM providers. Set via `LLM_PROVIDER` in `.env`:
+The agent supports five LLM providers. Set via `LLM_PROVIDER` in `.env`:
 
 | Provider | Env Var | Key Format | Value |
 |----------|---------|------------|-------|
@@ -2030,10 +2085,13 @@ The agent supports four LLM providers. Set via `LLM_PROVIDER` in `.env`:
 | OpenAI | `OPENAI_API_KEY` | `sk-...` | `openai` |
 | Google | `GOOGLE_API_KEY` | `AIza...` | `google` |
 | AWS Bedrock | `AWS_REGION` | IAM credentials (no key) | `bedrock` |
+| Ollama (local) | `OLLAMA_BASE_URL` | none — local server URL | `ollama` |
 
-OpenAI, Google, and Bedrock are lazy-imported — install with `uv sync --extra all-providers` or individually with `--extra openai` / `--extra google` / `--extra bedrock`.
+OpenAI, Google, Bedrock, and Ollama are lazy-imported — install with `uv sync --extra all-providers` or individually with `--extra openai` / `--extra google` / `--extra bedrock` / `--extra ollama`.
 
 Bedrock uses IAM credentials automatically (instance role, `~/.aws/credentials`, or env vars). On Lightsail/EC2, the AWS profile is auto-detected from `~/.aws/config`. No API key required.
+
+Ollama needs no credentials at all — see [Local Mode (Ollama)](#-local-mode-ollama) for setup, model trade-offs, and how reliability is achieved on smaller local models.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.19.1"
+version = "2.20.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ openai = ["langchain-openai"]
 google = ["langchain-google-genai"]
 pdf = ["pymupdf"]
 bedrock = ["langchain-aws", "boto3"]
+# Local LLM via an Ollama server — free, private, no API key. See README:
+# "Local Mode (Ollama)".
+ollama = ["langchain-ollama"]
 # Voice input — record mic audio (sounddevice) and transcribe locally and
 # offline with faster-whisper. Lazy-imported in voice.py; needs no API key
 # (works with any LLM provider). The sounddevice wheels bundle PortAudio on
@@ -65,7 +68,7 @@ voice = ["sounddevice", "faster-whisper"]
 # Chart images embedded in exports (velocity / delivered-work PNGs). Lazy-
 # imported in charts.py — without the extra, exports simply skip the charts.
 charts = ["matplotlib>=3.8"]
-all-providers = ["langchain-openai", "langchain-google-genai", "langchain-aws", "boto3"]
+all-providers = ["langchain-openai", "langchain-google-genai", "langchain-aws", "boto3", "langchain-ollama"]
 dev = [
     "pytest",
     "pytest-asyncio",

--- a/src/yeaboi/agent/llm.py
+++ b/src/yeaboi/agent/llm.py
@@ -306,6 +306,14 @@ def get_llm(model: str | None = None, temperature: float = 0.0, json_mode: bool 
             client_kwargs={"timeout": 300},
             # format="json" is Ollama's constrained decoding — see json_mode docs.
             format="json" if json_mode else "",
+            # Thinking models (qwen3) spend generation budget on a reasoning
+            # pass BEFORE the constrained JSON — on a big planning prompt that
+            # can consume the entire num_predict and return EMPTY content after
+            # minutes of local compute. JSON calls therefore disable thinking
+            # (reasoning=False → "think": false); prose calls keep the model's
+            # default (thinking improves prose; strip_think_tags() handles the
+            # tags). None = omit the option entirely for maximum server compat.
+            reasoning=False if json_mode else None,
         )
         logger.info(
             "LLM ready: provider=ollama, model=%s, base_url=%s, num_ctx=%d, json_mode=%s",
@@ -460,9 +468,9 @@ def strip_think_tags(text: str) -> str:
     constrained decoding (format="json"), but prose paths — the conversational
     agent, llm_tools, the guardrail classifier — would show the raw tags to the
     user. Stripping at the consumption point is the zero-risk fix: cloud models
-    never emit these, and we deliberately do NOT set ChatOllama(reasoning=False)
-    because Ollama server versions differ on rejecting the think option for
-    non-think models (and qwen3's thinking improves prose quality anyway).
+    never emit these, and prose calls deliberately keep the model's default
+    thinking (it improves prose quality; JSON calls disable it in get_llm —
+    see the reasoning= comment there).
     """
     import re
 

--- a/src/yeaboi/agent/llm.py
+++ b/src/yeaboi/agent/llm.py
@@ -41,18 +41,51 @@ def track_usage(response) -> None:
     Call this after every LLM invoke() to track token consumption.
     Works with all providers (Anthropic, OpenAI, Google, Bedrock).
     """
-    meta = getattr(response, "response_metadata", None) or {}
-    logger.info("track_usage: response_metadata keys=%s", list(meta.keys()) if meta else "empty")
 
-    # Anthropic: meta has 'usage' dict with input_tokens/output_tokens
-    # OpenAI: meta has 'token_usage' dict with prompt_tokens/completion_tokens
-    usage = meta.get("usage", {}) or meta.get("token_usage", {})
-    if not usage:
-        usage = meta
-    logger.info("track_usage: usage keys=%s, values=%s", list(usage.keys()) if isinstance(usage, dict) else "?", usage)
+    def _as_int(value) -> int:
+        # Defensive: metadata shapes vary per provider (and mocks in tests) —
+        # anything non-numeric counts as "no data" rather than crashing a call.
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
 
-    inp = usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0)
-    out = usage.get("output_tokens", 0) or usage.get("completion_tokens", 0)
+    # Preferred source: LangChain's provider-neutral `usage_metadata` attribute
+    # (an AIMessage field with input_tokens/output_tokens). ChatOllama populates
+    # this while its response_metadata uses Ollama-native keys (prompt_eval_count/
+    # eval_count) that the metadata fallback below also understands.
+    usage_meta = getattr(response, "usage_metadata", None)
+    inp = out = 0
+    if isinstance(usage_meta, dict):
+        inp = _as_int(usage_meta.get("input_tokens", 0))
+        out = _as_int(usage_meta.get("output_tokens", 0))
+        if inp or out:
+            logger.info("track_usage: using usage_metadata (in=%d, out=%d)", inp, out)
+    if not (inp or out):
+        meta = getattr(response, "response_metadata", None)
+        meta = meta if isinstance(meta, dict) else {}
+        logger.info("track_usage: response_metadata keys=%s", list(meta.keys()) if meta else "empty")
+
+        # Anthropic: meta has 'usage' dict with input_tokens/output_tokens
+        # OpenAI: meta has 'token_usage' dict with prompt_tokens/completion_tokens
+        # Ollama: meta itself carries prompt_eval_count/eval_count
+        usage = meta.get("usage", {}) or meta.get("token_usage", {})
+        if not isinstance(usage, dict) or not usage:
+            usage = meta
+        logger.info(
+            "track_usage: usage keys=%s, values=%s", list(usage.keys()) if isinstance(usage, dict) else "?", usage
+        )
+
+        inp = (
+            _as_int(usage.get("input_tokens", 0))
+            or _as_int(usage.get("prompt_tokens", 0))
+            or _as_int(usage.get("prompt_eval_count", 0))
+        )
+        out = (
+            _as_int(usage.get("output_tokens", 0))
+            or _as_int(usage.get("completion_tokens", 0))
+            or _as_int(usage.get("eval_count", 0))
+        )
     if inp or out:
         _usage_stats["input_tokens"] += inp
         _usage_stats["output_tokens"] += out
@@ -103,13 +136,22 @@ _PROVIDER_DEFAULTS: dict[str, str] = {
     "openai": "gpt-4o",
     "google": "gemini-2.5-flash",
     "bedrock": "us.anthropic.claude-sonnet-4-6-v1:0",
+    # Local default: best small model for JSON adherence + tool calling that
+    # fits comfortably on a 16 GB machine. See README: "Local Mode (Ollama)"
+    # for the full model trade-off table.
+    "ollama": "qwen3:8b",
 }
 
 # Kept for backward compatibility — callers that imported DEFAULT_MODEL still work.
 DEFAULT_MODEL = _PROVIDER_DEFAULTS["anthropic"]
 
+# Output-token cap requested from Ollama. Single-sourced: get_llm() passes it
+# as num_predict, and the context-budget maths (warn_if_context_overflow,
+# nodes._trim_history_for_local) reserve the same amount out of OLLAMA_NUM_CTX.
+_OLLAMA_NUM_PREDICT = 8192
 
-def get_llm(model: str | None = None, temperature: float = 0.0) -> BaseChatModel:
+
+def get_llm(model: str | None = None, temperature: float = 0.0, json_mode: bool = False) -> BaseChatModel:
     """Create an LLM instance for the configured provider.
 
     # See README: "Agentic Blueprint Reference" — Core Graph Setup
@@ -132,6 +174,13 @@ def get_llm(model: str | None = None, temperature: float = 0.0) -> BaseChatModel
         model: Model ID override. None means use LLM_MODEL env var or provider default.
         temperature: Sampling temperature. 0.0 = deterministic (default for structured
             artifact generation). Use 0.2–0.5 for tools that benefit from variety.
+        json_mode: When True and the provider is Ollama, enables constrained JSON
+            decoding (ChatOllama's ``format="json"``) — the model literally cannot
+            emit anything but syntactically valid JSON, which is the main
+            reliability lever for weaker local models. A documented no-op for the
+            cloud providers (their JSON discipline comes from the prompts plus the
+            invoke_json() repair loop). Never set this for prose calls (the
+            conversational agent, llm_tools, guardrail classifiers).
 
     Returns:
         A configured BaseChatModel ready for use in LangGraph nodes.
@@ -226,8 +275,49 @@ def get_llm(model: str | None = None, temperature: float = 0.0) -> BaseChatModel
             temperature=temperature,
         )
 
+    if provider == "ollama":
+        # langchain-ollama is an optional dependency (install with: uv sync --extra ollama)
+        # # See README: "Local Mode (Ollama)" — keyless local provider. The model
+        # runs entirely on the user's machine via the Ollama server; there are no
+        # credentials, so get_llm() never raises OSError for this provider.
+        try:
+            from langchain_ollama import ChatOllama
+        except ImportError as e:
+            raise ImportError("langchain-ollama is not installed. Run: uv sync --extra ollama") from e
+
+        from yeaboi.config import get_ollama_base_url, get_ollama_num_ctx
+
+        base_url = get_ollama_base_url()
+        num_ctx = get_ollama_num_ctx()
+        llm = ChatOllama(
+            model=resolved_model,
+            base_url=base_url,
+            temperature=temperature,
+            # Request a context large enough for the biggest assembled prompts —
+            # Ollama's server default (2-4k tokens) silently truncates, which
+            # destroys JSON output. See config.get_ollama_num_ctx().
+            num_ctx=num_ctx,
+            # Cap output generously; Ollama's small default can cut JSON mid-array.
+            num_predict=_OLLAMA_NUM_PREDICT,
+            # The planning pipeline runs 5 sequential nodes — keep the model
+            # loaded in RAM between them instead of reloading every call.
+            keep_alive="10m",
+            # Local inference on CPU can be slow; mirror bedrock's read_timeout.
+            client_kwargs={"timeout": 300},
+            # format="json" is Ollama's constrained decoding — see json_mode docs.
+            format="json" if json_mode else "",
+        )
+        logger.info(
+            "LLM ready: provider=ollama, model=%s, base_url=%s, num_ctx=%d, json_mode=%s",
+            resolved_model,
+            base_url,
+            num_ctx,
+            json_mode,
+        )
+        return llm
+
     raise ValueError(
-        f"Unknown LLM_PROVIDER: {provider!r}. Valid options are: anthropic (default), openai, google, bedrock."
+        f"Unknown LLM_PROVIDER: {provider!r}. Valid options are: anthropic (default), openai, google, bedrock, ollama."
     )
 
 
@@ -308,3 +398,160 @@ def invoke_with_images(llm: BaseChatModel, prompt: str, image_paths=None):
     except Exception as exc:
         logger.warning("model rejected image blocks (%s); retrying text-only", exc)
         return llm.invoke([HumanMessage(content=prompt)])
+
+
+# ---------------------------------------------------------------------------
+# Reliable JSON invocation — constrained decoding + one-shot repair loop
+# ---------------------------------------------------------------------------
+#
+# # See README: "Local Mode (Ollama)" — how reliability is achieved
+# The planning pipeline and the mode engines all parse the model's reply as
+# JSON, and every parser falls back to a deterministic artifact when parsing
+# fails. That fallback never crashes — but it silently downgrades quality.
+# invoke_json() closes that gap for every provider:
+#   1. json_mode=True turns on Ollama's constrained JSON decoding (no-op for
+#      cloud providers).
+#   2. If the reply still fails json.loads (truncation, prose, fences), we
+#      re-ask ONCE with the exact parse error so the model can repair it.
+# The return value is the raw response object, so existing call sites keep
+# their `_parse_*_response(response.content)` line and fallback untouched.
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate (~4 chars per token for English prose/JSON).
+
+    Deliberately heuristic — an exact count needs the model's own tokenizer.
+    Used only for local context-window budget checks (warnings + history
+    trimming), where ±25% accuracy is plenty.
+    """
+    return len(text) // 4
+
+
+def warn_if_context_overflow(prompt: str) -> None:
+    """Log a warning when a local-Ollama prompt likely exceeds the context window.
+
+    Ollama silently LEFT-truncates anything beyond num_ctx − num_predict — no
+    error, just a prompt missing its beginning, which destroys structured
+    output. We can't prevent it from here; this makes it diagnosable in the
+    logs instead of an invisible quality cliff. No-op for cloud providers
+    (their windows are 200k+).
+    """
+    from yeaboi.config import get_llm_provider, get_ollama_num_ctx
+
+    if get_llm_provider() != "ollama":
+        return
+    est = estimate_tokens(prompt)
+    num_ctx = get_ollama_num_ctx()
+    if est + _OLLAMA_NUM_PREDICT > num_ctx:
+        logger.warning(
+            "prompt ~%d tokens + %d output reserve exceeds OLLAMA_NUM_CTX=%d — "
+            "Ollama truncates silently; raise OLLAMA_NUM_CTX in .env if output quality degrades",
+            est,
+            _OLLAMA_NUM_PREDICT,
+            num_ctx,
+        )
+
+
+def strip_think_tags(text: str) -> str:
+    """Remove ``<think>…</think>`` reasoning blocks from prose LLM output.
+
+    Think-by-default local models (e.g. qwen3, the Ollama default) embed their
+    chain-of-thought in the response content. JSON calls are protected by
+    constrained decoding (format="json"), but prose paths — the conversational
+    agent, llm_tools, the guardrail classifier — would show the raw tags to the
+    user. Stripping at the consumption point is the zero-risk fix: cloud models
+    never emit these, and we deliberately do NOT set ChatOllama(reasoning=False)
+    because Ollama server versions differ on rejecting the think option for
+    non-think models (and qwen3's thinking improves prose quality anyway).
+    """
+    import re
+
+    if not isinstance(text, str) or "<think>" not in text:
+        return text
+    # Closed blocks first; then an unclosed leading block (truncated generation).
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+    text = re.sub(r"^\s*<think>.*", "", text, flags=re.DOTALL)
+    return text.strip()
+
+
+def strip_json_fences(raw: str) -> str:
+    """Strip a surrounding markdown code fence from an LLM reply, if present.
+
+    Models often wrap JSON in ```json ... ``` despite instructions. This is the
+    shared version of the fence-strip idiom used by the `_parse_*_response`
+    helpers; invoke_json() uses it for validation only.
+    """
+    raw = (raw or "").strip()
+    if raw.startswith("```"):
+        raw = raw[raw.find("\n") + 1 :]
+    if raw.endswith("```"):
+        raw = raw[: raw.rfind("```")]
+    return raw.strip()
+
+
+def invoke_json(prompt: str, *, temperature: float = 0.0, image_paths=None, max_reasks: int = 1, get_llm_fn=None):
+    """Invoke the configured LLM expecting a JSON reply, with a repair re-ask.
+
+    Drop-in replacement for ``get_llm(temperature=...).invoke([HumanMessage(prompt)])``
+    (or ``invoke_with_images(...)``) at call sites whose response is parsed as
+    JSON. Calls track_usage() on every attempt, so callers must NOT track again.
+
+    Args:
+        prompt: The full prompt text.
+        temperature: Sampling temperature (0.0 for structured artifacts).
+        image_paths: Optional pasted-screenshot paths (see invoke_with_images).
+        max_reasks: How many repair rounds to attempt after an invalid reply.
+            Default 1 — one round captures nearly all the value; more just
+            doubles latency on slow local models for rare wins.
+        get_llm_fn: Optional factory used instead of this module's get_llm().
+            nodes.py passes its own module-level reference so the established
+            test seam (patching ``yeaboi.agent.nodes.get_llm``) keeps working.
+
+    Returns:
+        The last LLM response object. Its ``.content`` is best-effort valid
+        JSON; if every repair attempt failed, callers' existing deterministic
+        fallbacks take over exactly as before.
+    """
+    import json
+
+    from langchain_core.messages import AIMessage, HumanMessage
+
+    warn_if_context_overflow(prompt)
+    llm = (get_llm_fn or get_llm)(temperature=temperature, json_mode=True)
+    response = invoke_with_images(llm, prompt, image_paths)
+    track_usage(response)
+
+    for attempt in range(1, max_reasks + 1):
+        try:
+            json.loads(strip_json_fences(response.content))
+            if attempt > 1:
+                logger.info("invoke_json: repair re-ask produced valid JSON (attempt %d)", attempt)
+            return response
+        except (json.JSONDecodeError, TypeError) as err:
+            logger.warning("invoke_json: reply is not valid JSON (attempt %d): %s — re-asking", attempt, err)
+            previous = response.content if isinstance(response.content, str) else str(response.content)
+            response = llm.invoke(
+                [
+                    # Rebuild the original message with its image blocks — a
+                    # text-only repair round would silently drop pasted
+                    # screenshots the first attempt could see.
+                    HumanMessage(content=build_multimodal_content(prompt, image_paths)),
+                    AIMessage(content=previous),
+                    HumanMessage(
+                        content=(
+                            f"Your previous reply was not valid JSON ({err}). "
+                            "Reply again with ONLY the corrected JSON — no prose, no code fences."
+                        )
+                    ),
+                ]
+            )
+            track_usage(response)
+
+    # Final validation purely for logging — the caller's parser + deterministic
+    # fallback handle an invalid reply gracefully either way.
+    try:
+        json.loads(strip_json_fences(response.content))
+        logger.info("invoke_json: repair re-ask produced valid JSON")
+    except (json.JSONDecodeError, TypeError) as err:
+        logger.warning("invoke_json: reply still invalid after %d re-ask(s): %s — caller fallback", max_reasks, err)
+    return response

--- a/src/yeaboi/agent/nodes.py
+++ b/src/yeaboi/agent/nodes.py
@@ -25,7 +25,7 @@ from langchain_core.tools import BaseTool
 from langgraph.graph import END
 
 from yeaboi.agent.ceremony_history import gather_ceremony_context
-from yeaboi.agent.llm import get_llm, invoke_with_images
+from yeaboi.agent.llm import get_llm, invoke_json
 from yeaboi.agent.repo_signals import analyze_context, scan_repo_signals
 from yeaboi.agent.state import (
     DOD_ITEMS,
@@ -123,6 +123,185 @@ def _is_llm_auth_or_billing_error(exc: Exception) -> bool:
     return False
 
 
+def _is_llm_connection_error(exc: Exception) -> bool:
+    """Check whether an exception means the LLM server could not be reached.
+
+    Matters for the local Ollama provider: a down server would otherwise be
+    swallowed by the deterministic-fallback net and silently degrade every
+    artifact. Guard sites re-raise these (only when provider == "ollama") so
+    the user gets an actionable "is Ollama running?" message instead.
+
+    Walks the __cause__/__context__ chain because langchain and the ollama
+    client wrap the underlying httpx transport error.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        # Builtin connection errors (ConnectionRefusedError, ConnectionResetError, ...)
+        if isinstance(current, ConnectionError):
+            return True
+        # httpx transport errors — the ollama client and langchain use httpx
+        try:
+            import httpx
+
+            if isinstance(current, (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout)):
+                return True
+        except ImportError:
+            pass
+        msg = str(current).lower()
+        # "[Errno 61]" = macOS connection refused, "[Errno 111]" = Linux
+        if "connection refused" in msg or "[errno 61]" in msg or "[errno 111]" in msg:
+            return True
+        if "failed to connect" in msg and "ollama" in msg:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _ollama_connection_hint() -> str:
+    """Actionable message for a down/unreachable local Ollama server."""
+    from yeaboi.config import get_ollama_base_url
+
+    return (
+        f"Can't reach Ollama at {get_ollama_base_url()}. Is it running? "
+        "Start it with: ollama serve — or check OLLAMA_BASE_URL in your .env."
+    )
+
+
+def _is_local_llm_down(exc: Exception) -> bool:
+    """True when the active provider is the local Ollama server and it's unreachable.
+
+    Cloud transient network blips deliberately return False — they keep today's
+    graceful-fallback behaviour. Used by the mode engines to swap their generic
+    "request failed" warning for the actionable Ollama hint.
+    """
+    if not _is_llm_connection_error(exc):
+        return False
+    from yeaboi.config import get_llm_provider
+
+    return get_llm_provider() == "ollama"
+
+
+def _exception_chain(exc: Exception):
+    """Yield exc and every exception in its __cause__/__context__ chain (cycle-safe)."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _is_ollama_model_missing(exc: Exception) -> bool:
+    """True when the active provider is Ollama and the configured model isn't pulled.
+
+    The Ollama server answers 404 ``model '…' not found`` (ollama.ResponseError)
+    for a model that was never pulled or has been deleted. That's neither a
+    connection error nor an auth error, so without this check it would silently
+    degrade every artifact to its deterministic fallback — exactly what the
+    reliability layer exists to prevent.
+    """
+    from yeaboi.config import get_llm_provider
+
+    if get_llm_provider() != "ollama":
+        return False
+    for current in _exception_chain(exc):
+        try:
+            import ollama
+
+            if isinstance(current, ollama.ResponseError) and getattr(current, "status_code", None) == 404:
+                return True
+        except ImportError:
+            pass
+        msg = str(current).lower()
+        if "model" in msg and "not found" in msg:
+            return True
+    return False
+
+
+def _is_langchain_ollama_missing(exc: Exception) -> bool:
+    """True when the langchain-ollama package itself isn't installed.
+
+    It's an optional extra — a user can point LLM_PROVIDER=ollama at a working
+    server without ever installing the python package, and the first real call
+    would raise ImportError from get_llm(). Detected here so it surfaces as an
+    actionable install hint instead of a raw traceback or silent fallback.
+    """
+    for current in _exception_chain(exc):
+        if isinstance(current, ImportError) and "langchain" in str(current).lower():
+            return True
+    return False
+
+
+def _is_llm_read_timeout(exc: Exception) -> bool:
+    """True when the failure is a read timeout (server reachable but too slow)."""
+    try:
+        import httpx
+    except ImportError:
+        return False
+    return any(isinstance(current, httpx.ReadTimeout) for current in _exception_chain(exc))
+
+
+def _local_llm_hint(exc: Exception) -> str | None:
+    """Actionable message for a local-Ollama failure, or None for anything else.
+
+    The single decision point the REPL, TUI, and mode engines all share. Four
+    cases (package missing, model missing, timeout, server down), checked
+    most-specific first; cloud-provider errors always return None so their
+    graceful-fallback behaviour is untouched.
+    """
+    from yeaboi.config import get_llm_provider
+
+    if get_llm_provider() != "ollama":
+        return None
+    if _is_langchain_ollama_missing(exc):
+        return (
+            "Ollama support isn't installed — run: uv sync --extra ollama "
+            "(or: pip install langchain-ollama), then retry."
+        )
+    if _is_ollama_model_missing(exc):
+        from yeaboi.agent.llm import _PROVIDER_DEFAULTS
+        from yeaboi.config import get_llm_model
+
+        model = get_llm_model() or _PROVIDER_DEFAULTS["ollama"]
+        return f"Model '{model}' is not installed on the Ollama server. Pull it with: ollama pull {model}"
+    if _is_llm_read_timeout(exc):
+        return (
+            "Ollama timed out — the model may be too large or slow for this machine. "
+            "Try a smaller model (e.g. qwen3:8b) or a shorter project description."
+        )
+    if _is_llm_connection_error(exc):
+        return _ollama_connection_hint()
+    return None
+
+
+def _should_reraise_llm_error(exc: Exception) -> bool:
+    """Decide whether an LLM failure must surface to the user instead of falling back.
+
+    Cases that re-raise:
+    - Auth/billing errors on any provider (the user must fix credentials).
+    - Local-Ollama failures with an actionable fix — server down, model not
+      pulled, or timeout — which would otherwise silently degrade every
+      artifact to its deterministic fallback. Cloud transient network blips
+      keep today's graceful-fallback behaviour (the REPL already retries
+      rate limits).
+    """
+    return _is_llm_auth_or_billing_error(exc) or _local_llm_hint(exc) is not None
+
+
+def _invoke_json(prompt: str, *, image_paths=None):
+    """JSON-mode LLM invoke for this module's generation nodes.
+
+    Wraps agent/llm.py::invoke_json (constrained JSON decoding on Ollama + a
+    one-shot "fix your JSON" re-ask + track_usage) while routing model creation
+    through THIS module's ``get_llm`` reference — the lambda resolves it at call
+    time, so tests that patch ``yeaboi.agent.nodes.get_llm`` keep working.
+    # See README: "Local Mode (Ollama)" — reliability layer.
+    """
+    return invoke_json(prompt, image_paths=image_paths, get_llm_fn=lambda **kw: get_llm(**kw))
+
+
 # ---------------------------------------------------------------------------
 # High-risk tool constants
 # ---------------------------------------------------------------------------
@@ -182,6 +361,62 @@ def _attach_chat_images(state: ScrumState, all_messages: list[BaseMessage]) -> l
     return all_messages
 
 
+def _trim_history_for_local(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """Trim chat history to fit a local model's context window. No-op for cloud.
+
+    # See README: "Local Mode (Ollama)" — context window reliability
+    Cloud windows are 200k+ tokens, but Ollama silently LEFT-truncates anything
+    beyond num_ctx − num_predict — which eats the *system prompt* first, the
+    worst possible loss. Instead, drop the OLDEST turns explicitly: keep the
+    head message (the system prompt) pinned, walk the rest accumulating a rough
+    token estimate, and cut only at HumanMessage boundaries so an
+    AIMessage(tool_calls) is never separated from its ToolMessage results
+    (a split pair is an API error on every provider). The latest exchange is
+    always kept, even if it alone exceeds the budget.
+    """
+    from yeaboi.config import get_llm_provider
+
+    if get_llm_provider() != "ollama" or len(messages) < 2:
+        return messages
+
+    from langchain_core.messages import HumanMessage
+
+    from yeaboi.agent.llm import _OLLAMA_NUM_PREDICT, estimate_tokens
+    from yeaboi.config import get_ollama_num_ctx
+
+    def _msg_tokens(msg: BaseMessage) -> int:
+        content = getattr(msg, "content", "")
+        return estimate_tokens(content if isinstance(content, str) else str(content))
+
+    system, history = messages[0], messages[1:]
+    budget = get_ollama_num_ctx() - _OLLAMA_NUM_PREDICT - _msg_tokens(system)
+    sizes = [_msg_tokens(m) for m in history]
+    remaining = sum(sizes)  # at index i this holds sum(sizes[i:])
+    if remaining <= budget:
+        return messages
+
+    cut = None  # first HumanMessage index whose tail fits the budget
+    last_human = None
+    for i, msg in enumerate(history):
+        if isinstance(msg, HumanMessage):
+            last_human = i
+            if remaining <= budget:
+                cut = i
+                break
+        remaining -= sizes[i]
+    if cut is None:
+        cut = last_human  # over budget even at the latest exchange — keep it anyway
+    if not cut:  # None (no human message to cut at) or 0 (nothing to drop)
+        return messages
+
+    logger.info(
+        "local context trim: dropping %d oldest chat messages to fit OLLAMA_NUM_CTX (budget ~%d tokens)",
+        cut,
+        budget,
+    )
+    return [system, *history[cut:]]
+
+
 def make_call_model(tools: list[BaseTool]) -> Callable[[ScrumState], dict[str, list[BaseMessage]]]:
     """Return a call_model node function with the given tools bound to the LLM.
 
@@ -208,25 +443,74 @@ def make_call_model(tools: list[BaseTool]) -> Callable[[ScrumState], dict[str, l
     # The graph wires it as: graph.add_node("agent", make_call_model(tools))
     """
     _bound_llm = None  # initialised lazily on first call
+    _tools_unsupported = False  # set once a local model rejects tool schemas
+
+    def _is_tools_unsupported_error(exc: Exception) -> bool:
+        """True when the (local) model rejected the request because of tool schemas."""
+        return any("does not support tools" in str(current).lower() for current in _exception_chain(exc))
 
     def call_model_with_tools(state: ScrumState) -> dict[str, list[BaseMessage]]:
         """LangGraph node: invoke the LLM with bound tools."""
-        nonlocal _bound_llm
-        if _bound_llm is None:
+        nonlocal _bound_llm, _tools_unsupported
+        if _bound_llm is None and not _tools_unsupported:
             # bind_tools() returns a new Runnable (RunnableBinding) that wraps
             # the LLM and injects the tool schemas into every API request.
             # Claude reads these schemas to know what tools are available and
             # generates tool_calls when it wants to use one.
             _bound_llm = get_llm().bind_tools(tools)
         system_message = SystemMessage(content=get_system_prompt())
-        all_messages = _attach_chat_images(state, [system_message, *state["messages"]])
-        response = _bound_llm.invoke(all_messages)
+        # Trim BEFORE attaching images: the estimate is text-based, and the
+        # latest human message (where images attach) is always kept.
+        all_messages = _attach_chat_images(state, _trim_history_for_local([system_message, *state["messages"]]))
+        if _tools_unsupported:
+            response = get_llm().invoke(all_messages)
+        else:
+            try:
+                response = _bound_llm.invoke(all_messages)
+            except Exception as exc:
+                # Some local models can't call tools — Ollama rejects the whole
+                # request ("… does not support tools"). Degrade to plain chat
+                # (once discovered, skip the doomed bound attempt on later turns)
+                # instead of surfacing "Unexpected error". Cloud models always
+                # support tools, so any other exception propagates unchanged.
+                if not _is_tools_unsupported_error(exc):
+                    raise
+                logger.warning("model does not support tool calling — degrading to plain chat: %s", exc)
+                _tools_unsupported = True
+                _bound_llm = None
+                response = get_llm().invoke(all_messages)
+                _strip_response_think_tags(response)
+                if isinstance(response.content, str):
+                    response.content += (
+                        "\n\n_Note: this local model doesn't support tool calling, so actions like "
+                        "Jira/Confluence sync are unavailable in chat. Pick a tool-capable model "
+                        "(e.g. qwen3:8b) in Setup to enable them._"
+                    )
+                out_deg: dict = {"messages": [response]}
+                if state.get("chat_images"):
+                    out_deg["chat_images"] = []
+                return out_deg
+        _strip_response_think_tags(response)
         out: dict = {"messages": [response]}
         if state.get("chat_images"):
             out["chat_images"] = []  # consumed — clear so later turns don't re-send
         return out
 
     return call_model_with_tools
+
+
+def _strip_response_think_tags(response) -> None:
+    """Strip <think> blocks from a chat response's prose content, in place.
+
+    Local think-by-default models (qwen3) embed reasoning in .content — see
+    agent/llm.py:strip_think_tags. Mutates the message (tool_calls untouched)
+    so callers keep returning the original AIMessage object.
+    """
+    from yeaboi.agent.llm import strip_think_tags
+
+    content = getattr(response, "content", None)
+    if isinstance(content, str) and "<think>" in content:
+        response.content = strip_think_tags(content)
 
 
 def call_model(state: ScrumState) -> dict[str, list[BaseMessage]]:
@@ -270,9 +554,11 @@ def call_model(state: ScrumState) -> dict[str, list[BaseMessage]]:
     # each invocation so different nodes can use different system context.
     # Pasted screenshots (chat_images) are attached to the latest human
     # message here, at invoke time only — stored history stays text-only.
-    all_messages = _attach_chat_images(state, [system_message, *state["messages"]])
+    # Local models get their history trimmed to the context window first.
+    all_messages = _attach_chat_images(state, _trim_history_for_local([system_message, *state["messages"]]))
 
     response = get_llm().invoke(all_messages)
+    _strip_response_think_tags(response)
 
     # Return single-item list — the add_messages reducer on ScrumState["messages"]
     # will append this response to the existing conversation history.
@@ -434,7 +720,7 @@ def _extract_answers_from_description(description: str) -> dict[int, str]:
     try:
         # Single LLM call with low temperature for deterministic extraction.
         # See README: "Agentic Blueprint Reference" — using the LLM outside the main graph
-        response = get_llm(temperature=0.0).invoke([HumanMessage(content=prompt)])
+        response = _invoke_json(prompt)
         raw = response.content
 
         # Strip markdown code fences that LLMs sometimes wrap JSON in
@@ -465,7 +751,7 @@ def _extract_answers_from_description(description: str) -> dict[int, str]:
         return result
 
     except Exception as exc:
-        if _is_llm_auth_or_billing_error(exc):
+        if _should_reraise_llm_error(exc):
             raise
         # Graceful fallback: if anything goes wrong (bad JSON, LLM timeout,
         # network error), return empty dict. The questionnaire will ask all
@@ -2863,7 +3149,7 @@ def _check_vague_answer(question: str, answer: str, q_num: int = 0) -> tuple[str
     )
 
     try:
-        response = get_llm(temperature=0.0).invoke([HumanMessage(content=prompt)])
+        response = _invoke_json(prompt)
         raw = response.content.strip()
 
         # Strip markdown code fences that LLMs sometimes wrap JSON in
@@ -2888,7 +3174,7 @@ def _check_vague_answer(question: str, answer: str, q_num: int = 0) -> tuple[str
         return None
 
     except Exception as exc:
-        if _is_llm_auth_or_billing_error(exc):
+        if _should_reraise_llm_error(exc):
             raise
         # Graceful fallback: if anything goes wrong (bad JSON, LLM timeout,
         # network error), accept the answer as-is. The feature never breaks
@@ -5620,7 +5906,7 @@ def project_analyzer(state: ScrumState) -> dict:
 
     # Pasted screenshots (Ctrl+V in the description/questionnaire inputs, plus any
     # attached to review-edit feedback) — file paths converted to multimodal image
-    # blocks at invoke time only. See agent/llm.py:invoke_with_images.
+    # blocks at invoke time only. See agent/llm.py:invoke_json/invoke_with_images.
     images = list(state.get("pasted_images") or []) + list(state.get("review_feedback_images") or [])
     if images:
         logger.info("project_analyzer: attaching %d pasted image(s)", len(images))
@@ -5628,10 +5914,10 @@ def project_analyzer(state: ScrumState) -> dict:
     try:
         # Single LLM call with low temperature for deterministic JSON extraction.
         # See README: "Agentic Blueprint Reference" — using the LLM outside the main graph
-        response = invoke_with_images(get_llm(temperature=0.0), prompt, images)
+        response = _invoke_json(prompt, image_paths=images)
         analysis = _parse_analysis_response(response.content, questionnaire, team_size, velocity)
     except Exception as exc:
-        if _is_llm_auth_or_billing_error(exc):
+        if _should_reraise_llm_error(exc):
             raise
         # LLM call failed entirely — use deterministic fallback.
         logger.warning("LLM call failed in project_analyzer, using fallback", exc_info=True)
@@ -6014,10 +6300,10 @@ def feature_generator(state: ScrumState) -> dict:
     try:
         # Single LLM call with low temperature for deterministic JSON output.
         # See README: "Agentic Blueprint Reference" — using the LLM outside the main graph
-        response = invoke_with_images(get_llm(temperature=0.0), prompt, review_images)
+        response = _invoke_json(prompt, image_paths=review_images)
         features = _parse_features_response(response.content, analysis)
     except Exception as exc:
-        if _is_llm_auth_or_billing_error(exc):
+        if _should_reraise_llm_error(exc):
             raise
         # LLM call failed entirely — use deterministic fallback.
         logger.warning("LLM call failed in feature_generator, using fallback", exc_info=True)
@@ -7071,10 +7357,10 @@ def story_writer(state: ScrumState) -> dict:
     try:
         # Single LLM call with low temperature for deterministic JSON output.
         # See README: "Agentic Blueprint Reference" — using the LLM outside the main graph
-        response = invoke_with_images(get_llm(temperature=0.0), prompt, review_images)
+        response = _invoke_json(prompt, image_paths=review_images)
         stories = _parse_stories_response(response.content, features, analysis)
     except Exception as exc:
-        if _is_llm_auth_or_billing_error(exc):
+        if _should_reraise_llm_error(exc):
             raise
         # LLM call failed entirely — use deterministic fallback.
         logger.warning("LLM call failed in story_writer, using fallback", exc_info=True)
@@ -7472,10 +7758,10 @@ def _parallel_task_decompose(
         )
 
         try:
-            response = get_llm(temperature=0.0).invoke([HumanMessage(content=prompt)])
+            response = _invoke_json(prompt)
             return _parse_tasks_response(response.content, feature_stories)
         except Exception as exc:
-            if _is_llm_auth_or_billing_error(exc):
+            if _should_reraise_llm_error(exc):
                 raise
             logger.warning("LLM call failed for feature %s, using fallback", feature_id, exc_info=True)
             return _build_fallback_tasks(feature_stories)
@@ -7589,10 +7875,10 @@ def task_decomposer(state: ScrumState) -> dict:
         # Screenshots attached to review-edit feedback (Ctrl+V) — review passes only.
         review_images = list(state.get("review_feedback_images") or [])
         try:
-            response = invoke_with_images(get_llm(temperature=0.0), prompt, review_images)
+            response = _invoke_json(prompt, image_paths=review_images)
             tasks = _parse_tasks_response(response.content, stories)
         except Exception as exc:
-            if _is_llm_auth_or_billing_error(exc):
+            if _should_reraise_llm_error(exc):
                 raise
             logger.warning("LLM call failed in task_decomposer (review), using fallback", exc_info=True)
             tasks = _build_fallback_tasks(stories)
@@ -8379,10 +8665,10 @@ def sprint_planner(state: ScrumState) -> dict:
     try:
         # Single LLM call with low temperature for deterministic JSON output.
         # See README: "Agentic Blueprint Reference" — using the LLM outside the main graph
-        response = invoke_with_images(get_llm(temperature=0.0), prompt, review_images)
+        response = _invoke_json(prompt, image_paths=review_images)
         sprints = _parse_sprints_response(response.content, stories, velocity, starting_sprint_number)
     except Exception as exc:
-        if _is_llm_auth_or_billing_error(exc):
+        if _should_reraise_llm_error(exc):
             raise
         # LLM call failed entirely — use greedy bin-packing fallback.
         logger.warning("LLM call failed in sprint_planner, using fallback", exc_info=True)

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,18 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.20.0",
+      "date": "2026-07-20",
+      "summary": "You can now run yeaboi completely for free with no API key by using a local Ollama model instead of a cloud AI provider — planning, standups, retros, performance reviews, reporting, and chat all work fully offline with nothing leaving your machine. The setup wizard walks you through picking a downloaded model (or downloading one right from the app, with live progress) and explains the size/speed/RAM trade-offs of each. Extra work under the hood keeps local models just as reliable as cloud ones, with clear on-screen guidance if the local server isn't running or a model needs to be downloaded first.",
+      "highlights": [
+        {"text": "New free local mode: run yeaboi entirely offline with Ollama, no API key required", "areas": ["settings", "general"]},
+        {"text": "Setup wizard adds an Ollama option with live model discovery and per-model size/speed/RAM guidance", "areas": ["settings"]},
+        {"text": "Download and verify local models directly from the app, with live progress and resumable downloads", "areas": ["settings"]},
+        {"text": "Clearer, more reliable output from local models across planning and all ceremony modes", "areas": ["planning", "standup", "retro", "performance", "reporting"]},
+        {"text": "Usage page shows $0 cost for local runs while still tracking your past cloud spend", "areas": ["usage"]}
+      ]
+    },
+    {
       "version": "2.19.1",
       "date": "2026-07-20",
       "summary": "Fixed a bug where keys you pressed while the terminal UI was busy rendering a frame could be silently dropped instead of registering — now every keypress is reliably picked up, even ones sent while the app is mid-render.",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -1107,7 +1107,7 @@ def main(argv: list[str] | None = None) -> None:
     # ── First-run setup wizard ────────────────────────────────────────────────
     # Triggers when ~/.scrum-agent/.env is absent (first run) or --setup is passed.
     # If the user cancels the wizard, exit early — the agent can't run without
-    # a valid ANTHROPIC_API_KEY.
+    # a configured provider (a cloud API key, or a local Ollama server).
     # Runs immediately after splash — both use fullscreen Live, so no console
     # prints happen in between (avoids visible flicker on alt-screen exit).
     if args.setup or is_first_run():

--- a/src/yeaboi/config.py
+++ b/src/yeaboi/config.py
@@ -452,7 +452,7 @@ def get_llm_provider() -> str:
     """Return the active LLM provider name (lowercase).
 
     Set LLM_PROVIDER in .env to switch providers. Defaults to 'anthropic'.
-    Supported values: 'anthropic', 'openai', 'google'.
+    Supported values: 'anthropic', 'openai', 'google', 'bedrock', 'ollama'.
     """
     return os.getenv("LLM_PROVIDER", "anthropic").lower()
 
@@ -511,6 +511,32 @@ def get_google_api_key() -> str | None:
     return os.getenv("GOOGLE_API_KEY") or None
 
 
+def get_ollama_base_url() -> str:
+    """Return the base URL of the local Ollama server.
+
+    Ollama runs entirely on the user's machine — no API key, no cloud account.
+    Override with OLLAMA_BASE_URL for a non-default port or a server elsewhere
+    on the network. Trailing slashes are stripped so URL joining is predictable.
+    """
+    return os.getenv("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
+
+
+def get_ollama_num_ctx() -> int:
+    """Return the context window (tokens) requested from the Ollama model.
+
+    Ollama's server default context (2-4k tokens) is smaller than the biggest
+    assembled prompts in the planning pipeline (~5k tokens plus optional repo /
+    Confluence context). A too-small context silently truncates the prompt,
+    which destroys the JSON output the pipeline parses — so we default to 16384
+    and let power users tune it via OLLAMA_NUM_CTX (e.g. lower it on low-RAM
+    machines, raise it for very large projects).
+    """
+    try:
+        return int(os.getenv("OLLAMA_NUM_CTX", "16384"))
+    except ValueError:
+        return 16384
+
+
 def is_llm_configured() -> tuple[bool, str]:
     """Return (ok, message) for whether the selected LLM provider has credentials.
 
@@ -529,6 +555,10 @@ def is_llm_configured() -> tuple[bool, str]:
     if provider == "bedrock":
         ok = bool(os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or get_aws_profile())
         return (ok, "AWS credentials/region not configured for Bedrock")
+    if provider == "ollama":
+        # Local provider — no credentials to check. Server reachability is
+        # verified at call time (a down server surfaces an actionable error).
+        return (True, "")
     return (bool(os.getenv("ANTHROPIC_API_KEY")), f"No API key configured for provider '{provider}'")
 
 

--- a/src/yeaboi/input_guardrails.py
+++ b/src/yeaboi/input_guardrails.py
@@ -224,6 +224,10 @@ _CLASSIFIER_MODELS: dict[str, str] = {
     "anthropic": "claude-haiku-4-5-20251001",
     "openai": "gpt-4o-mini",
     "google": "gemini-2.5-flash",
+    # ollama deliberately absent: .get() → None → the user's main model. A
+    # second local model here would force Ollama to swap models in RAM on
+    # every classifier call, which is far slower than just reusing the one
+    # already loaded.
 }
 
 _CLASSIFIER_PROMPT = """\
@@ -322,10 +326,28 @@ def check_off_topic(text: str) -> str | None:
         llm = _llm_module.get_llm(model=model, temperature=0.0)
         # Disable retries — this is a non-critical guardrail; failing fast is
         # better than blocking the REPL for seconds on API overload (529).
-        llm.max_retries = 0
+        # hasattr guard: ChatOllama has no max_retries field, and assigning an
+        # undefined field to a pydantic model raises — which the except below
+        # would silently turn into a disabled guardrail.
+        if hasattr(llm, "max_retries"):
+            llm.max_retries = 0
+        # Local models (ChatOllama) generate on the user's CPU/GPU — an
+        # uncapped call lets a think-by-default model (qwen3) burn seconds of
+        # <think> tokens before its one-word verdict, on the input critical
+        # path. Cap the generation and turn thinking off for this one call.
+        # Constructor-level reasoning=False was deliberately avoided in
+        # get_llm() (older servers reject the option for non-think models),
+        # but here the except below already fails open, so the risk is zero.
+        # Cloud LLMs lack both fields — the hasattr guards make this a no-op.
+        if hasattr(llm, "num_predict"):
+            llm.num_predict = 64
+        if hasattr(llm, "reasoning"):
+            llm.reasoning = False
 
         response = llm.invoke(f"{_CLASSIFIER_PROMPT}\n\nUser input: {text}")
-        result = response.content.strip().upper()
+        # Local think-by-default models can bury the verdict token in a
+        # <think> block — strip it before matching.
+        result = _llm_module.strip_think_tags(response.content).strip().upper()
 
         if "OFF_TOPIC" in result:
             return (

--- a/src/yeaboi/performance/engine.py
+++ b/src/yeaboi/performance/engine.py
@@ -80,18 +80,23 @@ def _invoke_llm(prompt: str, *, what: str, images: Sequence[str] = ()) -> tuple[
         logger.warning("performance[%s]: LLM not configured (%s)", what, why)
         return {}, [f"AI output unavailable — {why}."]
 
-    from yeaboi.agent.llm import get_llm, invoke_with_images, track_usage
-    from yeaboi.agent.nodes import _is_llm_auth_or_billing_error
+    # invoke_json tracks usage + turns on JSON mode + re-asks once on bad JSON.
+    # See README: "Local Mode (Ollama)" — reliability layer.
+    from yeaboi.agent.llm import invoke_json
+    from yeaboi.agent.nodes import _is_llm_auth_or_billing_error, _local_llm_hint
 
     try:
         logger.info("performance[%s]: invoking LLM (%d image(s))", what, len(images))
-        response = invoke_with_images(get_llm(temperature=0.2), prompt, images)
-        track_usage(response)
+        response = invoke_json(prompt, temperature=0.2, image_paths=images)
         return _parse_json_response(response.content), []
     except Exception as exc:  # noqa: BLE001 — turn any LLM failure into a warning + fallback
         if _is_llm_auth_or_billing_error(exc):
             logger.warning("performance[%s]: LLM auth/billing error: %s", what, exc)
             return {}, ["AI output unavailable — API key invalid or billing issue."]
+        local_hint = _local_llm_hint(exc)
+        if local_hint:
+            logger.warning("performance[%s]: local Ollama failure: %s", what, exc)
+            return {}, [f"AI output unavailable — {local_hint}"]
         logger.warning("performance[%s]: LLM request failed: %s", what, exc)
         return {}, ["AI output unavailable — LLM request failed (see logs)."]
 

--- a/src/yeaboi/repl/__init__.py
+++ b/src/yeaboi/repl/__init__.py
@@ -1107,11 +1107,14 @@ def run_repl(
                 result = graph.invoke(invoke_state)
             elapsed = time.time() - start_time
             logger.info("Graph invoke complete: %.1fs", elapsed)
-        except anthropic.AuthenticationError:
+        except anthropic.AuthenticationError as e:
             console.print(
                 "[error]Authentication failed.[/error] "
                 "[warning]Check your ANTHROPIC_API_KEY in .env — it may be missing, expired, or invalid.[/warning]"
             )
+            if export_only:
+                # Headless auto-drive would retry the same doomed call forever.
+                raise SystemExit(1) from e
             continue
         except anthropic.RateLimitError:
             logger.warning("Rate limited — starting retry backoff")
@@ -1128,8 +1131,24 @@ def run_repl(
             console.print(f"[error]API error (status {e.status_code}):[/error] [warning]{e.message}[/warning]")
             continue
         except Exception as e:
+            # Local Ollama failures — actionable hint (server down / model not
+            # pulled / timeout), not a raw error. The node guards re-raise these
+            # only for the ollama provider (see nodes._should_reraise_llm_error).
+            from yeaboi.agent.nodes import _local_llm_hint
+
+            local_hint = _local_llm_hint(e)
+            if local_hint:
+                logger.error("Local Ollama failure: %s", e)
+                console.print(f"[error]{local_hint}[/error]")
+                if export_only:
+                    # Headless auto-drive would re-inject "continue" and hit the
+                    # same error forever — a broken local setup must exit instead.
+                    raise SystemExit(1) from e
+                continue
             logger.error("Unexpected graph invoke error: %s", e, exc_info=True)
             console.print(f"[error]Unexpected error: {e}[/error]")
+            if export_only:
+                raise SystemExit(1) from e
             continue
 
         # ── Outer try: post-processing (rendering, hints, state update) ──

--- a/src/yeaboi/reporting/engine.py
+++ b/src/yeaboi/reporting/engine.py
@@ -24,8 +24,6 @@ from collections import Counter
 from dataclasses import asdict
 from datetime import date, timedelta
 
-from langchain_core.messages import HumanMessage
-
 from yeaboi.agent.state import DeliveredItem, DeliveryReport
 from yeaboi.reporting import activity as activity_mod
 
@@ -109,18 +107,23 @@ def _invoke_llm(prompt: str) -> tuple[dict, list[str]]:
         logger.warning("reporting: LLM not configured (%s)", why)
         return {}, [f"AI narrative unavailable — {why}. Showing a plain summary."]
 
-    from yeaboi.agent.llm import get_llm, track_usage
-    from yeaboi.agent.nodes import _is_llm_auth_or_billing_error
+    # invoke_json tracks usage + turns on JSON mode + re-asks once on bad JSON.
+    # See README: "Local Mode (Ollama)" — reliability layer.
+    from yeaboi.agent.llm import invoke_json
+    from yeaboi.agent.nodes import _is_llm_auth_or_billing_error, _local_llm_hint
 
     try:
         logger.info("reporting: invoking LLM design pass")
-        response = get_llm(temperature=0.3).invoke([HumanMessage(content=prompt)])
-        track_usage(response)
+        response = invoke_json(prompt, temperature=0.3)
         return _parse_json_response(response.content), []
     except Exception as exc:  # noqa: BLE001 — turn any LLM failure into a warning + fallback
         if _is_llm_auth_or_billing_error(exc):
             logger.warning("reporting: LLM auth/billing error: %s", exc)
             return {}, ["AI narrative unavailable — API key invalid or billing issue. Showing a plain summary."]
+        local_hint = _local_llm_hint(exc)
+        if local_hint:
+            logger.warning("reporting: local Ollama failure: %s", exc)
+            return {}, [f"AI narrative unavailable — {local_hint} Showing a plain summary."]
         logger.warning("reporting: LLM request failed: %s", exc)
         return {}, ["AI narrative unavailable — LLM request failed (see logs). Showing a plain summary."]
 

--- a/src/yeaboi/retro/engine.py
+++ b/src/yeaboi/retro/engine.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 import json
 import logging
 
-from langchain_core.messages import HumanMessage
-
 from yeaboi.retro.board import RetroBoard
 
 logger = logging.getLogger(__name__)
@@ -85,20 +83,26 @@ def generate_action_items(board: RetroBoard) -> str:
         added = board.add_ai_cards(_build_fallback_action_items(didnt_raw))
         return f"AI unavailable ({why}) — added {added} basic action item(s)."
 
-    from yeaboi.agent.llm import get_llm, track_usage
-    from yeaboi.agent.nodes import _is_llm_auth_or_billing_error
+    # invoke_json tracks usage + turns on JSON mode + re-asks once on bad JSON.
+    # See README: "Local Mode (Ollama)" — reliability layer.
+    from yeaboi.agent.llm import invoke_json
+    from yeaboi.agent.nodes import _is_llm_auth_or_billing_error, _local_llm_hint
     from yeaboi.prompts.retro import get_retro_action_items_prompt
 
     prompt = get_retro_action_items_prompt(went_well=went, didnt_go_well=didnt)
     try:
-        response = get_llm(temperature=0.2).invoke([HumanMessage(content=prompt)])
-        track_usage(response)
+        response = invoke_json(prompt, temperature=0.2)
         items = _parse_action_items(response.content)
     except Exception as exc:
         if _is_llm_auth_or_billing_error(exc):
             logger.warning("retro: LLM auth/billing error — surfacing as warning: %s", exc)
             added = board.add_ai_cards(_build_fallback_action_items(didnt_raw))
             return f"AI unavailable (API key/billing) — added {added} basic action item(s)."
+        local_hint = _local_llm_hint(exc)
+        if local_hint:
+            logger.warning("retro: local Ollama failure: %s", exc)
+            added = board.add_ai_cards(_build_fallback_action_items(didnt_raw))
+            return f"{local_hint} Added {added} basic action item(s)."
         logger.warning("retro: LLM request failed, using fallback: %s", exc)
         added = board.add_ai_cards(_build_fallback_action_items(didnt_raw))
         return f"AI request failed — added {added} basic action item(s) (see logs)."

--- a/src/yeaboi/sessions.py
+++ b/src/yeaboi/sessions.py
@@ -548,6 +548,27 @@ class SessionStore:
         inp, out, calls = row if row else (0, 0, 0)
         return {"input_tokens": inp, "output_tokens": out, "total_tokens": inp + out, "call_count": calls}
 
+    def get_lifetime_usage_by_provider(self) -> dict[str, dict]:
+        """Return cumulative token usage grouped by provider.
+
+        Lets the Usage page price each provider's tokens at its own rate — a
+        history mixing Anthropic and (free) Ollama sessions must neither hide
+        real past cloud spend behind a $0 local rate nor price local tokens at
+        cloud rates. Rows recorded before providers were stamped group under "".
+        """
+        usage: dict[str, dict] = {}
+        for provider, inp, out, calls in self._conn.execute(
+            "SELECT provider, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COUNT(*) "
+            "FROM token_usage GROUP BY provider"
+        ).fetchall():
+            usage[provider] = {
+                "input_tokens": inp,
+                "output_tokens": out,
+                "total_tokens": inp + out,
+                "call_count": calls,
+            }
+        return usage
+
     # ── Lifecycle ─────────────────────────────────────────────────────────
 
     def close(self) -> None:

--- a/src/yeaboi/setup_wizard.py
+++ b/src/yeaboi/setup_wizard.py
@@ -57,6 +57,15 @@ _PROVIDERS: dict[str, dict[str, str]] = {
         "prefix": "",
         "instructions": "Uses IAM credentials from instance role, ~/.aws/credentials, or env vars",
     },
+    "5": {
+        "name": "Ollama (Local & Free — no API key)",
+        "env_var": "OLLAMA_BASE_URL",
+        "provider_val": "ollama",
+        "prefix": "",
+        "instructions": "Free, private, no API key. Install: https://ollama.com then run: ollama pull qwen3:8b",
+        # Not a secret — the local server URL; Enter accepts this default.
+        "default_input": "http://localhost:11434",
+    },
 }
 
 
@@ -170,6 +179,23 @@ def _collect_api_key(console: Console, provider: dict[str, str]) -> str | None:
     console.print("\n[bold]Step 2/3[/bold] API Key [required]")
     console.print(f"  {provider['instructions']}")
 
+    # Keyless providers (Ollama): the value is a server URL with a sensible
+    # default, not a secret — Enter accepts the default, input is unmasked.
+    default_input = provider.get("default_input", "")
+    if default_input:
+        # langchain-ollama is an optional extra — warn here rather than letting
+        # the first planning run crash with an ImportError after a green setup.
+        if provider.get("provider_val") == "ollama":
+            import importlib.util
+
+            if importlib.util.find_spec("langchain_ollama") is None:
+                console.print(
+                    "[yellow]Ollama support isn't installed — run: uv sync --extra ollama "
+                    "(or: pip install langchain-ollama) before your first planning run.[/yellow]"
+                )
+        value = prompt(f"  {provider['env_var']} [{default_input}]: ").strip()
+        return value or default_input
+
     while True:
         key = prompt(f"  {provider['env_var']}: ", is_password=True).strip()
         if not key:
@@ -199,8 +225,9 @@ def run_setup_wizard(console: Console) -> bool:
     # Welcome panel
     body = Text.from_markup(
         "[bold cyan]Welcome to yeaboi.ai — First-Time Setup[/bold cyan]\n\n"
-        "We'll collect your API credentials now. Everything is stored locally\n"
-        "in [cyan]~/.yeaboi/.env[/cyan] — never sent anywhere else."
+        "We'll set up your AI provider now — cloud (API key) or free local\n"
+        "(Ollama, no key needed). Everything is stored locally in\n"
+        "[cyan]~/.yeaboi/.env[/cyan] — never sent anywhere else."
     )
     console.print(Panel(body, border_style="cyan", padding=(1, 2)))
 

--- a/src/yeaboi/standup/engine.py
+++ b/src/yeaboi/standup/engine.py
@@ -412,8 +412,10 @@ def _summarize_members(
         logger.warning("standup: LLM not configured (%s) — using deterministic fallback", why)
         return _fallback([f"AI summary unavailable — {why}."])
 
-    from yeaboi.agent.llm import get_llm, invoke_with_images, track_usage
-    from yeaboi.agent.nodes import _is_llm_auth_or_billing_error
+    # invoke_json tracks usage + turns on JSON mode + re-asks once on bad JSON.
+    # See README: "Local Mode (Ollama)" — reliability layer.
+    from yeaboi.agent.llm import invoke_json
+    from yeaboi.agent.nodes import _is_llm_auth_or_billing_error, _local_llm_hint
     from yeaboi.prompts.standup import get_standup_summary_prompt
 
     prompt = get_standup_summary_prompt(
@@ -436,13 +438,16 @@ def _summarize_members(
             len(member_payload),
             len(images),
         )
-        response = invoke_with_images(get_llm(temperature=0.0), prompt, images)
-        track_usage(response)
+        response = invoke_json(prompt, image_paths=images)
         parsed = _parse_standup_response(response.content)
     except Exception as exc:
         if _is_llm_auth_or_billing_error(exc):
             logger.warning("standup: LLM auth/billing error — surfacing as warning: %s", exc)
             return _fallback(["AI summary unavailable — API key invalid or billing issue."])
+        local_hint = _local_llm_hint(exc)
+        if local_hint:
+            logger.warning("standup: local Ollama failure: %s", exc)
+            return _fallback([f"AI summary unavailable — {local_hint}"])
         logger.warning("standup: LLM summarization failed, using fallback: %s", exc)
         return _fallback(["AI summary unavailable — LLM request failed (see logs)."])
 

--- a/src/yeaboi/tools/llm_tools.py
+++ b/src/yeaboi/tools/llm_tools.py
@@ -98,7 +98,13 @@ def estimate_complexity(
     try:
         response = get_llm(temperature=0.2).invoke([HumanMessage(content=prompt)])
         logger.debug("estimate_complexity completed (%d chars response)", len(response.content))
-        return response.content
+        # Local think-by-default models embed <think> blocks in prose output.
+        from yeaboi.agent.llm import strip_think_tags, track_usage
+
+        # ReAct-tool calls bill like any other — without this the Usage page
+        # undercounts every conversational estimation request.
+        track_usage(response)
+        return strip_think_tags(response.content)
     except Exception as e:
         logger.error("Error in estimate_complexity: %s", e)
         return f"Error estimating complexity: {e}"
@@ -152,7 +158,12 @@ def generate_acceptance_criteria(
     try:
         response = get_llm(temperature=0.3).invoke([HumanMessage(content=prompt)])
         logger.debug("generate_acceptance_criteria completed (%d chars)", len(response.content))
-        return response.content
+        # Local think-by-default models embed <think> blocks in prose output.
+        from yeaboi.agent.llm import strip_think_tags, track_usage
+
+        # ReAct-tool calls bill like any other — see estimate_complexity.
+        track_usage(response)
+        return strip_think_tags(response.content)
     except Exception as e:
         logger.error("Error in generate_acceptance_criteria: %s", e)
         return f"Error generating acceptance criteria: {e}"

--- a/src/yeaboi/tools/team_learning.py
+++ b/src/yeaboi/tools/team_learning.py
@@ -45,14 +45,15 @@ logger = logging.getLogger(__name__)
 
 
 def _llm_invoke(prompt: str, *, temperature: float = 0.0):
-    """Invoke the LLM with a prompt and track token usage."""
-    from langchain_core.messages import HumanMessage
+    """Invoke the LLM expecting a JSON reply; tracks token usage internally.
 
-    from yeaboi.agent.llm import get_llm, track_usage
+    Every caller of this wrapper parses the response as JSON, so it routes
+    through invoke_json — JSON mode on Ollama plus a one-shot repair re-ask.
+    # See README: "Local Mode (Ollama)" — reliability layer.
+    """
+    from yeaboi.agent.llm import invoke_json
 
-    response = get_llm(temperature=temperature).invoke([HumanMessage(content=prompt)])
-    track_usage(response)
-    return response
+    return invoke_json(prompt, temperature=temperature)
 
 
 def _safe_float(val: object) -> float:

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -1099,25 +1099,19 @@ def _collect_usage_data() -> dict:
     provider = os.environ.get("LLM_PROVIDER", "anthropic")
     model = os.environ.get("LLM_MODEL", "")
     if not model:
-        _defaults = {
-            "anthropic": "claude-sonnet-4-6",
-            "openai": "gpt-4o",
-            "google": "gemini-2.5-flash",
-            "bedrock": "us.anthropic.claude-sonnet-4-6-v1:0",
-        }
-        model = _defaults.get(provider, "unknown")
+        # Single source of truth — was a drifting local copy before ollama landed.
+        from yeaboi.agent.llm import _PROVIDER_DEFAULTS
+
+        model = _PROVIDER_DEFAULTS.get(provider, "unknown")
     data["provider"] = provider
     data["model"] = model
 
-    # API key status
-    _key_vars = {
-        "anthropic": "ANTHROPIC_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "google": "GOOGLE_API_KEY",
-        "bedrock": "AWS_REGION",
-    }
-    key_var = _key_vars.get(provider, "ANTHROPIC_API_KEY")
-    data["api_key_status"] = "configured" if os.environ.get(key_var) else "not configured"
+    # API key status — is_llm_configured knows each provider's real requirement
+    # (ollama needs none, bedrock accepts a profile without AWS_REGION, ...).
+    from yeaboi.config import is_llm_configured
+
+    _configured, _ = is_llm_configured()
+    data["api_key_status"] = "configured" if _configured else "not configured"
 
     # Session history
     try:
@@ -1166,9 +1160,15 @@ def _collect_usage_data() -> dict:
         data["profiles"] = []
 
     # Token usage — session (in-memory) + lifetime (from DB)
-    def _calc_cost(inp: int, out: int) -> float:
+    def _cloud_cost(inp: int, out: int) -> float:
         # Claude Sonnet 4: $3/MTok input, $15/MTok output
-        return round((inp * 3.0 + out * 15.0) / 1_000_000, 4)
+        return (inp * 3.0 + out * 15.0) / 1_000_000
+
+    def _calc_cost(inp: int, out: int) -> float:
+        # Ollama runs on the user's own hardware — there is no per-token bill.
+        if provider == "ollama":
+            return 0.0
+        return round(_cloud_cost(inp, out), 4)
 
     try:
         from yeaboi.agent.llm import get_usage_stats
@@ -1195,16 +1195,27 @@ def _collect_usage_data() -> dict:
         from yeaboi.sessions import SessionStore
 
         with SessionStore(_ana_dbp) as store:
-            lifetime = store.get_lifetime_usage()
-            if lifetime.get("call_count", 0) > 0:
-                lt_inp = lifetime["input_tokens"]
-                lt_out = lifetime["output_tokens"]
+            # Grouped by provider so mixed histories price correctly: ollama
+            # rows are free, everything else (incl. legacy rows without a
+            # provider stamp, which predate local mode) at the cloud estimate.
+            by_provider = store.get_lifetime_usage_by_provider()
+            lt_inp = sum(u["input_tokens"] for u in by_provider.values())
+            lt_out = sum(u["output_tokens"] for u in by_provider.values())
+            lt_calls = sum(u["call_count"] for u in by_provider.values())
+            lt_cost = round(
+                sum(
+                    0.0 if prov == "ollama" else _cloud_cost(u["input_tokens"], u["output_tokens"])
+                    for prov, u in by_provider.items()
+                ),
+                4,
+            )
+            if lt_calls > 0:
                 data["lifetime_tokens"] = {
                     "input": lt_inp,
                     "output": lt_out,
                     "total": lt_inp + lt_out,
-                    "calls": lifetime["call_count"],
-                    "estimated_cost": _calc_cost(lt_inp, lt_out),
+                    "calls": lt_calls,
+                    "estimated_cost": lt_cost,
                 }
             else:
                 data["lifetime_tokens"] = {}
@@ -1228,6 +1239,9 @@ def _collect_settings_data() -> dict:
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
         "GOOGLE_API_KEY",
+        # Ollama (local provider — server URL + requested context window)
+        "OLLAMA_BASE_URL",
+        "OLLAMA_NUM_CTX",
         "JIRA_BASE_URL",
         "JIRA_EMAIL",
         "JIRA_API_TOKEN",

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -1582,6 +1582,8 @@ def _build_usage_screen(
         lt_cost = lifetime.get("estimated_cost", 0.0)
         if lt_cost > 0:
             _row("Estimated total cost", f"${lt_cost:.4f}", theme.warn)
+        elif usage_data.get("provider") == "ollama":
+            _row("Estimated total cost", "$0.00 — local model, runs on your hardware", theme.good)
 
     # ── Current Session Usage ─────────────────────────────────────
     _heading("Current Session")
@@ -1594,6 +1596,8 @@ def _build_usage_screen(
         cost = tokens.get("estimated_cost", 0.0)
         if cost > 0:
             _row("Session cost", f"${cost:.4f}", theme.warn)
+        elif usage_data.get("provider") == "ollama":
+            _row("Session cost", "$0.00 — local model", theme.good)
     else:
         body_lines.append(Text(_PAD + "    No calls in this session yet.", style=theme.muted, justify="left"))
 
@@ -3212,6 +3216,11 @@ def _build_settings_screen(
     _row("Anthropic Key", config_data.get("ANTHROPIC_API_KEY", ""), masked=True)
     _row("OpenAI Key", config_data.get("OPENAI_API_KEY", ""), masked=True)
     _row("Google Key", config_data.get("GOOGLE_API_KEY", ""), masked=True)
+    # Ollama is keyless — its server URL/context rows only appear when the user
+    # runs local mode (or has customised the vars), keeping the page uncluttered.
+    if config_data.get("LLM_PROVIDER", "") == "ollama" or config_data.get("OLLAMA_BASE_URL", ""):
+        _row("Ollama URL", config_data.get("OLLAMA_BASE_URL", "") or "http://localhost:11434 (default)")
+        _row("Ollama Context", config_data.get("OLLAMA_NUM_CTX", "") or "16384 (default)")
 
     # ── Jira ──────────────────────────────────────────────────────
     _heading("Jira")

--- a/src/yeaboi/ui/provider_select/__init__.py
+++ b/src/yeaboi/ui/provider_select/__init__.py
@@ -31,6 +31,7 @@ from yeaboi.ui.provider_select._verification import (
     _verify_model,
     _verify_vc_token,
     fetch_available_models,
+    pull_ollama_model,
 )
 from yeaboi.ui.provider_select.screens._screens import (
     _build_input_screen,
@@ -57,6 +58,24 @@ logger = logging.getLogger(__name__)
 # Cap the live-discovered model list so the (non-scrolling) select screen stays
 # usable; "Custom…" covers anything beyond the newest few.
 _MAX_LIVE_MODELS = 8
+
+# Verification failures that can be self-served with an in-app pull (Ollama
+# only) — matched against _verify_model's message.
+_NOT_PULLED_PREFIX = "Model not pulled"
+
+
+def _existing_model_for(existing_config: dict[str, str] | None, provider_val: str) -> str:
+    """The saved LLM_MODEL, but only if it was saved for *this* provider.
+
+    A saved model only makes sense for the provider it was saved with —
+    offering e.g. claude-sonnet-4-6 as "(current)" after switching to Ollama
+    would pre-select a model whose verification can only fail
+    ("ollama pull claude-sonnet-4-6").
+    """
+    cfg = existing_config or {}
+    if cfg.get("LLM_PROVIDER") != provider_val:
+        return ""
+    return cfg.get("LLM_MODEL", "")
 
 
 def _detect_aws_region() -> str | None:
@@ -187,6 +206,10 @@ def select_provider(
             models_cfg = provider.get("models") or {}
             presets = list(models_cfg.get("presets") or [])
             default_model = models_cfg.get("default", "")
+            # Ollama only: True when the shown presets are offline seeds the
+            # server does NOT have — they get a "not pulled" label and a P-to-
+            # download offer instead of a dead-end verification failure.
+            seeds_unpulled = False
 
             # Live discovery: ask the provider what this key can actually run, so
             # the menu never offers a retired id. The hardcoded presets above are
@@ -216,6 +239,8 @@ def select_provider(
                 logger.debug("provider_select: discovered %d models for %s", len(discovered), provider["provider_val"])
                 if discovered:
                     presets = discovered[:_MAX_LIVE_MODELS]
+                elif provider.get("provider_val") == "ollama":
+                    seeds_unpulled = True
 
             # A detected Bedrock model (from OpenClaw) or a previously-saved LLM_MODEL
             # is offered at the top of the list and pre-selected, preserving zero-config.
@@ -227,20 +252,29 @@ def select_provider(
                     detected = _detect_openclaw_bedrock_model()
                 except Exception:
                     detected = None
-            existing_model = (existing_config or {}).get("LLM_MODEL", "")
+            existing_model = _existing_model_for(existing_config, provider.get("provider_val", ""))
 
             model_ids: list[str] = []  # actual model id per entry ("" marks Custom…)
             labels: list[str] = []  # display label per entry
+            # Local models differ hugely in RAM needs and JSON discipline —
+            # the card's model_hints map one-liner trade-offs onto known ids
+            # (works for both seed presets and live-discovered names).
+            model_hints: dict[str, str] = provider.get("model_hints") or {}
 
-            def _add(mid: str, tag: str = "") -> None:
+            def _add(mid: str, tag: str = "", extra: str = "") -> None:
                 if mid and mid not in model_ids:
                     model_ids.append(mid)
+                    hint = model_hints.get(mid) or model_hints.get(mid.removesuffix(":latest"))
+                    if not tag and hint:
+                        tag = f"({hint})"
+                    if extra:
+                        tag = f"{tag} {extra}".strip()
                     labels.append(f"{mid}  {tag}" if tag else mid)
 
             _add(detected, "(detected)")
             _add(existing_model, "(current)")
             for m in presets:
-                _add(m)
+                _add(m, extra="· not pulled" if seeds_unpulled else "")
             model_ids.append("")  # Custom… sentinel
             labels.append("Custom…")
 
@@ -268,11 +302,54 @@ def select_provider(
                 thread.join()
                 return result[0]
 
+            def _run_model_pull(model_id: str, render_progress) -> tuple[bool, str]:
+                """Download *model_id* onto the Ollama server with live progress.
+
+                Runs pull_ollama_model on a worker thread (downloads take
+                minutes) while the frame loop keeps rendering via
+                ``render_progress(status_line)``; Esc cancels (Ollama keeps
+                partial layers, so a re-pull resumes). Returns (success, msg).
+                """
+                import threading
+
+                logger.info("in-app ollama pull requested: %s", model_id)
+                cancel = threading.Event()
+                prog: dict = {"status": "connecting…", "frac": None}
+
+                def _on_progress(status_text: str, frac) -> None:
+                    # Called from the worker thread — single dict-key writes
+                    # are atomic under the GIL, no lock needed for a progress
+                    # line the render loop merely reads.
+                    if status_text:
+                        prog["status"] = status_text
+                    if frac is not None:
+                        prog["frac"] = frac
+
+                result: list[tuple[bool, str]] = []
+
+                def _do() -> None:
+                    result.append(pull_ollama_model(api_key_val, model_id, _on_progress, cancel_event=cancel))
+
+                thread = threading.Thread(target=_do, daemon=True)
+                thread.start()
+                while thread.is_alive():
+                    frac = prog["frac"]
+                    pct = f"{frac * 100:3.0f}% · " if frac is not None else ""
+                    render_progress(f"⬇ Downloading {model_id} — {pct}{prog['status']}  ·  Esc cancels")
+                    if _supports_timeout:
+                        if read_key(timeout=FRAME_TIME_30FPS) == "esc":
+                            cancel.set()
+                    else:
+                        time.sleep(FRAME_TIME_30FPS)
+                thread.join()
+                return result[0] if result else (False, "Download failed")
+
             def _run_custom_input() -> str | None:
                 """Text-input loop for a typed model id. Returns id or None (back)."""
                 val = existing_model if existing_model not in presets else ""
                 err = ""
                 verified: bool | None = None
+                offer_pull = ""  # model id whose last verify failed with "not pulled"
                 while True:
                     w, h = console.size
                     live.update(
@@ -294,6 +371,24 @@ def select_provider(
                                 )
                             )
 
+                        # Second Enter on the same not-pulled id → download it
+                        # in-app (text input has no spare letter key: p types).
+                        if offer_pull and offer_pull == model_id:
+                            offer_pull = ""
+
+                            def _render_pull(status_line: str) -> None:
+                                w2, h2 = console.size
+                                live.update(
+                                    _build_model_input_screen(provider, val, width=w2, height=h2, status=status_line)
+                                )
+
+                            ok_pull, pull_msg = _run_model_pull(model_id, _render_pull)
+                            if not ok_pull:
+                                err = pull_msg
+                                verified = False
+                                continue
+                            # fall through to verify the freshly pulled model
+
                         ok, msg = _verify_pulsing(model_id, _render)
                         if ok:
                             logger.info("LLM model verified (custom): %s", model_id)
@@ -302,6 +397,9 @@ def select_provider(
                             time.sleep(0.5)
                             return model_id
                         logger.warning("LLM model verification failed (custom): %s — %s", model_id, msg)
+                        if msg.startswith(_NOT_PULLED_PREFIX):
+                            offer_pull = model_id
+                            msg = f"Model not pulled — press Enter again to download it, or run: ollama pull {model_id}"
                         err = msg
                         verified = False
                     elif key == "esc":
@@ -327,7 +425,19 @@ def select_provider(
 
             # Preset-list selection loop.
             err = ""
+            pull_offer = ""  # model id whose last verify failed with "not pulled"
             start_time = time.monotonic()
+
+            def _render_list(_border: str = "") -> None:
+                w2, h2 = console.size
+                live.update(_build_model_select_screen(provider, labels, selected, width=w2, height=h2))
+
+            def _render_list_status(status_line: str) -> None:
+                w2, h2 = console.size
+                live.update(
+                    _build_model_select_screen(provider, labels, selected, width=w2, height=h2, status=status_line)
+                )
+
             while True:
                 w, h = console.size
                 tick = time.monotonic() - start_time
@@ -340,9 +450,11 @@ def select_provider(
                 if key in ("up", "scroll_up"):
                     selected = (selected - 1) % len(labels)
                     err = ""
+                    pull_offer = ""
                 elif key in ("down", "scroll_down"):
                     selected = (selected + 1) % len(labels)
                     err = ""
+                    pull_offer = ""
                 elif key == "enter":
                     chosen_id = model_ids[selected]
                     if chosen_id == "":  # Custom…
@@ -352,15 +464,26 @@ def select_provider(
                         continue  # Esc from custom input → back to preset list
                     logger.info("LLM model chosen (preset): %s", chosen_id)
 
-                    def _render(_border: str) -> None:
-                        w2, h2 = console.size
-                        live.update(_build_model_select_screen(provider, labels, selected, width=w2, height=h2))
-
-                    ok, msg = _verify_pulsing(chosen_id, _render)
+                    ok, msg = _verify_pulsing(chosen_id, _render_list)
                     if ok:
                         logger.info("LLM model verified (preset): %s", chosen_id)
                         return chosen_id
                     logger.warning("LLM model verification failed (preset): %s — %s", chosen_id, msg)
+                    if msg.startswith(_NOT_PULLED_PREFIX):
+                        pull_offer = chosen_id
+                        msg = f"Model not pulled — press P to download it now, or run: ollama pull {chosen_id}"
+                    err = msg
+                elif key in ("p", "P") and pull_offer:
+                    model_to_pull = pull_offer
+                    pull_offer = ""
+                    ok_pull, pull_msg = _run_model_pull(model_to_pull, _render_list_status)
+                    if not ok_pull:
+                        err = pull_msg
+                        continue
+                    ok, msg = _verify_pulsing(model_to_pull, _render_list)
+                    if ok:
+                        logger.info("LLM model pulled + verified (preset): %s", model_to_pull)
+                        return model_to_pull
                     err = msg
                 elif key in ("q", "esc"):
                     return None
@@ -405,6 +528,10 @@ def select_provider(
                 input_value = _cfg.get(provider["env_var"], "")
                 if provider.get("is_region_input") and not input_value:
                     input_value = _detect_aws_region() or ""
+                # Ollama: the field holds the server URL, not a secret — pre-fill
+                # the standard localhost address so Enter-to-verify just works.
+                if provider.get("is_base_url_input") and not input_value:
+                    input_value = provider.get("default_input", "")
                 error = ""
                 verified: bool | None = None
 

--- a/src/yeaboi/ui/provider_select/_constants.py
+++ b/src/yeaboi/ui/provider_select/_constants.py
@@ -25,6 +25,7 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
         "env_var": "ANTHROPIC_API_KEY",
         "provider_val": "anthropic",
         "prefix": "sk-ant-",
+        "tagline": "Recommended cloud \u00b7 API key required",
         "instructions": "Get yours at: https://console.anthropic.com \u2192 API Keys",
         "color": "rgb(70,100,180)",
         "models": {
@@ -43,6 +44,7 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
         "env_var": "GOOGLE_API_KEY",
         "provider_val": "google",
         "prefix": "AIza",
+        "tagline": "Fast, affordable cloud \u00b7 API key required",
         "instructions": "Get yours at: https://aistudio.google.com \u2192 Get API key",
         "color": "rgb(70,100,180)",
         "models": {
@@ -61,6 +63,7 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
         "env_var": "OPENAI_API_KEY",
         "provider_val": "openai",
         "prefix": "sk-",
+        "tagline": "Cloud \u00b7 API key required",
         "instructions": "Get yours at: https://platform.openai.com \u2192 API keys",
         "color": "rgb(70,100,180)",
         "models": {
@@ -79,6 +82,7 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
         "env_var": "AWS_REGION",
         "provider_val": "bedrock",
         "prefix": "",
+        "tagline": "AWS-hosted · IAM credentials, no API key",
         "instructions": "Uses IAM credentials from instance role, ~/.aws/credentials, or env vars",
         "color": "rgb(70,100,180)",
         "is_region_input": True,
@@ -89,6 +93,40 @@ _PROVIDER_CARDS: list[dict[str, Any]] = [
             "presets": [
                 "us.anthropic.claude-sonnet-4-6-v1:0",
             ],
+        },
+    },
+    {
+        "name": "Ollama",
+        "full_name": "Ollama (Local)",
+        "env_var": "OLLAMA_BASE_URL",
+        "provider_val": "ollama",
+        "prefix": "",
+        "tagline": "Free · local · private · no API key",
+        "instructions": "Free, private, no API key. Install: https://ollama.com then run: ollama pull qwen3:8b",
+        "color": "rgb(70,100,180)",
+        # Like Bedrock's is_region_input: the "key" field holds a URL, not a
+        # secret — rendered unmasked and pre-filled with default_input.
+        "is_base_url_input": True,
+        "default_input": "http://localhost:11434",
+        "models": {
+            "default": "qwen3:8b",
+            "presets": [
+                "qwen3:8b",
+                "qwen3:14b",
+                "qwen2.5:14b",
+                "llama3.1:8b",
+            ],
+        },
+        # One-line trade-off shown next to each known model in the model list —
+        # local models differ hugely in RAM needs and JSON discipline, so the
+        # user should pick with eyes open. See README: "Local Mode (Ollama)".
+        # Every hint carries the same ~download-size · RAM suffix so no model
+        # can be picked without a size warning.
+        "model_hints": {
+            "qwen3:8b": "best balance · ~5 GB · fine on 16 GB RAM",
+            "qwen3:14b": "better plans · ~9 GB · wants 24 GB+ RAM",
+            "qwen2.5:14b": "proven JSON discipline · ~9 GB · wants 24 GB+ RAM",
+            "llama3.1:8b": "weaker JSON → more fallbacks · ~5 GB · fine on 16 GB RAM",
         },
     },
 ]

--- a/src/yeaboi/ui/provider_select/_verification.py
+++ b/src/yeaboi/ui/provider_select/_verification.py
@@ -11,6 +11,17 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Shared Ollama failure copy — the same situation is reachable from both
+# _verify_api_key and _verify_model, and the messages must stay identical so
+# tests (and users retrying) see one consistent instruction.
+_OLLAMA_PKG_MISSING = (
+    "Ollama support isn't installed — run: uv sync --extra ollama (or: pip install langchain-ollama), then retry"
+)
+_OLLAMA_UNREACHABLE = (
+    "Can't reach Ollama — is it running? Start it with: ollama serve"
+    "  ·  Not installed? https://ollama.com (or: brew install ollama)"
+)
+
 
 def _validate_key(provider: dict[str, Any], value: str) -> tuple[str, str]:
     """Realtime format validation of an API key (or region for Bedrock).
@@ -29,6 +40,14 @@ def _validate_key(provider: dict[str, Any], value: str) -> tuple[str, str]:
         if "-" in value and len(value) >= 7:
             return "valid_format", "Press Enter to verify \u2014 edit region or confirm"
         return "too_short", "Enter an AWS region (e.g. us-east-1, eu-west-2)"
+
+    # Ollama uses a local server URL, not an API key
+    if provider.get("is_base_url_input"):
+        if not value:
+            return "empty", ""
+        if value.startswith(("http://", "https://")):
+            return "valid_format", "Press Enter to verify \u2014 Ollama must be running"
+        return "bad_prefix", "Enter a URL (e.g. http://localhost:11434)"
 
     prefix = provider["prefix"]
     name = provider["full_name"]
@@ -129,8 +148,31 @@ def _verify_api_key(provider: dict[str, Any], api_key: str) -> tuple[bool, str]:
                 return True, "AWS credentials verified"
             return False, "Unexpected response from Bedrock"
 
+        elif provider_val == "ollama":
+            # Ollama verification — api_key is the local server base URL.
+            # langchain-ollama is an optional extra and everything below uses
+            # raw httpx, so without this guard setup would finish green and the
+            # first real LLM call would crash with an ImportError.
+            import importlib.util
+
+            if importlib.util.find_spec("langchain_ollama") is None:
+                return False, _OLLAMA_PKG_MISSING
+
+            # /api/tags lists installed models; a 200 proves the server is up.
+            import httpx
+
+            resp = httpx.get(f"{api_key.rstrip('/')}/api/tags", timeout=5)
+            if resp.status_code == 200:
+                models = resp.json().get("models") or []
+                if models:
+                    return True, "Ollama server verified"
+                return True, "Server verified — no models installed yet; run: ollama pull qwen3:8b"
+            return False, f"Unexpected response: {resp.status_code}"
+
     except Exception as e:
         err_str = str(e)
+        if provider_val == "ollama":
+            return False, _OLLAMA_UNREACHABLE
         if "NoCredentialsError" in type(e).__name__ or "NoCredentialsError" in err_str:
             return False, "No AWS credentials found \u2014 configure IAM role, ~/.aws/credentials, or env vars"
         if "InvalidIdentityToken" in err_str or "AccessDenied" in err_str or "403" in err_str:
@@ -237,8 +279,24 @@ def _verify_model(provider: dict[str, Any], api_key: str, model: str) -> tuple[b
                 return True, "Model verified"
             return False, "Model not available in this region"
 
+        elif provider_val == "ollama":
+            # api_key is the local server base URL. A model is usable iff it's
+            # been pulled — match names with and without the ":latest" suffix.
+            import httpx
+
+            resp = httpx.get(f"{api_key.rstrip('/')}/api/tags", timeout=5)
+            if resp.status_code != 200:
+                return False, f"Unexpected response: {resp.status_code}"
+            names = {m.get("name", "") for m in resp.json().get("models") or []}
+            candidates = {model, f"{model}:latest", model.removesuffix(":latest")}
+            if names & candidates:
+                return True, "Model verified"
+            return False, f"Model not pulled — run: ollama pull {model}"
+
     except Exception as e:
         err_str = str(e)
+        if provider_val == "ollama":
+            return False, _OLLAMA_UNREACHABLE
         if "NoCredentialsError" in type(e).__name__ or "NoCredentialsError" in err_str:
             return False, "No AWS credentials found — configure IAM role, ~/.aws/credentials, or env vars"
         if "InvalidIdentityToken" in err_str or "AccessDenied" in err_str or "403" in err_str:
@@ -332,6 +390,17 @@ def fetch_available_models(provider: dict[str, Any], api_key: str) -> list[str]:
             entries = [(m["id"], int(m.get("created", 0))) for m in data if isinstance(m, dict) and m.get("id")]
             return _filter_openai_chat_models(entries)
 
+        if provider_val == "ollama":
+            # api_key carries the base URL (same repurposing as Bedrock's region).
+            # /api/tags lists pulled models; sort newest-modified first so the
+            # model the user just pulled tops the list.
+            resp = httpx.get(f"{api_key.rstrip('/')}/api/tags", timeout=5)
+            if resp.status_code != 200:
+                return []
+            models = [m for m in resp.json().get("models") or [] if isinstance(m, dict) and m.get("name")]
+            models.sort(key=lambda m: str(m.get("modified_at", "")), reverse=True)
+            return [m["name"] for m in models]
+
         if provider_val == "google":
             resp = httpx.get(
                 f"https://generativelanguage.googleapis.com/v1/models?key={api_key}&pageSize=200",
@@ -355,6 +424,58 @@ def fetch_available_models(provider: dict[str, Any], api_key: str) -> list[str]:
     except Exception:
         return []
     return []
+
+
+def pull_ollama_model(base_url: str, model: str, on_progress: Any, cancel_event: Any = None) -> tuple[bool, str]:
+    """Download *model* onto the Ollama server, streaming progress.
+
+    Uses the server's HTTP API (POST /api/pull) rather than shelling out to the
+    ``ollama`` binary — the server may be remote or containerised with no CLI on
+    this machine's PATH. The response is a stream of JSON lines
+    ({status, total, completed}); each is folded into
+    ``on_progress(status_text, fraction_or_None)``. A set ``cancel_event``
+    (threading.Event) aborts between chunks — Ollama keeps partial layers, so a
+    cancelled pull resumes where it left off next time.
+
+    Returns (success, message). Never raises.
+    """
+    logger.info("Pulling Ollama model '%s'", model)
+    try:
+        import json as _json
+
+        import httpx
+
+        with httpx.stream(
+            "POST",
+            f"{base_url.rstrip('/')}/api/pull",
+            json={"model": model},
+            # Model downloads run for many minutes — no read timeout.
+            timeout=httpx.Timeout(10, read=None),
+        ) as resp:
+            if resp.status_code != 200:
+                return False, f"Unexpected response: {resp.status_code}"
+            for line in resp.iter_lines():
+                if cancel_event is not None and cancel_event.is_set():
+                    logger.info("Ollama pull cancelled for '%s'", model)
+                    return False, "Download cancelled — partial layers are kept, pulling again resumes"
+                if not line:
+                    continue
+                try:
+                    event = _json.loads(line)
+                except ValueError:
+                    continue
+                if event.get("error"):
+                    logger.warning("Ollama pull failed for '%s': %s", model, event["error"])
+                    return False, str(event["error"])
+                total = event.get("total") or 0
+                completed = event.get("completed") or 0
+                fraction = (completed / total) if total else None
+                on_progress(str(event.get("status", "")), fraction)
+        logger.info("Ollama model '%s' pulled", model)
+        return True, "Model downloaded"
+    except Exception as e:
+        logger.warning("Ollama pull error for '%s': %s", model, e)
+        return False, f"Download failed: {e}"
 
 
 def _verify_vc_token(vc: dict[str, Any], token: str) -> tuple[bool, str]:

--- a/src/yeaboi/ui/provider_select/screens/_screens.py
+++ b/src/yeaboi/ui/provider_select/screens/_screens.py
@@ -186,7 +186,7 @@ def _build_select_screen(
     show = visible if visible is not None else list(range(len(_PROVIDER_CARDS)))
     fading = fade_indices or []
 
-    rows: list[Text] = []
+    rows: list[tuple[int, Text]] = []
     for i, p in enumerate(_PROVIDER_CARDS):
         if i in show:
             if i == selected and selected_style:
@@ -196,18 +196,32 @@ def _build_select_screen(
             else:
                 override = ""
             rows.append(
-                _build_provider_row(
-                    p,
-                    selected=(i == selected),
-                    override_style=override,
-                    shimmer_tick=shimmer_tick,
+                (
+                    i,
+                    _build_provider_row(
+                        p,
+                        selected=(i == selected),
+                        override_style=override,
+                        shimmer_tick=shimmer_tick,
+                    ),
                 )
             )
 
-    body = [item for row in rows for item in (Align.center(row), Text(""))]
-    if body:
-        body = body[:-1]  # remove trailing blank
-    body_h = len(rows) * 3 - 1 if rows else 0
+    body: list = []
+    body_h = 0
+    for pos, (i, row) in enumerate(rows):
+        body.append(Align.center(row))
+        body_h += 2
+        # The selected card's separator row doubles as its tagline — a one-line
+        # "what am I signing up for" (e.g. Ollama's "Free · local · no API
+        # key") so the free option is visible before any card is entered.
+        tagline = _PROVIDER_CARDS[i].get("tagline", "") if i == selected else ""
+        if tagline:
+            body.append(Align.center(Text(tagline, style="dim")))
+            body_h += 1
+        elif pos < len(rows) - 1:
+            body.append(Text(""))
+            body_h += 1
 
     return _build_screen_frame(
         subtitle="Select your LLM provider",
@@ -251,8 +265,8 @@ def _build_input_screen(
     # Input box content — env var label goes in the panel border title.
     # Scroll: only show the rightmost chars that fit in one line.
     box_inner_w = min(70, width - 10) - 2 - 4  # panel border(2) + padding(4)
-    # Bedrock uses a region name (not a secret) — never mask it
-    if provider.get("is_region_input"):
+    # Bedrock uses a region name and Ollama a base URL (not secrets) — never mask
+    if provider.get("is_region_input") or provider.get("is_base_url_input"):
         masked = False
     display_val = "\u2022" * len(input_value) if masked else input_value
     cursor = "\u2588" if not verifying else ""
@@ -391,8 +405,12 @@ def _build_model_select_screen(
     height: int = 24,
     shimmer_tick: float = 0.0,  # accepted for caller compatibility; cards are static
     error: str = "",
+    status: str = "",
 ) -> Panel:
     """Build the model-selection screen — a stack of rounded, arrow-selectable cards.
+
+    ``status`` is a neutral live-progress line (e.g. an in-flight Ollama model
+    download) rendered in the accent colour where ``error`` would go.
 
     Each ``entries`` item (presets/live models + a trailing "Custom…") renders as
     a rounded card matching the app's project cards / action buttons. The list is
@@ -407,7 +425,7 @@ def _build_model_select_screen(
 
     # Vertical budget: the frame's header + footer inside its inner height.
     middle_h = max(_MODEL_CARD_H, (height - 4) - _FRAME_HEADER_H - _FRAME_FOOTER_H)
-    reserve = 2 if error else 0
+    reserve = 2 if (error or status) else 0
     avail = max(_MODEL_CARD_H, middle_h - reserve)
     max_cards = max(1, avail // _MODEL_CARD_H)
 
@@ -430,7 +448,11 @@ def _build_model_select_screen(
         body.append(Align.center(Text(f"↑↓  {hidden} more", style="dim")))
         body_h += 1
 
-    if error:
+    if status:
+        body.append(Text(""))
+        body.append(Align.center(Text(status, style=_ACCENT)))
+        body_h += 2
+    elif error:
         body.append(Text(""))
         body.append(Align.center(Text(f"✗ {error}", style="bright_red")))
         body_h += 2
@@ -485,8 +507,12 @@ def _build_model_input_screen(
     verified: bool | None = None,
     verifying: bool = False,
     border_override: str = "",
+    status: str = "",
 ) -> Panel:
     """Build the custom-model text-input screen.
+
+    ``status`` is a neutral live-progress line (e.g. an in-flight Ollama model
+    download) rendered in the accent colour in place of the error/hint lines.
 
     A near-clone of _build_input_screen, but model ids are never secrets — the
     value is always shown in plaintext (no masking).
@@ -529,14 +555,16 @@ def _build_model_input_screen(
         width=min(70, width - 10),
     )
 
-    if verifying or verified is True:
+    if status:
+        status_text = Text(status, style=_ACCENT, justify="center")
+    elif verifying or verified is True:
         status_text = Text("")
     elif verified is False or error:
         status_text = Text(f"✗ {error}", style="bright_red", justify="center")
     else:
         status_text = Text("")
 
-    if verifying or verified is True:
+    if status or verifying or verified is True:
         hint_text = Text("")
     else:
         hint_text = Text(

--- a/src/yeaboi/ui/session/_utils.py
+++ b/src/yeaboi/ui/session/_utils.py
@@ -177,6 +177,16 @@ def _classify_api_error(err: Exception) -> str:
     Optional-dependency SDKs are matched by class/module name + status code
     rather than isinstance, so this module never has to import them.
     """
+    # Local Ollama first — its failures carry generic shapes (httpx.ConnectError,
+    # a 404 ResponseError) that the branches below would mis-classify. The hint
+    # helper is provider-gated, so this is a no-op for every cloud provider.
+    # See README: "Local Mode (Ollama)" — reliability layer.
+    from yeaboi.agent.nodes import _local_llm_hint
+
+    local_hint = _local_llm_hint(err)
+    if local_hint:
+        return local_hint
+
     # Anthropic — the default provider, always installed.
     if isinstance(err, anthropic.AuthenticationError):
         return "Authentication failed — check your ANTHROPIC_API_KEY in .env (may be missing, expired, or invalid)."

--- a/tests/unit/guardrails/test_input_guardrails.py
+++ b/tests/unit/guardrails/test_input_guardrails.py
@@ -341,6 +341,42 @@ class TestCheckOffTopic:
         assert check_off_topic("do you love me") is None
 
     @patch(_LLM_PATCH)
+    @patch(_PROVIDER_PATCH, return_value="ollama")
+    def test_think_block_does_not_bury_verdict(self, _mock_provider, mock_get_llm):
+        # Local think-by-default models wrap the verdict in <think> reasoning —
+        # the verdict after the block must still be matched.
+        mock_get_llm.return_value.invoke.return_value = _mock_llm_response(
+            "<think>the user asks about the OFF_TOPIC-adjacent weather...</think>\nRELEVANT"
+        )
+        assert check_off_topic("how was your weekend") is None
+
+    @patch(_LLM_PATCH)
+    @patch(_PROVIDER_PATCH, return_value="ollama")
+    def test_local_classifier_capped(self, _mock_provider, mock_get_llm):
+        # ChatOllama-like models (they expose num_predict/reasoning fields) get
+        # their generation capped and thinking disabled — a one-word verdict
+        # must not cost seconds of local CPU per input.
+        mock_get_llm.return_value.invoke.return_value = _mock_llm_response("RELEVANT")
+        check_off_topic("how was your weekend")
+        assert mock_get_llm.return_value.num_predict == 64
+        assert mock_get_llm.return_value.reasoning is False
+
+    @patch(_LLM_PATCH)
+    @patch(_PROVIDER_PATCH, return_value="anthropic")
+    def test_llm_without_cap_fields_untouched(self, _mock_provider, mock_get_llm):
+        # Pydantic models raise on unknown-field assignment — the hasattr
+        # guards must prevent the assignment from ever being attempted.
+        class _RigidLLM:
+            def invoke(self, prompt):
+                return _mock_llm_response("RELEVANT")
+
+            def __setattr__(self, name, value):
+                raise ValueError(f"unknown field: {name}")
+
+        mock_get_llm.return_value = _RigidLLM()
+        assert check_off_topic("how was your weekend") is None
+
+    @patch(_LLM_PATCH)
     @patch(_PROVIDER_PATCH, return_value="openai")
     def test_uses_cheap_model_openai(self, _mock_provider, mock_get_llm):
         mock_get_llm.return_value.invoke.return_value = _mock_llm_response("RELEVANT")

--- a/tests/unit/nodes/test_agent_core.py
+++ b/tests/unit/nodes/test_agent_core.py
@@ -2,11 +2,18 @@
 
 from unittest.mock import MagicMock
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langgraph.graph import END
 
 from yeaboi.agent.nodes import (
     _HIGH_RISK_TOOLS,
+    _is_llm_connection_error,
+    _is_local_llm_down,
+    _is_ollama_model_missing,
+    _local_llm_hint,
+    _should_reraise_llm_error,
+    _trim_history_for_local,
     _user_confirmed,
     call_model,
     human_review,
@@ -14,6 +21,272 @@ from yeaboi.agent.nodes import (
     should_continue,
 )
 from yeaboi.prompts import get_system_prompt
+
+# ── LLM error classification ─────────────────────────────────────────
+
+
+class TestLlmConnectionError:
+    """_is_llm_connection_error must catch a down local server, not auth errors."""
+
+    def test_builtin_connection_refused(self):
+        assert _is_llm_connection_error(ConnectionRefusedError("refused")) is True
+
+    def test_httpx_connect_error(self):
+        import httpx
+
+        assert _is_llm_connection_error(httpx.ConnectError("connection failed")) is True
+
+    def test_wrapped_cause_chain(self):
+        """langchain/ollama wrap the transport error — the __cause__ chain must be walked."""
+        inner = ConnectionRefusedError("refused")
+        outer = RuntimeError("request failed")
+        outer.__cause__ = inner
+        assert _is_llm_connection_error(outer) is True
+
+    def test_errno_message_patterns(self):
+        assert _is_llm_connection_error(Exception("[Errno 61] Connection refused")) is True
+        assert _is_llm_connection_error(Exception("[Errno 111] connection refused")) is True
+
+    def test_plain_error_is_not_connection(self):
+        assert _is_llm_connection_error(ValueError("bad json")) is False
+
+    def test_auth_error_is_not_connection(self):
+        assert _is_llm_connection_error(Exception("api key invalid")) is False
+
+
+class TestLocalLlmDown:
+    """_is_local_llm_down gates connection errors on the ollama provider."""
+
+    def test_true_for_ollama_provider(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _is_local_llm_down(ConnectionRefusedError("refused")) is True
+
+    def test_false_for_cloud_provider(self, monkeypatch):
+        """Cloud transient network blips keep the graceful-fallback behaviour."""
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        assert _is_local_llm_down(ConnectionRefusedError("refused")) is False
+
+    def test_false_for_non_connection_error(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _is_local_llm_down(ValueError("bad json")) is False
+
+
+class TestShouldReraiseLlmError:
+    def test_ollama_connection_error_reraises(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _should_reraise_llm_error(ConnectionRefusedError("refused")) is True
+
+    def test_cloud_connection_error_falls_back(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        assert _should_reraise_llm_error(ConnectionRefusedError("refused")) is False
+
+    def test_generic_error_falls_back(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _should_reraise_llm_error(ValueError("parse failed")) is False
+
+    def test_ollama_model_missing_reraises(self, monkeypatch):
+        """A not-pulled model must surface, never silently fall back."""
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _should_reraise_llm_error(Exception("model 'qwen3:8b' not found, try pulling it first")) is True
+
+
+class TestOllamaModelMissing:
+    """_is_ollama_model_missing must catch the server's 404 for un-pulled models."""
+
+    def test_message_pattern(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _is_ollama_model_missing(Exception("model 'qwen3:32b' not found")) is True
+
+    def test_real_ollama_response_error_404(self, monkeypatch):
+        ollama = pytest.importorskip("ollama", reason="ollama client not installed")
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        err = ollama.ResponseError("model 'x' not found", 404)
+        assert _is_ollama_model_missing(err) is True
+
+    def test_wrapped_cause_chain(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        inner = Exception("model 'qwen3:8b' not found")
+        outer = RuntimeError("request failed")
+        outer.__cause__ = inner
+        assert _is_ollama_model_missing(outer) is True
+
+    def test_false_for_cloud_provider(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        assert _is_ollama_model_missing(Exception("model 'x' not found")) is False
+
+    def test_false_for_other_errors(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _is_ollama_model_missing(ValueError("bad json")) is False
+
+
+class TestLocalLlmHint:
+    """_local_llm_hint is the shared decision point for REPL/TUI/engine messages."""
+
+    def test_model_missing_gets_pull_hint(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("LLM_MODEL", "qwen3:32b")
+        hint = _local_llm_hint(Exception("model 'qwen3:32b' not found"))
+        assert hint is not None
+        assert "ollama pull qwen3:32b" in hint
+
+    def test_model_missing_uses_provider_default_when_unset(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        hint = _local_llm_hint(Exception("model 'qwen3:8b' not found"))
+        assert "ollama pull qwen3:8b" in hint
+
+    def test_connection_refused_gets_serve_hint(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        hint = _local_llm_hint(ConnectionRefusedError("refused"))
+        assert hint is not None
+        assert "ollama serve" in hint
+
+    def test_read_timeout_gets_slowness_hint(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        hint = _local_llm_hint(httpx.ReadTimeout("timed out"))
+        assert hint is not None
+        assert "timed out" in hint.lower()
+        assert "ollama serve" not in hint  # not misreported as a down server
+
+    def test_none_for_cloud_provider(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        assert _local_llm_hint(ConnectionRefusedError("refused")) is None
+
+    def test_none_for_unrelated_errors(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _local_llm_hint(ValueError("bad json")) is None
+
+    def test_langchain_ollama_missing_gets_install_hint(self, monkeypatch):
+        # The optional extra was never installed — the wizard warns, but a
+        # hand-edited .env can still reach get_llm()'s ImportError at call time.
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        exc = ImportError("langchain-ollama is not installed. Run: uv sync --extra ollama")
+        hint = _local_llm_hint(exc)
+        assert hint is not None
+        assert "uv sync --extra ollama" in hint
+
+    def test_unrelated_import_error_no_hint(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert _local_llm_hint(ImportError("No module named 'pandas'")) is None
+
+
+class TestTrimHistoryForLocal:
+    """Chat history must fit Ollama's context window without splitting tool pairs."""
+
+    def _tokens_of(self, n_chars: int) -> str:
+        return "x" * n_chars
+
+    def test_cloud_provider_untouched(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        msgs = [SystemMessage(content="s"), HumanMessage(content=self._tokens_of(500_000))]
+        assert _trim_history_for_local(msgs) is msgs
+
+    def test_ollama_fits_untouched(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+        msgs = [SystemMessage(content="s"), HumanMessage(content="hi"), AIMessage(content="hello")]
+        assert _trim_history_for_local(msgs) is msgs
+
+    def test_overflow_drops_oldest_at_human_boundary(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        # Budget = 12000 − 8192 − sys ≈ 3800 tokens. Each message below is
+        # 1000 tokens (4000 chars): all four (4000) overflow, the last two
+        # (2000) fit — so the cut lands on the second HumanMessage.
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "12000")
+        h1 = HumanMessage(content=self._tokens_of(4000))
+        a1 = AIMessage(content=self._tokens_of(4000))
+        h2 = HumanMessage(content=self._tokens_of(4000))
+        a2 = AIMessage(content=self._tokens_of(4000))
+        result = _trim_history_for_local([SystemMessage(content="s"), h1, a1, h2, a2])
+        assert result == [result[0], h2, a2]
+        assert isinstance(result[0], SystemMessage)
+
+    def test_tool_call_pair_never_split(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "12000")
+        h1 = HumanMessage(content=self._tokens_of(4000))
+        a1 = AIMessage(content="", tool_calls=[{"name": "t", "args": {}, "id": "1"}])
+        t1 = ToolMessage(content=self._tokens_of(4000), tool_call_id="1")
+        a1b = AIMessage(content=self._tokens_of(4000))
+        h2 = HumanMessage(content=self._tokens_of(4000))
+        a2 = AIMessage(content="ok")
+        result = _trim_history_for_local([SystemMessage(content="s"), h1, a1, t1, a1b, h2, a2])
+        # The whole first exchange (incl. the AI/Tool pair) is dropped together.
+        assert result == [result[0], h2, a2]
+        assert not any(isinstance(m, ToolMessage) for m in result)
+
+    def test_latest_exchange_kept_even_over_budget(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "9000")  # budget ≈ 800 tokens
+        h1 = HumanMessage(content=self._tokens_of(8000))
+        a1 = AIMessage(content=self._tokens_of(8000))
+        h2 = HumanMessage(content=self._tokens_of(8000))  # alone exceeds budget
+        result = _trim_history_for_local([SystemMessage(content="s"), h1, a1, h2])
+        assert result == [result[0], h2]
+
+    def test_no_human_boundary_returns_unchanged(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "9000")
+        msgs = [SystemMessage(content="s"), AIMessage(content=self._tokens_of(40_000))]
+        assert _trim_history_for_local(msgs) is msgs
+
+
+class TestToolsUnsupportedDegradation:
+    """make_call_model must degrade to plain chat when a local model rejects tools."""
+
+    class _PlainLLM:
+        def __init__(self):
+            self.plain_invokes = 0
+            self.bind_calls = 0
+
+        def invoke(self, messages):
+            self.plain_invokes += 1
+            return AIMessage(content="plain reply")
+
+        def bind_tools(self, tools):
+            self.bind_calls += 1
+
+            class _Bound:
+                def invoke(self, messages):
+                    raise RuntimeError("registry.ollama.ai/library/foo does not support tools")
+
+            return _Bound()
+
+    def test_degrades_to_plain_chat_with_note(self, monkeypatch):
+        llm = self._PlainLLM()
+        monkeypatch.setattr("yeaboi.agent.nodes.get_llm", lambda **kw: llm)
+        node = make_call_model([])
+        result = node({"messages": [HumanMessage(content="hi")]})
+        reply = result["messages"][0]
+        assert "plain reply" in reply.content
+        assert "doesn't support tool calling" in reply.content
+        assert llm.plain_invokes == 1
+
+    def test_skips_bound_attempt_on_later_turns(self, monkeypatch):
+        llm = self._PlainLLM()
+        monkeypatch.setattr("yeaboi.agent.nodes.get_llm", lambda **kw: llm)
+        node = make_call_model([])
+        node({"messages": [HumanMessage(content="hi")]})
+        result2 = node({"messages": [HumanMessage(content="again")]})
+        assert llm.bind_calls == 1  # doomed binding not retried
+        assert result2["messages"][0].content == "plain reply"  # note appended only once
+
+    def test_other_errors_still_propagate(self, monkeypatch):
+        class _Llm:
+            def bind_tools(self, tools):
+                class _Bound:
+                    def invoke(self, messages):
+                        raise RuntimeError("boom")
+
+                return _Bound()
+
+        monkeypatch.setattr("yeaboi.agent.nodes.get_llm", lambda **kw: _Llm())
+        node = make_call_model([])
+        with pytest.raises(RuntimeError, match="boom"):
+            node({"messages": [HumanMessage(content="hi")]})
+
 
 # ── Core behaviour ───────────────────────────────────────────────────
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -389,6 +389,41 @@ class TestStandupConfig:
         assert ok is False
         assert "ANTHROPIC_API_KEY" in msg
 
+    def test_is_llm_configured_ollama_needs_no_credentials(self, monkeypatch):
+        """The keyless local provider is always 'configured' — reachability is checked at call time."""
+        from yeaboi.config import is_llm_configured
+
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        assert is_llm_configured() == (True, "")
+
+    def test_ollama_base_url_default(self, monkeypatch):
+        from yeaboi.config import get_ollama_base_url
+
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        assert get_ollama_base_url() == "http://localhost:11434"
+
+    def test_ollama_base_url_env_and_trailing_slash(self, monkeypatch):
+        from yeaboi.config import get_ollama_base_url
+
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://10.0.0.5:11434/")
+        assert get_ollama_base_url() == "http://10.0.0.5:11434"
+
+    def test_ollama_num_ctx_default_and_env(self, monkeypatch):
+        from yeaboi.config import get_ollama_num_ctx
+
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+        assert get_ollama_num_ctx() == 16384
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "8192")
+        assert get_ollama_num_ctx() == 8192
+
+    def test_ollama_num_ctx_invalid_falls_back(self, monkeypatch):
+        from yeaboi.config import get_ollama_num_ctx
+
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "not-a-number")
+        assert get_ollama_num_ctx() == 16384
+
 
 class TestConfluenceConfig:
     """Confluence reuses the Jira Atlassian creds, but the CONFLUENCE_* vars win when set

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -254,6 +254,15 @@ class TestGetLlmOllama:
         assert get_llm(json_mode=True).format == "json"
         assert get_llm().format in ("", None)
 
+    def test_ollama_json_mode_disables_thinking(self, monkeypatch):
+        """Thinking models (qwen3) can burn the whole num_predict budget on a
+        reasoning pass and return EMPTY constrained-JSON content — JSON calls
+        must send think:false. Prose calls keep the model default (None)."""
+        pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert get_llm(json_mode=True).reasoning is False
+        assert get_llm().reasoning is None
+
     def test_ollama_num_ctx_from_env(self, monkeypatch):
         """OLLAMA_NUM_CTX must be wired through (default 16384)."""
         pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -8,12 +8,17 @@ from yeaboi.agent.llm import (
     _PROVIDER_DEFAULTS,
     DEFAULT_MODEL,
     build_multimodal_content,
+    estimate_tokens,
     get_llm,
     get_usage_stats,
+    invoke_json,
     invoke_with_images,
     load_image_b64,
     reset_usage_stats,
+    strip_json_fences,
+    strip_think_tags,
     track_usage,
+    warn_if_context_overflow,
 )
 
 
@@ -196,6 +201,85 @@ class TestGetLlmGoogle:
             get_llm()
 
 
+class TestGetLlmOllama:
+    """Tests for the local Ollama provider (keyless)."""
+
+    def test_ollama_provider_returns_chat_ollama(self, monkeypatch):
+        """LLM_PROVIDER=ollama must return a ChatOllama instance."""
+        pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")
+        from langchain_ollama import ChatOllama
+
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        llm = get_llm()
+        assert isinstance(llm, ChatOllama)
+
+    def test_ollama_default_model(self, monkeypatch):
+        """Ollama provider default model must match _PROVIDER_DEFAULTS."""
+        pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        llm = get_llm()
+        assert llm.model == _PROVIDER_DEFAULTS["ollama"]
+
+    def test_ollama_needs_no_api_key(self, monkeypatch):
+        """The keyless guarantee: no API key env vars set → no exception."""
+        pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "AWS_REGION", "AWS_DEFAULT_REGION"):
+            monkeypatch.delenv(var, raising=False)
+        llm = get_llm()
+        assert isinstance(llm, BaseChatModel)
+
+    def test_ollama_base_url_from_env(self, monkeypatch):
+        """OLLAMA_BASE_URL must be wired through to ChatOllama (trailing slash stripped)."""
+        pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://10.0.0.5:11434/")
+        llm = get_llm()
+        assert llm.base_url == "http://10.0.0.5:11434"
+
+    def test_ollama_default_base_url(self, monkeypatch):
+        """Without OLLAMA_BASE_URL, the standard localhost address must be used."""
+        pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        llm = get_llm()
+        assert llm.base_url == "http://localhost:11434"
+
+    def test_ollama_json_mode_sets_format(self, monkeypatch):
+        """json_mode=True must turn on Ollama's constrained JSON decoding."""
+        pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        assert get_llm(json_mode=True).format == "json"
+        assert get_llm().format in ("", None)
+
+    def test_ollama_num_ctx_from_env(self, monkeypatch):
+        """OLLAMA_NUM_CTX must be wired through (default 16384)."""
+        pytest.importorskip("langchain_ollama", reason="langchain-ollama not installed")
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+        assert get_llm().num_ctx == 16384
+        monkeypatch.setenv("OLLAMA_NUM_CTX", "8192")
+        assert get_llm().num_ctx == 8192
+
+    def test_ollama_missing_package_raises_import_error(self, monkeypatch):
+        """Must raise ImportError with install instructions if langchain-ollama is absent."""
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "langchain_ollama":
+                raise ImportError("No module named 'langchain_ollama'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        with pytest.raises(ImportError, match="langchain-ollama is not installed"):
+            get_llm()
+
+
 class TestGetLlmUnknownProvider:
     """Tests for unknown/unsupported provider values."""
 
@@ -223,6 +307,9 @@ class TestProviderDefaults:
 
     def test_google_default_is_gemini_flash(self):
         assert _PROVIDER_DEFAULTS["google"] == "gemini-2.5-flash"
+
+    def test_ollama_default_is_qwen3(self):
+        assert _PROVIDER_DEFAULTS["ollama"] == "qwen3:8b"
 
     def test_default_model_constant_matches_anthropic(self):
         """DEFAULT_MODEL backward-compat constant must equal the Anthropic default."""
@@ -304,6 +391,31 @@ class TestTrackUsage:
         stats["input_tokens"] = 999999
         fresh = get_usage_stats()
         assert fresh["input_tokens"] != 999999
+
+    def test_usage_metadata_preferred(self):
+        """LangChain-standard usage_metadata (ChatOllama populates it) wins over response_metadata."""
+        from types import SimpleNamespace
+
+        resp = SimpleNamespace(
+            usage_metadata={"input_tokens": 40, "output_tokens": 15},
+            response_metadata={},
+        )
+        track_usage(resp)
+        stats = get_usage_stats()
+        assert stats["input_tokens"] == 40
+        assert stats["output_tokens"] == 15
+        assert stats["call_count"] == 1
+
+    def test_ollama_native_keys_in_response_metadata(self):
+        """Ollama-native prompt_eval_count/eval_count keys are understood as a fallback."""
+        from types import SimpleNamespace
+
+        resp = SimpleNamespace(response_metadata={"prompt_eval_count": 120, "eval_count": 30})
+        track_usage(resp)
+        stats = get_usage_stats()
+        assert stats["input_tokens"] == 120
+        assert stats["output_tokens"] == 30
+        assert stats["call_count"] == 1
 
     def test_reset_usage_stats_clears_counters(self):
         """reset_usage_stats clears counters."""
@@ -410,3 +522,175 @@ class TestInvokeWithImages:
         llm = self._FakeLLM(fail_first=True)
         with pytest.raises(ValueError):
             invoke_with_images(llm, "prompt", [])
+
+
+class TestStripThinkTags:
+    """strip_think_tags removes local models' chain-of-thought from prose output."""
+
+    def test_closed_block_removed(self):
+        assert strip_think_tags("<think>hmm, let me plan</think>\nHello!") == "Hello!"
+
+    def test_multiple_blocks_removed(self):
+        out = strip_think_tags("<think>a</think>one<think>b</think> two")
+        assert out == "one two"
+
+    def test_unclosed_leading_block_removed(self):
+        # Truncated generation: the model never closed its think block.
+        assert strip_think_tags("<think>rambling that never ends") == ""
+
+    def test_no_tags_passthrough(self):
+        assert strip_think_tags("plain answer") == "plain answer"
+
+    def test_non_string_passthrough(self):
+        blocks = [{"type": "text", "text": "hi"}]
+        assert strip_think_tags(blocks) is blocks
+
+
+class TestStripJsonFences:
+    """strip_json_fences must tolerate every common fencing style."""
+
+    def test_bare_json_unchanged(self):
+        assert strip_json_fences('{"a": 1}') == '{"a": 1}'
+
+    def test_plain_fence(self):
+        assert strip_json_fences('```\n{"a": 1}\n```') == '{"a": 1}'
+
+    def test_json_tagged_fence(self):
+        assert strip_json_fences('```json\n{"a": 1}\n```') == '{"a": 1}'
+
+    def test_whitespace_stripped(self):
+        assert strip_json_fences('  {"a": 1}  \n') == '{"a": 1}'
+
+    def test_empty_and_none_safe(self):
+        assert strip_json_fences("") == ""
+        assert strip_json_fences(None) == ""
+
+
+class TestInvokeJson:
+    """invoke_json: JSON-mode invoke with a one-shot repair re-ask."""
+
+    class _FakeResp:
+        def __init__(self, content):
+            self.content = content
+            self.response_metadata = {"usage": {"input_tokens": 1, "output_tokens": 1}}
+
+    class _FakeLLM:
+        """Returns queued responses in order; records every invoke's messages."""
+
+        def __init__(self, contents):
+            self.queue = list(contents)
+            self.calls = []
+
+        def invoke(self, messages):
+            self.calls.append(messages)
+            return TestInvokeJson._FakeResp(self.queue.pop(0))
+
+    def _patch(self, monkeypatch, llm):
+        import yeaboi.agent.llm as llm_module
+
+        captured = {}
+
+        def fake_get_llm(model=None, temperature=0.0, json_mode=False):
+            captured["json_mode"] = json_mode
+            captured["temperature"] = temperature
+            return llm
+
+        monkeypatch.setattr(llm_module, "get_llm", fake_get_llm)
+        return captured
+
+    def setup_method(self):
+        reset_usage_stats()
+
+    def test_valid_first_try_single_invoke(self, monkeypatch):
+        llm = self._FakeLLM(['{"ok": true}'])
+        captured = self._patch(monkeypatch, llm)
+        resp = invoke_json("prompt")
+        assert resp.content == '{"ok": true}'
+        assert len(llm.calls) == 1
+        assert captured["json_mode"] is True
+
+    def test_fenced_valid_json_accepted_without_reask(self, monkeypatch):
+        llm = self._FakeLLM(['```json\n{"ok": true}\n```'])
+        self._patch(monkeypatch, llm)
+        resp = invoke_json("prompt")
+        assert len(llm.calls) == 1
+        assert "ok" in resp.content
+
+    def test_invalid_then_valid_reasks_once_with_error(self, monkeypatch):
+        llm = self._FakeLLM(["not json at all", '{"fixed": 1}'])
+        self._patch(monkeypatch, llm)
+        resp = invoke_json("prompt")
+        assert resp.content == '{"fixed": 1}'
+        assert len(llm.calls) == 2
+        # The repair round must carry: original prompt, the bad reply, and the parse error.
+        repair_messages = llm.calls[1]
+        assert repair_messages[0].content == "prompt"
+        assert repair_messages[1].content == "not json at all"
+        assert "not valid JSON" in repair_messages[2].content
+
+    def test_invalid_twice_returns_last_response(self, monkeypatch):
+        """Caller-fallback contract: after the repair budget, the last reply is returned as-is."""
+        llm = self._FakeLLM(["garbage one", "garbage two"])
+        self._patch(monkeypatch, llm)
+        resp = invoke_json("prompt")
+        assert resp.content == "garbage two"
+        assert len(llm.calls) == 2
+
+    def test_tracks_usage_per_attempt(self, monkeypatch):
+        llm = self._FakeLLM(["bad", '{"ok": 1}'])
+        self._patch(monkeypatch, llm)
+        invoke_json("prompt")
+        assert get_usage_stats()["call_count"] == 2
+
+    def test_temperature_forwarded(self, monkeypatch):
+        llm = self._FakeLLM(['{"ok": 1}'])
+        captured = self._patch(monkeypatch, llm)
+        invoke_json("prompt", temperature=0.3)
+        assert captured["temperature"] == 0.3
+
+    def test_repair_reask_keeps_image_blocks(self, monkeypatch, tmp_path):
+        """The repair round must rebuild the multimodal first message — a
+        text-only re-ask would silently drop pasted screenshots."""
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG-fake-bytes")
+        llm = self._FakeLLM(["not json at all", '{"fixed": 1}'])
+        self._patch(monkeypatch, llm)
+        invoke_json("prompt", image_paths=[str(img)])
+        assert len(llm.calls) == 2
+        first_repair_content = llm.calls[1][0].content
+        assert isinstance(first_repair_content, list)
+        assert any(isinstance(b, dict) and b.get("type") == "image" for b in first_repair_content)
+
+
+class TestEstimateTokens:
+    def test_roughly_four_chars_per_token(self):
+        assert estimate_tokens("a" * 400) == 100
+
+    def test_empty_string(self):
+        assert estimate_tokens("") == 0
+
+
+class TestWarnIfContextOverflow:
+    """Ollama silently truncates past num_ctx — the guard must make it loggable."""
+
+    def test_warns_for_oversized_ollama_prompt(self, monkeypatch, caplog):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+        # Default budget: 16384 ctx − 8192 output reserve → ~8192 prompt tokens
+        # (~32 768 chars). 40k chars is safely over.
+        with caplog.at_level("WARNING", logger="yeaboi.agent.llm"):
+            warn_if_context_overflow("x" * 40_000)
+        assert "OLLAMA_NUM_CTX" in caplog.text
+
+    def test_silent_for_small_prompt(self, monkeypatch, caplog):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.delenv("OLLAMA_NUM_CTX", raising=False)
+        with caplog.at_level("WARNING", logger="yeaboi.agent.llm"):
+            warn_if_context_overflow("a small prompt")
+        assert "OLLAMA_NUM_CTX" not in caplog.text
+
+    def test_noop_for_cloud_provider(self, monkeypatch, caplog):
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        with caplog.at_level("WARNING", logger="yeaboi.agent.llm"):
+            warn_if_context_overflow("x" * 200_000)
+        assert "OLLAMA_NUM_CTX" not in caplog.text

--- a/tests/unit/test_provider_model_select.py
+++ b/tests/unit/test_provider_model_select.py
@@ -266,8 +266,30 @@ class TestValidateKeyOllama:
         assert _validate_key(_card("ollama"), "")[0] == "empty"
 
 
+@pytest.fixture
+def ollama_pkg_installed(monkeypatch):
+    """Pretend langchain-ollama is importable.
+
+    CI runs without the optional ``ollama`` extra, so these tests must not
+    depend on the real environment: any test exercising the post-install
+    verification paths stubs the package check to "installed" here (and
+    the missing-package test stubs it to None), making both paths
+    deterministic everywhere.
+    """
+    import importlib.util
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "langchain_ollama":
+            return object()  # any non-None value means "installed"
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+
 class TestVerifyApiKeyOllama:
-    def test_server_up_with_models(self, monkeypatch):
+    def test_server_up_with_models(self, monkeypatch, ollama_pkg_installed):
         import httpx
 
         from yeaboi.ui.provider_select._verification import _verify_api_key
@@ -277,7 +299,7 @@ class TestVerifyApiKeyOllama:
         assert ok is True
         assert "verified" in msg.lower()
 
-    def test_server_up_no_models_still_ok_with_pull_hint(self, monkeypatch):
+    def test_server_up_no_models_still_ok_with_pull_hint(self, monkeypatch, ollama_pkg_installed):
         import httpx
 
         from yeaboi.ui.provider_select._verification import _verify_api_key
@@ -287,7 +309,7 @@ class TestVerifyApiKeyOllama:
         assert ok is True
         assert "ollama pull" in msg
 
-    def test_server_down_actionable_message(self, monkeypatch):
+    def test_server_down_actionable_message(self, monkeypatch, ollama_pkg_installed):
         import httpx
 
         from yeaboi.ui.provider_select._verification import _verify_api_key
@@ -375,9 +397,9 @@ class TestOllamaPackageCheck:
         assert ok is False
         assert "uv sync --extra ollama" in msg
 
-    def test_installed_package_proceeds_to_server_check(self, monkeypatch):
-        # langchain-ollama IS installed in the test env — the check passes
-        # through to the normal /api/tags verification.
+    def test_installed_package_proceeds_to_server_check(self, monkeypatch, ollama_pkg_installed):
+        # With the package present, the check passes through to the normal
+        # /api/tags verification.
         import httpx
 
         from yeaboi.ui.provider_select._verification import _verify_api_key
@@ -388,7 +410,7 @@ class TestOllamaPackageCheck:
 
 
 class TestOllamaInstallGuidance:
-    def test_unreachable_message_says_how_to_install(self, monkeypatch):
+    def test_unreachable_message_says_how_to_install(self, monkeypatch, ollama_pkg_installed):
         import httpx
 
         from yeaboi.ui.provider_select._verification import _verify_api_key

--- a/tests/unit/test_provider_model_select.py
+++ b/tests/unit/test_provider_model_select.py
@@ -15,6 +15,7 @@ from rich.panel import Panel
 
 from yeaboi.agent.llm import _PROVIDER_DEFAULTS
 from yeaboi.setup_wizard import _PROVIDERS, run_setup_wizard
+from yeaboi.ui.provider_select import _existing_model_for
 from yeaboi.ui.provider_select._constants import (
     _AZDEVOPS_TRACKING_FIELDS,
     _CONFLUENCE_FIELDS,
@@ -32,6 +33,7 @@ from yeaboi.ui.provider_select._verification import (
     _verify_confluence,
     _verify_model,
     fetch_available_models,
+    pull_ollama_model,
 )
 from yeaboi.ui.provider_select.screens._screens import (
     _STEPS,
@@ -229,6 +231,267 @@ class TestVerifyModelUnknownProvider:
         ok, msg = _verify_model({"provider_val": "mystery"}, "key", "some-model")
         assert ok is False
         assert "Unknown provider" in msg
+
+
+# ---------------------------------------------------------------------------
+# Ollama — _validate_key / _verify_api_key / _verify_model / fetch_available_models
+# (the "api_key" argument carries the local server base URL)
+# ---------------------------------------------------------------------------
+
+_OLLAMA_TAGS = {
+    "models": [
+        {"name": "qwen3:8b", "modified_at": "2026-07-01T10:00:00Z"},
+        {"name": "llama3.1:8b", "modified_at": "2026-06-01T10:00:00Z"},
+    ]
+}
+
+
+class TestValidateKeyOllama:
+    def test_url_accepted(self):
+        from yeaboi.ui.provider_select._verification import _validate_key
+
+        status, hint = _validate_key(_card("ollama"), "http://localhost:11434")
+        assert status == "valid_format"
+        assert "Ollama" in hint
+
+    def test_non_url_rejected(self):
+        from yeaboi.ui.provider_select._verification import _validate_key
+
+        status, _ = _validate_key(_card("ollama"), "localhost:11434")
+        assert status == "bad_prefix"
+
+    def test_empty(self):
+        from yeaboi.ui.provider_select._verification import _validate_key
+
+        assert _validate_key(_card("ollama"), "")[0] == "empty"
+
+
+class TestVerifyApiKeyOllama:
+    def test_server_up_with_models(self, monkeypatch):
+        import httpx
+
+        from yeaboi.ui.provider_select._verification import _verify_api_key
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200, _OLLAMA_TAGS))
+        ok, msg = _verify_api_key(_card("ollama"), "http://localhost:11434")
+        assert ok is True
+        assert "verified" in msg.lower()
+
+    def test_server_up_no_models_still_ok_with_pull_hint(self, monkeypatch):
+        import httpx
+
+        from yeaboi.ui.provider_select._verification import _verify_api_key
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200, {"models": []}))
+        ok, msg = _verify_api_key(_card("ollama"), "http://localhost:11434")
+        assert ok is True
+        assert "ollama pull" in msg
+
+    def test_server_down_actionable_message(self, monkeypatch):
+        import httpx
+
+        from yeaboi.ui.provider_select._verification import _verify_api_key
+
+        def _boom(*a, **kw):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "get", _boom)
+        ok, msg = _verify_api_key(_card("ollama"), "http://localhost:11434")
+        assert ok is False
+        assert "ollama serve" in msg
+
+
+class TestVerifyModelOllama:
+    def test_pulled_model_verified(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200, _OLLAMA_TAGS))
+        ok, _ = _verify_model(_card("ollama"), "http://localhost:11434", "qwen3:8b")
+        assert ok is True
+
+    def test_latest_suffix_matches(self, monkeypatch):
+        import httpx
+
+        tags = {"models": [{"name": "qwen3:8b:latest"}]}
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200, tags))
+        ok, _ = _verify_model(_card("ollama"), "http://localhost:11434", "qwen3:8b")
+        assert ok is True
+
+    def test_missing_model_pull_hint(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200, _OLLAMA_TAGS))
+        ok, msg = _verify_model(_card("ollama"), "http://localhost:11434", "qwen3:14b")
+        assert ok is False
+        assert "ollama pull qwen3:14b" in msg
+
+    def test_server_down(self, monkeypatch):
+        import httpx
+
+        def _boom(*a, **kw):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "get", _boom)
+        ok, msg = _verify_model(_card("ollama"), "http://localhost:11434", "qwen3:8b")
+        assert ok is False
+        assert "ollama serve" in msg
+
+
+class TestFetchAvailableModelsOllama:
+    def test_lists_newest_first(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200, _OLLAMA_TAGS))
+        models = fetch_available_models(_card("ollama"), "http://localhost:11434")
+        assert models == ["qwen3:8b", "llama3.1:8b"]
+
+    def test_server_down_returns_empty(self, monkeypatch):
+        import httpx
+
+        def _boom(*a, **kw):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "get", _boom)
+        assert fetch_available_models(_card("ollama"), "http://localhost:11434") == []
+
+
+class TestOllamaPackageCheck:
+    """Setup must not finish green when the langchain-ollama extra isn't installed."""
+
+    def test_missing_package_blocks_before_network(self, monkeypatch):
+        import importlib.util
+
+        import httpx
+
+        from yeaboi.ui.provider_select._verification import _verify_api_key
+
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+
+        def _no_network(*a, **kw):
+            raise AssertionError("must not touch the network when the package is missing")
+
+        monkeypatch.setattr(httpx, "get", _no_network)
+        ok, msg = _verify_api_key(_card("ollama"), "http://localhost:11434")
+        assert ok is False
+        assert "uv sync --extra ollama" in msg
+
+    def test_installed_package_proceeds_to_server_check(self, monkeypatch):
+        # langchain-ollama IS installed in the test env — the check passes
+        # through to the normal /api/tags verification.
+        import httpx
+
+        from yeaboi.ui.provider_select._verification import _verify_api_key
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _FakeResponse(200, _OLLAMA_TAGS))
+        ok, _ = _verify_api_key(_card("ollama"), "http://localhost:11434")
+        assert ok is True
+
+
+class TestOllamaInstallGuidance:
+    def test_unreachable_message_says_how_to_install(self, monkeypatch):
+        import httpx
+
+        from yeaboi.ui.provider_select._verification import _verify_api_key
+
+        def _boom(*a, **kw):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "get", _boom)
+        _, msg = _verify_api_key(_card("ollama"), "http://localhost:11434")
+        assert "https://ollama.com" in msg
+        _, msg = _verify_model(_card("ollama"), "http://localhost:11434", "qwen3:8b")
+        assert "https://ollama.com" in msg
+
+
+class _FakePullStream:
+    """Context-manager stand-in for httpx.stream() yielding /api/pull JSON lines."""
+
+    def __init__(self, status_code: int, lines: list[str]):
+        self.status_code = status_code
+        self._lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def iter_lines(self):
+        yield from self._lines
+
+
+class TestPullOllamaModel:
+    def test_success_streams_progress(self, monkeypatch):
+        import httpx
+
+        lines = [
+            '{"status": "pulling manifest"}',
+            '{"status": "downloading", "total": 100, "completed": 50}',
+            '{"status": "success"}',
+        ]
+        monkeypatch.setattr(httpx, "stream", lambda *a, **kw: _FakePullStream(200, lines))
+        seen: list[tuple[str, float | None]] = []
+        ok, msg = pull_ollama_model("http://localhost:11434", "qwen3:8b", lambda s, f: seen.append((s, f)))
+        assert ok is True
+        assert msg == "Model downloaded"
+        assert ("downloading", 0.5) in seen
+
+    def test_server_error_event(self, monkeypatch):
+        import httpx
+
+        lines = ['{"error": "pull model manifest: file does not exist"}']
+        monkeypatch.setattr(httpx, "stream", lambda *a, **kw: _FakePullStream(200, lines))
+        ok, msg = pull_ollama_model("http://localhost:11434", "nope:1b", lambda s, f: None)
+        assert ok is False
+        assert "does not exist" in msg
+
+    def test_non_200_response(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "stream", lambda *a, **kw: _FakePullStream(500, []))
+        ok, msg = pull_ollama_model("http://localhost:11434", "qwen3:8b", lambda s, f: None)
+        assert ok is False
+        assert "500" in msg
+
+    def test_cancel_event_aborts(self, monkeypatch):
+        import threading
+
+        import httpx
+
+        lines = ['{"status": "downloading", "total": 100, "completed": 1}'] * 5
+        monkeypatch.setattr(httpx, "stream", lambda *a, **kw: _FakePullStream(200, lines))
+        cancel = threading.Event()
+        cancel.set()
+        ok, msg = pull_ollama_model("http://localhost:11434", "qwen3:8b", lambda s, f: None, cancel_event=cancel)
+        assert ok is False
+        assert "cancel" in msg.lower()
+
+    def test_network_error_never_raises(self, monkeypatch):
+        import httpx
+
+        def _boom(*a, **kw):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "stream", _boom)
+        ok, msg = pull_ollama_model("http://localhost:11434", "qwen3:8b", lambda s, f: None)
+        assert ok is False
+        assert "failed" in msg.lower()
+
+
+class TestExistingModelFor:
+    """A saved LLM_MODEL is only offered for the provider it was saved with."""
+
+    def test_same_provider_carries_over(self):
+        cfg = {"LLM_PROVIDER": "ollama", "LLM_MODEL": "qwen3:14b"}
+        assert _existing_model_for(cfg, "ollama") == "qwen3:14b"
+
+    def test_switched_provider_drops_stale_model(self):
+        cfg = {"LLM_PROVIDER": "anthropic", "LLM_MODEL": "claude-sonnet-4-6"}
+        assert _existing_model_for(cfg, "ollama") == ""
+
+    def test_no_config(self):
+        assert _existing_model_for(None, "ollama") == ""
+        assert _existing_model_for({}, "anthropic") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_standup_engine.py
+++ b/tests/unit/test_standup_engine.py
@@ -216,6 +216,24 @@ class TestRunStandup:
         alice = next(m for m in report.member_updates if m.name == "Alice")
         assert "x" in alice.summary  # deterministic fallback used
 
+    def test_ollama_model_missing_becomes_pull_hint_warning(self, monkeypatch, db_path, seeded_session):
+        _patch_common(
+            monkeypatch,
+            items=[{"author": "Alice", "kind": "commit", "title": "x", "source": "github"}],
+            counts=[("github", 1)],
+        )
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("LLM_MODEL", "qwen3:8b")
+
+        def boom(self, m):
+            raise RuntimeError("model 'qwen3:8b' not found, try pulling it first")
+
+        monkeypatch.setattr("yeaboi.agent.llm.get_llm", lambda **k: type("L", (), {"invoke": boom})())
+        report = engine.run_standup(seeded_session, deliver=False, db_path=db_path, today=date(2026, 7, 10))
+        assert any("ollama pull qwen3:8b" in w for w in report.warnings)
+        alice = next(m for m in report.member_updates if m.name == "Alice")
+        assert "x" in alice.summary  # deterministic fallback still used
+
     def test_no_api_key_warns(self, monkeypatch, db_path, seeded_session):
         _patch_common(
             monkeypatch,

--- a/tests/unit/test_ui_error_classification.py
+++ b/tests/unit/test_ui_error_classification.py
@@ -113,3 +113,25 @@ class TestGenericAndFallback:
 
     def test_short_fallback_passthrough(self):
         assert _classify_api_error(ValueError("boom")) == "Unexpected error: boom"
+
+
+class TestOllamaLocal:
+    """Local-Ollama failures get actionable hints instead of generic messages."""
+
+    def test_server_down_gets_serve_hint(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        msg = _classify_api_error(httpx.ConnectError("All connection attempts failed"))
+        assert "ollama serve" in msg
+
+    def test_model_not_pulled_gets_pull_hint(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("LLM_MODEL", "qwen3:32b")
+        msg = _classify_api_error(Exception("model 'qwen3:32b' not found, try pulling it first"))
+        assert "ollama pull qwen3:32b" in msg
+
+    def test_cloud_provider_unaffected(self, monkeypatch):
+        # The hint helper is provider-gated — cloud errors keep today's messages.
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        assert "Network error" in _classify_api_error(ConnectionError("refused"))

--- a/tests/unit/test_usage_page.py
+++ b/tests/unit/test_usage_page.py
@@ -1,0 +1,102 @@
+"""Tests for the Usage page data collection (`_collect_usage_data`).
+
+Focus: the local Ollama provider must report a real model name, a
+"configured" API status (it needs no key), and a $0 cost — local models run
+on the user's own hardware, so a fabricated cloud-priced cost would mislead.
+"""
+
+from __future__ import annotations
+
+import yeaboi.ui.mode_select as mode_select
+from yeaboi.ui.mode_select import _collect_usage_data
+
+
+def _collect(monkeypatch, tmp_path, provider: str, **env: str) -> dict:
+    """Run _collect_usage_data with a scratch DB and a controlled environment."""
+    monkeypatch.setattr(mode_select, "_ana_dbp", tmp_path / "usage-test.db")
+    monkeypatch.setenv("LLM_PROVIDER", provider)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return _collect_usage_data()
+
+
+class TestUsageDataOllama:
+    def test_model_resolves_to_provider_default(self, monkeypatch, tmp_path):
+        data = _collect(monkeypatch, tmp_path, "ollama")
+        assert data["model"] == "qwen3:8b"
+
+    def test_keyless_provider_shows_configured(self, monkeypatch, tmp_path):
+        data = _collect(monkeypatch, tmp_path, "ollama")
+        assert data["api_key_status"] == "configured"
+
+    def test_cost_is_zero_for_local(self, monkeypatch, tmp_path):
+        from yeaboi.agent.llm import reset_usage_stats, track_usage
+
+        reset_usage_stats()
+        try:
+            from types import SimpleNamespace
+
+            track_usage(SimpleNamespace(response_metadata={"usage": {"input_tokens": 1000, "output_tokens": 500}}))
+            data = _collect(monkeypatch, tmp_path, "ollama")
+            assert data["tokens"]["estimated_cost"] == 0.0
+        finally:
+            reset_usage_stats()
+
+
+class TestLifetimeUsageByProvider:
+    def _seed(self, db_path):
+        from yeaboi.sessions import SessionStore
+
+        with SessionStore(db_path) as store:
+            store.record_token_usage(1_000_000, 1_000_000, model="claude-sonnet-4-6", provider="anthropic")
+            store.record_token_usage(2_000_000, 2_000_000, model="qwen3:8b", provider="ollama")
+
+    def test_store_groups_by_provider(self, tmp_path):
+        from yeaboi.sessions import SessionStore
+
+        db = tmp_path / "usage.db"
+        self._seed(db)
+        with SessionStore(db) as store:
+            usage = store.get_lifetime_usage_by_provider()
+        assert usage["anthropic"]["input_tokens"] == 1_000_000
+        assert usage["ollama"]["total_tokens"] == 4_000_000
+        assert usage["anthropic"]["call_count"] == 1
+
+    def test_mixed_history_prices_only_cloud_rows(self, monkeypatch, tmp_path):
+        """Anthropic rows keep their real cost even when the CURRENT provider is
+        the free local one — switching to Ollama must not hide past cloud spend."""
+        db = tmp_path / "usage-test.db"
+        self._seed(db)
+        data = _collect(monkeypatch, tmp_path, "ollama")
+        lt = data["lifetime_tokens"]
+        assert lt["calls"] == 2
+        assert lt["total"] == 6_000_000
+        # 1M in @ $3/M + 1M out @ $15/M = $18 for the anthropic rows; ollama rows $0.
+        assert lt["estimated_cost"] == 18.0
+
+
+class TestUsageDataCloud:
+    def test_anthropic_without_key_not_configured(self, monkeypatch, tmp_path):
+        data = _collect(monkeypatch, tmp_path, "anthropic")
+        assert data["api_key_status"] == "not configured"
+
+    def test_anthropic_with_key_configured(self, monkeypatch, tmp_path):
+        data = _collect(monkeypatch, tmp_path, "anthropic", ANTHROPIC_API_KEY="sk-ant-x")
+        assert data["api_key_status"] == "configured"
+        assert data["model"] == "claude-sonnet-4-6"
+
+    def test_cloud_cost_still_estimated(self, monkeypatch, tmp_path):
+        from yeaboi.agent.llm import reset_usage_stats, track_usage
+
+        reset_usage_stats()
+        try:
+            from types import SimpleNamespace
+
+            track_usage(SimpleNamespace(response_metadata={"usage": {"input_tokens": 1000, "output_tokens": 500}}))
+            data = _collect(monkeypatch, tmp_path, "anthropic", ANTHROPIC_API_KEY="sk-ant-x")
+            assert data["tokens"]["estimated_cost"] > 0
+        finally:
+            reset_usage_stats()

--- a/uv.lock
+++ b/uv.lock
@@ -2912,7 +2912,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.19.1"
+version = "2.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },

--- a/uv.lock
+++ b/uv.lock
@@ -1170,6 +1170,19 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-ollama"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ollama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/9b/6641afe8a5bf807e454fd464eddfc7eb2f2df53cb0b29744381171f9c609/langchain_ollama-1.1.0.tar.gz", hash = "sha256:f776f56f6782ae4da7692579b94a6575906118318d1023b455d7207f9d059811", size = 133075, upload-time = "2026-04-07T02:48:00.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/b2/c2acb076590a98bee2816ed5f285e00df162a34238f9e276e175e14ebc35/langchain_ollama-1.1.0-py3-none-any.whl", hash = "sha256:43ac83a6eacb0f43855810739794dd55019e0d9b17bdcf3ecb3b1991ac3b59dd", size = 31413, upload-time = "2026-04-07T02:47:59.642Z" },
+]
+
+[[package]]
 name = "langchain-openai"
 version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1501,6 +1514,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "ollama"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
 ]
 
 [[package]]
@@ -2910,6 +2936,7 @@ all-providers = [
     { name = "boto3" },
     { name = "langchain-aws" },
     { name = "langchain-google-genai" },
+    { name = "langchain-ollama" },
     { name = "langchain-openai" },
 ]
 bedrock = [
@@ -2929,6 +2956,9 @@ dev = [
 ]
 google = [
     { name = "langchain-google-genai" },
+]
+ollama = [
+    { name = "langchain-ollama" },
 ]
 openai = [
     { name = "langchain-openai" },
@@ -2961,6 +2991,8 @@ requires-dist = [
     { name = "langchain-aws", marker = "extra == 'bedrock'" },
     { name = "langchain-google-genai", marker = "extra == 'all-providers'" },
     { name = "langchain-google-genai", marker = "extra == 'google'" },
+    { name = "langchain-ollama", marker = "extra == 'all-providers'" },
+    { name = "langchain-ollama", marker = "extra == 'ollama'" },
     { name = "langchain-openai", marker = "extra == 'all-providers'" },
     { name = "langchain-openai", marker = "extra == 'openai'" },
     { name = "langgraph" },
@@ -2981,7 +3013,7 @@ requires-dist = [
     { name = "segno" },
     { name = "sounddevice", marker = "extra == 'voice'" },
 ]
-provides-extras = ["openai", "google", "pdf", "bedrock", "voice", "charts", "all-providers", "dev"]
+provides-extras = ["openai", "google", "pdf", "bedrock", "ollama", "voice", "charts", "all-providers", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "syrupy", specifier = ">=5.1.0" }]


### PR DESCRIPTION
## Summary

yeaboi previously required a paid cloud API key to do anything. This adds a **fully free local mode** via [Ollama](https://ollama.com): pick "Ollama (Local)" in the setup wizard, and everything — planning pipeline, all 4 ceremony modes, chat — runs on a local model with no key, no cloud, no data leaving the machine.

### Reliability layer (local output ≈ cloud reliability)

Local models are weaker at emitting valid JSON, and every pipeline stage parses JSON. Three layers close the gap:

1. **Constrained decoding** — JSON calls run ChatOllama with `format="json"`, so the model cannot emit invalid JSON syntax (no-op for cloud providers).
2. **One-shot repair re-ask** — new `invoke_json()` wraps every JSON-parsed call site (planning nodes, standup/retro/performance/reporting engines, team_learning); a reply that fails `json.loads` is sent back with the exact parse error for one repair round. Applies to **all** providers.
3. **Loud, actionable failures** — new `_local_llm_hint()` is the single decision point (REPL, TUI error classifier, mode engines, headless): server down → "Start it with: ollama serve", model not pulled (404) → "ollama pull <model>", package missing → "uv sync --extra ollama", timeout → "try a smaller model". These re-raise instead of silently degrading every artifact to deterministic fallbacks; cloud transient blips keep the graceful fallback.

### Local-model correctness

- `strip_think_tags()` — qwen3-style `<think>` blocks stripped on all prose paths (chat, llm_tools, guardrail classifier — where a think block could bury the verdict token)
- Chat history trimmed to `OLLAMA_NUM_CTX` (cut at HumanMessage boundaries only; tool-call pairs never split) + prompt-overflow warning, since Ollama silently left-truncates
- Off-topic classifier capped (`num_predict=64`, `reasoning=False`) so a one-word verdict doesn't cost seconds of CPU per input
- Models without tool calling degrade to plain chat with a one-time notice instead of erroring
- Headless (`--non-interactive`) exits 1 on local failures instead of retry-looping forever

### Setup UX

- Ollama wizard card: base-URL input (pre-filled), live model discovery from `/api/tags`, per-model trade-off hints (size/RAM/JSON discipline), `langchain-ollama` install check before finishing green
- **In-app model download**: pick an un-pulled model → press P → streamed `POST /api/pull` with live progress, Esc-cancel (resumable), auto-verify on completion
- Provider taglines on the picker (Ollama: "Free · local · private · no API key"); wizard copy no longer implies an API key is mandatory
- Usage page: $0 cost for local, lifetime cost priced per provider (past cloud spend stays visible after switching); Settings shows Ollama rows

### Docs & packaging

- New `ollama` extra (`uv sync --extra ollama`), README "Local Mode (Ollama)" section with model trade-off table, CLAUDE.md + .env.example updated

## Test plan

- 4,300 unit + integration tests pass (≈90 new: provider factory, invoke_json repair, think-tag stripping, hint mapping, history trimming, pull streaming, classifier caps, usage pricing, wizard verification)
- `make lint` clean
- Manually verified against a live `ollama serve` + brew install: wizard end-to-end, server-down/model-missing failure drills, in-app pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)