### PR TITLE
route automation workflows to cost-matched models and cap turns

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -92,7 +92,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash,Read,Edit,Write"'
+          # Semver classification is mechanical (labels always win; the bump is a
+          # script; the changelog paragraph is short) — routed to Haiku for cost.
+          # If wrong-level bumps appear, promote to claude-sonnet-5 (one line).
+          claude_args: '--model claude-haiku-4-5 --max-turns 15 --allowedTools "Bash,Read,Edit,Write"'
           prompt: |
             You are the release-versioning bot for this repository. Pull request #${{ github.event.pull_request.number }} is open; decide whether and how to bump the project version. The version lives only in pyproject.toml. Changelog-only mode: ${{ steps.guard.outputs.changelog_only || 'false' }}.
 
@@ -122,7 +125,7 @@ jobs:
             5. Commit the pyproject.toml and changelog_data.json changes together (changelog-only mode: just changelog_data.json) to this PR branch and push. Use commit message:
                  chore: bump version to <new-version> [auto]
                with trailer:
-                 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+                 Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
 
             6. Post one short PR comment naming the level, the new version, and a one-sentence reason.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -106,4 +106,6 @@ jobs:
             If there are no significant findings, post one line saying the review passed.
             Do not comment on style that ruff already enforces. Do not request changes on
             nitpicks. This review is advisory — never attempt to approve, merge, or block.
-          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment ${{ steps.pr.outputs.number }}:*),Bash(gh run view:*),Read,Grep,Glob"'
+          # Review stays on the default (Opus-tier) model — judgment quality is
+          # the point, and volume is already gated to green PRs by workflow_run.
+          claude_args: '--max-turns 25 --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment ${{ steps.pr.outputs.number }}:*),Bash(gh run view:*),Read,Grep,Glob"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,10 +43,9 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Open-ended assistance keeps the default (Opus-tier) model; the turn
+          # cap is a cost guard against runaway sessions, not a quality lever.
+          claude_args: '--max-turns 50'
 
   # Issue-to-PR: adding the `claude-implement` label to an issue kicks off an
   # implementation run that opens a PR. The PR then flows through ci.yml,
@@ -73,6 +72,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Full implementation runs stay on the default (Opus-tier) model; the
+          # higher turn cap covers implement + verify + PR without being unbounded.
+          claude_args: '--max-turns 75'
           prompt: |
             Implement GitHub issue #${{ github.event.issue.number }} in ${{ github.repository }}.
 

--- a/.github/workflows/dependabot-auto.yml
+++ b/.github/workflows/dependabot-auto.yml
@@ -90,7 +90,9 @@ jobs:
           # Write-capable gh commands are pinned to THIS PR's number so
           # prompt-injected content can't steer the agent at other PRs;
           # gh api is scoped to repo reads (release notes/changelogs).
-          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment ${{ steps.pr.outputs.number }}:*),Bash(gh pr edit ${{ steps.pr.outputs.number }}:*),Bash(gh pr merge ${{ steps.pr.outputs.number }}:*),Bash(gh api repos/:*),Bash(gh release view:*),Read,Grep,Glob,WebFetch"'
+          # Release-notes-vs-usage verification is structured judgment — Sonnet
+          # is enough; the safety policy (not the model) is the real gate.
+          claude_args: '--model claude-sonnet-5 --max-turns 20 --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment ${{ steps.pr.outputs.number }}:*),Bash(gh pr edit ${{ steps.pr.outputs.number }}:*),Bash(gh pr merge ${{ steps.pr.outputs.number }}:*),Bash(gh api repos/:*),Bash(gh release view:*),Read,Grep,Glob,WebFetch"'
           prompt: |
             You are the dependency-verification bot for this repository. Dependabot
             opened PR #${{ steps.pr.outputs.number }} and its CI has just passed.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -53,7 +53,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash,Read,Edit,Write,Glob,Grep"'
+          # Scoped remediation (fix a finding / bump a package, re-verify) —
+          # Sonnet-tier; the fix PR is re-scanned by CI and human-reviewed anyway.
+          claude_args: '--model claude-sonnet-5 --max-turns 40 --allowedTools "Bash,Read,Edit,Write,Glob,Grep"'
           prompt: |
             You are the security-remediation bot for this repository. The scheduled scanner
             found issues on `main`. Fix the genuine ones and open a pull request — you must
@@ -80,7 +82,7 @@ jobs:
 
             3. Create a new branch named `security/auto-fix-${{ github.run_id }}`, commit your
                changes there (commit message: `fix(security): remediate scanner findings [auto]`
-               with trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`), push it,
+               with trailer `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>`), push it,
                and open a PR to `main` using `gh pr create`. The PR body must summarize, per
                finding: what it was, and whether you fixed it, bumped a dependency, or judged it
                a false positive (with reasoning).


### PR DESCRIPTION
## What

First increment of the Phase-4 (supervised autonomy) plan: model routing + cost caps across all 5 Claude automation workflows. Every workflow now has an explicit `--max-turns` ceiling, and mechanical jobs route to cheaper models:

| Workflow | Model | Cap |
|---|---|---|
| `claude.yml` @mention | default (Opus) | 50 |
| `claude.yml` implement | default (Opus) | 75 |
| `claude-review.yml` | default (Opus — review quality is the point; volume already CI-gated) | 25 |
| `auto-version.yml` | **claude-haiku-4-5** | 15 |
| `dependabot-auto.yml` | **claude-sonnet-5** | 20 |
| `security-scan.yml` | **claude-sonnet-5** | 40 |

Co-Authored-By trailer text in routed prompts updated to name the model that actually authors those commits.

## Why these choices

- **auto-version → Haiku**: classification is mechanical — `semver:*` labels always win, the bump itself is `scripts/bump_version.py`, and the changelog paragraph is short. **Watch item**: if wrong-level bumps appear on the first few PRs, promote to `claude-sonnet-5` (one-line change; labels always override in the meantime).
- **dependabot-auto / security-scan → Sonnet**: structured verification/remediation where the safety policy and CI re-scan are the real gates, not the model tier.
- **Review + implement stay Opus**: judgment quality is the product there.

## Verification

- All 8 workflow YAMLs parse (`yaml.safe_load` sweep).
- No Python touched; behavior change is limited to `claude_args`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)