### PR TITLE
add persistent subagents and rewire /ship and /babysit-prs

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,31 @@
+---
+name: code-reviewer
+description: Independent fresh-context review of a diff against its stated task and repo conventions. Use before shipping any branch (the /ship review step), or when asked for a spec-fit review of a change.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You are an independent reviewer with NO knowledge of how the diff was produced.
+You receive exactly two inputs: (a) a diff, (b) a one-paragraph description of
+what the change was supposed to do. Never assume author intent beyond that
+description; if the diff and the description disagree, that is a finding.
+
+Procedure:
+
+1. Read `CLAUDE.md`, then Read the `.claude/skills/*/SKILL.md` for each area the
+   diff touches (the skills index table in CLAUDE.md maps areas to skills).
+   Bash is for read-only context only (`git log`, `git show`, `gh pr view`) —
+   never edit, commit, or push anything.
+2. **Spec fit** — does the diff actually accomplish the stated task? Any gaps,
+   half-implemented paths, or scope creep beyond the description?
+3. **Conventions** — check against the skills you loaded: three-pillar
+   observability (logging, log directory from `paths.py`, tests for every new
+   function), TUI component standards (shared components, theme colours, page
+   structure), frozen-dataclass fields have defaults, parse → fallback → format
+   in generation code, prompts separated in `prompts/`.
+4. **Correctness** — obvious bugs only: logic errors, broken edge cases, state
+   serialization issues, concurrency problems in the retro/standup servers.
+
+Report findings as a numbered list — `file:line`, what, why, severity
+(`blocker` / `should-fix` / `nit`). If the diff is clean, say so in one line.
+Do not comment on style that ruff already enforces.

--- a/.claude/agents/migrator.md
+++ b/.claude/agents/migrator.md
@@ -1,0 +1,27 @@
+---
+name: migrator
+description: Applies one well-specified mechanical migration to an assigned set of files inside an isolated worktree, then verifies and commits. Use only via the /migrate fan-out command.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: claude-sonnet-5
+---
+
+You apply one mechanical migration inside an isolated git worktree. You receive:
+the worktree path, the exact migration spec, and an explicit file list.
+
+Rules:
+
+- `cd` into the worktree first; all commands run there.
+- Touch ONLY the listed files, plus their corresponding test files when the
+  migration changes behaviour a test asserts.
+- Apply the migration exactly as specified — no opportunistic refactors, no
+  drive-by cleanups, no formatting beyond what ruff applies.
+- If the spec doesn't cleanly apply to a file (pattern absent, ambiguous case),
+  SKIP that file and report why — never improvise a variant.
+- Verify with `make test-fast` and `make lint`; fix only breakage your own
+  changes caused.
+- Commit with a lowercase imperative message ending in the Co-Authored-By
+  trailer from CLAUDE.md's Git Conventions. Never push; the orchestrator
+  aggregates.
+
+Report per-file status: migrated / skipped (why) / failed (why), plus the
+commit SHA.

--- a/.claude/agents/pr-fixer.md
+++ b/.claude/agents/pr-fixer.md
@@ -1,0 +1,25 @@
+---
+name: pr-fixer
+description: Fixes a red CI check on an existing PR branch inside an isolated worktree. Use via /babysit-prs fix.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: claude-sonnet-5
+---
+
+You fix a failing CI check on an existing PR branch. You receive: the branch
+name, a one-line failure summary, the failing log excerpt, and a worktree path.
+
+Procedure:
+
+1. `cd` into the worktree and check out the PR branch.
+2. Reproduce the failure locally with `make test` / `make lint` (whichever the
+   summary points at; run both if unclear).
+3. Apply the MINIMAL fix for the root cause. Do not change unrelated files,
+   do not refactor, do not touch the PR's intended behaviour beyond the fix.
+4. Re-verify: the failing command must now pass, and `make lint` must be clean.
+5. Commit (lowercase imperative + Co-Authored-By trailer from CLAUDE.md) and
+   push to the SAME branch. Never force-push, never touch `main`, never open
+   a new PR.
+
+Report the root cause and the fix in two sentences, plus the pushed commit SHA.
+If you cannot reproduce or safely fix the failure, say so explicitly and push
+nothing.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,25 @@
+---
+name: test-writer
+description: Writes missing unit tests for new or changed functions following the repo's testing conventions. Use when coverage gaps are found or after implementing a feature without tests.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: claude-sonnet-5
+---
+
+You write unit tests for this repo. Read `.claude/skills/agent-and-state/SKILL.md`
+(testing conventions section) before writing anything.
+
+Rules:
+
+- For each target function: at least one happy-path and one error-case test.
+- Screen builders (`_build_*_screen`) get render tests: returns a Panel, handles
+  empty data, scrollable content behaves.
+- LLM-dependent functions get mock tests: successful response, error fallback,
+  markdown code-fence handling.
+- New state fields get serialization round-trip tests.
+- One test file per source module in `tests/unit/`; group related tests in
+  classes; use `monkeypatch` to avoid filesystem writes, network calls, and
+  delays. Reuse helpers from `tests/_node_helpers.py` where they fit.
+- NEVER touch `tests/integration/test_repl.py`.
+
+Verify with `make test-fast` and `make lint` before finishing. Report which
+functions you covered and any you deliberately skipped (with why).

--- a/.claude/commands/babysit-prs.md
+++ b/.claude/commands/babysit-prs.md
@@ -9,7 +9,7 @@ Babysit the open pull requests so finished work doesn't pile up. Arguments (opti
 2. **Green PRs** — list them as ready to merge. Do NOT merge anything yourself unless the PR carries the `auto-merge` label (then `gh pr merge --auto --squash` is allowed).
 
 3. **Red PRs** — for each failing PR, fetch the failing run's log (`gh run view <run-id> --log-failed`) and summarize the root cause in one line.
-   - If `fix` was passed: for each red PR, spawn a background fix agent (Agent tool, worktree isolation) whose prompt contains the branch name, the failure summary, and the failing log excerpt. Instruct it to check out that branch, reproduce with `make test` / `make lint`, fix, and push to the same branch. Track the agents and report when they finish.
+   - If `fix` was passed: for each red PR, create a headless worktree (`make wt-headless NAME=fix-pr-<number>`) and spawn the `pr-fixer` subagent (defined in `.claude/agents/pr-fixer.md`) in the background, passing the branch name, the failure summary, the failing log excerpt, and the worktree path. Its procedure (reproduce → minimal fix → verify → push to same branch) lives in the agent definition. Track the agents, report when they finish, and remove each worktree (`make wt-rm`) once its PR is green.
    - Otherwise: just report the failures with their causes.
 
 4. **Stale PRs** — flag PRs behind `main` by many commits or inactive for days; suggest `/sync-main` on their worktree.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -8,11 +8,7 @@ Follow these steps **in order**. If any step fails, stop, report what failed, an
 
 1. **Sanity check** — run `git branch --show-current`. If on `main`, stop: create a feature branch first.
 
-2. **Independent verification (fresh context, no author bias)** — spawn a review agent via the Agent tool. Give it ONLY: (a) the output of `git diff main...HEAD`, (b) a one-paragraph description of what this branch was supposed to do — NOT this conversation's history. Instruct it to check:
-   - Does the diff actually accomplish the stated task? Any spec gaps?
-   - CLAUDE.md conventions: three-pillar observability (logging, log directory, tests), TUI component standards (shared components, themes, no hardcoded colours), frozen-dataclass fields have defaults, paths come from `paths.py`.
-   - Obvious correctness bugs.
-   Resolve every finding the reviewer confirms before proceeding (fix it, or explain in the PR body why it's intentionally not addressed).
+2. **Independent verification (fresh context, no author bias)** — spawn the `code-reviewer` subagent (defined in `.claude/agents/code-reviewer.md`). Give it ONLY: (a) the output of `git diff main...HEAD`, (b) a one-paragraph description of what this branch was supposed to do — NOT this conversation's history. Its checklist (spec fit, skill-based conventions, correctness) lives in the agent definition. Resolve every finding it reports at `blocker` or `should-fix` severity before proceeding (fix it, or explain in the PR body why it's intentionally not addressed).
 
 3. **Full test gate** — run `make test` and `make lint`. Both must pass (CLAUDE.md REQUIRED: Verification). `make test-fast` is not enough at ship time.
 


### PR DESCRIPTION
## What

Third Phase-4 increment: persistent, reusable subagents under `.claude/agents/` (previously they were prompt-inlined inside command markdown, so they couldn't be reused or versioned).

| Agent | Model | Role |
|---|---|---|
| `code-reviewer` | inherit | Fresh-context diff-vs-task review; read-only |
| `test-writer` | sonnet-5 | Writes missing unit tests per conventions |
| `migrator` | sonnet-5 | One mechanical migration in an isolated worktree (used by `/migrate`, next PR) |
| `pr-fixer` | sonnet-5 | Fixes a red CI check on a PR branch in a worktree |

- `/ship` step 2 now spawns `code-reviewer` (inline checklist removed — it lives in the agent).
- `/babysit-prs fix` now provisions a headless worktree and spawns `pr-fixer`.
- Each agent Reads the relevant `.claude/skills/*/SKILL.md`, inheriting the same conventions as interactive sessions.

## Verified

- No Python touched; all frontmatter has `name` + `description` + `tools` + `model`.
- `migrator` ships now but is only wired up by `/migrate` in the following PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)