### PR TITLE
add three proactive automation routines

### DIFF
--- a/.github/workflows/backlog-groomer.yml
+++ b/.github/workflows/backlog-groomer.yml
@@ -1,0 +1,92 @@
+# Weekly backlog groomer — proactive Step-3 routine.
+#
+# Open issues (especially the in-TUI feedback-form ones) accumulate unlabeled,
+# duplicated, and unprioritized until someone finds the time. This job keeps the
+# backlog tidy on a schedule: normalize labels, cross-link duplicates, nudge
+# stale issues, and maintain ONE living "Backlog grooming report" issue that
+# surfaces the top candidates for implementation.
+#
+# It is deliberately advisory: it NEVER applies the `claude-implement` label
+# itself (that would auto-start an implementation run) — it only nominates
+# candidates in the report for a human to green-light.
+#
+# Loop-safe: its own report issue is `github-actions[bot]`-authored and labeled
+# `groomer-report`, and the bash pre-step excludes bot-authored issues, so it
+# never grooms its own output and never re-triggers itself.
+
+name: Backlog Groomer
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: backlog-groomer
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write # label, comment, maintain the report issue
+  id-token: write # claude-code-action OIDC
+
+jobs:
+  groom:
+    name: Groom the open backlog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect open issues (exclude bots + own report)
+        id: collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          gh issue list --state open --limit 200 \
+            --json number,title,labels,author,createdAt,updatedAt,body \
+            --jq '[.[]
+              | select(.author.login != "github-actions[bot]")
+              | select(.author.login != "dependabot[bot]")
+              | select([.labels[].name] | index("groomer-report") | not)]' > issues.json
+          COUNT=$(python -c "import json;print(len(json.load(open('issues.json'))))")
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "::notice::$COUNT open issue(s) to groom."
+
+      - name: Groom with Claude
+        if: steps.collect.outputs.count != '0'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Many-item judgment (dedupe, prioritize) — Sonnet; Haiku tends to
+          # mislabel near-duplicates.
+          claude_args: '--model claude-sonnet-5 --max-turns 30 --allowedTools "Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh issue create:*),Read"'
+          prompt: |
+            You are the backlog groomer. The open issues to groom are in `issues.json`
+            at the repo root (bot-authored issues and the groomer's own report are
+            already excluded). The feedback form files issues with `[Bug]` / `[Feature]`
+            / `[Improvement]` / `[Other]` title prefixes and `type:*` / `area:*` labels
+            (label vocabulary: type=bug/feature/improvement/other; area=analysis,
+            planning, standup, retro, performance, reporting, usage, settings, general).
+
+            For each issue:
+            1. Normalize labels — if a `type:*` or `area:*` label is clearly missing,
+               add it with `gh issue edit <n> --add-label ...` (infer type from the
+               title prefix; infer area from the body). Do not remove existing labels.
+            2. Duplicates — if two issues clearly describe the same thing, add a
+               comment on the newer one cross-linking the older (`Possible duplicate of
+               #<older>`). NEVER close an issue.
+            3. Stale — if an issue has had no update in >60 days, add one comment
+               asking whether it's still relevant and add the `stale-candidate` label.
+
+            Then create-or-update ONE issue titled exactly `Backlog grooming report`
+            (label `groomer-report`; find it with
+            `gh issue list --label groomer-report --state open`). Its body:
+            - a priority-ordered list of the top ~10 open issues with a one-line reason,
+            - a "Duplicate clusters" section,
+            - a "Stale" section,
+            - a "claude-implement candidates" section: well-specified, self-contained
+              issues a human could green-light for implementation.
+
+            HARD RULE: never apply the `claude-implement` label yourself — only
+            nominate candidates in the report. The human decides.

--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -1,0 +1,111 @@
+# CI sentinel — proactive responder to a red `main`.
+#
+# When CI fails ON MAIN (i.e. something merged and broke the build, or a flaky
+# failure slipped through), this diagnoses the failure and either opens a fix PR
+# or files an issue — instead of waiting for a human to notice the red badge.
+#
+# Trigger is `workflow_run` on CI completion filtered to conclusion == failure
+# AND head_branch == 'main'. That branch filter is the primary loop guard: the
+# sentinel's OWN fix PR runs CI on a `ci-sentinel/…` branch, whose failure can
+# never re-trigger this workflow. A bash dedupe step adds a second guard so it
+# doesn't pile up PRs/issues while a fix is already pending.
+#
+# It NEVER pushes to main — only a fix PR (which flows through the normal CI +
+# required-checks + human-merge gate) or an issue.
+
+name: CI Sentinel
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "A failed CI run id on main to diagnose (for manual testing)"
+        required: false
+
+concurrency:
+  group: ci-sentinel
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the fix branch
+  pull-requests: write # open the fix PR
+  issues: write # or file a diagnosis issue
+  id-token: write # claude-code-action OIDC
+  actions: read # read the failed run log
+
+jobs:
+  sentinel:
+    name: Diagnose red main
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dedupe — skip if a fix is already pending
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          open_pr=$(gh pr list --label ci-sentinel --state open --json number --jq 'length')
+          open_issue=$(gh issue list --label ci-sentinel --state open --json number --jq 'length')
+          if [ "$open_pr" != "0" ] || [ "$open_issue" != "0" ]; then
+            echo "A ci-sentinel PR/issue is already open — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "run_id=${{ github.event.inputs.run_id || github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main
+        if: steps.dedupe.outputs.skip == 'false'
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v7
+        if: steps.dedupe.outputs.skip == 'false'
+      - run: uv python install 3.11
+        if: steps.dedupe.outputs.skip == 'false'
+      - run: uv sync --extra dev
+        if: steps.dedupe.outputs.skip == 'false'
+
+      - name: Diagnose and remediate with Claude
+        if: steps.dedupe.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FAILED_RUN_ID: ${{ steps.dedupe.outputs.run_id }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Diagnosis is the hard case — keep the default (Opus-tier) model.
+          claude_args: '--max-turns 40 --allowedTools "Bash,Read,Edit,Write,Glob,Grep"'
+          prompt: |
+            CI failed on `main` (run id: ${{ steps.dedupe.outputs.run_id }}). You are
+            on a fresh checkout of `main`. Diagnose the failure and act — NEVER push
+            or commit to `main` directly.
+
+            1. Read the failing logs: `gh run view ${{ steps.dedupe.outputs.run_id }} --log-failed`.
+               Identify which CI job failed and the specific failing test/lint/check.
+            2. Reproduce locally: run the matching command (`make test`, `make lint`,
+               or `make security`).
+            3. Decide:
+               - If it reproduces AND you are confident in a minimal, correct fix:
+                 create a branch `ci-sentinel/fix-${{ steps.dedupe.outputs.run_id }}`,
+                 apply the smallest fix, verify `make test` and `make lint` both pass,
+                 commit (lowercase imperative + the Co-Authored-By trailer from
+                 CLAUDE.md), push, and open a PR to `main` with the `ci-sentinel`
+                 label. The PR body must state the root cause and what you changed.
+               - If it does NOT reproduce (likely a flake) OR you are not confident:
+                 do NOT change code. Open an issue with labels `ci-red-main` and
+                 `ci-sentinel` describing the failure, what you tried, and your best
+                 hypothesis, so a human can take over.
+
+            Rules: never touch `main`; one PR or one issue, not both; keep any fix
+            minimal and scoped strictly to the failing check.

--- a/.github/workflows/flaky-test-hunter.yml
+++ b/.github/workflows/flaky-test-hunter.yml
@@ -1,0 +1,147 @@
+# Weekly flaky-test hunter — proactive Step-3 routine.
+#
+# Flaky tests erode trust in the whole verification loop (a red CI that "just
+# needs a re-run" trains everyone to ignore red). This job hunts them down on a
+# schedule so they get filed and fixed instead of silently re-run.
+#
+# Deterministic-FIRST: a bash stage does all the detection with zero Claude
+# tokens — (a) it scans recent CI history for the same commit passing AND
+# failing (a re-run that flipped to green is a flake signal), and (b) it reruns
+# the suite several times and diffs the JUnit XML for tests that fail in some
+# runs but not others. Claude runs ONLY if flakes are found, and only to file /
+# update issues (cheap formatting work → Haiku). It opens ISSUES, not fix PRs —
+# a flake fix needs judgment; a human escalates by adding `claude-implement`.
+#
+# Loop-safe: the issues it files are `github-actions[bot]`-authored and labeled
+# `flaky-test`, which triggers nothing (claude.yml only fires on the
+# `claude-implement` label; the feedback pipeline skips bot authors).
+
+name: Flaky Test Hunter
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      reruns:
+        description: "How many times to rerun the suite (default 5)"
+        required: false
+        default: "5"
+
+concurrency:
+  group: flaky-test-hunter
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write # file / update flaky-test issues
+  id-token: write # claude-code-action OIDC
+  actions: read # read CI run history
+
+jobs:
+  hunt:
+    name: Detect flaky tests and file issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.11
+      - run: uv sync --extra dev
+
+      - name: Detect flakes (deterministic, no Claude)
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RERUNS: ${{ github.event.inputs.reruns || '5' }}
+        run: |
+          set -uo pipefail
+
+          # (a) History scan: a commit on main whose ci.yml produced BOTH a
+          #     failure and a success run is flaky by definition (a re-run
+          #     flipped it). Purely informational context for Claude.
+          gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=main&per_page=100" \
+            --jq '[.workflow_runs[] | {sha: .head_sha, c: .conclusion}]' > runs.json || echo "[]" > runs.json
+          python - <<'PY'
+          import json, collections
+          runs = json.load(open("runs.json"))
+          by_sha = collections.defaultdict(set)
+          for r in runs:
+              if r["c"]:
+                  by_sha[r["sha"]].add(r["c"])
+          flapped = [s[:10] for s, cs in by_sha.items() if "failure" in cs and "success" in cs]
+          json.dump(flapped, open("flapped_shas.json", "w"))
+          print(f"history: {len(flapped)} commit(s) both passed and failed")
+          PY
+
+          # (b) Active reruns: run the suite N times capturing JUnit XML, then
+          #     flag any test that is not consistent across runs.
+          rc=0
+          for i in $(seq 1 "$RERUNS"); do
+            uv run pytest tests/unit tests/integration \
+              --junitxml="junit-$i.xml" -p no:cacheprovider -q || rc=1
+          done
+
+          python - <<'PY'
+          import glob, json, xml.etree.ElementTree as ET
+          from collections import defaultdict
+          outcomes = defaultdict(set)  # test id -> {"pass","fail"}
+          files = sorted(glob.glob("junit-*.xml"))
+          for f in files:
+              root = ET.parse(f).getroot()
+              for tc in root.iter("testcase"):
+                  tid = f'{tc.get("classname")}::{tc.get("name")}'
+                  failed = any(c.tag in ("failure", "error") for c in tc)
+                  outcomes[tid].add("fail" if failed else "pass")
+          flaky = sorted(t for t, o in outcomes.items() if {"pass", "fail"} <= o)
+          json.dump({"reruns": len(files), "flaky": flaky}, open("flaky.json", "w"))
+          print(f"reruns: {len(files)}; flaky-by-rerun: {len(flaky)}")
+          for t in flaky:
+              print("  FLAKY:", t)
+          PY
+
+          COUNT=$(python -c "import json;print(len(json.load(open('flaky.json'))['flaky']))")
+          FLAPPED=$(python -c "import json;print(len(json.load(open('flapped_shas.json'))))")
+          if [ "$COUNT" != "0" ] || [ "$FLAPPED" != "0" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No flaky tests detected."
+          fi
+
+      - name: File / update flaky-test issues with Claude
+        if: steps.detect.outputs.found == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Filing issues from a prepared JSON is classification + formatting,
+          # not deep reasoning — routed to Haiku.
+          claude_args: '--model claude-haiku-4-5 --max-turns 15 --allowedTools "Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue comment:*),Read,Grep"'
+          prompt: |
+            The deterministic flake detector just ran on `main`. Its results are in
+            two files at the repo root:
+            - `flaky.json` — {"reruns": N, "flaky": ["Class::test", ...]} tests that
+              failed in some of N identical reruns but passed in others.
+            - `flapped_shas.json` — commit SHAs whose CI both passed and failed (a
+              re-run flipped them); supporting evidence only.
+
+            For EACH test id in `flaky.json`'s "flaky" list:
+            1. Search existing issues: `gh issue list --label flaky-test --search "<test id>" --state all`.
+            2. If an open issue already covers it, add a brief comment noting this
+               week's recurrence (how many of N reruns failed) — do NOT open a duplicate.
+            3. If none exists, open one issue titled exactly `[Flaky] <test id>` with
+               label `flaky-test`. Body: the rerun failure ratio, the test's file
+               path (Grep/Read to confirm it), and a one-paragraph hypothesis of the
+               likely cause (timing, ordering, shared state, real clock/random use).
+               Do NOT propose or apply a fix — this is triage only.
+
+            If `flaky.json`'s "flaky" list is empty but `flapped_shas.json` is not,
+            open (or update) a single issue `[Flaky] CI history shows intermittent
+            failures` summarizing the flapped commits so a human can investigate.
+
+            Keep every issue/comment concise. Never edit code, never open a PR.


### PR DESCRIPTION
## What

Fourth Phase-4 increment: proactive scheduled/event routines — the "Claude does work you'd have kicked off manually" layer. Previously the repo had exactly one proactive cron (`security-scan.yml`); this adds three more.

| Workflow | Trigger | Does |
|---|---|---|
| `flaky-test-hunter.yml` | Weekly cron + manual | **Deterministic-first** detection (rerun suite 5×, diff JUnit XML + scan CI history), then Haiku files/updates `[Flaky] …` issues only if flakes found |
| `ci-sentinel.yml` | CI fails on `main` (`workflow_run`) | Opus diagnoses red main → `ci-sentinel/…` fix PR **or** `ci-red-main` issue; never pushes main |
| `backlog-groomer.yml` | Weekly cron + manual | Sonnet labels/dedupes/nudges open issues + maintains one `Backlog grooming report` issue |

## Safety / loop-prevention

- **flaky-hunter**: zero Claude tokens when no flakes (the detector is pure bash/python); files bot-authored `flaky-test` issues that trigger nothing.
- **ci-sentinel**: `head_branch == 'main'` filter means its own `ci-sentinel/…` fix PR can't re-trigger it; an open-PR/issue dedupe step prevents pile-up; **never** commits to main.
- **backlog-groomer**: excludes bot-authored issues (won't groom its own report); **hard rule** never applies `claude-implement` itself — only nominates candidates for a human.
- All three: explicit least-privilege `permissions`, `--max-turns` caps, cost-matched models.

## Rollout note

The five labels these use (`flaky-test`, `ci-sentinel`, `ci-red-main`, `groomer-report`, `stale-candidate`) have **already been created** on the repo, so the routines work on first fire.

## Verify

- All workflow YAMLs parse. Fire each via `workflow_dispatch` after merge — flaky-hunter should report "no flakes → no Claude step" on a clean suite; groomer's labels should be sanity-checked on the real backlog before trusting the cron.
- Docs: the `ci-and-release` skill CI/CD table gets these rows once #74 (skills) is on main (tracked as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)