### PR TITLE
add feedback-remediation agent-sdk pilot (step-4)

### DIFF
--- a/.github/workflows/feedback-remediation.yml
+++ b/.github/workflows/feedback-remediation.yml
@@ -1,0 +1,67 @@
+# Feedback remediation — nightly Agent-SDK triage of GitHub issues.
+#
+# The Step-4 (AI-native) pilot: unlike the other Claude workflows (which use the
+# hosted claude-code-action), this runs a Python Claude Agent SDK script that
+# classifies fresh issues and routes actionable bugs into the existing
+# `claude-implement` pathway (which opens a normal PR through CI + review + human
+# merge). The SDK owns triage/orchestration/rate-limiting only.
+#
+# Auth: the Agent SDK authenticates with ANTHROPIC_API_KEY (NOT the App's
+# CLAUDE_CODE_OAUTH_TOKEN, which is only for claude-code-action). Add an
+# ANTHROPIC_API_KEY repo secret before enabling this. The Python SDK is
+# self-contained (no Claude Code CLI install needed).
+#
+# Safety: `issues: write` only — cannot touch PRs or merge. Caps fixes per run,
+# idempotent via the `triaged` label, skips bot authors, and the workflow_dispatch
+# path defaults to dry-run. See automation/feedback_remediation/README.md.
+
+name: Feedback Remediation
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # nightly 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log intended actions without changing anything"
+        type: boolean
+        required: false
+        default: true
+
+concurrency:
+  group: feedback-remediation
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write # label / comment / maintain the digest issue
+
+jobs:
+  triage:
+    name: Triage new feedback issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.11
+
+      - name: Triage
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          # Scheduled runs act for real; manual runs default to dry-run.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+          # Weekly digest on Mondays (day-of-week 1); harmless on other days.
+          RUN_DIGEST: ${{ github.event.schedule == '0 2 * * *' }}
+        run: |
+          set -euo pipefail
+          ARGS=""
+          [ "$DRY_RUN" = "true" ] && ARGS="$ARGS --dry-run"
+          # Only build the digest on Mondays to avoid daily churn.
+          if [ "$(date -u +%u)" = "1" ]; then ARGS="$ARGS --digest"; fi
+          echo "running: triage.py$ARGS"
+          uv run automation/feedback_remediation/triage.py $ARGS

--- a/automation/feedback_remediation/README.md
+++ b/automation/feedback_remediation/README.md
@@ -1,0 +1,74 @@
+# Feedback remediation pilot
+
+A Claude **Agent SDK** pipeline that triages incoming GitHub issues nightly and
+routes actionable bugs into the existing implementation flow. This is the
+repo's Step-4 (AI-native) pilot — the first automation built on the Agent SDK
+rather than the hosted `claude-code-action`.
+
+## What it does
+
+For every open issue that is *fresh feedback* (no `triaged` label, not
+bot-authored, not an automation issue), it makes one cheap **Haiku**
+classification call and acts:
+
+| Classification | Action |
+|---|---|
+| bug · actionable · high-confidence | Sonnet double-checks it's specific enough, then labels `claude-implement` (capped at 3/run; overflow → `feedback:fix-queued`) |
+| feature | labels `feature-candidate` (a human decides whether to implement) |
+| question | comments asking for detail + labels `feedback:needs-info` |
+| noise | labels `feedback:noise` (never auto-closed) |
+
+Every triaged issue also gets the `triaged` cursor label (so it's processed
+once) plus a `type:*` label inferred from the feedback-form title prefix.
+
+## Why label `claude-implement` instead of fixing here
+
+Fix *execution* is delegated to the existing `claude-implement` → `claude.yml`
+pathway: labeling the issue opens a normal PR that flows through CI +
+`claude-review.yml` + **human merge**. The SDK owns triage, orchestration, and
+rate-limiting; it does not check out or push code. Labeling `claude-implement`
+is the "Claude kicks off Claude" hand-off, composed through the proven pipeline.
+
+## Safety
+
+- Runs with **`issues: write` only** — it structurally cannot touch PRs or merge.
+- Caps `claude-implement` labels per run (default 3).
+- Idempotent via the `triaged` label cursor; skips bot-authored issues.
+- `--dry-run` logs every intended action and changes nothing.
+
+## Auth
+
+Two credentials, both in the GitHub Actions secret store:
+
+- **`ANTHROPIC_API_KEY`** — the Agent SDK authenticates with an API key, *not*
+  the Claude GitHub App's `CLAUDE_CODE_OAUTH_TOKEN` (that token is only for
+  `claude-code-action`). **This is a one-time setup step:** add an
+  `ANTHROPIC_API_KEY` repo secret before enabling the nightly workflow.
+- **`GH_TOKEN`** — the workflow's `github.token`, used by the `gh` CLI wrappers.
+
+## Run locally
+
+```bash
+# Dry run against the live repo — prints intended actions, changes nothing:
+GH_TOKEN=$(gh auth token) ANTHROPIC_API_KEY=sk-... \
+  uv run automation/feedback_remediation/triage.py --dry-run
+
+# Weekly digest (also upserts the "Feedback digest" issue):
+uv run automation/feedback_remediation/triage.py --dry-run --digest
+```
+
+## Labels this uses (must pre-exist)
+
+`triaged`, `feature-candidate`, `feedback:needs-info`, `feedback:noise`,
+`feedback:fix-queued`, `feedback-digest`, plus the app's existing
+`claude-implement` and `type:*` labels.
+
+## Tests
+
+```bash
+uv run pytest automation/feedback_remediation/test_triage.py
+```
+
+The pure helpers (issue filtering, title-prefix inference, classification
+parsing, digest rendering) are unit-tested without the SDK or network. The SDK
+calls are exercised in production behind the `--dry-run` safety valve.

--- a/automation/feedback_remediation/github_io.py
+++ b/automation/feedback_remediation/github_io.py
@@ -1,0 +1,101 @@
+"""Thin ``gh`` CLI wrappers for the feedback-remediation pilot.
+
+No PyGithub dependency — every call shells out to the ``gh`` CLI already
+present on the GitHub Actions runner (and on the maintainer's machine for local
+dry-runs), authenticated by ``GH_TOKEN``. All write operations honour a global
+dry-run flag: when set, they log the intended action and change nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+
+logger = logging.getLogger("feedback_remediation")
+
+_DRY_RUN = False
+
+
+def set_dry_run(value: bool) -> None:
+    """Toggle dry-run mode. When on, write calls only log their intent."""
+    global _DRY_RUN
+    _DRY_RUN = value
+
+
+def _run(args: list[str]) -> str:
+    """Run a ``gh`` command and return stdout (raises on non-zero exit)."""
+    result = subprocess.run(  # noqa: S603 - args are code-controlled, never user input
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def list_open_issues(limit: int = 200) -> list[dict]:
+    """Return open issues as dicts (number, title, body, author, labels, dates)."""
+    out = _run(
+        [
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,body,author,labels,createdAt,updatedAt",
+        ]
+    )
+    return json.loads(out or "[]")
+
+
+def add_labels(number: int, labels: list[str]) -> None:
+    """Add labels to an issue (idempotent on GitHub's side)."""
+    if not labels:
+        return
+    if _DRY_RUN:
+        logger.info("[dry-run] would add labels %s to #%s", labels, number)
+        return
+    _run(["issue", "edit", str(number), "--add-label", ",".join(labels)])
+    logger.info("added labels %s to #%s", labels, number)
+
+
+def comment(number: int, body: str) -> None:
+    """Post a comment on an issue."""
+    if _DRY_RUN:
+        logger.info("[dry-run] would comment on #%s: %s", number, body[:80])
+        return
+    _run(["issue", "comment", str(number), "--body", body])
+    logger.info("commented on #%s", number)
+
+
+def find_open_issue_by_label(label: str) -> int | None:
+    """Return the number of the first open issue carrying ``label``, or None."""
+    out = _run(["issue", "list", "--state", "open", "--label", label, "--json", "number"])
+    rows = json.loads(out or "[]")
+    return rows[0]["number"] if rows else None
+
+
+def create_issue(title: str, body: str, labels: list[str]) -> int:
+    """Create an issue and return its number."""
+    if _DRY_RUN:
+        logger.info("[dry-run] would create issue %r with labels %s", title, labels)
+        return -1
+    args = ["issue", "create", "--title", title, "--body", body]
+    if labels:
+        args += ["--label", ",".join(labels)]
+    url = _run(args).strip()
+    number = int(url.rstrip("/").rsplit("/", 1)[-1])
+    logger.info("created issue #%s (%s)", number, title)
+    return number
+
+
+def update_issue_body(number: int, body: str) -> None:
+    """Replace an issue's body (used to refresh the living digest/report issue)."""
+    if _DRY_RUN:
+        logger.info("[dry-run] would update body of #%s", number)
+        return
+    _run(["issue", "edit", str(number), "--body", body])
+    logger.info("updated body of #%s", number)

--- a/automation/feedback_remediation/test_triage.py
+++ b/automation/feedback_remediation/test_triage.py
@@ -1,0 +1,92 @@
+"""Unit tests for the pure (SDK-free) helpers in triage.py.
+
+Run: uv run pytest automation/feedback_remediation/test_triage.py
+(Not part of `make test`, which scopes to tests/ — this module lives beside the
+automation script it covers.)
+"""
+
+from __future__ import annotations
+
+import pytest
+import triage
+
+
+class TestShouldProcess:
+    def test_fresh_feedback_is_processed(self):
+        issue = {"author": {"login": "someuser"}, "labels": [{"name": "type:bug"}]}
+        assert triage.should_process(issue) is True
+
+    def test_already_triaged_is_skipped(self):
+        issue = {"author": {"login": "someuser"}, "labels": [{"name": "triaged"}]}
+        assert triage.should_process(issue) is False
+
+    @pytest.mark.parametrize("bot", ["github-actions[bot]", "dependabot[bot]"])
+    def test_bot_authored_is_skipped(self, bot):
+        issue = {"author": {"login": bot}, "labels": []}
+        assert triage.should_process(issue) is False
+
+    @pytest.mark.parametrize("label", ["groomer-report", "flaky-test", "ci-sentinel", "ci-red-main"])
+    def test_automation_issues_are_skipped(self, label):
+        issue = {"author": {"login": "someuser"}, "labels": [{"name": label}]}
+        assert triage.should_process(issue) is False
+
+    def test_missing_author_and_labels(self):
+        assert triage.should_process({}) is True
+
+
+class TestTypeLabelFromTitle:
+    @pytest.mark.parametrize(
+        "title,expected",
+        [
+            ("[Bug] login crashes", "type:bug"),
+            ("[Feature] add dark mode", "type:feature"),
+            ("[Improvement] faster export", "type:improvement"),
+            ("[Other] question about setup", "type:other"),
+            ("[bug] lowercase prefix", "type:bug"),
+            ("  [Bug] leading spaces", "type:bug"),
+        ],
+    )
+    def test_known_prefixes(self, title, expected):
+        assert triage.type_label_from_title(title) == expected
+
+    def test_no_prefix_returns_none(self):
+        assert triage.type_label_from_title("plain title, no prefix") is None
+
+    def test_unknown_prefix_returns_none(self):
+        assert triage.type_label_from_title("[Random] not a type") is None
+
+
+class TestParseClassification:
+    def test_plain_json(self):
+        out = triage.parse_classification(
+            '{"category": "Bug", "actionable": true, "confidence": "High", "reason": "x"}'
+        )
+        assert out == {"category": "bug", "actionable": True, "confidence": "high", "reason": "x"}
+
+    def test_code_fenced_json(self):
+        text = '```json\n{"category": "feature", "actionable": false, "confidence": "low", "reason": "y"}\n```'
+        out = triage.parse_classification(text)
+        assert out["category"] == "feature"
+        assert out["actionable"] is False
+
+    def test_missing_keys_get_safe_defaults(self):
+        out = triage.parse_classification('{"category": "noise"}')
+        assert out == {"category": "noise", "actionable": False, "confidence": "low", "reason": ""}
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError):
+            triage.parse_classification("not json at all")
+
+
+class TestBuildDigest:
+    def test_lists_candidates_and_fixes(self):
+        body = triage.build_digest(
+            feature_candidates=[{"number": 5, "title": "add X"}],
+            fixed=[{"number": 9, "title": "fix Y"}],
+        )
+        assert "#5 add X" in body
+        assert "#9 fix Y" in body
+
+    def test_empty_sections_say_none(self):
+        body = triage.build_digest(feature_candidates=[], fixed=[])
+        assert body.count("_none this week_") == 2

--- a/automation/feedback_remediation/triage.py
+++ b/automation/feedback_remediation/triage.py
@@ -1,0 +1,254 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["claude-agent-sdk>=0.1.0"]
+# ///
+"""Feedback-remediation pilot — the Step-4 (AI-native) Agent-SDK pipeline.
+
+Nightly, this triages new GitHub issues (especially the ones the in-TUI feedback
+form files) and decides what to do with each:
+
+    bug + actionable + confident  -> label `claude-implement` (capped per run)
+                                     so claude.yml's implement job opens a fix PR
+    feature                       -> label `feature-candidate` (human decides)
+    question                      -> comment + `feedback:needs-info`
+    noise                         -> `feedback:noise` (never auto-closed)
+
+The SDK owns *triage + orchestration + rate-limiting*; fix *execution* is
+delegated to the existing `claude-implement` label pathway, so every automated
+fix flows through the same CI + advisory review + human-merge gate as human
+code. Labeling `claude-implement` IS "Claude kicks off Claude", composed through
+the proven workflow rather than duplicating checkout/push logic here.
+
+Safety: this process has `issues: write` only — it structurally cannot touch PRs
+or merge anything. It caps `claude-implement` labels per run, is idempotent via
+the `triaged` label cursor, skips bot-authored issues, and supports `--dry-run`.
+
+Run locally:  uv run automation/feedback_remediation/triage.py --dry-run
+Auth:         ANTHROPIC_API_KEY (the Agent SDK) + GH_TOKEN (the gh CLI).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as _dt
+import json
+import logging
+import re
+
+import github_io as gh
+
+try:
+    from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
+except ImportError:  # keeps the module importable for tests / lint without the SDK
+    ClaudeAgentOptions = ResultMessage = query = None  # type: ignore[assignment,misc]
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("feedback_remediation")
+
+# --- policy constants -------------------------------------------------------
+
+MAX_FIXES_PER_RUN = 3  # cap on claude-implement labels applied in one run
+
+# Labels whose presence means "not fresh feedback" — skip these issues entirely.
+SKIP_LABELS = frozenset({"triaged", "groomer-report", "flaky-test", "ci-sentinel", "ci-red-main"})
+SKIP_AUTHORS = frozenset({"github-actions[bot]", "dependabot[bot]"})
+
+# Feedback-form title prefixes → type label (a strong prior when labels were
+# dropped, which happens when the form files without a token).
+_TITLE_PREFIX = re.compile(r"^\[(bug|feature|improvement|other)\]", re.IGNORECASE)
+
+_AREAS = ("analysis", "planning", "standup", "retro", "performance", "reporting", "usage", "settings", "general")
+
+
+# --- pure helpers (unit-tested) --------------------------------------------
+
+
+def should_process(issue: dict) -> bool:
+    """True if the issue is fresh feedback worth triaging this run."""
+    if issue.get("author", {}).get("login") in SKIP_AUTHORS:
+        return False
+    labels = {label_dict["name"] for label_dict in issue.get("labels", [])}
+    return not (labels & SKIP_LABELS)
+
+
+def type_label_from_title(title: str) -> str | None:
+    """Infer a ``type:*`` label from the feedback-form title prefix, if present."""
+    match = _TITLE_PREFIX.match(title.strip())
+    if not match:
+        return None
+    kind = match.group(1).lower()
+    return f"type:{kind}"
+
+
+def parse_classification(text: str) -> dict:
+    """Extract the classification JSON, tolerating markdown code fences."""
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```[a-zA-Z]*\n?", "", cleaned)
+        cleaned = re.sub(r"\n?```$", "", cleaned).strip()
+    data = json.loads(cleaned)
+    return {
+        "category": str(data.get("category", "")).lower(),
+        "actionable": bool(data.get("actionable", False)),
+        "confidence": str(data.get("confidence", "low")).lower(),
+        "reason": str(data.get("reason", "")),
+    }
+
+
+# --- SDK calls --------------------------------------------------------------
+
+_CLASSIFY_SYSTEM = (
+    "You are a GitHub issue triager for a terminal AI Scrum Master app. You return ONLY a JSON object, no prose."
+)
+
+
+async def _ask(prompt: str, system: str, model: str) -> str:
+    """One SDK round-trip with no tools; return the final assistant text."""
+    if query is None:  # pragma: no cover - only when SDK missing
+        raise RuntimeError("claude-agent-sdk is not installed")
+    options = ClaudeAgentOptions(
+        model=model,
+        system_prompt=system,
+        allowed_tools=[],
+        max_turns=1,
+        permission_mode="dontAsk",
+    )
+    async for message in query(prompt=prompt, options=options):
+        if isinstance(message, ResultMessage):
+            return message.result
+    return ""
+
+
+async def classify(title: str, body: str) -> dict:
+    """Classify one issue with Haiku (cheap). Returns the parsed dict."""
+    prompt = (
+        f"Classify this issue.\n\nTitle: {title}\n\nBody:\n{body[:4000]}\n\n"
+        'Return ONLY JSON: {"category": "bug"|"feature"|"question"|"noise", '
+        '"actionable": true|false, "confidence": "high"|"medium"|"low", '
+        '"reason": "<one short sentence>"}. '
+        '"actionable" means a maintainer could act on it as-is without more info.'
+    )
+    raw = await _ask(prompt, _CLASSIFY_SYSTEM, model="haiku")
+    return parse_classification(raw)
+
+
+async def is_implementable(title: str, body: str) -> bool:
+    """Second-stage Sonnet check: is a bug specific enough to auto-implement?"""
+    prompt = (
+        f"An automated triager flagged this bug as actionable. Before we start an "
+        f"implementation run, confirm it is specific enough to fix WITHOUT asking "
+        f"the reporter any questions (clear repro or unambiguous expected behaviour).\n\n"
+        f"Title: {title}\n\nBody:\n{body[:4000]}\n\n"
+        'Return ONLY JSON: {"implementable": true|false}.'
+    )
+    raw = await _ask(prompt, _CLASSIFY_SYSTEM, model="sonnet")
+    try:
+        return bool(parse_classification(raw.replace("implementable", "actionable")).get("actionable"))
+    except (json.JSONDecodeError, ValueError):
+        return False
+
+
+# --- orchestration ----------------------------------------------------------
+
+
+async def triage_issue(issue: dict, fixes_used: int, max_fixes: int) -> int:
+    """Triage one issue and act. Returns the number of fixes consumed (0 or 1)."""
+    number = issue["number"]
+    title = issue["title"]
+    body = issue.get("body") or ""
+    consumed = 0
+
+    cls = await classify(title, body)
+    logger.info(
+        "#%s [%s] actionable=%s conf=%s — %s",
+        number,
+        cls["category"],
+        cls["actionable"],
+        cls["confidence"],
+        cls["reason"],
+    )
+
+    # Labels every triaged issue gets: the cursor + an inferred type label.
+    to_add = ["triaged"]
+    type_label = type_label_from_title(title)
+    if type_label:
+        to_add.append(type_label)
+
+    if cls["category"] == "bug" and cls["actionable"] and cls["confidence"] == "high":
+        if fixes_used < max_fixes and await is_implementable(title, body):
+            to_add.append("claude-implement")
+            consumed = 1
+            logger.info("#%s -> claude-implement (fix %s/%s)", number, fixes_used + 1, max_fixes)
+        else:
+            to_add.append("feedback:fix-queued")
+            logger.info("#%s -> fix queued (cap reached or not implementable)", number)
+    elif cls["category"] == "feature":
+        to_add.append("feature-candidate")
+    elif cls["category"] == "question":
+        to_add.append("feedback:needs-info")
+        gh.comment(
+            number,
+            "Thanks for the report! Could you add a bit more detail (steps to reproduce, "
+            "what you expected)? — automated triage",
+        )
+    elif cls["category"] == "noise":
+        to_add.append("feedback:noise")
+
+    gh.add_labels(number, to_add)
+    return consumed
+
+
+def build_digest(feature_candidates: list[dict], fixed: list[dict]) -> str:
+    """Render the weekly digest body from this run's feature/fix outcomes."""
+    lines = ["## Feedback digest", "", f"_Updated {_dt.date.today().isoformat()} by automated triage._", ""]
+    lines.append("### Feature candidates (awaiting a human `claude-implement`)")
+    lines += [f"- #{issue['number']} {issue['title']}" for issue in feature_candidates] or ["- _none this week_"]
+    lines += ["", "### Bugs sent to implementation this week"]
+    lines += [f"- #{issue['number']} {issue['title']}" for issue in fixed] or ["- _none this week_"]
+    return "\n".join(lines)
+
+
+async def run(dry_run: bool, do_digest: bool, max_fixes: int) -> None:
+    gh.set_dry_run(dry_run)
+    issues = [issue for issue in gh.list_open_issues() if should_process(issue)]
+    logger.info("triaging %s fresh issue(s) (dry_run=%s)", len(issues), dry_run)
+
+    fixes_used = 0
+    feature_candidates: list[dict] = []
+    fixed: list[dict] = []
+    for issue in issues:
+        consumed = await triage_issue(issue, fixes_used, max_fixes)
+        fixes_used += consumed
+        if consumed:
+            fixed.append(issue)
+
+    if do_digest:
+        # Re-list to catch feature-candidate labels applied this run.
+        for issue in issues:
+            names = {label_dict["name"] for label_dict in issue.get("labels", [])}
+            if "feature-candidate" in names or type_label_from_title(issue["title"]) == "type:feature":
+                feature_candidates.append(issue)
+        body = build_digest(feature_candidates, fixed)
+        existing = gh.find_open_issue_by_label("feedback-digest")
+        if existing:
+            gh.update_issue_body(existing, body)
+        else:
+            gh.create_issue("Feedback digest", body, ["feedback-digest"])
+
+    logger.info("done — %s issue(s) triaged, %s sent to implementation", len(issues), fixes_used)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Triage GitHub feedback issues.")
+    parser.add_argument("--dry-run", action="store_true", help="Log intended actions without changing anything.")
+    parser.add_argument("--digest", action="store_true", help="Also create/update the weekly feedback digest issue.")
+    parser.add_argument(
+        "--max-fixes", type=int, default=MAX_FIXES_PER_RUN, help="Cap on claude-implement labels this run."
+    )
+    args = parser.parse_args()
+    asyncio.run(run(dry_run=args.dry_run, do_digest=args.digest, max_fixes=args.max_fixes))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The Step-4 (AI-native) pilot — the repo's **first Claude Agent SDK** automation (every other Claude workflow uses the hosted `claude-code-action`). Nightly, it triages fresh GitHub issues (the in-TUI feedback form from #68 files them here) and routes each:

| Classification | Action |
|---|---|
| bug · actionable · high-confidence | Sonnet confirms it's specific enough → label `claude-implement` (capped **3/run**; overflow → `feedback:fix-queued`) |
| feature | `feature-candidate` (human decides) |
| question | comment + `feedback:needs-info` |
| noise | `feedback:noise` (never auto-closed) |

**The SDK owns triage/orchestration/rate-limiting only.** Fix *execution* is delegated to the existing `claude-implement` → `claude.yml` → CI → `claude-review` → **human-merge** pipeline. Labeling `claude-implement` is the "Claude kicks off Claude" hand-off, composed through the proven path instead of duplicating checkout/push here.

## Files

- `automation/feedback_remediation/triage.py` — PEP 723 script (`claude-agent-sdk`); Haiku classify + Sonnet implementability check; `triaged` label cursor; `--dry-run` / `--digest`.
- `github_io.py` — dry-run-aware `gh` CLI wrappers (no PyGithub).
- `test_triage.py` — **23 unit tests** for the pure helpers (filter, title-prefix inference, JSON parse, digest), no SDK/network. `uv run pytest automation/feedback_remediation/test_triage.py` → 23 passed.
- `feedback-remediation.yml` — nightly cron; `issues: write` only (structurally can't touch PRs/merge); manual runs default to dry-run.

## ⚠️ One-time setup required before enabling

**Add an `ANTHROPIC_API_KEY` secret** to the Actions store. The Agent SDK authenticates with an API key, **not** the Claude GitHub App's `CLAUDE_CODE_OAUTH_TOKEN` (that token only works with `claude-code-action`). Without it the nightly job errors; nothing else is affected. Verified against the current Agent SDK docs; the Python SDK is self-contained (no CLI install needed).

## Labels

All pipeline labels were **created on the repo** as part of this work — including **`claude-implement`, `type:*`, and `area:*`, which did not previously exist** (a latent gap: `claude.yml`'s implement job and the shipped feedback form both reference them). So `/babysit-prs`, the groomer, the feedback form, and this pilot now all have the labels they need.

## Safety

`issues: write` only · caps fixes/run · idempotent via `triaged` · skips bot authors · dry-run valve · never merges. Every automated fix still flows through the full CI + review + human-merge gate.

## Notes

- `automation/` is outside `src/`|`tests/`, so `make lint`/`test`/`security` (which scope there) are unaffected; the pilot is separately linted (ruff clean) and tested.
- Not enabled until the `ANTHROPIC_API_KEY` secret exists — safe to merge now; dry-run it first via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)