### PR TITLE
fix: self-heal stray core.bare in worktree scripts

### DIFF
--- a/scripts/wt-list.sh
+++ b/scripts/wt-list.sh
@@ -11,6 +11,10 @@ else
   GREEN=""; YELLOW=""; DIM=""; BOLD=""; RESET=""
 fi
 
+# Self-heal a stray `core.bare=true` left by an interrupted parallel session
+# (see scripts/wt.sh) so `make wt-list` never dies with "must be run in a work tree".
+git config core.bare false 2>/dev/null || true
+
 MAIN_ROOT="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
 
 printf "%s%-24s  %-7s  %s%s\n" "$BOLD" "BRANCH" "STATUS" "PATH" "$RESET"

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -23,6 +23,14 @@ NAME="${1:?usage: wt.sh <name> [open|headless|rm]}"
 ACTION="${2:-create}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Self-heal: a stray `core.bare=true` (left by an interrupted "clean checkout of
+# main" from a parallel session) makes every work-tree git command fail with
+# "this operation must be run in a work tree". This repo is never legitimately
+# bare, so force it off. `git config` writes the config file directly and works
+# even while the flag is set, so this must run BEFORE any rev-parse below.
+git -C "$SCRIPT_DIR" config core.bare false 2>/dev/null || true
+
 ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 # Always operate against the MAIN checkout, even when invoked from inside a
 # worktree (the main worktree is the first `git worktree list` entry).


### PR DESCRIPTION
## Problem

Running `make wt-new`, `make wt-list`, or even a plain `git pull` in this repo intermittently fails with:

```
fatal: this operation must be run in a work tree
```

Root cause: something sets `core.bare=true` in the shared `.git/config`. A bare repo has no working tree, so the flag strands **every** work-tree git command. The fingerprint (an orphan `tmp-main-check` worktree in a `/T/tmp.XXXX/` dir + `core.bare=true` left behind) points to an interrupted *"check out clean main somewhere temporary"* dance run by a parallel Claude/agent session:

```
git config core.bare true          # treat repo as bare so main checks out elsewhere
git worktree add /tmp/xxx/main-check
… inspect clean main …
git config core.bare false         # ← restore, skipped if the process is killed
```

If that process dies before the restore, `core.bare=true` is stranded. This repo is never legitimately bare.

## Fix

Reset `core.bare=false` at the top of `scripts/wt.sh` and `scripts/wt-list.sh`, **before** their first work-tree git call. `git config` writes the config file directly and works even while the flag is set, so the guard runs regardless of the stray state — `make wt-*` now self-heals instead of dying.

## Scope / limitations

- Covers the `make wt-*` targets. A bare `git pull` typed in the terminal is not wrapped by these scripts — recovery there stays `git config core.bare false`.
- Does not address *what* sets the flag (a separate parallel-session behaviour); this just makes the worktree tooling resilient to it.

## Test

- `bash -n` parses both scripts.
- Set `core.bare=true`, ran `make wt-list`: listed cleanly and left `core.bare=false` (previously errored out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)