### PR TITLE
show token creation links and required scopes on setup surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.24.0"
+version = "2.25.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,16 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.25.0",
+      "date": "2026-07-21",
+      "summary": "The token setup wizard now shows you exactly where to create each credential and what access to grant it. GitHub PAT, Azure DevOps PAT, and Jira/Notion/Confluence token fields display a clickable creation URL as an OSC-8 terminal hyperlink and show the required scopes underneath — the same scopes that power all your integrations. The Settings page's credential dashboard now shows these links and scopes too, so you can review them any time and quickly re-create or upgrade a token without searching the documentation.",
+      "highlights": [
+        {"text": "Setup wizard shows clickable token creation URLs and required scopes under each credential field", "areas": ["settings"]},
+        {"text": "Settings dashboard displays token creation links and scopes for every configured credential", "areas": ["settings"]},
+        {"text": "Scopes accurately reflect what each integration actually uses — GitHub repo access, Azure work-item creation, Jira ticket reads, etc.", "areas": ["settings"]}
+      ]
+    },
+    {
       "version": "2.24.0",
       "date": "2026-07-21",
       "summary": "You can now share real yeaboi output publicly without leaking anything private. Every mode's result screen — planning, analysis, standups, retros, performance, reporting, and roadmaps — has a new Anonymize button: press it and the sensitive words (people's names, team and project names, your company name, internal tools, and links) get masked right there in the same cards and tables — the layout never changes, only the words do, so it still reads as a realistic example. It uses AI for the smart cases and always masks the obvious company terms it already knows about, even offline. Refine it in plain language with Adjust (\"also hide this\", \"leave that — it's public\"), flip back to the real names with Revert, then copy the clean version to your clipboard or export it to Files, Notion, or Confluence. Great for READMEs, your website, and posts.",

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -3533,6 +3533,31 @@ def _build_settings_screen(
             r.append("not set", style=theme.dim)
         body_lines.append(r)
 
+    # Token help sub-lines: where to create the token + the minimum scope it needs.
+    # Sourced from the shared TOKEN_HELP registry (same one the setup wizard uses)
+    # so both token surfaces stay consistent. The creation URL is a clickable
+    # OSC-8 hyperlink; both lines are dim so they read as a secondary hint.
+    #
+    # Each line MUST render as exactly one visual row — the viewport height math
+    # below (visible = body_lines[scroll : scroll + viewport_h]) assumes one row
+    # per body line, so a wrapped line would overflow the fixed-height panel. We
+    # force single-row with no_wrap + ellipsis; the full scope is always visible in
+    # the setup wizard, and wide terminals show it in full here too.
+    from yeaboi.ui.provider_select._constants import TOKEN_HELP
+
+    def _token_help(env_var: str) -> None:
+        entry = TOKEN_HELP.get(env_var)
+        if not entry:
+            return
+        link = Text(_PAD + "      ", justify="left", no_wrap=True, overflow="ellipsis")
+        link.append("↳ create: ", style=theme.muted)
+        link.append(entry["url"], style=f"{theme.dim} underline link {entry['url']}")
+        body_lines.append(link)
+        scope = Text(_PAD + "        ", justify="left", no_wrap=True, overflow="ellipsis")
+        scope.append("scope: ", style=theme.muted)
+        scope.append(entry["scope"], style=theme.dim)
+        body_lines.append(scope)
+
     # ── LLM Provider ──────────────────────────────────────────────
     _heading("LLM Provider")
     _row("Provider", config_data.get("LLM_PROVIDER", "anthropic"))
@@ -3551,6 +3576,7 @@ def _build_settings_screen(
     _row("Base URL", config_data.get("JIRA_BASE_URL", ""))
     _row("Email", config_data.get("JIRA_EMAIL", ""))
     _row("API Token", config_data.get("JIRA_API_TOKEN", ""), masked=True)
+    _token_help("JIRA_API_TOKEN")
     _row("Project Key", config_data.get("JIRA_PROJECT_KEY", ""))
     _row("Confluence Space", config_data.get("CONFLUENCE_SPACE_KEY", ""))
 
@@ -3559,16 +3585,19 @@ def _build_settings_screen(
     _row("Org URL", config_data.get("AZURE_DEVOPS_ORG_URL", ""))
     _row("Project", config_data.get("AZURE_DEVOPS_PROJECT", ""))
     _row("PAT", config_data.get("AZURE_DEVOPS_TOKEN", ""), masked=True)
+    _token_help("AZURE_DEVOPS_TOKEN")
     _row("Team", config_data.get("AZURE_DEVOPS_TEAM", ""))
 
     # ── GitHub ────────────────────────────────────────────────────
     _heading("GitHub")
     _row("Token", config_data.get("GITHUB_TOKEN", ""), masked=True)
+    _token_help("GITHUB_TOKEN")
 
     # ── Notion ────────────────────────────────────────────────────
     # Independent doc tool (its own integration token, unlike Confluence).
     _heading("Notion")
     _row("Token", config_data.get("NOTION_TOKEN", ""), masked=True)
+    _token_help("NOTION_TOKEN")
     _row("Root Page/DB", config_data.get("NOTION_ROOT_PAGE_ID", ""))
 
     # ── Storage ───────────────────────────────────────────────────

--- a/src/yeaboi/ui/provider_select/_constants.py
+++ b/src/yeaboi/ui/provider_select/_constants.py
@@ -9,6 +9,40 @@ from __future__ import annotations
 from typing import Any
 
 # ---------------------------------------------------------------------------
+# Token help — where to create each credential token and the minimum scope it
+# needs. Single source of truth shared by the setup wizard (provider_select
+# screens) and the read-only Settings dashboard (mode_select), so the two token
+# surfaces stay consistent. Keyed by the token's env var.
+#
+# Scope text mirrors the per-token comments in .env.example and README.md — keep
+# them in sync. The scopes are the minimum the tools/*.py integrations actually
+# exercise (e.g. Azure DevOps creates work items, so it needs Work Items R/W).
+# ---------------------------------------------------------------------------
+TOKEN_HELP: dict[str, dict[str, str]] = {
+    "GITHUB_TOKEN": {
+        "url": "https://github.com/settings/tokens",
+        "scope": "Fine-grained: Contents Read · Issues Read · Metadata Read "
+        "(classic: public_repo, or repo for private)",
+    },
+    "AZURE_DEVOPS_TOKEN": {
+        "url": "https://dev.azure.com",
+        "scope": "Work Items Read & Write · Project and Team Read · Code Read",
+    },
+    "JIRA_API_TOKEN": {
+        "url": "https://id.atlassian.com/manage-profile/security/api-tokens",
+        "scope": "Token inherits your Jira role — account needs browse project, create/edit issues, manage sprints",
+    },
+    "NOTION_TOKEN": {
+        "url": "https://notion.so/my-integrations",
+        "scope": "Capabilities: Read + Insert + Update content — then share your pages with the integration",
+    },
+    "CONFLUENCE_API_TOKEN": {
+        "url": "https://id.atlassian.com/manage-profile/security/api-tokens",
+        "scope": "Account needs view + create/update pages (and attachments) in the target space",
+    },
+}
+
+# ---------------------------------------------------------------------------
 # Provider definitions (order matters — matches row layout top-to-bottom)
 # ---------------------------------------------------------------------------
 

--- a/src/yeaboi/ui/provider_select/screens/_screens.py
+++ b/src/yeaboi/ui/provider_select/screens/_screens.py
@@ -7,13 +7,14 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from rich.align import Align
 from rich.panel import Panel
 from rich.text import Text
 
-from yeaboi.ui.provider_select._constants import _PROVIDER_CARDS
+from yeaboi.ui.provider_select._constants import _PROVIDER_CARDS, TOKEN_HELP
 from yeaboi.ui.provider_select._verification import _validate_key
 from yeaboi.ui.shared._animations import shimmer_style
 from yeaboi.ui.shared._ascii_font import render_ascii_text
@@ -37,6 +38,66 @@ _ACCENT = "rgb(70,100,180)"
 _FRAME_TITLE_ROWS = 6
 _FRAME_HEADER_H = _FRAME_TITLE_ROWS + 3  # title + blank + subtitle + blank
 _FRAME_FOOTER_H = 2  # blank + progress bar
+
+# Field-hint palette. The where-to-get-it line is styled as *help*, distinct from
+# the pure-dim keyboard footer and the red error line: soft blue-grey lead-in
+# prose with a brighter/underlined + clickable URL so the eye lands on the
+# actionable part. Shared with _screens_vc.py's hint renderer.
+_HINT_MUTED = "rgb(120,130,150)"
+_HINT_URL = "rgb(140,170,235)"
+_SCOPE_LOCK = "rgb(150,150,120)"
+
+# Matches the first URL / domain-path token in a hint (the actionable bit): a
+# full http(s) URL, or a lowercase domain (any 2+ letter TLD — .com, .so, .net…)
+# with an optional path. Bounded by whitespace/commas so trailing prose
+# ("…, then share …") isn't swallowed, and lowercase-only so uppercase prose like
+# "MYPROJ-123" never false-matches.
+_HINT_URL_RE = re.compile(r"https?://[^\s,]+|[a-z0-9][a-z0-9.-]*\.[a-z]{2,}(?:/[^\s,]*)?")
+
+
+def _link_target(matched: str) -> str:
+    """Full https URL for an OSC-8 hyperlink from a matched URL/domain token."""
+    return matched if matched.startswith("http") else f"https://{matched}"
+
+
+def _linkify(text: str, *, lead_style: str, url_style: str, justify: str = "center") -> Text:
+    """Render prose with its first URL/domain token as a clickable OSC-8 link.
+
+    The matched URL span carries a ``link <url>`` attribute (Rich emits an OSC-8
+    hyperlink) plus ``url_style`` + underline; surrounding prose uses
+    ``lead_style``. Text with no URL renders entirely in ``lead_style``. Pure
+    rendering — returns a Rich ``Text``.
+    """
+    out = Text(justify=justify)
+    match = _HINT_URL_RE.search(text)
+    if match:
+        url = _link_target(match.group(0))
+        out.append(text[: match.start()], style=lead_style)
+        out.append(match.group(0), style=f"{url_style} underline link {url}")
+        out.append(text[match.end() :], style=lead_style)
+    else:
+        out.append(text, style=lead_style)
+    return out
+
+
+def _build_scope_text(scope: str, *, style: str = _HINT_MUTED) -> Text:
+    """Render a required-scope help line for a credential token.
+
+    A leading lock glyph flags the line as an access requirement; the scope text
+    is rendered in the muted help style. Pairs with the where-to-get-it link so a
+    user filling in a token sees both *where to create it* and *what access to
+    grant it*. Pure rendering.
+
+    The line is forced to a single visual row (``no_wrap`` + ellipsis): the
+    callers reserve exactly one row in their ``body_height`` math, so a wrapped
+    scope would drift the frame's centering / progress footer. Full scope shows on
+    normal-width terminals and truncates gracefully on narrow ones (mirrors the
+    settings dashboard's token-help lines).
+    """
+    text = Text(justify="center", no_wrap=True, overflow="ellipsis")
+    text.append("\U0001f512  ", style=_SCOPE_LOCK)  # 🔒 lock glyph
+    text.append(f"Scope: {scope}", style=style)
+    return text
 
 
 def _build_progress(current_step: int) -> Text:
@@ -256,8 +317,12 @@ def _build_input_screen(
 
     # The provider identity is carried by the tall ANSI-Shadow frame title now, so
     # the body starts at the instructions (no duplicate compact provider art).
-    instr_style = input_fade if input_fade else "dim"
-    instructions = Text(provider["instructions"], style=instr_style, justify="center")
+    # The "get yours at: <url>" line renders the URL as a clickable OSC-8 link;
+    # during the fade-in animation we keep it flat so the whole line fades evenly.
+    if input_fade:
+        instructions = Text(provider["instructions"], style=input_fade, justify="center")
+    else:
+        instructions = _linkify(provider["instructions"], lead_style="dim", url_style=_HINT_URL)
 
     # Realtime format validation
     status, validation_hint = _validate_key(provider, input_value)
@@ -337,15 +402,23 @@ def _build_input_screen(
             justify="center",
         )
 
-    body = [
-        Align.center(instructions),
+    # Required-scope line for credential tokens (not shown for LLM API keys, which
+    # don't have granular scopes). Suppressed during the fade animation so the
+    # intro reads cleanly, matching the keyboard hint above.
+    _help = TOKEN_HELP.get(provider["env_var"])
+    show_scope = _help is not None and not input_fade
+
+    body = [Align.center(instructions)]
+    if show_scope:
+        body.append(Align.center(_build_scope_text(_help["scope"])))
+    body += [
         Text(""),
         Align.center(input_box),
         Align.center(status_text),
         Align.center(error_text),
         Align.center(hint_text),
     ]
-    body_h = 9  # instructions(1) + blank + input_box(5) + status + error + hint
+    body_h = 9 + (1 if show_scope else 0)  # instructions[+scope] + blank + input_box(5) + status + error + hint
 
     return _build_screen_frame(
         subtitle="Enter your API key",

--- a/src/yeaboi/ui/provider_select/screens/_screens_vc.py
+++ b/src/yeaboi/ui/provider_select/screens/_screens_vc.py
@@ -7,51 +7,44 @@
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from rich.align import Align
 from rich.panel import Panel
 from rich.text import Text
 
-from yeaboi.ui.provider_select._constants import _ISSUE_TRACKING_FIELDS, _VC_OPTIONS
+from yeaboi.ui.provider_select._constants import _ISSUE_TRACKING_FIELDS, _VC_OPTIONS, TOKEN_HELP
 from yeaboi.ui.provider_select.screens._screens import (
     _ACCENT,
     _FRAME_FOOTER_H,
     _FRAME_HEADER_H,
+    _HINT_MUTED,
+    _HINT_URL,
+    _HINT_URL_RE,
     _build_provider_row,
+    _build_scope_text,
     _build_screen_frame,
+    _link_target,
+    _linkify,
 )
-
-# Field-hint palette. The where-to-get-it line is styled as *help*, distinct from
-# the pure-dim keyboard footer and the red error line: an accent-blue info glyph,
-# soft blue-grey lead-in text, and a brighter/underlined URL so the eye lands on
-# the actionable part.
-_HINT_MUTED = "rgb(120,130,150)"
-_HINT_URL = "rgb(140,170,235)"
-
-# Matches the first URL / domain-path token in a hint (the actionable bit): a
-# full http(s) URL, or a lowercase domain (any 2+ letter TLD — .com, .so, .net…)
-# with an optional path. Bounded by whitespace/commas so trailing prose
-# ("…, then share …") isn't swallowed, and lowercase-only so uppercase prose like
-# "MYPROJ-123" never false-matches.
-_HINT_URL_RE = re.compile(r"https?://[^\s,]+|[a-z0-9][a-z0-9.-]*\.[a-z]{2,}(?:/[^\s,]*)?")
 
 
 def _build_hint_text(hint: str) -> Text:
-    """Render a where-to-get-it hint with an info glyph and emphasized URL.
+    """Render a where-to-get-it hint with an info glyph and clickable URL.
 
     The leading ``ⓘ`` glyph (accent blue) flags the line as help; the lead-in
-    prose is soft blue-grey; any URL/domain token is brightened + underlined so
-    the actionable part stands out. Hints without a URL render entirely in the
-    muted style. Pure rendering — returns a centered Rich ``Text``.
+    prose is soft blue-grey; any URL/domain token is brightened, underlined and
+    rendered as a clickable OSC-8 hyperlink so the actionable part stands out.
+    Hints without a URL render entirely in the muted style. Pure rendering —
+    returns a centered Rich ``Text``.
     """
     text = Text(justify="center")
     text.append("ⓘ  ", style=_ACCENT)  # ⓘ info glyph
     match = _HINT_URL_RE.search(hint)
     if match:
+        url = _link_target(match.group(0))
         text.append(hint[: match.start()], style=_HINT_MUTED)
-        text.append(match.group(0), style=f"{_HINT_URL} underline")
+        text.append(match.group(0), style=f"{_HINT_URL} underline link {url}")
         text.append(hint[match.end() :], style=_HINT_MUTED)
     else:
         text.append(hint, style=_HINT_MUTED)
@@ -121,9 +114,13 @@ def _build_vc_input_screen(
     """Build the PAT token input screen for version control."""
     import rich.box
 
-    # Provider identity is carried by the tall ANSI-Shadow frame title.
-    instr_style = input_fade if input_fade else "dim"
-    instructions = Text(vc["instructions"], style=instr_style, justify="center")
+    # Provider identity is carried by the tall ANSI-Shadow frame title. The
+    # "get yours at: <url>" line renders the URL as a clickable OSC-8 link; during
+    # the fade-in animation we keep it flat so the whole line fades evenly.
+    if input_fade:
+        instructions = Text(vc["instructions"], style=input_fade, justify="center")
+    else:
+        instructions = _linkify(vc["instructions"], lead_style="dim", url_style=_HINT_URL)
 
     box_inner_w = min(70, width - 10) - 2 - 4
     display_val = "\u2022" * len(input_value)
@@ -169,13 +166,22 @@ def _build_vc_input_screen(
     else:
         status_text = Text("")
 
+    # Required-scope line for the PAT — shown under the input box so the user
+    # sees what access to grant it. Hidden during the fade-in so the intro reads
+    # cleanly. GitHub is the only VC token, but keying off TOKEN_HELP keeps this
+    # generic for any future provider.
+    help_entry = TOKEN_HELP.get(vc["env_var"])
+    show_scope = help_entry is not None and not input_fade
+
     body = [
         Align.center(instructions),
         Text(""),
         Align.center(input_box),
         Align.center(status_text),
     ]
-    body_h = 8
+    if show_scope:
+        body.append(Align.center(_build_scope_text(help_entry["scope"])))
+    body_h = 8 + (1 if show_scope else 0)
 
     return _build_screen_frame(
         subtitle="Enter your PAT token",
@@ -351,6 +357,15 @@ def _build_issue_tracking_screen(
         hint = field.get("hint", "")
         if hint and is_active and not err and not border_overrides:
             body.append(_build_hint_text(hint))
+            body_h += 1
+
+        # Required-scope line for credential-token fields (Azure DevOps PAT, Jira/
+        # Notion/Confluence tokens) — shown under the where-to-get-it hint on the
+        # focused field so the user sees both where to create the token and what
+        # access to grant it. Same suppression rules as the hint above.
+        help_entry = TOKEN_HELP.get(field["env_var"])
+        if help_entry and is_active and not err and not border_overrides:
+            body.append(_build_scope_text(help_entry["scope"]))
             body_h += 1
 
     # Keyboard hint — makes editing/clearing/skipping discoverable, matching the

--- a/tests/unit/test_provider_model_select.py
+++ b/tests/unit/test_provider_model_select.py
@@ -20,9 +20,12 @@ from yeaboi.ui.provider_select._config import _save_progress
 from yeaboi.ui.provider_select._constants import (
     _AZDEVOPS_TRACKING_FIELDS,
     _CONFLUENCE_FIELDS,
+    _CONFLUENCE_STANDALONE_FIELDS,
     _ISSUE_TRACKING_FIELDS,
     _NOTION_FIELDS,
     _PROVIDER_CARDS,
+    _VC_OPTIONS,
+    TOKEN_HELP,
 )
 from yeaboi.ui.provider_select._nav import (
     _LAST_STEP,
@@ -38,13 +41,20 @@ from yeaboi.ui.provider_select._verification import (
 )
 from yeaboi.ui.provider_select.screens._screens import (
     _STEPS,
+    _build_input_screen,
     _build_model_input_screen,
     _build_model_loading_screen,
     _build_model_select_screen,
     _build_progress,
     _build_screen_frame,
+    _link_target,
+    _linkify,
 )
-from yeaboi.ui.provider_select.screens._screens_vc import _build_hint_text, _build_issue_tracking_screen
+from yeaboi.ui.provider_select.screens._screens_vc import (
+    _build_hint_text,
+    _build_issue_tracking_screen,
+    _build_vc_input_screen,
+)
 from yeaboi.ui.shared._wordmarks import get_shadow_wordmark
 
 # ---------------------------------------------------------------------------
@@ -775,6 +785,84 @@ class TestConnectionFieldHints:
     def test_all_fields_have_hints(self, fields):
         for field in fields:
             assert field.get("hint"), f"{field['env_var']} is missing a where-to-get-it hint"
+
+
+class TestLinkify:
+    """`_linkify` / `_link_target` — clickable-URL rendering helpers."""
+
+    def test_link_target_keeps_full_url(self):
+        assert _link_target("https://github.com/settings/tokens") == "https://github.com/settings/tokens"
+
+    def test_link_target_prefixes_bare_domain(self):
+        assert _link_target("id.atlassian.com/x") == "https://id.atlassian.com/x"
+
+    def test_linkify_wraps_url_span(self):
+        text = _linkify("Get yours at: https://example.com/x", lead_style="dim", url_style="blue")
+        assert text.plain == "Get yours at: https://example.com/x"
+        assert any("link https://example.com/x" in str(sp.style) for sp in text.spans)
+
+    def test_linkify_no_url_renders_plainly(self):
+        text = _linkify("no link here at all", lead_style="dim", url_style="blue")
+        assert text.plain == "no link here at all"
+        assert not any("link " in str(sp.style) for sp in text.spans)
+
+
+class TestTokenHelp:
+    """Credential-token screens surface the required scope + a clickable link."""
+
+    def test_hint_url_is_clickable(self):
+        # The where-to-get-it URL is rendered as an OSC-8 hyperlink (Rich `link`
+        # style) so it's click/cmd-clickable in modern terminals.
+        text = _build_hint_text("Create at: id.atlassian.com/manage-profile/security/api-tokens")
+        assert any("link https://id.atlassian.com" in str(sp.style) for sp in text.spans)
+
+    def test_scope_line_shown_for_token_field(self):
+        # Field 2 of the Azure DevOps form is AZURE_DEVOPS_TOKEN → its scope shows.
+        out = _render(
+            _build_issue_tracking_screen(
+                2, {}, width=100, height=30, fields=_AZDEVOPS_TRACKING_FIELDS, title_text="Azure"
+            )
+        )
+        assert "Work Items" in out
+
+    def test_no_scope_line_for_non_token_field(self):
+        # Field 0 is AZURE_DEVOPS_ORG_URL (not a credential) → no scope line.
+        out = _render(
+            _build_issue_tracking_screen(
+                0, {}, width=100, height=30, fields=_AZDEVOPS_TRACKING_FIELDS, title_text="Azure"
+            )
+        )
+        assert "Scope:" not in out
+
+    def test_github_pat_screen_shows_scope(self):
+        # _VC_OPTIONS[0] is GitHub → the PAT screen shows the required scope.
+        out = _render(_build_vc_input_screen(_VC_OPTIONS[0], "ghp_x", width=100, height=30))
+        assert "Contents Read" in out
+
+    def test_llm_key_screen_has_no_scope(self):
+        # LLM API keys have no granular scopes — the scope line must not appear.
+        out = _render(_build_input_screen(_PROVIDER_CARDS[0], "sk-ant-x", width=100, height=30))
+        assert "Scope:" not in out
+
+    def test_registry_entries_complete(self):
+        for env_var, entry in TOKEN_HELP.items():
+            assert entry.get("url", "").startswith("http"), f"{env_var} url"
+            assert entry.get("scope"), f"{env_var} scope"
+
+    def test_masked_token_fields_are_covered(self):
+        # Every API-token credential in the connection forms is covered by
+        # TOKEN_HELP so the user always sees what access to grant. (Space keys /
+        # page ids are masked=False and not credentials — they stay uncovered.)
+        credential_env = {"JIRA_API_TOKEN", "AZURE_DEVOPS_TOKEN", "NOTION_TOKEN", "CONFLUENCE_API_TOKEN"}
+        for fields in (
+            _ISSUE_TRACKING_FIELDS,
+            _AZDEVOPS_TRACKING_FIELDS,
+            _NOTION_FIELDS,
+            _CONFLUENCE_STANDALONE_FIELDS,
+        ):
+            for field in fields:
+                if field["env_var"] in credential_env:
+                    assert field["env_var"] in TOKEN_HELP, f"{field['env_var']} missing scope help"
 
 
 class TestHintStyling:

--- a/tests/unit/test_shared_components.py
+++ b/tests/unit/test_shared_components.py
@@ -434,12 +434,15 @@ class TestSettingsScreen:
         return buf.getvalue()
 
     def test_storage_section_rendered(self):
-        output = self._render({"YEABOI_HOME": "/data/yeaboi"})
+        # Storage sits below the token sections (each of which now carries a
+        # create-link + scope sub-line), so render tall enough to bring it into
+        # the viewport rather than requiring a scroll.
+        output = self._render({"YEABOI_HOME": "/data/yeaboi"}, height=80)
         assert "Storage" in output
         assert "/data/yeaboi" in output
 
     def test_data_dir_default_label_when_unset(self):
-        output = self._render({})
+        output = self._render({}, height=80)
         assert "~/.yeaboi (default)" in output
 
     def test_data_dir_button_rendered(self):
@@ -453,6 +456,32 @@ class TestSettingsScreen:
     def test_notion_token_masked(self):
         output = self._render({"NOTION_TOKEN": "ntn_verysecretvalue12345"})
         assert "verysecretvalue12345" not in output
+
+    def test_token_help_link_and_scope_rendered(self):
+        # Each token row carries a "create: <url> · scope: <...>" sub-line so a
+        # user knows where to make the token and what access to grant it.
+        output = self._render(
+            {"GITHUB_TOKEN": "ghp_x", "AZURE_DEVOPS_TOKEN": "az", "JIRA_API_TOKEN": "jt", "NOTION_TOKEN": "nt"},
+            height=80,
+        )
+        assert "create:" in output
+        assert "scope:" in output
+        assert "github.com/settings/tokens" in output  # creation link
+        assert "Work Items" in output  # Azure scope text
+
+    def test_token_help_url_is_clickable(self):
+        # The creation URL is an OSC-8 hyperlink in the read-only dashboard too.
+        from io import StringIO
+
+        from rich.console import Console
+
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_settings_screen
+
+        result = _build_settings_screen({"GITHUB_TOKEN": "ghp_x"}, width=120, height=80)
+        buf = StringIO()
+        Console(file=buf, width=120, force_terminal=True).print(result)
+        assert "https://github.com/settings/tokens" in buf.getvalue()
+        assert "\x1b]8;" in buf.getvalue()  # OSC-8 hyperlink escape
 
 
 class TestCollectSettingsData:

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.23.0"
+version = "2.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

Configuring integration tokens (GitHub PAT, Azure DevOps PAT, Jira/Notion/Confluence tokens) previously required a user to already know **where to create the token** and **what access to grant it** — that info lived only in `.env.example` comments and the README, never in the UI. This adds both, right where tokens are entered and reviewed.

- **Shared registry** — new `TOKEN_HELP` in `provider_select/_constants.py` maps each credential env var → `{url, scope}`. Single source of truth consumed by both token surfaces, so they stay consistent. Scope text mirrors `.env.example`/README and reflects what each `tools/*.py` integration actually calls (e.g. Azure DevOps creates work items → Work Items Read & Write).
- **Setup wizard** — creation URLs now render as **clickable OSC-8 terminal hyperlinks**; a `🔒 Scope: …` line appears under each credential token field (GitHub PAT screen + the Jira/Azure/Notion/Confluence multi-field forms). LLM API-key screens show no scope line (no granular scopes).
- **Read-only Settings dashboard** — each token row gains a dim `↳ create: <clickable url>` + `scope: …` sub-line.
- Scope/help lines are forced single-row (`no_wrap` + ellipsis) so the wizard frame's centering and the dashboard's fixed-height viewport keep their layout on narrow terminals; full scope shows on normal-width terminals.

An independent fresh-context review flagged one should-fix (wizard scope line could wrap and drift the progress footer at ~80 cols) — addressed by the single-row guard above — plus a test-coverage nit, addressed with direct `_linkify`/`_link_target` tests.

The commit also syncs `uv.lock` to a pre-existing pyproject version bump (2.23.0 → 2.24.0) that `uv run` rewrites on every invocation.

## Test plan

- `make lint` — clean
- `make test` — **4818 passed, 16 skipped, 0 failed**
- New tests: `TestTokenHelp` + `TestLinkify` (scope rendering, OSC-8 hyperlink emission, registry completeness, every masked credential field covered, no-scope on LLM/non-token fields) in `test_provider_model_select.py`; settings-dashboard link+scope + clickable-URL assertions in `test_shared_components.py`
- Verified single-row scope rendering at widths 80 and 100 (no orphan continuation rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)