### PR TITLE
AI-usage & documentation analysis for team-analysis mode

### DIFF
--- a/claude-plugin/yeaboi/skills/team-analysis/SKILL.md
+++ b/claude-plugin/yeaboi/skills/team-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-analysis
-description: "Analyse a team's Jira/Azure DevOps history with yeaboi into a calibration profile: velocity, story-point calibration, estimation accuracy, writing style, and coaching insights. Use when the user asks how the team is performing, wants velocity/estimation analysis, coaching insights, or to calibrate planning to the team's real delivery data."
+description: "Analyse a team's Jira/Azure DevOps history with yeaboi into a calibration profile: velocity, story-point calibration, estimation accuracy, writing style, AI-tool adoption, documentation clarity + AI-usage, and coaching insights. Use when the user asks how the team is performing, wants velocity/estimation analysis, how the team uses AI, whether their docs are clear, coaching insights, or to calibrate planning to the team's real delivery data."
 ---
 
 # Team analysis with yeaboi
@@ -13,13 +13,32 @@ description: "Analyse a team's Jira/Azure DevOps history with yeaboi into a cali
    LLM calls — it takes minutes. Tell the user before calling it. Options:
    `source` ('jira'/'azdevops', auto-detected when blank), `sprint_count`
    (default 8 closed sprints), `include_insights` (start/stop/keep/try
-   coaching), `generate_samples` (sample tickets in the team's style — extra
-   LLM calls, only when asked).
+   coaching), `include_ai_usage` (scan the team's commits/PRs for AI-tool
+   markers — on by default), `include_doc_quality` (read recent
+   Notion/Confluence pages for clarity + AI-usage — on by default),
+   `generate_samples` (sample tickets in the team's
+   style — extra LLM calls, only when asked).
 
 3. **Present it in layers.** Lead with the headline stats (velocity ± stddev,
    estimation accuracy, sprint completion), then the coaching `insights` as
-   start/stop/keep/try, then offer to go deeper into calibration or writing
+   start/stop/keep/try, then the **AI adoption** footprint (`profile.ai_adoption`
+   + `examples.ai_adoption`), then offer to go deeper into calibration or writing
    patterns from the profile. Surface any `warnings`.
+
+   **AI adoption is a LOWER BOUND** — it only counts AI tools that leave a marker
+   in commit messages or PR descriptions (Co-Authored-By: Claude, Copilot, Cursor,
+   …). Inline IDE assist (Copilot ghost-text, Cursor Tab) leaves no trace, so real
+   usage is at least the reported footprint. Never tell the user the team "doesn't
+   use AI" from a low number — frame it as *detectable* usage and coach on making
+   it broader and more visible.
+
+   Then the **Documentation** read (`profile.doc_quality` + `examples.doc_quality`):
+   an average clarity score (0–100), a clear/mixed/unclear split, and how AI shows
+   up in the writing. Two different confidence levels — never conflate them:
+   **clarity** is a readability score; **AI-likelihood** is a *stylometric estimate*,
+   NOT a detection (prose carries no reliable AI marker — never assert a page "was
+   written by AI"); **explicit AI markers** are a lower bound. Coach on clearer
+   writing and effective AI use, not on policing.
 
 4. **Close the loop.** The saved profile automatically calibrates future
    `plan_generate` runs. For "how did the last plan actually go?", call

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.26.0"
+version = "2.27.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/analysis/ai_usage.py
+++ b/src/yeaboi/analysis/ai_usage.py
@@ -1,0 +1,687 @@
+"""AI-adoption footprint — detect how much of a team's tracked work shows an AI-tool trace.
+
+# See README: "Architecture" — engines are UI-free pipelines; this is a sub-analysis
+# of team-analysis mode (CLAUDE.md "REQUIRED: Surface Parity" — the TUI/CLI/MCP are
+# thin adapters over ``analysis/engine.py:run_team_analysis``, which calls into here).
+
+What this does
+--------------
+Fans out over the team's code sources (GitHub, local git clone, Azure DevOps),
+pulls recent commits + PRs *with their message bodies / descriptions*, and scans
+that text for markers left by AI coding tools — ``Co-Authored-By: Claude``,
+"Generated with Claude Code", Copilot's co-author line, Cursor / aider / Devin /
+Codeium, and a catch-all AI trailer. It then aggregates a per-tool / per-author /
+per-activity-type breakdown into an :class:`AiAdoptionSignal` and coaches the lead
+on improving adoption (start / stop / keep / try).
+
+Honesty contract — LOWER BOUND, never ground truth
+--------------------------------------------------
+Only tools that leave a *textual* trace in commit/PR metadata are counted. Inline
+IDE assist (Copilot ghost-text, Cursor Tab) leaves no trace, so real usage is
+always *at least* the reported footprint. Every surface must frame it that way;
+``AiAdoptionSignal.is_lower_bound`` stays ``True`` to force it.
+
+Error contract
+--------------
+Everything here is best-effort and NEVER raises: a missing SDK/credential or a
+failing source contributes zero and is recorded as a coverage gap. ``run_ai_adoption``
+wraps the whole thing so the analysis pipeline can call it unguarded.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+
+from yeaboi.team_profile import AiAdoptionSignal
+
+logger = logging.getLogger(__name__)
+
+# Look-back window for the commit/PR scan. The recent-activity helpers cap at ~100
+# rows/source, so this is a "recent sample" for a footprint %, not an exhaustive audit.
+_SCAN_DAYS = 120
+
+# ---------------------------------------------------------------------------
+# Marker table — extensible. Each entry: (tool_id, compiled regex over commit/PR text).
+# Order matters: ``other_ai`` is the last-resort catch-all and is suppressed when a
+# specific tool already matched (see _classify_ai_markers).
+# ---------------------------------------------------------------------------
+_AI_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "claude",
+        re.compile(
+            r"co-authored-by:\s*claude|generated with \[?claude code|noreply@anthropic\.com|claude\.com/claude-code",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "copilot",
+        re.compile(
+            r"github-copilot\[bot\]|co-authored-by:.*copilot|copilot@github\.com|gpt-4-copilot",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "cursor",
+        re.compile(r"co-authored-by:.*cursor|\bcursor\s*(ai|assistant|agent)\b|cursor\.com", re.IGNORECASE),
+    ),
+    (
+        "aider",
+        re.compile(r"co-authored-by:.*aider|\baider\b\s*(commit|edit|chat)?|aider\.chat", re.IGNORECASE),
+    ),
+    (
+        "devin",
+        re.compile(r"co-authored-by:.*devin|\bdevin[\s\-]?ai\b|devin\.ai", re.IGNORECASE),
+    ),
+    (
+        "codeium",
+        re.compile(r"co-authored-by:.*(codeium|windsurf)|\bcodeium\b|\bwindsurf\b", re.IGNORECASE),
+    ),
+    # Catch-all: an explicit co-author/trailer that names *some* AI/bot but matched
+    # none of the specific tools above. Kept last; suppressed when a specific hit exists.
+    (
+        "other_ai",
+        re.compile(r"co-authored-by:.*\b(ai|assistant|bot|llm|gpt|agent)\b", re.IGNORECASE),
+    ),
+)
+
+# A commit whose subject looks documentation-shaped is bucketed as "docs", not "code".
+_DOCS_TITLE = re.compile(r"\breadme\b|\bdocs?/|\.md\b|\bdocumentation\b|\bchangelog\b", re.IGNORECASE)
+
+# Human-readable source labels — the raw tags ("local_git") don't tell the user whether
+# they scanned their local clone or the remote repo. Single source of truth for renderers.
+_SOURCE_LABELS: dict[str, str] = {
+    "local_git": "Local clone",
+    "github": "GitHub (remote)",
+    "azdo": "Azure DevOps (remote)",
+}
+
+
+def _source_label(tag: str) -> str:
+    """Friendly label for a source tag ('local_git' → 'Local clone'); passthrough otherwise."""
+    return _SOURCE_LABELS.get(tag, tag)
+
+
+def _classify_ai_markers(text: str) -> set[str]:
+    """Return the set of AI-tool ids whose markers appear in ``text``.
+
+    Pure, no I/O — the core unit-test seam. ``other_ai`` is dropped when a specific
+    tool matched, so a Claude commit that also has a generic ``Co-Authored-By`` line
+    is credited to "claude", not double-counted. Returns ``set()`` for empty text.
+    """
+    if not text:
+        return set()
+    hits: set[str] = set()
+    for tool_id, pattern in _AI_MARKERS:
+        if pattern.search(text):
+            hits.add(tool_id)
+    if len(hits) > 1:
+        hits.discard("other_ai")
+    return hits
+
+
+def _activity_bucket(item: dict) -> str:
+    """Map a normalized activity item to an adoption activity type: pr / docs / code."""
+    if item.get("kind") == "pr":
+        return "pr"
+    if _DOCS_TITLE.search(str(item.get("title", ""))):
+        return "docs"
+    return "code"
+
+
+def aggregate_ai_markers(items: list[dict]) -> AiAdoptionSignal:
+    """Aggregate scanned commit/PR items into an :class:`AiAdoptionSignal`.
+
+    Pure over its input (no network). Each item is a normalized activity dict with
+    ``kind`` ('commit'/'pr'), ``author``, ``title``, optional ``body``, and
+    ``source``. An item is "AI-marked" when :func:`_classify_ai_markers` over its
+    ``title + body`` is non-empty. Returns an all-zero signal for an empty list.
+    """
+    scanned_commits = scanned_prs = ai_commits = ai_prs = 0
+    per_tool: dict[str, int] = {}
+    per_author: dict[str, int] = {}
+    per_activity: dict[str, int] = {}
+    per_source: dict[str, int] = {}
+    sources: list[str] = []
+
+    for item in items:
+        kind = item.get("kind")
+        is_pr = kind == "pr"
+        if is_pr:
+            scanned_prs += 1
+        elif kind == "commit":
+            scanned_commits += 1
+        else:
+            continue  # only commits/PRs carry an AI footprint
+
+        src = str(item.get("source", "")).strip()
+        if src and src not in sources:
+            sources.append(src)
+
+        tools = _classify_ai_markers(f"{item.get('title', '')}\n{item.get('body', '')}")
+        if not tools:
+            continue
+
+        if is_pr:
+            ai_prs += 1
+        else:
+            ai_commits += 1
+        for t in tools:
+            per_tool[t] = per_tool.get(t, 0) + 1
+        author = (item.get("author") or "").strip() or "unknown"
+        per_author[author] = per_author.get(author, 0) + 1
+        bucket = _activity_bucket(item)
+        per_activity[bucket] = per_activity.get(bucket, 0) + 1
+        if src:
+            per_source[src] = per_source.get(src, 0) + 1
+
+    scanned = scanned_commits + scanned_prs
+    footprint = round((ai_commits + ai_prs) / scanned * 100, 1) if scanned else 0.0
+
+    def _sorted_pairs(d: dict[str, int]) -> tuple[tuple[str, int], ...]:
+        return tuple(sorted(d.items(), key=lambda kv: (-kv[1], kv[0])))
+
+    return AiAdoptionSignal(
+        scanned_commits=scanned_commits,
+        scanned_prs=scanned_prs,
+        ai_commits=ai_commits,
+        ai_prs=ai_prs,
+        footprint_pct=footprint,
+        per_tool=_sorted_pairs(per_tool),
+        per_author=_sorted_pairs(per_author),
+        per_activity=_sorted_pairs(per_activity),
+        per_source=_sorted_pairs(per_source),
+        sources_scanned=tuple(sources),
+        is_lower_bound=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data gathering — graceful, best-effort fan-out (mirrors standup/collector.py)
+# ---------------------------------------------------------------------------
+
+
+def _discover_local_repo() -> str:
+    """Return a local git working-copy path to scan, or "".
+
+    Uses the current working directory when it is a git repo — the natural case
+    for ``yeaboi analyze`` run from inside the team's checkout. Best-effort only.
+    """
+    try:
+        cwd = Path(os.getcwd())
+        if (cwd / ".git").exists():
+            return str(cwd)
+    except Exception:  # pragma: no cover - defensive
+        return ""
+    return ""
+
+
+def collect_ai_activity(source: str, project_key: str) -> tuple[list[dict], list[str], list[str], list[str]]:
+    """Fan out over GitHub + local git + Azure DevOps for recent commits/PRs with bodies.
+
+    Returns ``(items, sources_scanned, coverage_notes, repos_scanned)``. Every source
+    is best-effort and lazily imported (optional SDKs); a missing credential/SDK or a
+    failing source contributes zero and is added to ``coverage_notes`` so absent
+    coverage is visible rather than silent. ``repos_scanned`` holds friendly
+    "what was actually scanned" labels (local path / remote slug / project) so the
+    report can distinguish the local clone from the remote repo. Never raises.
+    """
+    from yeaboi.config import (
+        get_azure_devops_project,
+        get_azure_devops_token,
+        get_github_token,
+        get_standup_github_repo,
+    )
+
+    items: list[dict] = []
+    sources_scanned: list[str] = []
+    coverage: list[str] = []
+    repos_scanned: list[str] = []
+
+    def _run(name: str, tag: str, fetcher) -> None:
+        try:
+            raw = fetcher()
+        except ImportError as e:
+            logger.warning("AI-usage source %s skipped — SDK not installed: %s", name, e)
+            coverage.append(f"{name}: SDK not installed")
+            return
+        except Exception as e:  # helpers already guard; never let one source abort
+            logger.warning("AI-usage source %s failed: %s", name, e)
+            coverage.append(f"{name}: error ({e})")
+            return
+        if not raw:
+            return
+        for item in raw:
+            item["source"] = tag
+            items.append(item)
+        sources_scanned.append(tag)
+        logger.info("AI-usage source %s contributed %d item(s)", name, len(raw))
+
+    # GitHub — needs STANDUP_GITHUB_REPO (owner/repo) + a token.
+    github_repo = get_standup_github_repo()
+    if github_repo and get_github_token():
+
+        def _github() -> list[dict]:
+            from yeaboi.tools.github import github_recent_commits, github_recent_prs
+
+            return github_recent_commits(github_repo, days=_SCAN_DAYS) + github_recent_prs(github_repo, days=_SCAN_DAYS)
+
+        _run("github", "github", _github)
+        if "github" in sources_scanned:
+            repos_scanned.append(f"GitHub (remote): {github_repo}")
+    else:
+        coverage.append("github: STANDUP_GITHUB_REPO / GITHUB_TOKEN not set")
+
+    # Local git — scan the current checkout when it is a repo.
+    local_path = _discover_local_repo()
+    if local_path:
+
+        def _local() -> list[dict]:
+            from yeaboi.tools.local_git import local_git_recent_commits
+
+            return local_git_recent_commits(local_path, days=_SCAN_DAYS)
+
+        _run("local_git", "local_git", _local)
+        if "local_git" in sources_scanned:
+            repos_scanned.append(f"Local clone: {local_path}")
+    else:
+        coverage.append("local_git: current directory is not a git repo")
+
+    # Azure DevOps — scan the resolved project's repos when AzDO is configured.
+    azdo_project = project_key if source == "azdevops" else (get_azure_devops_project() or "")
+    if azdo_project and get_azure_devops_token():
+
+        def _azdo() -> list[dict]:
+            from yeaboi.tools.azure_devops import azdevops_recent_commits, azdevops_recent_prs
+
+            return azdevops_recent_commits(azdo_project, days=_SCAN_DAYS) + azdevops_recent_prs(
+                azdo_project, days=_SCAN_DAYS
+            )
+
+        _run("azdo", "azdo", _azdo)
+        if "azdo" in sources_scanned:
+            repos_scanned.append(f"Azure DevOps (remote): {azdo_project}")
+    else:
+        coverage.append("azdo: AZURE_DEVOPS_PROJECT / AZURE_DEVOPS_TOKEN not set")
+
+    return items, sources_scanned, coverage, repos_scanned
+
+
+def run_ai_adoption(
+    source: str,
+    project_key: str,
+    delivery_stories: list[dict],
+    all_stories: list[dict],
+) -> tuple[AiAdoptionSignal, dict]:
+    """Orchestrate the AI-adoption scan: discover sources → collect → aggregate.
+
+    Returns ``(signal, examples_blob)``. ``examples_blob`` carries the aggregated
+    summary, up to ~20 illustrative samples for the report, and coverage notes.
+    Wholly best-effort — any failure yields an empty signal and a coverage note,
+    never an exception (the pipeline calls this unguarded). ``delivery_stories`` /
+    ``all_stories`` are accepted for future ticket-derived repo discovery and to
+    keep the signature stable; scanning currently uses configured code sources.
+    """
+    logger.info("run_ai_adoption: source=%s project=%s", source, project_key)
+    try:
+        items, sources_scanned, coverage, repos_scanned = collect_ai_activity(source, project_key)
+        signal = aggregate_ai_markers(items)
+
+        # Repo/source provenance onto the signal for honest, source-aware rendering.
+        from dataclasses import replace
+
+        signal = replace(signal, sources_scanned=tuple(sources_scanned), repos_scanned=tuple(repos_scanned))
+
+        samples = _collect_samples(items)
+        blob: dict = {
+            "summary": {
+                "scanned_commits": signal.scanned_commits,
+                "scanned_prs": signal.scanned_prs,
+                "ai_commits": signal.ai_commits,
+                "ai_prs": signal.ai_prs,
+                "footprint_pct": signal.footprint_pct,
+                "per_tool": [list(p) for p in signal.per_tool],
+                "per_author": [list(p) for p in signal.per_author],
+                "per_activity": [list(p) for p in signal.per_activity],
+                "per_source": [list(p) for p in signal.per_source],
+                "repos_scanned": list(repos_scanned),
+                "is_lower_bound": True,
+            },
+            "samples": samples,
+            "coverage": coverage,
+        }
+        logger.info(
+            "run_ai_adoption: scanned=%d ai=%d footprint=%.1f%% sources=%s",
+            signal.scanned_commits + signal.scanned_prs,
+            signal.ai_commits + signal.ai_prs,
+            signal.footprint_pct,
+            ",".join(sources_scanned) or "none",
+        )
+        return signal, blob
+    except Exception:  # pragma: no cover - collect/aggregate already guard
+        logger.exception("run_ai_adoption failed; returning empty signal")
+        return AiAdoptionSignal(), {"summary": {}, "samples": [], "coverage": ["ai-usage scan failed"]}
+
+
+def _collect_samples(items: list[dict], limit: int = 20) -> list[dict]:
+    """Up to ``limit`` illustrative AI-marked items for the report (never bodies)."""
+    out: list[dict] = []
+    for item in items:
+        tools = _classify_ai_markers(f"{item.get('title', '')}\n{item.get('body', '')}")
+        if not tools:
+            continue
+        out.append(
+            {
+                "author": (item.get("author") or "").strip() or "unknown",
+                "tool": sorted(tools)[0],
+                "activity": _activity_bucket(item),
+                "title": str(item.get("title", ""))[:80],
+                "source": item.get("source", ""),
+                "key": str(item.get("key", "")),
+                "url": item.get("url", ""),
+            }
+        )
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _pick_sample(samples: list[dict], **filters) -> dict | None:
+    """First sample matching all ``filters`` (e.g. activity="code"), or None."""
+    for s in samples:
+        if all(str(s.get(k, "")) == str(v) for k, v in filters.items()):
+            return s
+    return samples[0] if samples and not filters else None
+
+
+def _sample_ref(sample: dict) -> str:
+    """Short human reference to a sampled item, e.g. "commit a1b2c3d4 'Fix login' by Dinho"."""
+    kind = "PR" if sample.get("activity") == "pr" else "commit"
+    key = sample.get("key", "") or ""
+    title = (sample.get("title", "") or "").strip()
+    author = (sample.get("author", "") or "").strip()
+    ref = f"{kind} {key}".strip()
+    if title:
+        ref += f" '{title}'"
+    if author and author != "unknown":
+        ref += f" by {author}"
+    return ref
+
+
+def _with_link(item: dict, sample: dict | None) -> dict:
+    """Attach a best-effort ``link`` (the sample's url) to an insight item when present."""
+    if sample and sample.get("url"):
+        item["link"] = sample["url"]
+    return item
+
+
+# ---------------------------------------------------------------------------
+# Coaching insights — start / stop / keep / try (mirrors team_learning insights)
+# ---------------------------------------------------------------------------
+
+_LOWER_BOUND_NOTE = (
+    "This footprint is a lower bound — it only counts AI tools that leave a marker in "
+    "commit messages or PR descriptions. Inline IDE assist (Copilot ghost-text, Cursor "
+    "Tab) leaves no trace, so real usage is at least this."
+)
+
+
+def _fallback_ai_adoption_insights(signal: AiAdoptionSignal, samples: list[dict] | None = None) -> dict:
+    """Deterministic AI-adoption coaching when the LLM is unavailable.
+
+    Pure — no LLM, no I/O, never raises. Every category is guaranteed non-empty so
+    the screen always has content. Framed as a lower bound throughout. When
+    ``samples`` are given, relevant items cite a concrete example (with a link).
+    """
+    from yeaboi.tools.team_learning import _INSIGHT_MAX_ITEMS, _insight_item
+
+    samples = samples or []
+    footprint = signal.footprint_pct
+    scanned = signal.scanned_commits + signal.scanned_prs
+    top_tool = signal.per_tool[0][0] if signal.per_tool else ""
+    n_authors = len(signal.per_author)
+    activity = dict(signal.per_activity)
+
+    start: list[dict] = []
+    stop: list[dict] = []
+    keep: list[dict] = []
+    try_items: list[dict] = []
+
+    # START — grow adoption where it's thin.
+    if footprint < 25:
+        start.append(
+            _insight_item(
+                "Adopt an AI pairing tool team-wide",
+                "Only a small share of tracked work shows an AI marker. Pick one tool and "
+                "roll it out so the whole team benefits, not just early adopters.",
+                f"{footprint:.0f}% detectable AI footprint across {scanned} commits/PRs",
+            )
+        )
+    if activity.get("pr", 0) == 0 and signal.ai_commits > 0:
+        # Cite an actual AI-marked code commit so the advice points at real work.
+        raw_commit = _pick_sample(samples, activity="code") or _pick_sample(samples)
+        evidence = "AI shows up in commits but no PRs were scanned"
+        if raw_commit:
+            evidence = f"e.g. {_sample_ref(raw_commit)} — an AI-assisted commit with no PR"
+        start.append(
+            _with_link(
+                _insight_item(
+                    "Use AI to draft PR descriptions",
+                    "AI shows up in commits but not PR descriptions. Move that work through a PR "
+                    "and have authors generate a first-draft summary — it improves review context.",
+                    evidence,
+                ),
+                raw_commit,
+            )
+        )
+    if not start:
+        start.append(
+            _insight_item(
+                "Standardise AI co-author trailers",
+                "Agree on a Co-Authored-By convention so AI-assisted work is visible and "
+                "this footprint reflects reality more closely.",
+                _LOWER_BOUND_NOTE,
+            )
+        )
+
+    # STOP — avoid mismeasurement / over-reliance blind spots.
+    if any(t == "other_ai" for t, _ in signal.per_tool):
+        stop.append(
+            _insight_item(
+                "Stop relying on unlabelled AI trailers",
+                "Some commits carry a generic AI co-author with no tool name. Standardising "
+                "the tool makes adoption measurable and reviewable.",
+                "Generic 'AI' co-author trailers detected",
+            )
+        )
+    if not stop:
+        stop.append(
+            _insight_item(
+                "Don't treat this number as the whole picture",
+                "Inline AI assist is invisible here. Avoid concluding low usage from the "
+                "footprint alone — pair it with a quick team check-in.",
+                _LOWER_BOUND_NOTE,
+            )
+        )
+
+    # KEEP — reinforce what's working.
+    if top_tool:
+        tool_sample = _pick_sample(samples, tool=top_tool)
+        evidence = f"{top_tool} is the most-seen tool across scanned work"
+        if tool_sample:
+            evidence = f"e.g. {_sample_ref(tool_sample)} ({top_tool})"
+        keep.append(
+            _with_link(
+                _insight_item(
+                    f"Your investment in {top_tool}",
+                    "There is a consistent AI footprint on the team's work — keep sharing "
+                    "prompts and workflows so the habit spreads.",
+                    evidence,
+                ),
+                tool_sample,
+            )
+        )
+    if footprint >= 40:
+        keep.append(
+            _insight_item(
+                "A healthy AI-assisted cadence",
+                "A large share of tracked work already shows an AI trace — keep the momentum "
+                "and capture what's working in a short playbook.",
+                f"{footprint:.0f}% detectable footprint",
+            )
+        )
+    if not keep:
+        keep.append(
+            _insight_item(
+                "Making AI-assisted work visible",
+                "Even a partial footprint means the team is leaving a trail — keep tagging "
+                "AI-assisted commits so adoption stays measurable.",
+                f"{scanned} commits/PRs scanned",
+            )
+        )
+
+    # TRY — experiments to broaden or deepen adoption.
+    if n_authors and n_authors <= 3 and scanned > 0:
+        try_items.append(
+            _insight_item(
+                "Run an AI-tooling brown-bag",
+                "AI markers cluster on a few people. A 30-minute demo from an adopter often "
+                "unblocks the rest of the team.",
+                f"AI markers seen from {n_authors} author(s)",
+            )
+        )
+    if activity.get("docs", 0) == 0:
+        try_items.append(
+            _insight_item(
+                "Try AI for documentation, not just code",
+                "No AI footprint on docs/README changes. Drafting docs with AI is a low-risk way to widen adoption.",
+                "No AI markers on documentation-shaped commits",
+            )
+        )
+    if not try_items:
+        try_items.append(
+            _insight_item(
+                "A shared prompt library",
+                "Collect the prompts your adopters use into a team doc — it turns individual "
+                "wins into a repeatable practice.",
+                _LOWER_BOUND_NOTE,
+            )
+        )
+
+    return {
+        "start": start[:_INSIGHT_MAX_ITEMS],
+        "stop": stop[:_INSIGHT_MAX_ITEMS],
+        "keep": keep[:_INSIGHT_MAX_ITEMS],
+        "try": try_items[:_INSIGHT_MAX_ITEMS],
+    }
+
+
+def generate_ai_adoption_insights(signal: AiAdoptionSignal, examples: dict) -> dict:
+    """Use the LLM to coach on AI adoption: start / stop / keep / try.
+
+    Returns ``{"start": [...], "stop": [...], "keep": [...], "try": [...]}`` where
+    each item is ``{"title", "detail", "evidence"}``. Falls back to deterministic
+    insights on any failure — must never raise (runs inside the analysis pipeline).
+    The prompt explicitly frames the footprint as a lower bound.
+    """
+    import json
+
+    from yeaboi.tools.team_learning import _INSIGHT_KEYS, _INSIGHT_MAX_ITEMS, _insight_item, _llm_invoke
+
+    samples = examples.get("samples", []) if isinstance(examples, dict) else []
+    fallback = _fallback_ai_adoption_insights(signal, samples)
+
+    # Valid link set — LLM-returned links are accepted only if they cite a real sample.
+    valid_links = {str(s.get("url", "")) for s in samples if s.get("url")}
+
+    per_tool = ", ".join(f"{t}={n}" for t, n in signal.per_tool) or "none detected"
+    per_activity = ", ".join(f"{a}={n}" for a, n in signal.per_activity) or "none"
+    per_source = ", ".join(f"{_source_label(s)}={n}" for s, n in signal.per_source) or "none"
+    digest = (
+        f"Scanned {signal.scanned_commits} commits and {signal.scanned_prs} PRs from sources: "
+        f"{', '.join(_source_label(s) for s in signal.sources_scanned) or 'none'}.\n"
+        f"AI-marked: {signal.ai_commits} commits, {signal.ai_prs} PRs "
+        f"(detectable footprint {signal.footprint_pct:.0f}%).\n"
+        f"By tool: {per_tool}.\n"
+        f"By activity type: {per_activity}.\n"
+        f"By source: {per_source}.\n"
+        f"AI markers seen from {len(signal.per_author)} distinct author(s)."
+    )
+
+    # Concrete items the LLM can cite (with links) so coaching points at real work.
+    example_lines = []
+    for s in samples[:12]:
+        ref = _sample_ref(s)
+        url = s.get("url", "")
+        example_lines.append(f"- [{_source_label(s.get('source', ''))}] {ref}" + (f" — {url}" if url else ""))
+    examples_block = "\n".join(example_lines) or "(no illustrative samples available)"
+
+    # See README: "Prompt Construction" — ARC: Ask (coach adoption), Requirements
+    # (categories, item shape, lower-bound honesty), Context (footprint digest).
+    prompt = (
+        "You are an engineering enablement coach helping a team lead grow effective, "
+        "healthy use of AI coding tools. A scan of the team's commits and pull requests "
+        "for AI-tool markers produced the digest below.\n\n"
+        "CRITICAL framing: this footprint is a LOWER BOUND. It only counts AI tools that "
+        "leave a textual marker in commit messages or PR descriptions; inline IDE assist "
+        "(Copilot autocomplete, Cursor Tab) leaves no trace. Never claim the team does not "
+        "use AI from a low number — coach on making usage more visible, broader, and more "
+        "effective.\n\n"
+        "Requirements:\n"
+        '- Four categories: "start" (things to start), "stop" (things to stop/avoid), '
+        '"keep" (things working well), "try" (experiments worth trying).\n'
+        '- 2-4 items per category. Each item: "title" (imperative, max 10 words), '
+        '"detail" (1-2 plain-English sentences of practical advice), "evidence" (one short '
+        'phrase; where possible cite a specific example from the list below, e.g. "e.g. commit '
+        'a1b2c3d4 \'Fix login\'"), and optionally "link" (the exact URL of that example, copied '
+        "verbatim from the list — omit if none applies).\n"
+        "- Prefer coaching that references a real example: 'here is where you did Y (link), do X "
+        "instead'. Do NOT invent links; only use URLs from the list.\n"
+        "- Ground every item in the digest. At least one item must remind the lead the "
+        "footprint is a lower bound.\n\n"
+        "## Footprint digest\n" + digest + "\n\n"
+        "## Examples you can cite (use these exact URLs)\n" + examples_block + "\n\n"
+        "Return ONLY a JSON object: "
+        '{"start": [{"title": "...", "detail": "...", "evidence": "...", "link": "..."}], '
+        '"stop": [...], "keep": [...], "try": [...]}'
+    )
+
+    try:
+        response = _llm_invoke(prompt, temperature=0.0)
+        text = response.content if hasattr(response, "content") else str(response)
+        text = text.strip()
+        if text.startswith("```"):
+            text = re.sub(r"^```\w*\n?", "", text)
+            text = re.sub(r"\n?```$", "", text)
+        result = json.loads(text)
+        if isinstance(result, dict):
+            insights: dict = {}
+            for key in _INSIGHT_KEYS:
+                raw = result.get(key)
+                items = []
+                if isinstance(raw, list):
+                    for it in raw:
+                        if isinstance(it, dict) and isinstance(it.get("title"), str) and it["title"].strip():
+                            item = _insight_item(
+                                it["title"].strip(),
+                                it["detail"].strip() if isinstance(it.get("detail"), str) else "",
+                                it["evidence"].strip() if isinstance(it.get("evidence"), str) else "",
+                            )
+                            # Accept a link only if it cites a real sample URL (no hallucinations).
+                            link = it.get("link")
+                            if isinstance(link, str) and link.strip() in valid_links:
+                                item["link"] = link.strip()
+                            items.append(item)
+                insights[key] = items[:_INSIGHT_MAX_ITEMS] if items else fallback[key]
+            logger.info(
+                "LLM AI-adoption insights generated (%s)",
+                ", ".join(f"{k}={len(v)}" for k, v in insights.items()),
+            )
+            return insights
+        logger.warning("LLM AI-adoption insights had unexpected shape; using fallback")
+    except Exception as exc:
+        logger.warning("LLM AI-adoption insights generation failed: %s", exc)
+
+    return fallback

--- a/src/yeaboi/analysis/doc_quality.py
+++ b/src/yeaboi/analysis/doc_quality.py
@@ -1,0 +1,737 @@
+"""Documentation quality — is the team's written knowledge clear, and how does AI show up in it?
+
+# See README: "Architecture" — engines are UI-free pipelines; this is a sub-analysis
+# of team-analysis mode (CLAUDE.md "REQUIRED: Surface Parity" — the TUI/CLI/MCP are
+# thin adapters over ``analysis/engine.py:run_team_analysis``, which calls into here).
+
+What this does
+--------------
+Reads the pages the team has recently written or updated in Notion & Confluence
+(pairing the ``*_recent_pages`` metadata helpers with the never-raise
+``*_read_page_text`` body readers), then per page computes:
+
+- a **clarity score** (deterministic, readability-based; 0–100, higher = clearer), and
+- an **AI-likelihood estimate** (heuristic stylometry over prose features), plus
+- an **explicit AI-marker** check (a pasted "Generated with Claude" style disclosure).
+
+It aggregates those into a :class:`DocQualitySignal` and coaches the lead on writing
+clearer docs and using AI effectively in them (start / stop / keep / try).
+
+Honesty contract — two different confidence levels, never conflated
+-------------------------------------------------------------------
+Clarity is a heuristic readability score. The AI-likelihood is a stylometric
+**ESTIMATE**, not a detection — prose (unlike a commit) carries no reliable AI
+marker, so the number is a conversation-starter, never proof. Explicit AI markers
+are a genuine **lower bound**. Every surface must frame it that way;
+``DocQualitySignal.is_ai_estimate`` stays ``True`` to force it.
+
+Error contract
+--------------
+Everything here is best-effort and NEVER raises: a missing SDK/credential or a
+failing platform contributes zero and is recorded as a coverage gap.
+``run_doc_quality`` wraps the whole thing so the analysis pipeline can call it
+unguarded.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from yeaboi.analysis.ai_usage import _classify_ai_markers
+from yeaboi.team_profile import DocQualitySignal
+
+logger = logging.getLogger(__name__)
+
+# Look-back window and per-platform cap. The recent-page helpers already page a
+# bounded set; this keeps the scan a "recent sample" for a quality read, not an
+# exhaustive audit, and bounds the number of body-read API calls.
+_SCAN_DAYS = 90
+_MAX_PAGES_PER_PLATFORM = 20
+_READ_CHARS = 8_000  # per-page body budget fed to the analysis
+
+# Clarity score bands (0–100, higher = clearer). Aligned to Flesch reading-ease:
+# ~60 is "plain English", below ~40 is "difficult".
+_CLEAR_MIN = 60.0
+_UNCLEAR_MAX = 40.0
+# A page whose stylometric AI-likelihood crosses this is counted "likely AI" — an
+# ESTIMATE, deliberately conservative.
+_AI_LIKELY_MIN = 55.0
+
+_ESTIMATE_NOTE = (
+    "AI-likelihood is a heuristic estimate from writing style, not a detection — prose "
+    "carries no reliable AI marker. Treat it as a prompt for a conversation, not proof."
+)
+
+# Phrases that skew AI-generated prose (formal connectors + LLM tics). Not proof on
+# their own — they feed a weighted estimate, never a verdict.
+_AI_TELL_PHRASES: tuple[str, ...] = (
+    "moreover",
+    "furthermore",
+    "in conclusion",
+    "in summary",
+    "it's worth noting",
+    "it is worth noting",
+    "it is important to note",
+    "delve",
+    "leverage",
+    "seamless",
+    "robust",
+    "firstly",
+    "additionally",
+    "notably",
+    "utilize",
+    "underscore",
+    "a testament to",
+    "in the realm of",
+    "tapestry",
+    "navigating",
+    "holistic",
+    "paramount",
+    "facilitate",
+    "streamline",
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-page heuristics — pure, deterministic, no I/O (the core unit-test seams)
+# ---------------------------------------------------------------------------
+
+
+def _count_syllables(word: str) -> int:
+    """Rough syllable count for the Flesch approximation — vowel groups, silent-e trim."""
+    groups = re.findall(r"[aeiouy]+", word.lower())
+    n = len(groups)
+    if word.lower().endswith("e") and n > 1:
+        n -= 1
+    return max(1, n)
+
+
+def _clarity_metrics(text: str) -> dict:
+    """Deterministic readability metrics for one page.
+
+    Returns a dict with ``word_count``, ``sentence_count``, ``avg_sentence_words``,
+    ``long_sentence_pct``, ``heading_count``, ``has_lists`` and a **clarity** score
+    (0–100, higher = clearer) from a Flesch reading-ease approximation plus a small
+    structure bonus (headings/lists aid a doc's clarity). Pure — no I/O.
+    """
+    sentences = [s for s in re.split(r"[.!?]+(?:\s|$)", text) if s.strip()]
+    words = re.findall(r"[A-Za-z']+", text)
+    n_sentences = len(sentences)
+    n_words = len(words)
+    if n_words == 0 or n_sentences == 0:
+        return {
+            "word_count": n_words,
+            "sentence_count": n_sentences,
+            "avg_sentence_words": 0.0,
+            "long_sentence_pct": 0.0,
+            "heading_count": 0,
+            "has_lists": False,
+            "clarity": 0.0,
+        }
+
+    avg_sentence_words = n_words / n_sentences
+    long_sentences = sum(1 for s in sentences if len(s.split()) > 25)
+    long_sentence_pct = round(long_sentences / n_sentences * 100, 1)
+    syllables = sum(_count_syllables(w) for w in words)
+
+    heading_count = len(re.findall(r"(?m)^\s{0,3}#{1,6}\s", text))
+    has_lists = bool(re.search(r"(?m)^\s*(?:[-*•]|\d+[.)])\s", text))
+
+    # Flesch Reading Ease — higher = easier to read. Clamp to 0–100.
+    flesch = 206.835 - 1.015 * avg_sentence_words - 84.6 * (syllables / n_words)
+    clarity = flesch
+    # Small structure bonus: a doc with headings/lists reads more clearly than a wall.
+    if heading_count:
+        clarity += 4
+    if has_lists:
+        clarity += 3
+    clarity = max(0.0, min(100.0, clarity))
+
+    return {
+        "word_count": n_words,
+        "sentence_count": n_sentences,
+        "avg_sentence_words": round(avg_sentence_words, 1),
+        "long_sentence_pct": long_sentence_pct,
+        "heading_count": heading_count,
+        "has_lists": has_lists,
+        "clarity": round(clarity, 1),
+    }
+
+
+def _ai_likelihood(text: str) -> float:
+    """Heuristic 0–100 ESTIMATE that a page's prose was AI-generated.
+
+    Pure, no I/O. Sums weighted, capped signals: em-dash density, LLM-tell phrase
+    rate, unusually low contraction rate, "not only … but also" cadence, and uniform
+    paragraph lengths. This is a stylometric *guess*, not a detector — see the module
+    docstring. Returns 0.0 for empty text.
+    """
+    if not text.strip():
+        return 0.0
+    lower = text.lower()
+    words = re.findall(r"[a-z']+", lower)
+    n_words = len(words) or 1
+    score = 0.0
+
+    # Em-dashes per 1000 words — AI prose leans on them heavily.
+    em_dashes = text.count("—")
+    score += min(25.0, em_dashes / n_words * 1000 * 3.0)
+
+    # LLM-tell connector/filler phrases per 1000 words.
+    tell_hits = sum(lower.count(p) for p in _AI_TELL_PHRASES)
+    score += min(40.0, tell_hits / n_words * 1000 * 4.0)
+
+    # Formality: AI drafts rarely use contractions.
+    contractions = len(re.findall(r"\b\w+'(?:t|re|ll|ve|d|s|m)\b", lower))
+    if n_words >= 80 and contractions / n_words < 0.004:
+        score += 15.0
+
+    # Tricolon "not only … but also" cadence.
+    if "not only" in lower and "but also" in lower:
+        score += 8.0
+
+    # Uniform paragraph lengths (low coefficient of variation) — AI output is even.
+    paras = [p for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if len(paras) >= 3:
+        lengths = [len(p.split()) for p in paras]
+        mean = sum(lengths) / len(lengths)
+        if mean > 0:
+            var = sum((length - mean) ** 2 for length in lengths) / len(lengths)
+            if (var**0.5) / mean < 0.35:
+                score += 12.0
+
+    return round(min(100.0, score), 1)
+
+
+def aggregate_doc_quality(pages: list[dict]) -> DocQualitySignal:
+    """Aggregate scanned page dicts into a :class:`DocQualitySignal`.
+
+    Pure over its input (no network). Each page is a normalized dict with
+    ``platform``, ``title``, ``text`` (+ optional ``author``/``url``). Returns an
+    all-zero signal for an empty list.
+    """
+    if not pages:
+        return DocQualitySignal()
+
+    platforms: list[str] = []
+    per_platform: dict[str, int] = {}
+    clarities: list[float] = []
+    ai_scores: list[float] = []
+    clear = mixed = unclear = likely_ai = ai_marked = 0
+    # (clarity, likelihood, title) per page — used to pick flagged call-outs.
+    scored: list[tuple[float, float, str]] = []
+
+    for page in pages:
+        text = str(page.get("text", ""))
+        platform = str(page.get("platform", "")).strip()
+        title = str(page.get("title", "Untitled")).strip()[:80] or "Untitled"
+        if platform and platform not in platforms:
+            platforms.append(platform)
+        per_platform[platform] = per_platform.get(platform, 0) + 1
+
+        clarity = _clarity_metrics(text)["clarity"]
+        clarities.append(clarity)
+        if clarity >= _CLEAR_MIN:
+            clear += 1
+        elif clarity < _UNCLEAR_MAX:
+            unclear += 1
+        else:
+            mixed += 1
+
+        likelihood = _ai_likelihood(text)
+        ai_scores.append(likelihood)
+        if likelihood >= _AI_LIKELY_MIN:
+            likely_ai += 1
+        if _classify_ai_markers(text):
+            ai_marked += 1
+
+        scored.append((clarity, likelihood, title))
+
+    avg_clarity = round(sum(clarities) / len(clarities), 1) if clarities else 0.0
+    avg_ai = round(sum(ai_scores) / len(ai_scores), 1) if ai_scores else 0.0
+
+    # Flagged call-outs: the least-clear pages and the most-AI-likely pages, deduped.
+    flagged: list[tuple[str, str]] = []
+    seen_titles: set[str] = set()
+    for clarity, _lk, title in sorted(scored, key=lambda x: x[0])[:2]:
+        if clarity < _CLEAR_MIN and title not in seen_titles:
+            flagged.append((title, f"clarity {clarity:.0f}/100 — dense or long-winded"))
+            seen_titles.add(title)
+    for _cl, likelihood, title in sorted(scored, key=lambda x: -x[1])[:2]:
+        if likelihood >= _AI_LIKELY_MIN and title not in seen_titles:
+            flagged.append((title, f"reads as AI-generated (estimate {likelihood:.0f}/100)"))
+            seen_titles.add(title)
+
+    def _sorted_pairs(d: dict[str, int]) -> tuple[tuple[str, int], ...]:
+        return tuple(sorted(d.items(), key=lambda kv: (-kv[1], kv[0])))
+
+    return DocQualitySignal(
+        pages_scanned=len(pages),
+        platforms_scanned=tuple(platforms),
+        avg_clarity=avg_clarity,
+        clear_pages=clear,
+        mixed_pages=mixed,
+        unclear_pages=unclear,
+        avg_ai_likelihood=avg_ai,
+        likely_ai_pages=likely_ai,
+        ai_marked_pages=ai_marked,
+        per_platform=_sorted_pairs(per_platform),
+        flagged_pages=tuple(flagged[:4]),
+        is_ai_estimate=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data gathering — graceful, best-effort fan-out (mirrors analysis/ai_usage.py)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_confluence_pages() -> list[dict]:
+    """Recent Confluence pages, each paired with its body text. Lazily imports the SDK-backed tool."""
+    from yeaboi.tools.confluence import confluence_read_page_text, confluence_recent_pages
+
+    recent = confluence_recent_pages(days=_SCAN_DAYS)
+    return _read_bodies(recent, lambda pid: confluence_read_page_text(page_id=pid, max_chars=_READ_CHARS))
+
+
+def _fetch_notion_pages() -> list[dict]:
+    """Recent Notion pages, each paired with its body text. Lazily imports the SDK-backed tool."""
+    from yeaboi.tools.notion import notion_read_page_text, notion_recent_pages
+
+    recent = notion_recent_pages(days=_SCAN_DAYS)
+    return _read_bodies(recent, lambda pid: notion_read_page_text(pid, max_chars=_READ_CHARS))
+
+
+def _read_bodies(recent: list[dict], reader) -> list[dict]:
+    """Pair recent-page metadata with body text via ``reader(page_id) -> {title,text,…}``.
+
+    Dedupes by page id (Confluence emits one item per editor), caps the number of
+    body reads, and drops pages with no readable text. ``reader`` never raises.
+    """
+    out: list[dict] = []
+    seen: set[str] = set()
+    for meta in recent:
+        page_id = str(meta.get("key", "")).strip()
+        if not page_id or page_id in seen:
+            continue
+        seen.add(page_id)
+        doc = reader(page_id)
+        text = doc.get("text", "") if isinstance(doc, dict) else ""
+        if not text.strip():
+            continue
+        out.append(
+            {
+                "title": meta.get("title") or (doc.get("title", "") if isinstance(doc, dict) else "") or "Untitled",
+                "author": meta.get("author", ""),
+                "url": meta.get("url", ""),
+                "key": page_id,
+                "timestamp": meta.get("timestamp", ""),
+                "text": text,
+            }
+        )
+        if len(out) >= _MAX_PAGES_PER_PLATFORM:
+            break
+    return out
+
+
+def collect_doc_pages(source: str, project_key: str) -> tuple[list[dict], list[str], list[str]]:
+    """Fan out over Confluence + Notion for recently-changed pages with their body text.
+
+    Returns ``(pages, platforms_scanned, coverage_notes)``. Every platform is
+    best-effort and lazily imported (optional SDKs); a missing credential/SDK or a
+    failing platform contributes zero and is added to ``coverage_notes`` so absent
+    coverage is visible rather than silent. Never raises. ``source``/``project_key``
+    are accepted for signature parity with the other sub-analyses; doc platforms are
+    resolved purely from their own config.
+    """
+    from yeaboi.config import get_confluence_base_url, get_confluence_token, get_notion_token
+
+    pages: list[dict] = []
+    platforms_scanned: list[str] = []
+    coverage: list[str] = []
+
+    def _run(name: str, tag: str, fetcher) -> None:
+        try:
+            raw = fetcher()
+        except ImportError as e:
+            logger.warning("Doc-quality source %s skipped — SDK not installed: %s", name, e)
+            coverage.append(f"{name}: SDK not installed")
+            return
+        except Exception as e:  # helpers already guard; never let one platform abort
+            logger.warning("Doc-quality source %s failed: %s", name, e)
+            coverage.append(f"{name}: error ({e})")
+            return
+        if not raw:
+            coverage.append(f"{name}: no pages changed in the last {_SCAN_DAYS} days")
+            return
+        for page in raw:
+            page["platform"] = tag
+            pages.append(page)
+        platforms_scanned.append(tag)
+        logger.info("Doc-quality source %s contributed %d page(s)", name, len(raw))
+
+    # Confluence — reuses the Jira Atlassian creds unless CONFLUENCE_* is set.
+    if get_confluence_token() and get_confluence_base_url():
+        _run("confluence", "confluence", _fetch_confluence_pages)
+    else:
+        coverage.append("confluence: CONFLUENCE_API_TOKEN / base URL not set")
+
+    # Notion — standalone integration token.
+    if get_notion_token():
+        _run("notion", "notion", _fetch_notion_pages)
+    else:
+        coverage.append("notion: NOTION_TOKEN not set")
+
+    return pages, platforms_scanned, coverage
+
+
+def _collect_samples(pages: list[dict], limit: int = 12) -> list[dict]:
+    """Up to ``limit`` illustrative page call-outs for the report (never page bodies)."""
+    out: list[dict] = []
+    for page in pages:
+        text = str(page.get("text", ""))
+        out.append(
+            {
+                "title": str(page.get("title", "Untitled"))[:80],
+                "platform": page.get("platform", ""),
+                "clarity": _clarity_metrics(text)["clarity"],
+                "ai_likelihood": _ai_likelihood(text),
+                "marked": bool(_classify_ai_markers(text)),
+                "url": page.get("url", ""),
+            }
+        )
+        if len(out) >= limit:
+            break
+    return out
+
+
+def run_doc_quality(source: str, project_key: str) -> tuple[DocQualitySignal, dict]:
+    """Orchestrate the doc-quality scan: collect recent pages → score → aggregate.
+
+    Returns ``(signal, examples_blob)``. ``examples_blob`` carries the aggregated
+    summary, up to ~12 illustrative page samples (titles/scores only — never bodies),
+    and coverage notes. Wholly best-effort — any failure yields an empty signal and a
+    coverage note, never an exception (the pipeline calls this unguarded).
+    """
+    logger.info("run_doc_quality: source=%s project=%s", source, project_key)
+    try:
+        pages, platforms_scanned, coverage = collect_doc_pages(source, project_key)
+        signal = aggregate_doc_quality(pages)
+
+        samples = _collect_samples(pages)
+        blob: dict = {
+            "summary": {
+                "pages_scanned": signal.pages_scanned,
+                "platforms_scanned": list(signal.platforms_scanned),
+                "avg_clarity": signal.avg_clarity,
+                "clear_pages": signal.clear_pages,
+                "mixed_pages": signal.mixed_pages,
+                "unclear_pages": signal.unclear_pages,
+                "avg_ai_likelihood": signal.avg_ai_likelihood,
+                "likely_ai_pages": signal.likely_ai_pages,
+                "ai_marked_pages": signal.ai_marked_pages,
+                "per_platform": [list(p) for p in signal.per_platform],
+                "flagged_pages": [list(p) for p in signal.flagged_pages],
+                "is_ai_estimate": True,
+            },
+            "samples": samples,
+            "coverage": coverage,
+        }
+        logger.info(
+            "run_doc_quality: pages=%d avg_clarity=%.0f avg_ai=%.0f marked=%d platforms=%s",
+            signal.pages_scanned,
+            signal.avg_clarity,
+            signal.avg_ai_likelihood,
+            signal.ai_marked_pages,
+            ",".join(platforms_scanned) or "none",
+        )
+        return signal, blob
+    except Exception:  # pragma: no cover - collect/aggregate already guard
+        logger.exception("run_doc_quality failed; returning empty signal")
+        return DocQualitySignal(), {"summary": {}, "samples": [], "coverage": ["doc-quality scan failed"]}
+
+
+# ---------------------------------------------------------------------------
+# Coaching insights — start / stop / keep / try (mirrors ai_usage insights)
+# ---------------------------------------------------------------------------
+
+
+def _doc_ref(sample: dict) -> str:
+    """Short human reference to a sampled page, e.g. "'Onboarding' (confluence, clarity 30/100)"."""
+    title = (sample.get("title", "") or "Untitled").strip()
+    platform = sample.get("platform", "") or ""
+    return f"'{title}' ({platform}, clarity {sample.get('clarity', 0):.0f}/100)"
+
+
+def _with_doc_link(item: dict, sample: dict | None) -> dict:
+    """Attach a best-effort ``link`` (the page url) to an insight item when present."""
+    if sample and sample.get("url"):
+        item["link"] = sample["url"]
+    return item
+
+
+def _fallback_doc_quality_insights(signal: DocQualitySignal, samples: list[dict] | None = None) -> dict:
+    """Deterministic doc-quality coaching when the LLM is unavailable.
+
+    Pure — no LLM, no I/O, never raises. Every category is guaranteed non-empty so
+    the screen always has content. Clarity is framed as a score, AI-likelihood as an
+    estimate, and explicit markers as a lower bound throughout. When ``samples`` are
+    given, relevant items cite a concrete page (with a link).
+    """
+    from yeaboi.tools.team_learning import _INSIGHT_MAX_ITEMS, _insight_item
+
+    samples = samples or []
+    # Representative pages: the least-clear and the most-AI-likely, for concrete call-outs.
+    least_clear = min(samples, key=lambda s: s.get("clarity", 100), default=None) if samples else None
+    most_ai = max(samples, key=lambda s: s.get("ai_likelihood", 0), default=None) if samples else None
+
+    pages = signal.pages_scanned
+    clarity = signal.avg_clarity
+    ai_est = signal.avg_ai_likelihood
+
+    start: list[dict] = []
+    stop: list[dict] = []
+    keep: list[dict] = []
+    try_items: list[dict] = []
+
+    # START — raise the clarity floor.
+    if clarity < 55 and pages:
+        evidence = f"Average clarity {clarity:.0f}/100 across {pages} page(s)"
+        if least_clear:
+            evidence = f"e.g. {_doc_ref(least_clear)} — the least-clear page scanned"
+        start.append(
+            _with_doc_link(
+                _insight_item(
+                    "Tighten the least-clear pages",
+                    "Several docs read as dense or long-winded. Shorter sentences, headings and "
+                    "bullet lists make them faster to act on.",
+                    evidence,
+                ),
+                least_clear,
+            )
+        )
+    if signal.unclear_pages:
+        start.append(
+            _insight_item(
+                "Add structure to wall-of-text docs",
+                "Break the hardest-to-read pages into sections with headings and lists — "
+                "structure is the cheapest clarity win.",
+                f"{signal.unclear_pages} page(s) scored unclear",
+            )
+        )
+    if not start:
+        start.append(
+            _insight_item(
+                "Set a shared clarity bar",
+                "Agree a lightweight doc standard (a lead paragraph, headings, short sentences) "
+                "so new pages start clear.",
+                f"{pages} page(s) scanned" if pages else "No pages scanned yet",
+            )
+        )
+
+    # STOP — avoid unedited AI output and dense prose.
+    if ai_est >= _AI_LIKELY_MIN:
+        evidence = f"Estimated AI-likelihood {ai_est:.0f}/100 — {_ESTIMATE_NOTE}"
+        ai_sample = most_ai if most_ai and most_ai.get("ai_likelihood", 0) >= _AI_LIKELY_MIN else None
+        if ai_sample:
+            evidence = (
+                f"e.g. {_doc_ref(ai_sample)} reads as AI-drafted "
+                f"(estimate {ai_sample.get('ai_likelihood', 0):.0f}/100) — {_ESTIMATE_NOTE}"
+            )
+        stop.append(
+            _with_doc_link(
+                _insight_item(
+                    "Stop shipping unedited AI drafts",
+                    "Some pages read like raw AI output. Have authors edit for the team's voice and "
+                    "concrete detail before publishing.",
+                    evidence,
+                ),
+                ai_sample,
+            )
+        )
+    if not stop:
+        stop.append(
+            _insight_item(
+                "Don't publish walls of text",
+                "Long unbroken paragraphs slow everyone down. Split them and lead with the point.",
+                _ESTIMATE_NOTE,
+            )
+        )
+
+    # KEEP — reinforce what's working.
+    if clarity >= 60:
+        keep.append(
+            _insight_item(
+                "Your clear, structured writing",
+                "The team's docs are largely readable — keep leading with the point and using "
+                "headings so the habit sticks.",
+                f"Average clarity {clarity:.0f}/100",
+            )
+        )
+    if signal.ai_marked_pages:
+        keep.append(
+            _insight_item(
+                "Disclosing AI-assisted docs",
+                "Some pages explicitly note AI assistance — keep that transparency; it builds "
+                "trust and makes review easier.",
+                f"{signal.ai_marked_pages} page(s) carry an explicit AI marker (a lower bound)",
+            )
+        )
+    if not keep:
+        keep.append(
+            _insight_item(
+                "Keeping docs current",
+                "The team is actively updating its written knowledge — keep that cadence and the "
+                "docs stay worth trusting.",
+                f"{pages} page(s) changed recently" if pages else "Keep updating shared docs",
+            )
+        )
+
+    # TRY — experiments to raise quality and use AI well.
+    if signal.likely_ai_pages:
+        try_items.append(
+            _insight_item(
+                "Try an AI-draft-then-edit workflow",
+                "Where AI is already drafting docs, add a short human edit pass for accuracy and "
+                "team-specific context — best of both.",
+                f"~{signal.likely_ai_pages} page(s) look AI-drafted (estimate)",
+            )
+        )
+    if clarity and clarity < 65:
+        try_items.append(
+            _insight_item(
+                "Ask AI to simplify a dense page",
+                "Pick the least-clear doc and prompt an AI tool to rewrite it at a plain-English "
+                "reading level, then review — a fast clarity experiment.",
+                f"Average clarity {clarity:.0f}/100",
+            )
+        )
+    if not try_items:
+        try_items.append(
+            _insight_item(
+                "A shared doc template",
+                "Capture a page template (purpose, TL;DR, sections) so every new doc starts clear and consistent.",
+                f"{pages} page(s) scanned" if pages else "Start with a template",
+            )
+        )
+
+    return {
+        "start": start[:_INSIGHT_MAX_ITEMS],
+        "stop": stop[:_INSIGHT_MAX_ITEMS],
+        "keep": keep[:_INSIGHT_MAX_ITEMS],
+        "try": try_items[:_INSIGHT_MAX_ITEMS],
+    }
+
+
+def generate_doc_quality_insights(signal: DocQualitySignal, examples: dict) -> dict:
+    """Use the LLM to coach on doc clarity + AI usage: start / stop / keep / try.
+
+    Returns ``{"start": [...], "stop": [...], "keep": [...], "try": [...]}`` where
+    each item is ``{"title", "detail", "evidence"}``. Falls back to deterministic
+    insights on any failure — must never raise (runs inside the analysis pipeline).
+    The prompt frames clarity as a score, AI-likelihood as an estimate, and explicit
+    markers as a lower bound.
+    """
+    import json
+
+    from yeaboi.tools.team_learning import _INSIGHT_KEYS, _INSIGHT_MAX_ITEMS, _insight_item, _llm_invoke
+
+    samples = examples.get("samples", []) if isinstance(examples, dict) else []
+    fallback = _fallback_doc_quality_insights(signal, samples)
+
+    # Valid link set — LLM-returned links are accepted only if they cite a real page.
+    valid_links = {str(s.get("url", "")) for s in samples if s.get("url")}
+
+    per_platform = ", ".join(f"{p}={n}" for p, n in signal.per_platform) or "none"
+    flagged = "; ".join(f"{title} ({reason})" for title, reason in signal.flagged_pages) or "none"
+    digest = (
+        f"Scanned {signal.pages_scanned} recently-changed page(s) across: "
+        f"{', '.join(signal.platforms_scanned) or 'none'} (by platform: {per_platform}).\n"
+        f"Clarity (0-100, higher=clearer): average {signal.avg_clarity:.0f} "
+        f"— {signal.clear_pages} clear, {signal.mixed_pages} mixed, {signal.unclear_pages} unclear.\n"
+        f"AI-likelihood ESTIMATE (stylometric, not a detection): average {signal.avg_ai_likelihood:.0f}/100, "
+        f"~{signal.likely_ai_pages} page(s) look AI-drafted.\n"
+        f"Explicit AI markers (lower bound): {signal.ai_marked_pages} page(s).\n"
+        f"Flagged pages: {flagged}."
+    )
+
+    # Concrete pages the LLM can cite (with links) so coaching points at real docs.
+    example_lines = []
+    for s in samples[:12]:
+        url = s.get("url", "")
+        line = (
+            f"- '{s.get('title', 'Untitled')}' ({s.get('platform', '')}, "
+            f"clarity {s.get('clarity', 0):.0f}/100, AI-likelihood {s.get('ai_likelihood', 0):.0f}/100)"
+        )
+        example_lines.append(line + (f" — {url}" if url else ""))
+    examples_block = "\n".join(example_lines) or "(no illustrative pages available)"
+
+    # See README: "Prompt Construction" — ARC: Ask (coach doc quality + AI usage),
+    # Requirements (categories, item shape, estimate/lower-bound honesty), Context (digest).
+    prompt = (
+        "You are a technical-writing and enablement coach helping a team lead improve the "
+        "clarity of their written docs (Notion/Confluence) and use AI effectively in them. A "
+        "scan of the team's recently-changed pages produced the digest below.\n\n"
+        "CRITICAL framing:\n"
+        "- Clarity is a heuristic readability score, not a grade on correctness.\n"
+        "- AI-likelihood is a STYLOMETRIC ESTIMATE from writing style, NOT a detection — prose "
+        "carries no reliable AI marker. Never assert a page 'was written by AI'; coach on "
+        "editing and effective use instead.\n"
+        "- The explicit-AI-marker count is a LOWER BOUND (only pages with a pasted disclosure).\n\n"
+        "Requirements:\n"
+        '- Four categories: "start" (things to start), "stop" (things to stop/avoid), '
+        '"keep" (things working well), "try" (experiments worth trying).\n'
+        '- 2-4 items per category. Each item: "title" (imperative, max 10 words), '
+        '"detail" (1-2 plain-English sentences of practical advice), "evidence" (one short '
+        "phrase; where possible cite a specific page from the list below, e.g. \"e.g. 'Onboarding' "
+        'reads as dense"), and optionally "link" (the exact URL of that page, copied verbatim '
+        "from the list — omit if none applies).\n"
+        "- Prefer coaching that references a real page: 'here is the page (link), do X'. Do NOT "
+        "invent links; only use URLs from the list.\n"
+        "- Ground every item in the digest. At least one item must remind the lead the "
+        "AI-likelihood is an estimate, not a detection.\n\n"
+        "## Doc-quality digest\n" + digest + "\n\n"
+        "## Pages you can cite (use these exact URLs)\n" + examples_block + "\n\n"
+        "Return ONLY a JSON object: "
+        '{"start": [{"title": "...", "detail": "...", "evidence": "...", "link": "..."}], '
+        '"stop": [...], "keep": [...], "try": [...]}'
+    )
+
+    try:
+        response = _llm_invoke(prompt, temperature=0.0)
+        text = response.content if hasattr(response, "content") else str(response)
+        text = text.strip()
+        if text.startswith("```"):
+            text = re.sub(r"^```\w*\n?", "", text)
+            text = re.sub(r"\n?```$", "", text)
+        result = json.loads(text)
+        if isinstance(result, dict):
+            insights: dict = {}
+            for key in _INSIGHT_KEYS:
+                raw = result.get(key)
+                items = []
+                if isinstance(raw, list):
+                    for it in raw:
+                        if isinstance(it, dict) and isinstance(it.get("title"), str) and it["title"].strip():
+                            item = _insight_item(
+                                it["title"].strip(),
+                                it["detail"].strip() if isinstance(it.get("detail"), str) else "",
+                                it["evidence"].strip() if isinstance(it.get("evidence"), str) else "",
+                            )
+                            # Accept a link only if it cites a real page URL (no hallucinations).
+                            link = it.get("link")
+                            if isinstance(link, str) and link.strip() in valid_links:
+                                item["link"] = link.strip()
+                            items.append(item)
+                insights[key] = items[:_INSIGHT_MAX_ITEMS] if items else fallback[key]
+            logger.info(
+                "LLM doc-quality insights generated (%s)",
+                ", ".join(f"{k}={len(v)}" for k, v in insights.items()),
+            )
+            return insights
+        logger.warning("LLM doc-quality insights had unexpected shape; using fallback")
+    except Exception as exc:
+        logger.warning("LLM doc-quality insights generation failed: %s", exc)
+
+    return fallback

--- a/src/yeaboi/analysis/engine.py
+++ b/src/yeaboi/analysis/engine.py
@@ -85,6 +85,8 @@ def run_team_analysis(
     sprint_count: int = 8,
     generate_samples: bool = False,
     include_insights: bool = True,
+    include_ai_usage: bool = True,
+    include_doc_quality: bool = True,
     *,
     progress: list | None = None,
     db_path=None,
@@ -106,6 +108,13 @@ def run_team_analysis(
             (epic/stories/tasks/sprint) in the team's style — extra LLM calls.
         include_insights: also generate the start/stop/keep/try coaching
             insights (one extra LLM call).
+        include_ai_usage: also scan the team's commits/PRs for AI-tool markers
+            and attach an AI-adoption footprint + coaching to the profile. This
+            makes best-effort GitHub/AzDO network calls; set False to skip them.
+        include_doc_quality: also read the team's recent Notion/Confluence pages
+            and attach a documentation clarity score + stylometric AI-likelihood
+            estimate + coaching. Best-effort doc-platform network calls; set
+            False to skip them.
         progress: optional shared list the analysis workers append status
             strings to (the TUI reads it from its frame loop).
         db_path: sessions DB override (tests). Defaults to paths.get_db_path().
@@ -141,7 +150,12 @@ def run_team_analysis(
     sprint_names = [sd.get("sprint_name", "") for sd in sprint_data]
 
     profile, examples = _run_parallel_analysis(
-        resolved_source, resolved_project or "unknown", sprint_data, progress if progress is not None else []
+        resolved_source,
+        resolved_project or "unknown",
+        sprint_data,
+        progress if progress is not None else [],
+        include_ai_usage=include_ai_usage,
+        include_doc_quality=include_doc_quality,
     )
     if resolved_team and not profile.team_name:
         from dataclasses import replace

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,17 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.27.0",
+      "date": "2026-07-22",
+      "summary": "Team analysis now includes two new sub-analyses that deepen your understanding of how your team works. AI adoption scanning finds markers of Claude, Copilot, Cursor, aider, Devin, Codeium, and other AI tools in your recent commits and pull requests across GitHub, Azure DevOps, and your local git clone — showing you the AI footprint as a lower bound with source-aware reporting and real evidence links. Documentation quality analysis scores the clarity and AI-likelihood of your team's Notion and Confluence pages, again with cited examples and improvement suggestions. Both ride on the existing team profile machinery, gracefully skip when nothing is configured, and frame their findings honestly as footprints and heuristics rather than definitive counts.",
+      "highlights": [
+        {"text": "New AI adoption sub-analysis: detect Claude, Copilot, Cursor, aider, Devin, Codeium markers in commits and PRs", "areas": ["analysis"]},
+        {"text": "AI adoption scans GitHub, Azure DevOps, and local git clones with source-aware breakdowns and evidence links", "areas": ["analysis"]},
+        {"text": "New documentation quality sub-analysis: score Notion/Confluence page clarity and estimated AI likelihood", "areas": ["analysis"]},
+        {"text": "Both analyses include evidence-linked coaching citing specific commits, PRs, and pages with real links", "areas": ["analysis"]}
+      ]
+    },
+    {
       "version": "2.26.0",
       "date": "2026-07-21",
       "summary": "Retro now carries action items forward from the previous retro to this one, showing them in a dedicated \"Last sprint's actions\" review column on the browser board and TUI host view. Your team sets a status for each carried item — Done, Pending, In Progress, Carried Over, or Not Relevant — and these statuses persist in the report. Items marked as Carried Over re-enter the current sprint's action grid and keep the team focused on the context that still matters; Done and Not Relevant items drop out. Carry-forward works whether an item was AI-generated or typed in by hand, and now also survives closing and reopening a retro under the same session. The \"Share Remotely\" button also hardened: it now waits until the Cloudflare tunnel hostname is externally resolvable before advertising the URL, so opening the link doesn't hit an NXDOMAIN that resolvers will cache for 30 minutes.",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -569,6 +569,18 @@ def build_parser() -> argparse.ArgumentParser:
     analyze_p.add_argument("--sprints", type=int, default=8, help="Closed sprints to analyse (default 8)")
     analyze_p.add_argument("--samples", action="store_true", help="Also generate sample tickets (extra LLM calls)")
     analyze_p.add_argument("--no-insights", action="store_true", help="Skip the coaching-insights LLM call")
+    analyze_p.add_argument(
+        "--no-ai-usage",
+        dest="include_ai_usage",
+        action="store_false",
+        help="Skip the AI-adoption scan (commit/PR AI-tool markers)",
+    )
+    analyze_p.add_argument(
+        "--no-doc-quality",
+        dest="include_doc_quality",
+        action="store_false",
+        help="Skip the documentation scan (Notion/Confluence clarity + AI-likelihood)",
+    )
     analyze_p.add_argument("--strict", action="store_true", help="Exit 3 on a degraded run (warnings present)")
     analyze_p.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
 
@@ -1267,6 +1279,8 @@ def _cmd_analyze(args: argparse.Namespace, console: "Console") -> int:
         sprint_count=args.sprints,
         generate_samples=args.samples,
         include_insights=not args.no_insights,
+        include_ai_usage=args.include_ai_usage,
+        include_doc_quality=args.include_doc_quality,
     )
     for warning in result["warnings"]:
         print(f"⚠ {warning}", file=sys.stderr)

--- a/src/yeaboi/mcp/tools_team.py
+++ b/src/yeaboi/mcp/tools_team.py
@@ -36,7 +36,14 @@ class _BridgedProgress(list):
 
 
 def _team_analyze(
-    source: str, project_key: str, sprint_count: int, generate_samples: bool, include_insights: bool, progress=None
+    source: str,
+    project_key: str,
+    sprint_count: int,
+    generate_samples: bool,
+    include_insights: bool,
+    include_ai_usage: bool,
+    include_doc_quality: bool,
+    progress=None,
 ):
     if source not in ("", "jira", "azdevops"):
         raise ValueError(f"source must be 'jira' or 'azdevops' (blank auto-detects) — got {source!r}")
@@ -48,6 +55,8 @@ def _team_analyze(
         sprint_count=sprint_count,
         generate_samples=generate_samples,
         include_insights=include_insights,
+        include_ai_usage=include_ai_usage,
+        include_doc_quality=include_doc_quality,
         progress=progress,
     )
 
@@ -89,13 +98,21 @@ def register(app) -> None:
         sprint_count: int = 8,
         generate_samples: bool = False,
         include_insights: bool = True,
+        include_ai_usage: bool = True,
+        include_doc_quality: bool = True,
     ) -> dict:
         """Analyse the team's tracker history (closed sprints) into a calibration profile:
         velocity, story-point calibration, writing style, DoD signals, plus coaching insights
         and headline stats. The profile is saved and feeds future planning. HEAVY: several LLM
         calls plus tracker API paging — takes minutes; warn the user before running.
         source: 'jira' or 'azdevops' (blank auto-detects); generate_samples additionally drafts
-        sample tickets in the team's style (more LLM calls)."""
+        sample tickets in the team's style (more LLM calls). include_ai_usage also scans the
+        team's commits/PRs for AI-tool markers (Co-Authored-By: Claude, Copilot, Cursor, …) and
+        reports a detectable AI-adoption footprint — a LOWER BOUND (inline IDE assist leaves no
+        trace); set False to skip those GitHub/AzDO network calls. include_doc_quality also reads
+        the team's recent Notion/Confluence pages and reports a documentation clarity score plus a
+        stylometric AI-likelihood ESTIMATE (not a detection); set False to skip those doc-platform
+        network calls."""
         import asyncio
 
         try:
@@ -103,7 +120,16 @@ def register(app) -> None:
         except RuntimeError:  # non-asyncio backend — run without progress
             progress = None
         return await run_engine(
-            ctx, _team_analyze, source, project_key, sprint_count, generate_samples, include_insights, progress
+            ctx,
+            _team_analyze,
+            source,
+            project_key,
+            sprint_count,
+            generate_samples,
+            include_insights,
+            include_ai_usage,
+            include_doc_quality,
+            progress,
         )
 
     @app.tool()

--- a/src/yeaboi/team_profile.py
+++ b/src/yeaboi/team_profile.py
@@ -165,6 +165,72 @@ class SprintScopeTimeline:
 
 
 @dataclass(frozen=True)
+class AiAdoptionSignal:
+    """How much the team's *tracked* work shows an AI-tool footprint.
+
+    Built by scanning commit message bodies and PR descriptions for markers left
+    by AI coding tools (``Co-Authored-By: Claude``, "Generated with Claude Code",
+    Copilot's co-author line, Cursor/aider/Devin/Codeium, …).
+
+    IMPORTANT — this is a **lower bound**, never ground truth: only tools that
+    leave a textual trace in commit/PR metadata are counted. Inline IDE
+    autocomplete (Copilot ghost-text, Cursor Tab) leaves no trace, so real usage
+    is always *at least* this. ``is_lower_bound`` stays True to force honest
+    framing everywhere this is rendered.
+
+    All fields default so old saved profiles (no ``ai_adoption`` key) deserialize
+    to an empty signal. Collection fields are tuple-of-pairs to stay JSON-round-trippable.
+    """
+
+    scanned_commits: int = 0  # commits whose text we inspected
+    scanned_prs: int = 0  # PRs whose text we inspected
+    ai_commits: int = 0  # commits with >= 1 AI marker
+    ai_prs: int = 0  # PRs with >= 1 AI marker
+    footprint_pct: float = 0.0  # (ai_commits + ai_prs) / (scanned_commits + scanned_prs) * 100
+    per_tool: tuple[tuple[str, int], ...] = ()  # (("claude", 12), ("copilot", 3), ...)
+    per_author: tuple[tuple[str, int], ...] = ()  # (author, ai-marked-item count), desc
+    per_activity: tuple[tuple[str, int], ...] = ()  # (("code", n), ("pr", n), ("docs", n))
+    per_source: tuple[tuple[str, int], ...] = ()  # (("local_git", n), ("github", n), ("azdo", n)) AI-marked
+    repos_scanned: tuple[str, ...] = ()  # friendly "what was scanned" labels (path/slug/project)
+    sources_scanned: tuple[str, ...] = ()  # ("github", "local_git", "azdo")
+    is_lower_bound: bool = True  # always True — honesty flag, see class docstring
+
+
+@dataclass(frozen=True)
+class DocQualitySignal:
+    """How clear the team's *written* knowledge is, and how AI shows up in it.
+
+    Built by reading recently-changed Notion & Confluence pages and, per page,
+    computing a deterministic clarity score plus a heuristic AI-likelihood estimate
+    from prose features. Explicit AI markers (e.g. a pasted "Generated with Claude"
+    disclosure) are also counted as a genuine lower bound.
+
+    IMPORTANT — two different confidence levels, never conflate them:
+    - ``avg_clarity`` is a **heuristic readability score** (0–100, higher = clearer).
+    - ``avg_ai_likelihood`` / ``likely_ai_pages`` are a **stylometric ESTIMATE**, not a
+      detection — prose has no reliable AI marker. ``is_ai_estimate`` stays True to
+      force honest framing everywhere this is rendered.
+    - ``ai_marked_pages`` is a **lower bound** — pages carrying an explicit AI trailer.
+
+    All fields default so old saved profiles (no ``doc_quality`` key) deserialize to
+    an empty signal. Collection fields are tuple-of-pairs to stay JSON-round-trippable.
+    """
+
+    pages_scanned: int = 0  # doc pages whose body we read
+    platforms_scanned: tuple[str, ...] = ()  # ("confluence", "notion")
+    avg_clarity: float = 0.0  # mean readability score 0–100 (higher = clearer)
+    clear_pages: int = 0  # pages scoring clear
+    mixed_pages: int = 0  # pages scoring mixed
+    unclear_pages: int = 0  # pages scoring unclear
+    avg_ai_likelihood: float = 0.0  # mean stylometric AI-likelihood ESTIMATE 0–100
+    likely_ai_pages: int = 0  # pages whose estimate crosses the "likely AI" threshold
+    ai_marked_pages: int = 0  # pages with an EXPLICIT AI marker (lower bound)
+    per_platform: tuple[tuple[str, int], ...] = ()  # (("confluence", 12), ("notion", 3))
+    flagged_pages: tuple[tuple[str, str], ...] = ()  # ((title, reason), …) sample call-outs
+    is_ai_estimate: bool = True  # always True — honesty flag, see class docstring
+
+
+@dataclass(frozen=True)
 class TeamProfile:
     """Top-level container for a team's calibration data.
 
@@ -191,6 +257,8 @@ class TeamProfile:
     spillover: SpilloverStats = field(default_factory=SpilloverStats)
     dod_signal: DoDSignal = field(default_factory=DoDSignal)
     writing_patterns: WritingPatterns = field(default_factory=WritingPatterns)
+    ai_adoption: AiAdoptionSignal = field(default_factory=AiAdoptionSignal)
+    doc_quality: DocQualitySignal = field(default_factory=DocQualitySignal)
     sprints_fully_completed: int = 0
     sprints_partially_completed: int = 0
     sprints_analysed: int = 0
@@ -285,6 +353,10 @@ def merge_profiles(old: TeamProfile, new: TeamProfile) -> TeamProfile:
         spillover=new.spillover,
         dod_signal=new.dod_signal,
         writing_patterns=new.writing_patterns,
+        # AI-adoption reflects current behaviour — replace outright (like DoD/writing).
+        ai_adoption=new.ai_adoption,
+        # Doc quality reflects the latest scan — replace outright (like ai_adoption).
+        doc_quality=new.doc_quality,
         sprints_fully_completed=old.sprints_fully_completed + new.sprints_fully_completed,
         sprints_partially_completed=old.sprints_partially_completed + new.sprints_partially_completed,
         sprints_analysed=old.sprints_analysed + new.sprints_analysed,
@@ -460,6 +532,81 @@ def _dict_to_writing_patterns(d: dict) -> WritingPatterns:
     )
 
 
+def _dict_to_ai_adoption(d: dict) -> AiAdoptionSignal:
+    """Reconstruct an AiAdoptionSignal from a JSON-parsed dict.
+
+    Tuple-izes the pair lists (JSON turns them into lists of lists). ``.get``
+    defaults mean an old profile without an ``ai_adoption`` key round-trips to
+    an empty signal — backward compatible with pre-feature saved rows.
+    """
+
+    def _pairs(raw: object) -> tuple[tuple[str, int], ...]:
+        if not isinstance(raw, (list, tuple)):
+            return ()
+        out: list[tuple[str, int]] = []
+        for pair in raw:
+            if isinstance(pair, (list, tuple)) and len(pair) == 2:
+                out.append((str(pair[0]), int(pair[1])))
+        return tuple(out)
+
+    return AiAdoptionSignal(
+        scanned_commits=d.get("scanned_commits", 0),
+        scanned_prs=d.get("scanned_prs", 0),
+        ai_commits=d.get("ai_commits", 0),
+        ai_prs=d.get("ai_prs", 0),
+        footprint_pct=d.get("footprint_pct", 0.0),
+        per_tool=_pairs(d.get("per_tool", ())),
+        per_author=_pairs(d.get("per_author", ())),
+        per_activity=_pairs(d.get("per_activity", ())),
+        per_source=_pairs(d.get("per_source", ())),
+        repos_scanned=tuple(str(r) for r in d.get("repos_scanned", ())),
+        sources_scanned=tuple(str(s) for s in d.get("sources_scanned", ())),
+        is_lower_bound=d.get("is_lower_bound", True),
+    )
+
+
+def _dict_to_doc_quality(d: dict) -> DocQualitySignal:
+    """Reconstruct a DocQualitySignal from a JSON-parsed dict.
+
+    Tuple-izes the pair lists (JSON turns them into lists of lists). ``.get``
+    defaults mean an old profile without a ``doc_quality`` key round-trips to an
+    empty signal — backward compatible with pre-feature saved rows.
+    """
+
+    def _pairs(raw: object) -> tuple[tuple[str, int], ...]:
+        if not isinstance(raw, (list, tuple)):
+            return ()
+        out: list[tuple[str, int]] = []
+        for pair in raw:
+            if isinstance(pair, (list, tuple)) and len(pair) == 2:
+                out.append((str(pair[0]), int(pair[1])))
+        return tuple(out)
+
+    def _str_pairs(raw: object) -> tuple[tuple[str, str], ...]:
+        if not isinstance(raw, (list, tuple)):
+            return ()
+        out: list[tuple[str, str]] = []
+        for pair in raw:
+            if isinstance(pair, (list, tuple)) and len(pair) == 2:
+                out.append((str(pair[0]), str(pair[1])))
+        return tuple(out)
+
+    return DocQualitySignal(
+        pages_scanned=d.get("pages_scanned", 0),
+        platforms_scanned=tuple(str(p) for p in d.get("platforms_scanned", ())),
+        avg_clarity=d.get("avg_clarity", 0.0),
+        clear_pages=d.get("clear_pages", 0),
+        mixed_pages=d.get("mixed_pages", 0),
+        unclear_pages=d.get("unclear_pages", 0),
+        avg_ai_likelihood=d.get("avg_ai_likelihood", 0.0),
+        likely_ai_pages=d.get("likely_ai_pages", 0),
+        ai_marked_pages=d.get("ai_marked_pages", 0),
+        per_platform=_pairs(d.get("per_platform", ())),
+        flagged_pages=_str_pairs(d.get("flagged_pages", ())),
+        is_ai_estimate=d.get("is_ai_estimate", True),
+    )
+
+
 def _dict_to_profile(d: dict) -> TeamProfile:
     """Reconstruct a TeamProfile from a plain dict (JSON-parsed or ``asdict`` output).
 
@@ -482,6 +629,8 @@ def _dict_to_profile(d: dict) -> TeamProfile:
         spillover=_dict_to_spillover_stats(d.get("spillover", {})),
         dod_signal=_dict_to_dod_signal(d.get("dod_signal", {})),
         writing_patterns=_dict_to_writing_patterns(d.get("writing_patterns", {})),
+        ai_adoption=_dict_to_ai_adoption(d.get("ai_adoption", {})),
+        doc_quality=_dict_to_doc_quality(d.get("doc_quality", {})),
         sprints_fully_completed=d.get("sprints_fully_completed", 0),
         sprints_partially_completed=d.get("sprints_partially_completed", 0),
         sprints_analysed=d.get("sprints_analysed", 0),

--- a/src/yeaboi/team_profile_exporter.py
+++ b/src/yeaboi/team_profile_exporter.py
@@ -19,6 +19,7 @@ from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 
+from yeaboi.analysis.ai_usage import _source_label
 from yeaboi.team_profile import TeamProfile
 from yeaboi.tools.team_learning import ANALYSIS_GLOSSARY, INSIGHT_CATEGORIES
 
@@ -88,6 +89,72 @@ def _kv_table(rows: list[tuple[str, str]]) -> str:
         for lbl, v in rows
     )
     return f'<div class="card" style="padding:0;overflow:hidden;"><table class="data-table">{trs}</table></div>'
+
+
+def _insight_html(it: dict) -> str:
+    """Render one coaching insight as an <li>, linking the cited example when present."""
+    body = f"<strong>{_e(str(it.get('title', '')))}</strong> &mdash; {_e(str(it.get('detail', '')))}"
+    if it.get("evidence"):
+        body += f" <em>({_e(str(it['evidence']))})</em>"
+    link = str(it.get("link", "") or "").strip()
+    if link:
+        body += f' <a href="{_e(link)}">↳ example</a>'
+    return f"<li>{body}</li>"
+
+
+def _insight_md(it: dict) -> str:
+    """Render one coaching insight as a Markdown bullet, linking the cited example when present."""
+    line = f"- **{it.get('title', '')}** — {it.get('detail', '')}"
+    if it.get("evidence"):
+        line += f" *({it['evidence']})*"
+    link = str(it.get("link", "") or "").strip()
+    if link:
+        line += f" [↳ example]({link})"
+    return line
+
+
+def _ai_example_md(s: dict) -> str:
+    """Render one AI-adoption sample as a Markdown bullet (link when available, else SHA)."""
+    tool = "unlabelled AI" if s.get("tool") == "other_ai" else str(s.get("tool", ""))
+    title = str(s.get("title", ""))
+    url = str(s.get("url", "") or "")
+    if url:
+        return f"- [{tool}] [{title}]({url}) — {_source_label(str(s.get('source', '')))}"
+    key = str(s.get("key", "") or "")
+    return f"- [{tool}] {title}" + (f" — commit `{key}`" if key else "")
+
+
+def _doc_example_md(s: dict) -> str:
+    """Render one documentation sample as a Markdown bullet (linked page + scores)."""
+    title = str(s.get("title", "Untitled"))
+    url = str(s.get("url", "") or "")
+    head = f"[{title}]({url})" if url else title
+    meta = f"{s.get('platform', '')} · clarity {s.get('clarity', 0):.0f} · AI-est {s.get('ai_likelihood', 0):.0f}"
+    return f"- {head} ({meta})"
+
+
+def _ai_example_html(s: dict) -> str:
+    """Render one AI-adoption sample as an <li> (link when available, else SHA/key)."""
+    tool = "unlabelled AI" if s.get("tool") == "other_ai" else str(s.get("tool", ""))
+    title = _e(str(s.get("title", "")))
+    label = f"[{_e(tool)}] {title}"
+    url = str(s.get("url", "") or "")
+    if url:
+        return f'<li>{label} — <a href="{_e(url)}">{_e(_source_label(str(s.get("source", ""))))}</a></li>'
+    key = str(s.get("key", "") or "")
+    ref = f" — commit {_e(key)}" if key else ""
+    return f"<li>{label}{ref}</li>"
+
+
+def _doc_example_html(s: dict) -> str:
+    """Render one documentation sample as an <li> (linked page title + scores)."""
+    title = _e(str(s.get("title", "Untitled")))
+    meta = (
+        f"{_e(str(s.get('platform', '')))} · clarity {s.get('clarity', 0):.0f} · AI-est {s.get('ai_likelihood', 0):.0f}"
+    )
+    url = str(s.get("url", "") or "")
+    head = f'<a href="{_e(url)}">{title}</a>' if url else title
+    return f"<li>{head} <span style='color:var(--text-muted);'>({meta})</span></li>"
 
 
 def _ceremony_rows(ceremony) -> list[tuple[str, str]]:
@@ -196,6 +263,100 @@ def export_team_profile_html(
         if i_parts:
             _nav("insights", "Insights")
             sections.append(_section("insights", "Team Insights", "".join(i_parts)))
+
+    # ── AI Adoption (detectable AI-tool footprint — lower bound) ─────
+    ai_sig = getattr(profile, "ai_adoption", None)
+    ai_blob = ex.get("ai_adoption", {})
+    ai_scanned = (getattr(ai_sig, "scanned_commits", 0) + getattr(ai_sig, "scanned_prs", 0)) if ai_sig else 0
+    if ai_sig and ai_scanned:
+        disclaimer = (
+            '<p class="muted"><em>Lower bound — only AI tools that leave a marker in commit '
+            "messages or PR descriptions are counted. Inline IDE assist (Copilot ghost-text, "
+            "Cursor Tab) leaves no trace, so real usage is at least this.</em></p>"
+        )
+        a_rows = [
+            ("Detectable footprint", f"{ai_sig.footprint_pct:.0f}%"),
+            ("Commits with AI marker", f"{ai_sig.ai_commits} of {ai_sig.scanned_commits}"),
+        ]
+        if ai_sig.scanned_prs:
+            a_rows.append(("PRs with AI marker", f"{ai_sig.ai_prs} of {ai_sig.scanned_prs}"))
+        if ai_sig.sources_scanned:
+            a_rows.append(("Sources scanned", ", ".join(_source_label(s) for s in ai_sig.sources_scanned)))
+        for repo in getattr(ai_sig, "repos_scanned", ()):
+            a_rows.append(("Scanned", repo))
+        a_html = disclaimer + _kv_table(a_rows)
+        if ai_sig.per_tool:
+            tool_lis = "".join(
+                f"<li>{_e('unlabelled AI' if t == 'other_ai' else t)}: {n}</li>" for t, n in ai_sig.per_tool
+            )
+            a_html += f"<h4>By tool</h4><ul>{tool_lis}</ul>"
+        if getattr(ai_sig, "per_source", ()):
+            src_lis = "".join(f"<li>{_e(_source_label(s))}: {n}</li>" for s, n in ai_sig.per_source)
+            a_html += f"<h4>By source</h4><ul>{src_lis}</ul>"
+        if ai_sig.per_activity:
+            act_lis = "".join(f"<li>{_e(a)}: {n}</li>" for a, n in ai_sig.per_activity)
+            a_html += f"<h4>By activity</h4><ul>{act_lis}</ul>"
+        if ai_sig.per_author:
+            auth_lis = "".join(f"<li>{_e(a)}: {n}</li>" for a, n in ai_sig.per_author[:8])
+            a_html += f"<h4>By contributor</h4><ul>{auth_lis}</ul>"
+        ai_coverage = ai_blob.get("coverage") if isinstance(ai_blob, dict) else None
+        if ai_coverage:
+            gap_lis = "".join(f"<li>{_e(g)}</li>" for g in ai_coverage[:4])
+            a_html += f"<h4>Not scanned</h4><ul>{gap_lis}</ul>"
+        ai_samples = ai_blob.get("samples") if isinstance(ai_blob, dict) else None
+        if ai_samples:
+            ex_lis = "".join(_ai_example_html(s) for s in ai_samples[:5])
+            a_html += f"<h4>Examples</h4><ul>{ex_lis}</ul>"
+        ai_insights = ai_blob.get("insights", {}) if isinstance(ai_blob, dict) else {}
+        if isinstance(ai_insights, dict) and any(ai_insights.get(k) for k, _ in INSIGHT_CATEGORIES):
+            for ik, ilabel in INSIGHT_CATEGORIES:
+                i_items = ai_insights.get(ik)
+                if not isinstance(i_items, list) or not i_items:
+                    continue
+                i_lis = "".join(_insight_html(it) for it in i_items if isinstance(it, dict) and it.get("title"))
+                if i_lis:
+                    a_html += f'<div class="card"><strong>{_e(ilabel)}</strong><ul>{i_lis}</ul></div>'
+        _nav("ai-adoption", "AI Adoption")
+        sections.append(_section("ai-adoption", "AI Adoption", a_html))
+
+    # ── Documentation (Notion/Confluence clarity + AI-usage estimate) ─────
+    dq_sig = getattr(profile, "doc_quality", None)
+    dq_blob = ex.get("doc_quality", {})
+    dq_pages = getattr(dq_sig, "pages_scanned", 0) if dq_sig else 0
+    if dq_sig and dq_pages:
+        dq_disclaimer = (
+            '<p class="muted"><em>Clarity is a readability score. AI-likelihood is a heuristic '
+            "estimate from writing style, not a detection — prose has no reliable AI marker. "
+            "Explicit AI markers are a lower bound.</em></p>"
+        )
+        d_split = f"{dq_sig.clear_pages} clear / {dq_sig.mixed_pages} mixed / {dq_sig.unclear_pages} unclear"
+        d_ai = f"{dq_sig.avg_ai_likelihood:.0f}/100 — ~{dq_sig.likely_ai_pages} page(s) look AI-drafted"
+        d_rows = [
+            ("Average clarity", f"{dq_sig.avg_clarity:.0f}/100"),
+            ("Pages scanned", f"{dq_pages} ({', '.join(dq_sig.platforms_scanned) or 'n/a'})"),
+            ("Clarity split", d_split),
+            ("AI-likelihood (estimate)", d_ai),
+            ("Explicit AI markers", f"{dq_sig.ai_marked_pages} page(s) (lower bound)"),
+        ]
+        d_html = dq_disclaimer + _kv_table(d_rows)
+        if dq_sig.flagged_pages:
+            flag_lis = "".join(f"<li>{_e(title)}: {_e(reason)}</li>" for title, reason in dq_sig.flagged_pages)
+            d_html += f"<h4>Flagged pages</h4><ul>{flag_lis}</ul>"
+        dq_samples = dq_blob.get("samples") if isinstance(dq_blob, dict) else None
+        if dq_samples:
+            ex_lis = "".join(_doc_example_html(s) for s in dq_samples[:5])
+            d_html += f"<h4>Examples</h4><ul>{ex_lis}</ul>"
+        dq_insights = dq_blob.get("insights", {}) if isinstance(dq_blob, dict) else {}
+        if isinstance(dq_insights, dict) and any(dq_insights.get(k) for k, _ in INSIGHT_CATEGORIES):
+            for ik, ilabel in INSIGHT_CATEGORIES:
+                i_items = dq_insights.get(ik)
+                if not isinstance(i_items, list) or not i_items:
+                    continue
+                i_lis = "".join(_insight_html(it) for it in i_items if isinstance(it, dict) and it.get("title"))
+                if i_lis:
+                    d_html += f'<div class="card"><strong>{_e(ilabel)}</strong><ul>{i_lis}</ul></div>'
+        _nav("documentation", "Documentation")
+        sections.append(_section("documentation", "Documentation", d_html))
 
     # ── Team & Velocity ─────────────────────────────────────────────
     vel_rows: list[tuple[str, str]] = []
@@ -1452,6 +1613,94 @@ def build_team_profile_markdown(
                 lines.append(i_line)
             lines.append("")
 
+    # ── AI Adoption (detectable AI-tool footprint — lower bound) ─────
+    ai_sig = getattr(profile, "ai_adoption", None)
+    ai_blob = ex.get("ai_adoption", {})
+    ai_scanned = (getattr(ai_sig, "scanned_commits", 0) + getattr(ai_sig, "scanned_prs", 0)) if ai_sig else 0
+    if ai_sig and ai_scanned:
+        lines.extend(["## AI Adoption", ""])
+        lines.append(
+            "> _Lower bound — only AI tools that leave a marker in commit messages or PR "
+            "descriptions are counted. Inline IDE assist (Copilot ghost-text, Cursor Tab) "
+            "leaves no trace, so real usage is at least this._"
+        )
+        lines.append("")
+        lines.append(f"- **Detectable footprint:** {ai_sig.footprint_pct:.0f}%")
+        lines.append(f"- **Commits with AI marker:** {ai_sig.ai_commits} of {ai_sig.scanned_commits}")
+        if ai_sig.scanned_prs:
+            lines.append(f"- **PRs with AI marker:** {ai_sig.ai_prs} of {ai_sig.scanned_prs}")
+        if ai_sig.sources_scanned:
+            lines.append(f"- **Sources scanned:** {', '.join(_source_label(s) for s in ai_sig.sources_scanned)}")
+        for repo in getattr(ai_sig, "repos_scanned", ()):
+            lines.append(f"- **Scanned:** {repo}")
+        if ai_sig.per_tool:
+            tools = ", ".join(f"{'unlabelled AI' if t == 'other_ai' else t} ({n})" for t, n in ai_sig.per_tool)
+            lines.append(f"- **By tool:** {tools}")
+        if getattr(ai_sig, "per_source", ()):
+            lines.append(f"- **By source:** {', '.join(f'{_source_label(s)} ({n})' for s, n in ai_sig.per_source)}")
+        if ai_sig.per_activity:
+            lines.append(f"- **By activity:** {', '.join(f'{a} ({n})' for a, n in ai_sig.per_activity)}")
+        if ai_sig.per_author:
+            lines.append(f"- **By contributor:** {', '.join(f'{a} ({n})' for a, n in ai_sig.per_author[:8])}")
+        ai_coverage = ai_blob.get("coverage") if isinstance(ai_blob, dict) else None
+        if ai_coverage:
+            lines.append(f"- **Not scanned:** {'; '.join(ai_coverage[:4])}")
+        lines.append("")
+        ai_samples = ai_blob.get("samples") if isinstance(ai_blob, dict) else None
+        if ai_samples:
+            lines.extend(["### Examples", ""])
+            lines.extend(_ai_example_md(s) for s in ai_samples[:5])
+            lines.append("")
+        ai_insights = ai_blob.get("insights", {}) if isinstance(ai_blob, dict) else {}
+        if isinstance(ai_insights, dict) and any(ai_insights.get(k) for k, _ in INSIGHT_CATEGORIES):
+            for ik, ilabel in INSIGHT_CATEGORIES:
+                i_items = ai_insights.get(ik)
+                if not isinstance(i_items, list) or not i_items:
+                    continue
+                lines.extend([f"### {ilabel}", ""])
+                lines.extend(_insight_md(it) for it in i_items if isinstance(it, dict) and it.get("title"))
+                lines.append("")
+
+    # ── Documentation (Notion/Confluence clarity + AI-usage estimate) ─────
+    dq_sig = getattr(profile, "doc_quality", None)
+    dq_blob = ex.get("doc_quality", {})
+    dq_pages = getattr(dq_sig, "pages_scanned", 0) if dq_sig else 0
+    if dq_sig and dq_pages:
+        lines.extend(["## Documentation", ""])
+        lines.append(
+            "> _Clarity is a readability score. AI-likelihood is a heuristic estimate from "
+            "writing style, not a detection — prose has no reliable AI marker. Explicit AI "
+            "markers are a lower bound._"
+        )
+        lines.append("")
+        dq_platforms = ", ".join(dq_sig.platforms_scanned) or "n/a"
+        dq_split = f"{dq_sig.clear_pages} clear / {dq_sig.mixed_pages} mixed / {dq_sig.unclear_pages} unclear"
+        lines.append(f"- **Average clarity:** {dq_sig.avg_clarity:.0f}/100")
+        lines.append(f"- **Pages scanned:** {dq_pages} ({dq_platforms})")
+        lines.append(f"- **Clarity split:** {dq_split}")
+        lines.append(
+            f"- **AI-likelihood (estimate):** {dq_sig.avg_ai_likelihood:.0f}/100 — "
+            f"~{dq_sig.likely_ai_pages} page(s) look AI-drafted"
+        )
+        lines.append(f"- **Explicit AI markers:** {dq_sig.ai_marked_pages} page(s) (lower bound)")
+        if dq_sig.flagged_pages:
+            lines.append(f"- **Flagged:** {', '.join(f'{t} ({r})' for t, r in dq_sig.flagged_pages)}")
+        lines.append("")
+        dq_samples = dq_blob.get("samples") if isinstance(dq_blob, dict) else None
+        if dq_samples:
+            lines.extend(["### Examples", ""])
+            lines.extend(_doc_example_md(s) for s in dq_samples[:5])
+            lines.append("")
+        dq_insights = dq_blob.get("insights", {}) if isinstance(dq_blob, dict) else {}
+        if isinstance(dq_insights, dict) and any(dq_insights.get(k) for k, _ in INSIGHT_CATEGORIES):
+            for ik, ilabel in INSIGHT_CATEGORIES:
+                i_items = dq_insights.get(ik)
+                if not isinstance(i_items, list) or not i_items:
+                    continue
+                lines.extend([f"### {ilabel}", ""])
+                lines.extend(_insight_md(it) for it in i_items if isinstance(it, dict) and it.get("title"))
+                lines.append("")
+
     # ── Recurring work ──────────────────────────────────────────────
     rec_count = ex.get("recurring_count", 0)
     del_count = ex.get("delivery_count", 0)
@@ -2364,6 +2613,74 @@ def write_analysis_log(
                 if isinstance(it, dict) and it.get("title"):
                     ev = f" ({it['evidence']})" if it.get("evidence") else ""
                     sections.append(f"  {ilabel.upper():<14s}{it['title']}{ev}")
+
+    # AI-adoption footprint (lower bound — commit/PR markers only)
+    ai_sig = getattr(profile, "ai_adoption", None)
+    ai_blob = examples.get("ai_adoption", {}) if examples else {}
+    ai_scanned = (getattr(ai_sig, "scanned_commits", 0) + getattr(ai_sig, "scanned_prs", 0)) if ai_sig else 0
+    if ai_sig and ai_scanned:
+        sections.extend(["", "AI Adoption (lower bound — commit/PR markers only):"])
+        sections.append(f"  Detectable footprint: {ai_sig.footprint_pct:.0f}%")
+        sections.append(f"  Commits with AI marker: {ai_sig.ai_commits} of {ai_sig.scanned_commits}")
+        if ai_sig.scanned_prs:
+            sections.append(f"  PRs with AI marker: {ai_sig.ai_prs} of {ai_sig.scanned_prs}")
+        if ai_sig.sources_scanned:
+            sections.append(f"  Sources: {', '.join(_source_label(s) for s in ai_sig.sources_scanned)}")
+        for repo in getattr(ai_sig, "repos_scanned", ()):
+            sections.append(f"  Scanned: {repo}")
+        if ai_sig.per_tool:
+            sections.append(
+                "  By tool: "
+                + ", ".join(f"{'unlabelled AI' if t == 'other_ai' else t}={n}" for t, n in ai_sig.per_tool)
+            )
+        if getattr(ai_sig, "per_source", ()):
+            sections.append("  By source: " + ", ".join(f"{_source_label(s)}={n}" for s, n in ai_sig.per_source))
+        ai_coverage = ai_blob.get("coverage") if isinstance(ai_blob, dict) else None
+        if ai_coverage:
+            sections.append(f"  Not scanned: {'; '.join(ai_coverage[:4])}")
+        ai_samples = ai_blob.get("samples") if isinstance(ai_blob, dict) else None
+        if ai_samples:
+            sections.append("  Examples:")
+            for s in ai_samples[:5]:
+                ref = s.get("url") or (f"commit {s.get('key')}" if s.get("key") else "")
+                sections.append(f"    [{s.get('tool', '')}] {s.get('title', '')} {ref}".rstrip())
+        ai_insights = ai_blob.get("insights", {}) if isinstance(ai_blob, dict) else {}
+        if isinstance(ai_insights, dict) and any(ai_insights.get(k) for k, _ in INSIGHT_CATEGORIES):
+            for ik, ilabel in INSIGHT_CATEGORIES:
+                for it in ai_insights.get(ik) or []:
+                    if isinstance(it, dict) and it.get("title"):
+                        ev = f" ({it['evidence']})" if it.get("evidence") else ""
+                        link = f" [{it['link']}]" if it.get("link") else ""
+                        sections.append(f"  {ilabel.upper():<14s}{it['title']}{ev}{link}")
+
+    # Documentation quality (clarity score + AI-likelihood estimate + explicit-marker lower bound)
+    dq_sig = getattr(profile, "doc_quality", None)
+    dq_blob = examples.get("doc_quality", {}) if examples else {}
+    dq_pages = getattr(dq_sig, "pages_scanned", 0) if dq_sig else 0
+    if dq_sig and dq_pages:
+        dq_platforms = ", ".join(dq_sig.platforms_scanned) or "n/a"
+        dq_split = f"{dq_sig.clear_pages} clear / {dq_sig.mixed_pages} mixed / {dq_sig.unclear_pages} unclear"
+        dq_ai = f"{dq_sig.avg_ai_likelihood:.0f}/100, ~{dq_sig.likely_ai_pages} page(s) look AI-drafted"
+        sections.extend(["", "Documentation (clarity score; AI-likelihood is an estimate, markers a lower bound):"])
+        sections.append(f"  Average clarity: {dq_sig.avg_clarity:.0f}/100")
+        sections.append(f"  Pages scanned: {dq_pages} ({dq_platforms})")
+        sections.append(f"  Clarity split: {dq_split}")
+        sections.append(f"  AI-likelihood (estimate): {dq_ai}")
+        sections.append(f"  Explicit AI markers: {dq_sig.ai_marked_pages} page(s)")
+        dq_samples = dq_blob.get("samples") if isinstance(dq_blob, dict) else None
+        if dq_samples:
+            sections.append("  Examples:")
+            for s in dq_samples[:5]:
+                ref = f" {s['url']}" if s.get("url") else ""
+                sections.append(f"    {s.get('title', '')} ({s.get('platform', '')}){ref}".rstrip())
+        dq_insights = dq_blob.get("insights", {}) if isinstance(dq_blob, dict) else {}
+        if isinstance(dq_insights, dict) and any(dq_insights.get(k) for k, _ in INSIGHT_CATEGORIES):
+            for ik, ilabel in INSIGHT_CATEGORIES:
+                for it in dq_insights.get(ik) or []:
+                    if isinstance(it, dict) and it.get("title"):
+                        ev = f" ({it['evidence']})" if it.get("evidence") else ""
+                        link = f" [{it['link']}]" if it.get("link") else ""
+                        sections.append(f"  {ilabel.upper():<14s}{it['title']}{ev}{link}")
 
     # Full profile JSON for machine-readable recovery
     sections.extend(["", "=" * 60, "", "Raw profile JSON:", ""])

--- a/src/yeaboi/tools/azure_devops.py
+++ b/src/yeaboi/tools/azure_devops.py
@@ -1055,7 +1055,8 @@ def azdevops_recent_commits(project: str = "", days: int = 1, since=None) -> lis
     Scans up to the first _MAX_ACTIVITY_REPOS repositories in the project (all
     branches are NOT walked — the commit search covers the default branch per
     repo, which is where merged work lands). Each item: {author, author_email,
-    kind='commit', title(first line + repo name), timestamp, key(sha[:8])}.
+    kind='commit', title(first line + repo name), body, timestamp, key(sha[:8])}.
+    ``body`` is the commit message body (Co-Authored-By / AI-tool trailers).
     Returns [] when Azure DevOps is unconfigured or the API fails.
     """
     project = project or get_azure_devops_project() or ""
@@ -1081,6 +1082,7 @@ def azdevops_recent_commits(project: str = "", days: int = 1, since=None) -> lis
             for commit in commits or []:
                 author = getattr(commit, "author", None)
                 message = (getattr(commit, "comment", "") or "").splitlines()
+                body = "\n".join(message[1:]).strip()  # Co-Authored-By / AI-tool trailers live here
                 sha = getattr(commit, "commit_id", "") or ""
                 items.append(
                     {
@@ -1088,6 +1090,7 @@ def azdevops_recent_commits(project: str = "", days: int = 1, since=None) -> lis
                         "author_email": getattr(author, "email", "") or "",
                         "kind": "commit",
                         "title": f"{message[0] if message else ''} ({repo.name})",
+                        "body": body,
                         "timestamp": str(getattr(author, "date", "") or "")[:19],
                         "key": sha[:8],
                         "url": f"{repo_web}/commit/{sha}" if repo_web and sha else "",
@@ -1114,8 +1117,9 @@ def azdevops_recent_prs(project: str = "", days: int = 1, since=None) -> list[di
 
     The v7_1 PR search criteria has no time filters, so PRs are fetched
     newest-first per repo (top 25) and filtered client-side by creation/closed
-    date. Each item: {author, author_email, kind='pr', title(+repo name),
-    status, timestamp, key(!id)}. Returns [] on missing config or API failure.
+    date. Each item: {author, author_email, kind='pr', title(+repo name), body,
+    status, timestamp, key(!id)} (``body`` is the PR description). Returns [] on
+    missing config or API failure.
     """
     project = project or get_azure_devops_project() or ""
     logger.info("azdevops_recent_prs: project=%r days=%d since=%s", project, days, since)
@@ -1151,6 +1155,7 @@ def azdevops_recent_prs(project: str = "", days: int = 1, since=None) -> list[di
                         "author_email": getattr(creator, "unique_name", "") or "",
                         "kind": "pr",
                         "title": f"{getattr(pr, 'title', '') or ''} ({repo.name})",
+                        "body": getattr(pr, "description", "") or "",  # PR description
                         "status": "merged" if status == "completed" else status,
                         "timestamp": str(closed or created or "")[:19],
                         "key": f"!{pr_id}",

--- a/src/yeaboi/tools/github.py
+++ b/src/yeaboi/tools/github.py
@@ -374,8 +374,9 @@ def github_recent_commits(repo_url: str, days: int = 1, since=None) -> list[dict
     """Return commits pushed to the default branch since the window start.
 
     The window is ``since → now`` when ``since`` (tz-aware datetime) is given,
-    else the last ``days`` days. Each item: {author, kind='commit', title,
-    timestamp, key(sha)}. Returns [] when the repo can't be read (no token /
+    else the last ``days`` days. Each item: {author, kind='commit', title, body,
+    timestamp, key(sha)}. ``body`` is the commit message body (Co-Authored-By /
+    AI-tool trailers). Returns [] when the repo can't be read (no token /
     not found / rate-limited).
     """
     logger.info("github_recent_commits: repo=%r days=%d since=%s", repo_url, days, since)
@@ -388,7 +389,10 @@ def github_recent_commits(repo_url: str, days: int = 1, since=None) -> list[dict
             commit = c.commit
             author = commit.author.name if commit.author else ""
             email = (getattr(commit.author, "email", "") or "") if commit.author else ""
-            msg = (commit.message or "").splitlines()[0] if commit.message else ""
+            full = commit.message or ""
+            lines = full.splitlines()
+            msg = lines[0] if lines else ""
+            body = "\n".join(lines[1:]).strip()  # message body: Co-Authored-By / AI-tool trailers live here
             ts = commit.author.date.isoformat()[:19] if commit.author and commit.author.date else ""
             items.append(
                 {
@@ -396,6 +400,7 @@ def github_recent_commits(repo_url: str, days: int = 1, since=None) -> list[dict
                     "author_email": email,
                     "kind": "commit",
                     "title": msg,
+                    "body": body,
                     "timestamp": ts,
                     "key": c.sha[:8],
                     "url": getattr(c, "html_url", "") or "",
@@ -436,13 +441,17 @@ def _pr_branch_commit_items(pr, cutoff) -> list[dict]:
         when = commit.author.date if commit.author else None
         if when is None or when.tzinfo is None or when < cutoff:
             continue
-        msg = (commit.message or "").splitlines()[0] if commit.message else ""
+        full = commit.message or ""
+        lines = full.splitlines()
+        msg = lines[0] if lines else ""
+        body = "\n".join(lines[1:]).strip()
         items.append(
             {
                 "author": commit.author.name if commit.author else "",
                 "author_email": (getattr(commit.author, "email", "") or "") if commit.author else "",
                 "kind": "commit",
                 "title": f"{msg} (PR #{pr.number})",
+                "body": body,
                 "timestamp": commit.author.date.isoformat()[:19],
                 "key": c.sha[:8],
                 "url": getattr(c, "html_url", "") or "",
@@ -455,8 +464,9 @@ def github_recent_prs(repo_url: str, days: int = 1, since=None) -> list[dict]:
     """Return pull requests updated since the window start, plus their branch commits.
 
     The window is ``since → now`` when ``since`` (tz-aware datetime) is given,
-    else the last ``days`` days. Each PR item: {author, kind='pr', title, status,
-    timestamp, key(#num)}. For the newest in-window PRs (open or merged, capped
+    else the last ``days`` days. Each PR item: {author, kind='pr', title, body,
+    status, timestamp, key(#num)} (``body`` is the PR description). For the newest
+    in-window PRs (open or merged, capped
     at _MAX_PR_COMMIT_LOOKUPS) the PR's branch commits are also emitted as
     kind='commit' items so unmerged feature-branch work is visible. Returns []
     on any error. Sorted by updated desc; stops once older than the window.
@@ -481,6 +491,7 @@ def github_recent_prs(repo_url: str, days: int = 1, since=None) -> list[dict]:
                     "author": pr.user.login if pr.user else "",
                     "kind": "pr",
                     "title": pr.title or "",
+                    "body": getattr(pr, "body", "") or "",  # PR description — AI-drafted summaries / trailers live here
                     "status": status,
                     "timestamp": ts,
                     "key": f"#{pr.number}",

--- a/src/yeaboi/tools/local_git.py
+++ b/src/yeaboi/tools/local_git.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -33,11 +34,60 @@ def git_subprocess_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
 
 
-# Unit-separator delimited format: author name, author email, ISO date, subject.
-# %x1f is the ASCII unit separator — safe against commit messages containing
-# commas/pipes/tabs. The email lets the standup engine match this commit to a
-# tracker member whose display name differs from the git author name.
-_LOG_FORMAT = "%an%x1f%ae%x1f%aI%x1f%s"
+# Unit-separator delimited format: full SHA, author name, author email, ISO date,
+# subject, body. %x1f is the ASCII unit separator (field delimiter) — safe against
+# commit messages containing commas/pipes/tabs. %x1e (record separator) terminates each
+# commit so the multi-line body (%b, where Co-Authored-By / AI-tool trailers live) can't
+# be confused with the next record. The SHA (%H) gives each commit a unique key (used for
+# dedup and to reference/link the commit); the email lets the standup engine match this
+# commit to a tracker member whose display name differs from the git author name.
+_LOG_FORMAT = "%H%x1f%an%x1f%ae%x1f%aI%x1f%s%x1f%b%x1e"
+
+
+def _origin_commit_url_base(repo_path: str) -> str:
+    """Best-effort web URL base for the repo's ``origin`` remote, or "".
+
+    Reads ``remote.origin.url`` and normalizes the common forms so a caller can
+    build ``f"{base}/commit/{sha}"``:
+    - ``git@github.com:owner/repo(.git)``      → ``https://github.com/owner/repo``
+    - ``https://github.com/owner/repo(.git)``  → ``https://github.com/owner/repo``
+    - ``https://dev.azure.com/org/proj/_git/repo`` → unchanged (Azure commit path is
+      ``/commit/<sha>`` under the repo)
+
+    Returns "" for an unknown host or any failure — the caller then falls back to a
+    SHA-only reference. Never raises.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(Path(repo_path).expanduser()), "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+            env=git_subprocess_env(),
+        )
+    except (FileNotFoundError, subprocess.SubprocessError) as e:  # pragma: no cover - defensive
+        logger.debug("origin-url lookup failed to run git: %s", e)
+        return ""
+    if proc.returncode != 0:
+        return ""
+    raw = proc.stdout.strip()
+    if not raw:
+        return ""
+    # git@host:owner/repo(.git) → https://host/owner/repo
+    m = re.match(r"^git@([^:]+):(.+?)(?:\.git)?/?$", raw)
+    if m:
+        host, path = m.group(1), m.group(2)
+        if "github.com" in host or "dev.azure.com" in host or "visualstudio.com" in host:
+            return f"https://{host}/{path}"
+        return ""
+    # https/http URL → strip trailing .git and credentials in userinfo
+    m = re.match(r"^https?://(?:[^@/]+@)?(.+?)(?:\.git)?/?$", raw)
+    if m:
+        rest = m.group(1)
+        if any(h in rest for h in ("github.com", "dev.azure.com", "visualstudio.com")):
+            return f"https://{rest}"
+    return ""
 
 
 def local_git_recent_commits(repo_path: str, days: int = 1, since=None) -> list[dict]:
@@ -45,8 +95,12 @@ def local_git_recent_commits(repo_path: str, days: int = 1, since=None) -> list[
 
     The window is ``since → now`` when ``since`` (a datetime) is given — git
     parses the ISO form directly — else the last ``days`` days. Each item:
-    {author, kind='commit', title, timestamp, key(sha)}. Returns [] when the
-    path is not a git repo, git is unavailable, or the command fails.
+    {author, kind='commit', title, body, timestamp, key(short sha), url}. ``body``
+    is the commit message body (where Co-Authored-By / AI-tool trailers appear),
+    empty when the commit has no body. ``url`` is a best-effort web link derived
+    from the ``origin`` remote (empty when the remote host is unknown; a derived
+    link may 404 for a commit that isn't pushed). Returns [] when the path is not a
+    git repo, git is unavailable, or the command fails.
     """
     logger.info("local_git_recent_commits: repo_path=%r days=%d since=%s", repo_path, days, since)
     if not repo_path:
@@ -82,22 +136,31 @@ def local_git_recent_commits(repo_path: str, days: int = 1, since=None) -> list[
         logger.warning("local_git_recent_commits: git exited %d: %s", proc.returncode, proc.stderr.strip()[:200])
         return []
 
+    # Derive the remote web-URL base once (best-effort); "" → SHA-only references.
+    # Skip the extra git call entirely when there are no commits to link.
+    url_base = _origin_commit_url_base(str(path)) if proc.stdout.strip() else ""
+
     items: list[dict] = []
-    for line in proc.stdout.splitlines():
-        if not line.strip():
+    # Records are %x1e-terminated (bodies are multi-line, so we can't split on newlines).
+    for record in proc.stdout.split("\x1e"):
+        if not record.strip():
             continue
-        parts = line.split("\x1f")
-        if len(parts) != 4:
+        # maxsplit=5 → the body (last field) keeps any embedded %x1f-free newlines.
+        parts = record.lstrip("\n").split("\x1f", 5)
+        if len(parts) < 5:
             continue
-        author, email, iso_date, subject = parts
+        sha, author, email, iso_date, subject = parts[0], parts[1], parts[2], parts[3], parts[4]
+        body = parts[5].strip() if len(parts) > 5 else ""
         items.append(
             {
                 "author": author,
                 "author_email": email,
                 "kind": "commit",
                 "title": subject,
+                "body": body,
                 "timestamp": iso_date[:19],
-                "key": "local",
+                "key": sha[:8],
+                "url": f"{url_base}/commit/{sha}" if url_base and sha else "",
             }
         )
     logger.info("local_git_recent_commits: %d commit(s) in last %d day(s)", len(items), days)

--- a/src/yeaboi/tools/team_learning.py
+++ b/src/yeaboi/tools/team_learning.py
@@ -2254,11 +2254,22 @@ def _run_parallel_analysis(
     project_key: str,
     sprint_data: list[dict],
     progress: list[str] | None = None,
+    include_ai_usage: bool = True,
+    include_doc_quality: bool = True,
 ) -> TeamProfile:
     """Run the 4-worker parallel analysis and merge results into a TeamProfile.
 
     ``progress`` is a shared list the TUI can read to display live status messages.
     Each worker appends a string when it starts (e.g. "Fetching sprint history\u2026").
+
+    When ``include_ai_usage`` is set, an extra best-effort step scans the team's
+    commits and PRs for AI-tool markers and attaches an ``AiAdoptionSignal`` to the
+    profile plus an ``examples["ai_adoption"]`` blob (see ``analysis/ai_usage.py``).
+
+    When ``include_doc_quality`` is set, another best-effort step reads the team's
+    recently-changed Notion/Confluence pages, scores their clarity + a stylometric
+    AI-likelihood estimate, and attaches a ``DocQualitySignal`` plus an
+    ``examples["doc_quality"]`` blob (see ``analysis/doc_quality.py``).
     """
     if progress is None:
         progress = []
@@ -2694,6 +2705,53 @@ def _run_parallel_analysis(
         len(examples),
         sum(len(v) for v in examples.values() if isinstance(v, list)),
     )
+
+    # AI-adoption footprint — scan the team's commits/PRs for AI-tool markers
+    # (Co-Authored-By: Claude, Copilot, Cursor, …) and coach on adoption. This is
+    # a network step (GitHub/AzDO) so it's gated by ``include_ai_usage`` and wholly
+    # best-effort — a failure leaves the default empty signal, never raises.
+    if include_ai_usage:
+        progress.append("Scanning AI-tool footprint…")
+        try:
+            from dataclasses import replace
+
+            from yeaboi.analysis.ai_usage import (
+                generate_ai_adoption_insights,
+                run_ai_adoption,
+            )
+
+            signal, ai_examples = run_ai_adoption(source, project_key, delivery_stories, all_stories)
+            # Only spend an LLM call on coaching when something was actually scanned;
+            # an empty footprint (no repos/creds) coaches deterministically.
+            if signal.scanned_commits + signal.scanned_prs > 0:
+                ai_examples["insights"] = generate_ai_adoption_insights(signal, ai_examples)
+            profile = replace(profile, ai_adoption=signal)
+            examples["ai_adoption"] = ai_examples  # type: ignore[assignment]
+        except Exception:  # pragma: no cover - defensive; run_ai_adoption already guards
+            logger.exception("AI-adoption analysis failed; continuing without it")
+
+    # Documentation quality — read the team's recent Notion/Confluence pages and
+    # score clarity + a stylometric AI-likelihood estimate (see analysis/doc_quality.py).
+    # Network step (doc platforms), gated by ``include_doc_quality`` and wholly
+    # best-effort — a failure leaves the default empty signal, never raises.
+    if include_doc_quality:
+        progress.append("Assessing documentation clarity…")
+        try:
+            from dataclasses import replace
+
+            from yeaboi.analysis.doc_quality import (
+                generate_doc_quality_insights,
+                run_doc_quality,
+            )
+
+            dq_signal, dq_examples = run_doc_quality(source, project_key)
+            # Only spend an LLM call on coaching when pages were actually read.
+            if dq_signal.pages_scanned > 0:
+                dq_examples["insights"] = generate_doc_quality_insights(dq_signal, dq_examples)
+            profile = replace(profile, doc_quality=dq_signal)
+            examples["doc_quality"] = dq_examples  # type: ignore[assignment]
+        except Exception:  # pragma: no cover - defensive; run_doc_quality already guards
+            logger.exception("Doc-quality analysis failed; continuing without it")
 
     # Plain-English narrative — one LLM call explaining what the numbers mean
     # per section card. Falls back to deterministic text; never raises.

--- a/src/yeaboi/ui/mode_select/screens/_analysis_sections.py
+++ b/src/yeaboi/ui/mode_select/screens/_analysis_sections.py
@@ -17,6 +17,7 @@ from rich.padding import Padding
 from rich.table import Table as RichTable
 from rich.text import Text
 
+from yeaboi.analysis.ai_usage import _source_label
 from yeaboi.tools.team_learning import ANALYSIS_GLOSSARY as _TA_GLOSSARY
 from yeaboi.tools.team_learning import INSIGHT_CATEGORIES, compute_recommendations
 from yeaboi.ui.shared._components import PAD
@@ -1650,7 +1651,258 @@ def _ta_insights(ctx: _TaCtx, profile) -> None:
                 _add(r)
 
 
-# The eight overview cards: title, section builders (render order), glossary terms.
+def _ta_ai_adoption(ctx: _TaCtx, profile) -> None:
+    """AI-adoption footprint: how much tracked work shows an AI-tool trace + coaching.
+
+    Reads ``profile.ai_adoption`` for the numbers and ``examples["ai_adoption"]`` for
+    coaching insights + coverage. Always frames the footprint as a lower bound. Old
+    profiles (no scan) show the same "run a new analysis" empty state as the other cards.
+    """
+    _add, _ex = ctx.add, ctx.ex
+    sig = getattr(profile, "ai_adoption", None)
+    blob = _ex.get("ai_adoption", {})
+    scanned = (getattr(sig, "scanned_commits", 0) + getattr(sig, "scanned_prs", 0)) if sig else 0
+
+    ctx.heading("AI Adoption")
+    # Lower-bound disclaimer — always shown so the number is never over-read.
+    max_w = max(40, ctx.width - len(PAD) - 10)
+    for wrapped in _ta_wrap(
+        "Lower bound — only AI tools that leave a marker in commit messages or PR "
+        "descriptions are counted. Inline IDE assist (Copilot ghost-text, Cursor Tab) "
+        "leaves no trace, so real usage is at least this.",
+        max_w,
+    ):
+        t = Text(PAD + "  ", justify="left")
+        t.append(wrapped, style=c_dim)
+        _add(t)
+
+    if not sig or scanned == 0:
+        _add(Text(""))
+        t = Text(PAD + "  ", justify="left")
+        note = (
+            "No AI-usage scan for this analysis — run a new analysis (with a repo/tracker configured) to generate one."
+        )
+        t.append(note, style=c_dim)
+        _add(t)
+        # Surface why nothing was scanned, if we know.
+        for gap in (blob.get("coverage") or [])[:4]:
+            g = Text(PAD + "    ", justify="left")
+            g.append(f"• {gap}", style=c_example)
+            _add(g)
+        return
+
+    _add(Text(""))
+    fp = getattr(sig, "footprint_pct", 0.0)
+    fp_sty = c_good if fp >= 40 else (c_warn if fp >= 15 else c_bad)
+    ctx.kv("Detectable footprint", ctx.pct_dots(fp), fp_sty)
+    ctx.kv("Commits scanned", f"{sig.ai_commits} of {sig.scanned_commits} show an AI marker")
+    if sig.scanned_prs:
+        ctx.kv("PRs scanned", f"{sig.ai_prs} of {sig.scanned_prs} show an AI marker")
+    if sig.sources_scanned:
+        ctx.kv("Sources", ", ".join(_source_label(s) for s in sig.sources_scanned))
+    # Which repo/path was actually scanned (local clone vs remote), so the source is unambiguous.
+    for repo in getattr(sig, "repos_scanned", ()):
+        ctx.kv("Scanned", repo)
+
+    # By tool
+    if sig.per_tool:
+        ctx.heading("By tool")
+        for tool, cnt in sig.per_tool:
+            label = "unlabelled AI" if tool == "other_ai" else tool
+            ctx.kv(label, f"{cnt} item(s)")
+
+    # By source (local clone vs remote) — where the AI-marked work was found
+    if getattr(sig, "per_source", ()):
+        ctx.heading("By source")
+        for src, cnt in sig.per_source:
+            ctx.kv(_source_label(src), f"{cnt} AI-marked item(s)")
+
+    # By activity type (code / PR / docs)
+    if sig.per_activity:
+        ctx.heading("By activity")
+        for act, cnt in sig.per_activity:
+            ctx.kv(act, f"{cnt} AI-marked item(s)")
+
+    # Who's leaving a footprint (top authors)
+    if sig.per_author:
+        ctx.heading("By contributor")
+        for author, cnt in sig.per_author[:8]:
+            ctx.kv(author, f"{cnt} AI-marked item(s)")
+
+    # Sources that were NOT scanned (so local-vs-remote coverage is explicit, not silent).
+    coverage = blob.get("coverage") if isinstance(blob, dict) else None
+    if coverage:
+        ctx.heading("Not scanned")
+        for gap in coverage[:4]:
+            g = Text(PAD + "  ", justify="left")
+            g.append(f"• {gap}", style=c_dim)
+            _add(g)
+
+    # Examples — real AI-marked items (with links/SHAs) so the numbers are inspectable.
+    samples = blob.get("samples") if isinstance(blob, dict) else None
+    if samples:
+        ctx.heading("Examples")
+        for s in samples[:5]:
+            tool = "unlabelled AI" if s.get("tool") == "other_ai" else s.get("tool", "")
+            title = str(s.get("title", "")).strip()
+            ref = s.get("url") or (f"commit {s.get('key')}" if s.get("key") else "")
+            line = Text(PAD + "  ", justify="left")
+            line.append(f"[{tool}] ", style=c_dim)
+            line.append(title, style=c_value)
+            if ref:
+                line.append(f"  {ref}", style=c_example)
+            _add(line)
+
+    # Coaching — start / stop / keep / try (mirrors _ta_insights)
+    insights = blob.get("insights", {}) if isinstance(blob, dict) else {}
+    if isinstance(insights, dict) and any(insights.get(k) for k, _ in INSIGHT_CATEGORIES):
+        for key, label in INSIGHT_CATEGORIES:
+            items = insights.get(key)
+            if not isinstance(items, list) or not items:
+                continue
+            icon, colour = _INSIGHT_STYLE[key]
+            _add(Text(""))
+            h = Text(PAD, justify="left")
+            h.append(f"{icon} {label.upper()}", style=f"bold {colour}")
+            _add(h)
+            _add(Text(PAD + "─" * min(len(label) + 2, 40), style="rgb(50,60,80)"))
+            for it in items:
+                if not isinstance(it, dict) or not str(it.get("title", "")).strip():
+                    continue
+                _add(Text(""))
+                t = Text(PAD + "  ", justify="left")
+                t.append(str(it["title"]).strip(), style=c_value)
+                _add(t)
+                for wrapped in _ta_wrap(str(it.get("detail", "") or ""), max_w):
+                    r = Text(PAD + "    ", justify="left")
+                    r.append(wrapped, style=c_muted)
+                    _add(r)
+                evidence = str(it.get("evidence", "") or "").strip()
+                if evidence:
+                    r = Text(PAD + "    ", justify="left")
+                    r.append(f"— {evidence}", style=c_dim)
+                    _add(r)
+                link = str(it.get("link", "") or "").strip()
+                if link:
+                    r = Text(PAD + "    ", justify="left")
+                    r.append(f"↳ {link}", style=c_example)
+                    _add(r)
+
+
+def _ta_doc_quality(ctx: _TaCtx, profile) -> None:
+    """Documentation quality: how clear the team's written pages are + how AI shows up.
+
+    Reads ``profile.doc_quality`` for the numbers and ``examples["doc_quality"]`` for
+    coaching insights + coverage. Clarity is a readability score; the AI-likelihood is
+    a stylometric ESTIMATE (never a detection). Old profiles (no scan) show the same
+    "run a new analysis" empty state as the other cards.
+    """
+    _add, _ex = ctx.add, ctx.ex
+    sig = getattr(profile, "doc_quality", None)
+    blob = _ex.get("doc_quality", {})
+    pages = getattr(sig, "pages_scanned", 0) if sig else 0
+
+    ctx.heading("Documentation")
+    # Estimate disclaimer — always shown so the AI number is never over-read.
+    max_w = max(40, ctx.width - len(PAD) - 10)
+    for wrapped in _ta_wrap(
+        "Clarity is a readability score. AI-likelihood is a heuristic estimate from writing "
+        "style, not a detection — prose has no reliable AI marker. Explicit AI markers are a "
+        "lower bound.",
+        max_w,
+    ):
+        t = Text(PAD + "  ", justify="left")
+        t.append(wrapped, style=c_dim)
+        _add(t)
+
+    if not sig or pages == 0:
+        _add(Text(""))
+        t = Text(PAD + "  ", justify="left")
+        note = (
+            "No documentation scan for this analysis — run a new analysis "
+            "(with Notion/Confluence configured) to generate one."
+        )
+        t.append(note, style=c_dim)
+        _add(t)
+        for gap in (blob.get("coverage") or [])[:4]:
+            g = Text(PAD + "    ", justify="left")
+            g.append(f"• {gap}", style=c_example)
+            _add(g)
+        return
+
+    _add(Text(""))
+    clarity = getattr(sig, "avg_clarity", 0.0)
+    cl_sty = c_good if clarity >= 60 else (c_warn if clarity >= 40 else c_bad)
+    ctx.kv("Avg clarity", f"{clarity:.0f}/100", cl_sty)
+    ctx.kv("Pages scanned", f"{pages} across {', '.join(sig.platforms_scanned) or 'n/a'}")
+    ctx.kv("Clarity split", f"{sig.clear_pages} clear · {sig.mixed_pages} mixed · {sig.unclear_pages} unclear")
+
+    # AI usage in the content — estimate + explicit-marker lower bound.
+    # 55 mirrors doc_quality._AI_LIKELY_MIN (the "likely AI-drafted" threshold).
+    ai_sty = c_bad if sig.avg_ai_likelihood >= 55 else c_muted
+    ai_val = f"{sig.avg_ai_likelihood:.0f}/100 · ~{sig.likely_ai_pages} page(s) look AI-drafted"
+    ctx.kv("AI-likelihood (est.)", ai_val, ai_sty)
+    ctx.kv("Explicit AI markers", f"{sig.ai_marked_pages} page(s) (lower bound)")
+
+    # Pages worth a look
+    if sig.flagged_pages:
+        ctx.heading("Flagged pages")
+        for title, reason in sig.flagged_pages:
+            ctx.kv(title, reason)
+
+    # Examples — real scanned pages (with links) so the scores are inspectable.
+    samples = blob.get("samples") if isinstance(blob, dict) else None
+    if samples:
+        ctx.heading("Examples")
+        for s in samples[:5]:
+            title = str(s.get("title", "")).strip()
+            meta = (
+                f"{s.get('platform', '')} · clarity {s.get('clarity', 0):.0f} · AI-est {s.get('ai_likelihood', 0):.0f}"
+            )
+            line = Text(PAD + "  ", justify="left")
+            line.append(title, style=c_value)
+            line.append(f"  {meta}", style=c_dim)
+            if s.get("url"):
+                line.append(f"  {s['url']}", style=c_example)
+            _add(line)
+
+    # Coaching — start / stop / keep / try (mirrors _ta_insights / _ta_ai_adoption)
+    insights = blob.get("insights", {}) if isinstance(blob, dict) else {}
+    if isinstance(insights, dict) and any(insights.get(k) for k, _ in INSIGHT_CATEGORIES):
+        for key, label in INSIGHT_CATEGORIES:
+            items = insights.get(key)
+            if not isinstance(items, list) or not items:
+                continue
+            icon, colour = _INSIGHT_STYLE[key]
+            _add(Text(""))
+            h = Text(PAD, justify="left")
+            h.append(f"{icon} {label.upper()}", style=f"bold {colour}")
+            _add(h)
+            _add(Text(PAD + "─" * min(len(label) + 2, 40), style="rgb(50,60,80)"))
+            for it in items:
+                if not isinstance(it, dict) or not str(it.get("title", "")).strip():
+                    continue
+                _add(Text(""))
+                t = Text(PAD + "  ", justify="left")
+                t.append(str(it["title"]).strip(), style=c_value)
+                _add(t)
+                for wrapped in _ta_wrap(str(it.get("detail", "") or ""), max_w):
+                    r = Text(PAD + "    ", justify="left")
+                    r.append(wrapped, style=c_muted)
+                    _add(r)
+                evidence = str(it.get("evidence", "") or "").strip()
+                if evidence:
+                    r = Text(PAD + "    ", justify="left")
+                    r.append(f"— {evidence}", style=c_dim)
+                    _add(r)
+                link = str(it.get("link", "") or "").strip()
+                if link:
+                    r = Text(PAD + "    ", justify="left")
+                    r.append(f"↳ {link}", style=c_example)
+                    _add(r)
+
+
+# The overview cards: title, section builders (render order), glossary terms.
 _TA_CARDS: dict[str, dict] = {
     "velocity": {
         "title": "Velocity & Sprints",
@@ -1699,6 +1951,16 @@ _TA_CARDS: dict[str, dict] = {
     "recommendations": {
         "title": "Recommendations",
         "builders": (_ta_recommendations,),
+        "glossary": (),
+    },
+    "ai-adoption": {
+        "title": "AI Adoption",
+        "builders": (_ta_ai_adoption,),
+        "glossary": (),
+    },
+    "documentation": {
+        "title": "Documentation",
+        "builders": (_ta_doc_quality,),
         "glossary": (),
     },
     "insights": {
@@ -1756,6 +2018,18 @@ def _ta_card_teaser(ctx: _TaCtx, profile, key: str) -> str:
     if key == "recommendations":
         n = len(compute_recommendations(profile, ex))
         return f"⚠ {n} flagged" if n else "none flagged"
+    if key == "ai-adoption":
+        sig = getattr(profile, "ai_adoption", None)
+        scanned = (getattr(sig, "scanned_commits", 0) + getattr(sig, "scanned_prs", 0)) if sig else 0
+        if scanned:
+            return f"{sig.footprint_pct:.0f}% AI footprint"
+        return "not scanned"
+    if key == "documentation":
+        sig = getattr(profile, "doc_quality", None)
+        pages = getattr(sig, "pages_scanned", 0) if sig else 0
+        if pages:
+            return f"{sig.avg_clarity:.0f}/100 clarity · {pages} pages"
+        return "not scanned"
     if key == "insights":
         ins = ex.get("insights", {})
         if isinstance(ins, dict):

--- a/tests/unit/test_ai_usage.py
+++ b/tests/unit/test_ai_usage.py
@@ -1,0 +1,518 @@
+"""Tests for the AI-adoption sub-analysis (analysis/ai_usage.py) and its wiring.
+
+Covers: the marker classifier (one case per tool + no-match + multi-tool suppression),
+the pure aggregation, the deterministic fallback coaching, the LLM insights path
+(mocked, happy + fallback), the graceful data-gathering fan-out, the round-trip of the
+new AiAdoptionSignal through the profile store, the enriched local-git body capture,
+and the TUI card builder (populated + empty state).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import asdict
+
+from yeaboi.analysis.ai_usage import (
+    _classify_ai_markers,
+    _fallback_ai_adoption_insights,
+    aggregate_ai_markers,
+    collect_ai_activity,
+    generate_ai_adoption_insights,
+    run_ai_adoption,
+)
+from yeaboi.team_profile import AiAdoptionSignal, TeamProfile, _dict_to_profile
+from yeaboi.tools.local_git import git_subprocess_env, local_git_recent_commits
+
+# ── Classifier ─────────────────────────────────────────────────────────────
+
+
+class TestClassifyAiMarkers:
+    def test_claude_co_author(self):
+        assert _classify_ai_markers("feat\n\nCo-Authored-By: Claude <noreply@anthropic.com>") == {"claude"}
+
+    def test_claude_generated_with(self):
+        assert _classify_ai_markers("🤖 Generated with [Claude Code](https://claude.com/claude-code)") == {"claude"}
+
+    def test_copilot(self):
+        assert _classify_ai_markers("Co-authored-by: Copilot <copilot@github.com>") == {"copilot"}
+
+    def test_cursor(self):
+        assert _classify_ai_markers("Co-authored-by: Cursor Agent <agent@cursor.com>") == {"cursor"}
+
+    def test_aider(self):
+        assert _classify_ai_markers("aider: refactor module\n\nCo-authored-by: aider (gpt-4)") == {"aider"}
+
+    def test_devin(self):
+        assert _classify_ai_markers("work by devin-ai") == {"devin"}
+
+    def test_codeium(self):
+        assert _classify_ai_markers("edited with Windsurf") == {"codeium"}
+
+    def test_generic_other_ai(self):
+        assert _classify_ai_markers("Co-Authored-By: Some Assistant <bot@x.com>") == {"other_ai"}
+
+    def test_no_match(self):
+        assert _classify_ai_markers("just a normal commit message") == set()
+
+    def test_empty(self):
+        assert _classify_ai_markers("") == set()
+        assert _classify_ai_markers(None) == set()  # type: ignore[arg-type]
+
+    def test_specific_suppresses_other_ai(self):
+        # A Claude commit that also carries a generic AI trailer is credited to claude only.
+        result = _classify_ai_markers("Co-Authored-By: Claude\nCo-Authored-By: some bot")
+        assert result == {"claude"}
+
+
+# ── Aggregation ────────────────────────────────────────────────────────────
+
+
+class TestAggregate:
+    def test_buckets_and_footprint(self):
+        items = [
+            {"kind": "commit", "author": "Alice", "title": "feat", "body": "Co-Authored-By: Claude", "source": "gh"},
+            {"kind": "commit", "author": "Bob", "title": "docs: update README", "body": "", "source": "local_git"},
+            {
+                "kind": "pr",
+                "author": "Alice",
+                "title": "Add feature",
+                "body": "Generated with Claude Code",
+                "source": "gh",
+            },
+        ]
+        sig = aggregate_ai_markers(items)
+        assert sig.scanned_commits == 2
+        assert sig.scanned_prs == 1
+        assert sig.ai_commits == 1
+        assert sig.ai_prs == 1
+        assert sig.footprint_pct == round(2 / 3 * 100, 1)
+        assert sig.per_tool == (("claude", 2),)
+        assert sig.per_author == (("Alice", 2),)
+        assert dict(sig.per_activity) == {"code": 1, "pr": 1}
+        assert dict(sig.per_source) == {"gh": 2}  # both AI-marked items came from the gh source
+        assert sig.is_lower_bound is True
+
+    def test_docs_bucket(self):
+        items = [
+            {"kind": "commit", "author": "A", "title": "docs: add guide.md", "body": "Co-Authored-By: Claude"},
+        ]
+        sig = aggregate_ai_markers(items)
+        assert dict(sig.per_activity) == {"docs": 1}
+
+    def test_empty(self):
+        sig = aggregate_ai_markers([])
+        assert sig.scanned_commits == 0 and sig.footprint_pct == 0.0
+        assert sig.per_tool == () and sig.per_author == ()
+
+    def test_non_commit_pr_kinds_ignored(self):
+        sig = aggregate_ai_markers([{"kind": "page", "title": "x", "body": "Co-Authored-By: Claude"}])
+        assert sig.scanned_commits == 0 and sig.scanned_prs == 0
+
+
+# ── Fallback coaching ──────────────────────────────────────────────────────
+
+
+class TestFallbackInsights:
+    def test_all_categories_non_empty_low_footprint(self):
+        sig = AiAdoptionSignal(
+            scanned_commits=10,
+            ai_commits=1,
+            footprint_pct=10.0,
+            per_tool=(("claude", 1),),
+            per_author=(("A", 1),),
+            per_activity=(("code", 1),),
+        )
+        fb = _fallback_ai_adoption_insights(sig)
+        for cat in ("start", "stop", "keep", "try"):
+            assert fb[cat], f"category {cat} is empty"
+
+    def test_all_categories_non_empty_empty_signal(self):
+        fb = _fallback_ai_adoption_insights(AiAdoptionSignal())
+        for cat in ("start", "stop", "keep", "try"):
+            assert fb[cat]
+
+    def test_other_ai_triggers_stop(self):
+        sig = AiAdoptionSignal(scanned_commits=4, ai_commits=2, footprint_pct=50.0, per_tool=(("other_ai", 2),))
+        fb = _fallback_ai_adoption_insights(sig)
+        titles = " ".join(it["title"].lower() for it in fb["stop"])
+        assert "unlabelled" in titles or "trailer" in titles
+
+    def test_cites_sample_with_link(self):
+        # Commits-with-AI but no PRs → the "draft PR descriptions" item cites a real commit + link.
+        sig = AiAdoptionSignal(
+            scanned_commits=5, ai_commits=3, footprint_pct=60.0, per_tool=(("claude", 3),), per_activity=(("code", 3),)
+        )
+        samples = [
+            {
+                "author": "Dinho",
+                "tool": "claude",
+                "activity": "code",
+                "title": "Fix login",
+                "source": "local_git",
+                "key": "a1b2c3d4",
+                "url": "https://github.com/o/r/commit/a1b2c3d4",
+            }
+        ]
+        fb = _fallback_ai_adoption_insights(sig, samples)
+        pr_item = next(it for it in fb["start"] if "PR" in it["title"])
+        assert "a1b2c3d4" in pr_item["evidence"] and "Fix login" in pr_item["evidence"]
+        assert pr_item["link"] == "https://github.com/o/r/commit/a1b2c3d4"
+
+
+# ── LLM insights (mocked) ──────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+
+class TestGenerateInsights:
+    _SIG = AiAdoptionSignal(
+        scanned_commits=10,
+        scanned_prs=2,
+        ai_commits=4,
+        ai_prs=1,
+        footprint_pct=41.7,
+        per_tool=(("claude", 5),),
+        per_author=(("A", 5),),
+        per_activity=(("code", 4), ("pr", 1)),
+        sources_scanned=("github",),
+    )
+
+    def test_happy_path_parses_json(self, monkeypatch):
+        payload = (
+            '{"start": [{"title": "Do X", "detail": "d", "evidence": "e"}], '
+            '"stop": [{"title": "Stop Y", "detail": "d", "evidence": "e"}], '
+            '"keep": [{"title": "Keep Z", "detail": "d", "evidence": "e"}], '
+            '"try": [{"title": "Try W", "detail": "d", "evidence": "e"}]}'
+        )
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", lambda *a, **k: _FakeResp(payload))
+        out = generate_ai_adoption_insights(self._SIG, {})
+        assert out["start"][0]["title"] == "Do X"
+        assert all(out[c] for c in ("start", "stop", "keep", "try"))
+
+    def test_llm_failure_falls_back(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("no llm")
+
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", boom)
+        out = generate_ai_adoption_insights(self._SIG, {})
+        # Falls back deterministically, never raises, every category populated.
+        assert all(out[c] for c in ("start", "stop", "keep", "try"))
+
+    def test_link_validated_against_samples(self, monkeypatch):
+        # A real sample URL is kept; a hallucinated one is dropped.
+        good = "https://github.com/o/r/commit/deadbeef"
+        payload = (
+            f'{{"start": [{{"title": "Real", "detail": "d", "evidence": "e", "link": "{good}"}}], '
+            '"stop": [{"title": "Fake", "detail": "d", "evidence": "e", "link": "https://evil.example/x"}], '
+            '"keep": [{"title": "K", "detail": "d", "evidence": "e"}], '
+            '"try": [{"title": "T", "detail": "d", "evidence": "e"}]}'
+        )
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", lambda *a, **k: _FakeResp(payload))
+        examples = {"samples": [{"url": good, "title": "x", "key": "deadbeef", "tool": "claude", "activity": "code"}]}
+        out = generate_ai_adoption_insights(self._SIG, examples)
+        assert out["start"][0]["link"] == good  # valid link kept
+        assert "link" not in out["stop"][0]  # hallucinated link dropped
+
+
+# ── Data gathering (graceful fan-out) ──────────────────────────────────────
+
+
+class TestCollectAiActivity:
+    def test_no_config_records_coverage_gaps(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.config.get_standup_github_repo", lambda: "")
+        monkeypatch.setattr("yeaboi.config.get_github_token", lambda: None)
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_project", lambda: "")
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_token", lambda: None)
+        monkeypatch.setattr("yeaboi.analysis.ai_usage._discover_local_repo", lambda: "")
+        items, sources, coverage, repos = collect_ai_activity("jira", "PROJ")
+        assert items == [] and sources == [] and repos == []
+        assert any("github" in c for c in coverage)
+        assert any("local_git" in c for c in coverage)
+        assert any("azdo" in c for c in coverage)
+
+    def test_github_items_tagged(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.config.get_standup_github_repo", lambda: "o/r")
+        monkeypatch.setattr("yeaboi.config.get_github_token", lambda: "tok")
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_project", lambda: "")
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_token", lambda: None)
+        monkeypatch.setattr("yeaboi.analysis.ai_usage._discover_local_repo", lambda: "")
+        monkeypatch.setattr(
+            "yeaboi.tools.github.github_recent_commits",
+            lambda repo, days=1: [{"kind": "commit", "author": "A", "title": "x", "body": ""}],
+        )
+        monkeypatch.setattr("yeaboi.tools.github.github_recent_prs", lambda repo, days=1: [])
+        items, sources, _, repos = collect_ai_activity("jira", "PROJ")
+        assert sources == ["github"]
+        assert items and items[0]["source"] == "github"
+        assert repos == ["GitHub (remote): o/r"]
+
+    def test_source_error_recorded_not_raised(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.config.get_standup_github_repo", lambda: "o/r")
+        monkeypatch.setattr("yeaboi.config.get_github_token", lambda: "tok")
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_project", lambda: "")
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_token", lambda: None)
+        monkeypatch.setattr("yeaboi.analysis.ai_usage._discover_local_repo", lambda: "")
+
+        def boom(repo, days=1):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("yeaboi.tools.github.github_recent_commits", boom)
+        monkeypatch.setattr("yeaboi.tools.github.github_recent_prs", lambda repo, days=1: [])
+        items, sources, coverage, repos = collect_ai_activity("jira", "PROJ")
+        assert items == [] and sources == [] and repos == []
+        assert any("github" in c and "error" in c for c in coverage)
+
+
+class TestRunAiAdoption:
+    def test_aggregates_collected_items(self, monkeypatch):
+        monkeypatch.setattr(
+            "yeaboi.analysis.ai_usage.collect_ai_activity",
+            lambda source, project: (
+                [
+                    {
+                        "kind": "commit",
+                        "author": "A",
+                        "title": "x",
+                        "body": "Co-Authored-By: Claude",
+                        "source": "github",
+                        "key": "a1b2c3d4",
+                        "url": "https://github.com/o/r/commit/a1b2c3d4",
+                    }
+                ],
+                ["github"],
+                [],
+                ["GitHub (remote): o/r"],
+            ),
+        )
+        sig, blob = run_ai_adoption("jira", "P", [], [])
+        assert sig.ai_commits == 1 and sig.footprint_pct == 100.0
+        assert sig.sources_scanned == ("github",)
+        assert sig.repos_scanned == ("GitHub (remote): o/r",)
+        assert sig.per_source == (("github", 1),)
+        assert blob["summary"]["ai_commits"] == 1
+        assert blob["summary"]["per_source"] == [["github", 1]]
+        # Samples carry a ref (key) and link so examples are inspectable.
+        assert blob["samples"] and blob["samples"][0]["tool"] == "claude"
+        assert blob["samples"][0]["key"] == "a1b2c3d4"
+        assert blob["samples"][0]["url"].endswith("/commit/a1b2c3d4")
+
+    def test_collect_failure_returns_empty_signal(self, monkeypatch):
+        def boom(source, project):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr("yeaboi.analysis.ai_usage.collect_ai_activity", boom)
+        sig, blob = run_ai_adoption("jira", "P", [], [])
+        assert sig == AiAdoptionSignal()
+        assert "coverage" in blob
+
+
+# ── Serialization round-trip ───────────────────────────────────────────────
+
+
+class TestSerialization:
+    def test_profile_roundtrip_preserves_signal(self):
+        sig = AiAdoptionSignal(
+            scanned_commits=5,
+            scanned_prs=2,
+            ai_commits=3,
+            ai_prs=1,
+            footprint_pct=57.1,
+            per_tool=(("claude", 3), ("copilot", 1)),
+            per_author=(("A", 3), ("B", 1)),
+            per_activity=(("code", 3), ("pr", 1)),
+            per_source=(("local_git", 3), ("github", 1)),
+            repos_scanned=("Local clone: /repo", "GitHub (remote): o/r"),
+            sources_scanned=("local_git", "github"),
+        )
+        profile = TeamProfile(team_id="t", source="jira", project_key="P", ai_adoption=sig)
+        restored = _dict_to_profile(asdict(profile))
+        assert restored.ai_adoption == sig
+        assert isinstance(restored.ai_adoption, AiAdoptionSignal)
+
+    def test_old_profile_without_key_defaults(self):
+        d = {"team_id": "t", "source": "jira", "project_key": "P"}  # pre-feature row
+        restored = _dict_to_profile(d)
+        assert restored.ai_adoption == AiAdoptionSignal()
+
+
+# ── Enriched local-git body capture ────────────────────────────────────────
+
+
+class TestLocalGitBody:
+    def test_captures_co_author_body(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args):
+            subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, env=git_subprocess_env())
+
+        git("init", "-q")
+        git("config", "user.email", "dev@example.com")
+        git("config", "user.name", "Dev Person")
+        (repo / "a.txt").write_text("hi")
+        git("add", ".")
+        git("commit", "-q", "-m", "feat: thing\n\nCo-Authored-By: Claude <noreply@anthropic.com>")
+
+        items = local_git_recent_commits(str(repo), days=1)
+        assert len(items) == 1
+        assert items[0]["title"] == "feat: thing"
+        assert "Co-Authored-By: Claude" in items[0]["body"]
+        # And the classifier sees it end-to-end.
+        assert _classify_ai_markers(items[0]["body"]) == {"claude"}
+        # key is now a real short SHA (8 hex chars), not the old constant "local".
+        assert items[0]["key"] != "local"
+        assert len(items[0]["key"]) == 8 and all(c in "0123456789abcdef" for c in items[0]["key"])
+        # No origin remote configured on this test repo → no derived URL.
+        assert items[0]["url"] == ""
+
+    def test_no_body_is_empty_string(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args):
+            subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, env=git_subprocess_env())
+
+        git("init", "-q")
+        git("config", "user.email", "dev@example.com")
+        git("config", "user.name", "Dev Person")
+        (repo / "a.txt").write_text("hi")
+        git("add", ".")
+        git("commit", "-q", "-m", "no body here")
+
+        items = local_git_recent_commits(str(repo), days=1)
+        assert items[0]["body"] == ""
+
+    def test_derives_github_url_from_origin(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args):
+            subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, env=git_subprocess_env())
+
+        git("init", "-q")
+        git("config", "user.email", "dev@example.com")
+        git("config", "user.name", "Dev Person")
+        git("remote", "add", "origin", "git@github.com:owner/repo.git")
+        (repo / "a.txt").write_text("hi")
+        git("add", ".")
+        git("commit", "-q", "-m", "feat: thing")
+
+        items = local_git_recent_commits(str(repo), days=1)
+        assert items[0]["url"].startswith("https://github.com/owner/repo/commit/")
+        # The URL carries the full SHA; the key is the short form.
+        assert items[0]["url"].split("/commit/")[1].startswith(items[0]["key"])
+
+
+# ── TUI card builder ───────────────────────────────────────────────────────
+
+
+def _render_lines(ctx) -> str:
+    from rich.text import Text
+
+    return "\n".join(line.plain for line in ctx.lines if isinstance(line, Text))
+
+
+class TestAiAdoptionCard:
+    def _ctx(self, examples):
+        from yeaboi.ui.mode_select.screens._analysis_sections import _TaCtx
+
+        return _TaCtx(width=100, examples=examples)
+
+    def test_renders_footprint_and_disclaimer(self):
+        from yeaboi.ui.mode_select.screens._analysis_sections import _ta_ai_adoption
+
+        sig = AiAdoptionSignal(
+            scanned_commits=10,
+            scanned_prs=2,
+            ai_commits=4,
+            ai_prs=1,
+            footprint_pct=42.0,
+            per_tool=(("claude", 5),),
+            per_author=(("Alice", 5),),
+            per_activity=(("code", 4), ("pr", 1)),
+            sources_scanned=("github",),
+        )
+        profile = TeamProfile(team_id="t", source="jira", project_key="P", ai_adoption=sig)
+        examples = {
+            "ai_adoption": {
+                "insights": {
+                    "start": [{"title": "Do X", "detail": "d", "evidence": "e"}],
+                    "stop": [],
+                    "keep": [],
+                    "try": [],
+                }
+            }
+        }
+        ctx = self._ctx(examples)
+        _ta_ai_adoption(ctx, profile)
+        out = _render_lines(ctx)
+        assert "Lower bound" in out
+        assert "42%" in out
+        assert "claude" in out
+        assert "Do X" in out
+
+    def test_renders_source_provenance_examples_and_links(self):
+        from yeaboi.ui.mode_select.screens._analysis_sections import _ta_ai_adoption
+
+        sig = AiAdoptionSignal(
+            scanned_commits=134,
+            ai_commits=133,
+            footprint_pct=99.0,
+            per_tool=(("claude", 131), ("other_ai", 2)),
+            per_author=(("Dinho", 53),),
+            per_activity=(("code", 127), ("docs", 6)),
+            per_source=(("local_git", 133),),
+            repos_scanned=("Local clone: /Users/dinho/repo",),
+            sources_scanned=("local_git",),
+        )
+        profile = TeamProfile(team_id="t", source="jira", project_key="P", ai_adoption=sig)
+        examples = {
+            "ai_adoption": {
+                "coverage": ["github: STANDUP_GITHUB_REPO / GITHUB_TOKEN not set"],
+                "samples": [
+                    {
+                        "tool": "claude",
+                        "activity": "code",
+                        "title": "Fix login",
+                        "source": "local_git",
+                        "key": "a1b2c3d4",
+                        "url": "https://github.com/o/r/commit/a1b2c3d4",
+                    }
+                ],
+                "insights": {
+                    "start": [
+                        {
+                            "title": "Open PRs",
+                            "detail": "d",
+                            "evidence": "e",
+                            "link": "https://github.com/o/r/commit/a1b2c3d4",
+                        }
+                    ],
+                    "stop": [],
+                    "keep": [],
+                    "try": [],
+                },
+            }
+        }
+        ctx = self._ctx(examples)
+        _ta_ai_adoption(ctx, profile)
+        out = _render_lines(ctx)
+        assert "Local clone" in out  # friendly source label (not raw "local_git")
+        assert "/Users/dinho/repo" in out  # Scanned line names the path
+        assert "By source" in out
+        assert "Not scanned" in out and "STANDUP_GITHUB_REPO" in out  # coverage shown even when populated
+        assert "Examples" in out and "Fix login" in out  # real example rendered
+        assert "https://github.com/o/r/commit/a1b2c3d4" in out  # link on the coaching item
+
+    def test_empty_state_when_not_scanned(self):
+        from yeaboi.ui.mode_select.screens._analysis_sections import _ta_ai_adoption
+
+        profile = TeamProfile(team_id="t", source="jira", project_key="P")  # default empty signal
+        ctx = self._ctx({"ai_adoption": {"coverage": ["github: STANDUP_GITHUB_REPO / GITHUB_TOKEN not set"]}})
+        _ta_ai_adoption(ctx, profile)
+        out = _render_lines(ctx)
+        assert "No AI-usage scan" in out
+        assert "STANDUP_GITHUB_REPO" in out

--- a/tests/unit/test_analysis_engine.py
+++ b/tests/unit/test_analysis_engine.py
@@ -40,9 +40,11 @@ def wired(monkeypatch, db, tmp_path):
         lambda project, count: [{"sprint_name": "Iteration 1"}],
     )
 
-    def fake_parallel(source, project, sprint_data, progress):
+    def fake_parallel(source, project, sprint_data, progress, include_ai_usage=True, include_doc_quality=True):
         progress.append("Analysing…")
         captured["parallel"] = (source, project, len(sprint_data))
+        captured["include_ai_usage"] = include_ai_usage
+        captured["include_doc_quality"] = include_doc_quality
         return _profile(source=source, project_key=project), {"sprint_details": []}
 
     monkeypatch.setattr("yeaboi.tools.team_learning._run_parallel_analysis", fake_parallel)

--- a/tests/unit/test_analysis_screens.py
+++ b/tests/unit/test_analysis_screens.py
@@ -1097,7 +1097,7 @@ class TestAnalysisOverview:
         # Selection auto-scrolls, so check the top half with card 0 selected
         # and the bottom half with the last card selected.
         top = self._render_view(examples=_NARRATIVE_EXAMPLES, selected_card=0)
-        bottom = self._render_view(examples=_NARRATIVE_EXAMPLES, selected_card=7)
+        bottom = self._render_view(examples=_NARRATIVE_EXAMPLES, selected_card=9)
         combined = top + bottom
         for title in (
             "Velocity & Sprints",
@@ -1107,6 +1107,8 @@ class TestAnalysisOverview:
             "Writing Style",
             "Trends & Repos",
             "Recommendations",
+            "AI Adoption",
+            "Documentation",
             "Team Insights",
         ):
             assert title in combined, title
@@ -1277,6 +1279,86 @@ class TestAnalysisSectionDetail:
         assert isinstance(panel, Panel)
 
 
+class TestDocumentationCard:
+    """The Documentation card: clarity + AI-usage estimate + coaching (populated + empty)."""
+
+    def _profile(self, sig):
+        from yeaboi.team_profile import TeamProfile
+
+        return TeamProfile(
+            team_id="jira-D",
+            source="jira",
+            project_key="D",
+            sample_sprints=4,
+            sample_stories=40,
+            velocity_avg=30.0,
+            doc_quality=sig,
+        )
+
+    def test_populated_renders_clarity_estimate_and_flag(self):
+        from yeaboi.team_profile import DocQualitySignal
+
+        sig = DocQualitySignal(
+            pages_scanned=6,
+            platforms_scanned=("confluence", "notion"),
+            avg_clarity=52.0,
+            clear_pages=2,
+            mixed_pages=2,
+            unclear_pages=2,
+            avg_ai_likelihood=61.0,
+            likely_ai_pages=3,
+            ai_marked_pages=1,
+            per_platform=(("confluence", 4), ("notion", 2)),
+            flagged_pages=(("Onboarding guide", "clarity 30/100 — dense or long-winded"),),
+        )
+        ex = {
+            "doc_quality": {
+                "samples": [
+                    {
+                        "title": "Onboarding guide",
+                        "platform": "confluence",
+                        "clarity": 30,
+                        "ai_likelihood": 12,
+                        "url": "https://wiki/onboarding",
+                    }
+                ],
+                "insights": {
+                    "start": [
+                        {
+                            "title": "Tighten the least-clear pages",
+                            "detail": "Trim it.",
+                            "evidence": "52/100",
+                            "link": "https://wiki/onboarding",
+                        }
+                    ],
+                    "stop": [],
+                    "keep": [],
+                    "try": [],
+                },
+            }
+        }
+        panel = _build_team_analysis_screen(self._profile(sig), examples=ex, view="documentation", width=100, height=60)
+        output = _render(panel, width=100)
+        assert "Documentation" in output
+        assert "52/100" in output  # clarity score
+        assert "estimate" in output.lower()  # AI-likelihood is framed as an estimate
+        assert "lower bound" in output.lower()  # explicit-marker framing
+        assert "Onboarding guide" in output  # flagged page
+        assert "Tighten the least-clear pages" in output  # coaching
+        assert "Examples" in output  # examples section
+        assert "https://wiki/onboarding" in output  # page link on example + coaching item
+
+    def test_empty_state_and_coverage(self):
+        from yeaboi.team_profile import TeamProfile
+
+        prof = TeamProfile(team_id="e", source="jira", project_key="X")
+        ex = {"doc_quality": {"coverage": ["notion: NOTION_TOKEN not set"]}}
+        panel = _build_team_analysis_screen(prof, examples=ex, view="documentation", width=90, height=30)
+        output = _render(panel, width=90)
+        assert "No documentation scan" in output
+        assert "NOTION_TOKEN not set" in output
+
+
 # ---------------------------------------------------------------------------
 # Team insights screen (results → insights → generate-tickets confirm)
 # ---------------------------------------------------------------------------
@@ -1361,7 +1443,7 @@ class TestBuildTeamInsightsScreen:
             _make_overview_profile(),
             examples=_NARRATIVE_EXAMPLES,
             view="overview",
-            selected_card=7,
+            selected_card=9,
             width=100,
             height=40,
         )

--- a/tests/unit/test_doc_quality.py
+++ b/tests/unit/test_doc_quality.py
@@ -1,0 +1,318 @@
+"""Tests for the documentation-quality sub-analysis (analysis/doc_quality.py) and its wiring.
+
+Covers: the deterministic clarity metrics (clear vs. dense prose), the stylometric
+AI-likelihood estimate (AI-tell text scores higher than plain), the pure aggregation
+(distribution, marker vs. estimate counts, empty→zeros), the deterministic fallback
+coaching, the LLM insights path (mocked, happy + fallback), the graceful page-collection
+fan-out (skip/coverage/swallow, never raises), and the run_doc_quality orchestrator.
+"""
+
+from __future__ import annotations
+
+from yeaboi.analysis.doc_quality import (
+    _ai_likelihood,
+    _clarity_metrics,
+    _fallback_doc_quality_insights,
+    aggregate_doc_quality,
+    collect_doc_pages,
+    generate_doc_quality_insights,
+    run_doc_quality,
+)
+from yeaboi.team_profile import DocQualitySignal
+
+# A plain, human, clear paragraph — short sentences, contractions, no AI tells.
+_CLEAR_TEXT = (
+    "# Onboarding\n\n"
+    "Welcome to the team. Here's how to set up.\n\n"
+    "- Clone the repo.\n"
+    "- Run the setup script.\n"
+    "- Ask if you're stuck.\n\n"
+    "That's it. You're ready to go."
+)
+
+# A dense, jargon-heavy wall of one very long sentence.
+_DENSE_TEXT = (
+    "Notwithstanding the aforementioned architectural considerations, the comprehensive "
+    "instrumentation subsystem necessitates meticulous reconfiguration across heterogeneous "
+    "deployment environments whilst simultaneously accommodating the multifarious "
+    "interdependencies inherent to distributed computational infrastructures and their "
+    "concomitant orchestration frameworks, thereby precipitating substantial reconsideration."
+)
+
+# Prose loaded with classic AI-tell connectors and em-dashes.
+_AI_TELL_TEXT = (
+    "Moreover, it is worth noting that this approach will seamlessly leverage a robust, "
+    "holistic framework — furthermore, it is important to note the paramount role of "
+    "streamlined processes. Additionally, this serves to facilitate a testament to "
+    "excellence. In conclusion, we delve into the realm of possibility — notably underscoring "
+    "the crucial nature of the endeavour. Furthermore, this holistic tapestry is paramount."
+)
+
+
+class TestClarityMetrics:
+    def test_clear_scores_higher_than_dense(self):
+        clear = _clarity_metrics(_CLEAR_TEXT)["clarity"]
+        dense = _clarity_metrics(_DENSE_TEXT)["clarity"]
+        assert clear > dense
+        assert clear >= 60  # plain-English band
+
+    def test_empty_text_is_zero(self):
+        m = _clarity_metrics("")
+        assert m["clarity"] == 0.0
+        assert m["word_count"] == 0
+
+    def test_reports_structure(self):
+        m = _clarity_metrics(_CLEAR_TEXT)
+        assert m["heading_count"] >= 1
+        assert m["has_lists"] is True
+
+    def test_long_sentence_pct(self):
+        m = _clarity_metrics(_DENSE_TEXT)
+        assert m["long_sentence_pct"] > 0
+
+
+class TestAiLikelihood:
+    def test_ai_tell_scores_higher_than_plain(self):
+        assert _ai_likelihood(_AI_TELL_TEXT) > _ai_likelihood(_CLEAR_TEXT)
+
+    def test_ai_tell_crosses_likely_threshold(self):
+        assert _ai_likelihood(_AI_TELL_TEXT) >= 55
+
+    def test_plain_text_low(self):
+        assert _ai_likelihood(_CLEAR_TEXT) < 40
+
+    def test_empty_is_zero(self):
+        assert _ai_likelihood("") == 0.0
+
+
+class TestAggregate:
+    def _pages(self):
+        return [
+            {"platform": "confluence", "title": "Clear one", "text": _CLEAR_TEXT},
+            {"platform": "confluence", "title": "Dense one", "text": _DENSE_TEXT},
+            {"platform": "notion", "title": "AI one", "text": _AI_TELL_TEXT},
+        ]
+
+    def test_counts_and_distribution(self):
+        sig = aggregate_doc_quality(self._pages())
+        assert sig.pages_scanned == 3
+        assert set(sig.platforms_scanned) == {"confluence", "notion"}
+        assert sig.clear_pages + sig.mixed_pages + sig.unclear_pages == 3
+        assert dict(sig.per_platform) == {"confluence": 2, "notion": 1}
+        assert sig.is_ai_estimate is True
+
+    def test_ai_estimate_flags_the_ai_page(self):
+        sig = aggregate_doc_quality(self._pages())
+        assert sig.likely_ai_pages >= 1
+        assert sig.avg_ai_likelihood > 0
+
+    def test_explicit_marker_counted_as_lower_bound(self):
+        disclosed = "Draft notes. Co-Authored-By: Claude <noreply@anthropic.com>"
+        pages = [
+            {"platform": "notion", "title": "Disclosed", "text": disclosed},
+            {"platform": "notion", "title": "Plain", "text": _CLEAR_TEXT},
+        ]
+        sig = aggregate_doc_quality(pages)
+        assert sig.ai_marked_pages == 1
+
+    def test_flagged_pages_populated(self):
+        sig = aggregate_doc_quality(self._pages())
+        # The dense page (low clarity) and/or the AI page should surface as call-outs.
+        assert sig.flagged_pages
+        titles = {t for t, _ in sig.flagged_pages}
+        assert "Dense one" in titles or "AI one" in titles
+
+    def test_empty_returns_zeros(self):
+        sig = aggregate_doc_quality([])
+        assert sig == DocQualitySignal()
+        assert sig.pages_scanned == 0
+
+
+class TestFallbackInsights:
+    def test_all_categories_non_empty_low_clarity(self):
+        sig = DocQualitySignal(
+            pages_scanned=5, avg_clarity=42.0, unclear_pages=2, avg_ai_likelihood=60.0, likely_ai_pages=2
+        )
+        out = _fallback_doc_quality_insights(sig)
+        assert all(out[c] for c in ("start", "stop", "keep", "try"))
+
+    def test_all_categories_non_empty_empty_signal(self):
+        out = _fallback_doc_quality_insights(DocQualitySignal())
+        assert all(out[c] for c in ("start", "stop", "keep", "try"))
+
+    def test_high_ai_estimate_triggers_stop_with_estimate_framing(self):
+        sig = DocQualitySignal(pages_scanned=4, avg_clarity=70.0, avg_ai_likelihood=70.0, likely_ai_pages=3)
+        out = _fallback_doc_quality_insights(sig)
+        blob = " ".join(it["detail"] + it["evidence"] for it in out["stop"]).lower()
+        assert "estimate" in blob  # never asserts detection
+
+    def test_cites_least_clear_page_with_link(self):
+        sig = DocQualitySignal(pages_scanned=3, avg_clarity=45.0, unclear_pages=1)
+        samples = [
+            {"title": "Clear one", "platform": "notion", "clarity": 80, "ai_likelihood": 5, "url": "u1"},
+            {"title": "Dense one", "platform": "confluence", "clarity": 25, "ai_likelihood": 5, "url": "u2"},
+        ]
+        out = _fallback_doc_quality_insights(sig, samples)
+        tighten = next(it for it in out["start"] if "Tighten" in it["title"])
+        assert "Dense one" in tighten["evidence"]  # the least-clear page
+        assert tighten["link"] == "u2"
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+
+class TestGenerateInsights:
+    _SIG = DocQualitySignal(
+        pages_scanned=6,
+        platforms_scanned=("confluence", "notion"),
+        avg_clarity=54.0,
+        clear_pages=2,
+        mixed_pages=2,
+        unclear_pages=2,
+        avg_ai_likelihood=58.0,
+        likely_ai_pages=3,
+        ai_marked_pages=1,
+        per_platform=(("confluence", 4), ("notion", 2)),
+        flagged_pages=(("Onboarding", "clarity 30/100 — dense or long-winded"),),
+    )
+
+    def test_happy_path_parses_json(self, monkeypatch):
+        payload = (
+            '{"start": [{"title": "Tighten docs", "detail": "d", "evidence": "e"}], '
+            '"stop": [{"title": "Stop walls", "detail": "d", "evidence": "e"}], '
+            '"keep": [{"title": "Keep clarity", "detail": "d", "evidence": "e"}], '
+            '"try": [{"title": "Try templates", "detail": "d", "evidence": "e"}]}'
+        )
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", lambda *a, **k: _FakeResp(payload))
+        out = generate_doc_quality_insights(self._SIG, {})
+        assert out["start"][0]["title"] == "Tighten docs"
+        assert all(out[c] for c in ("start", "stop", "keep", "try"))
+
+    def test_code_fence_stripped(self, monkeypatch):
+        body = '{"start": [{"title": "T", "detail": "d", "evidence": "e"}], "stop": [], "keep": [], "try": []}'
+        payload = f"```json\n{body}\n```"
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", lambda *a, **k: _FakeResp(payload))
+        out = generate_doc_quality_insights(self._SIG, {})
+        assert out["start"][0]["title"] == "T"
+        # Empty categories fall back to the deterministic skeleton, never empty.
+        assert all(out[c] for c in ("start", "stop", "keep", "try"))
+
+    def test_llm_failure_falls_back(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("no llm")
+
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", boom)
+        out = generate_doc_quality_insights(self._SIG, {})
+        assert all(out[c] for c in ("start", "stop", "keep", "try"))
+
+    def test_link_validated_against_page_urls(self, monkeypatch):
+        good = "https://notion.so/page-123"
+        payload = (
+            f'{{"start": [{{"title": "Real", "detail": "d", "evidence": "e", "link": "{good}"}}], '
+            '"stop": [{"title": "Fake", "detail": "d", "evidence": "e", "link": "https://evil.example/x"}], '
+            '"keep": [{"title": "K", "detail": "d", "evidence": "e"}], '
+            '"try": [{"title": "T", "detail": "d", "evidence": "e"}]}'
+        )
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", lambda *a, **k: _FakeResp(payload))
+        examples = {"samples": [{"url": good, "title": "x", "platform": "notion", "clarity": 40, "ai_likelihood": 20}]}
+        out = generate_doc_quality_insights(self._SIG, examples)
+        assert out["start"][0]["link"] == good
+        assert "link" not in out["stop"][0]
+
+
+class TestCollectDocPages:
+    def test_no_config_records_coverage_gaps(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.config.get_confluence_token", lambda: None)
+        monkeypatch.setattr("yeaboi.config.get_confluence_base_url", lambda: None)
+        monkeypatch.setattr("yeaboi.config.get_notion_token", lambda: None)
+        pages, platforms, coverage = collect_doc_pages("jira", "PROJ")
+        assert pages == []
+        assert platforms == []
+        assert any("confluence" in c for c in coverage)
+        assert any("notion" in c for c in coverage)
+
+    def test_confluence_pages_tagged_and_deduped(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.config.get_confluence_token", lambda: "tok")
+        monkeypatch.setattr("yeaboi.config.get_confluence_base_url", lambda: "https://x.atlassian.net/wiki")
+        monkeypatch.setattr("yeaboi.config.get_notion_token", lambda: None)
+        # Two recent items for the SAME page id (Confluence emits one per editor) → one read.
+        monkeypatch.setattr(
+            "yeaboi.tools.confluence.confluence_recent_pages",
+            lambda days=1: [
+                {"key": "123", "title": "Guide", "author": "A", "url": "u", "timestamp": "t"},
+                {"key": "123", "title": "Guide", "author": "B", "url": "u", "timestamp": "t"},
+            ],
+        )
+        reads: list[str] = []
+
+        def _read(page_id="", max_chars=0):
+            reads.append(page_id)
+            return {"title": "Guide", "text": _CLEAR_TEXT, "truncated": False, "error": ""}
+
+        monkeypatch.setattr("yeaboi.tools.confluence.confluence_read_page_text", _read)
+        pages, platforms, coverage = collect_doc_pages("jira", "PROJ")
+        assert len(pages) == 1  # deduped
+        assert reads == ["123"]  # only one body read
+        assert pages[0]["platform"] == "confluence"
+        assert platforms == ["confluence"]
+
+    def test_source_error_recorded_not_raised(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.config.get_confluence_token", lambda: "tok")
+        monkeypatch.setattr("yeaboi.config.get_confluence_base_url", lambda: "https://x/wiki")
+        monkeypatch.setattr("yeaboi.config.get_notion_token", lambda: None)
+
+        def boom(days=1):
+            raise RuntimeError("401 Unauthorized")
+
+        monkeypatch.setattr("yeaboi.tools.confluence.confluence_recent_pages", boom)
+        pages, platforms, coverage = collect_doc_pages("jira", "PROJ")
+        assert pages == []
+        assert any("confluence: error" in c for c in coverage)
+
+    def test_empty_text_pages_dropped(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.config.get_confluence_token", lambda: None)
+        monkeypatch.setattr("yeaboi.config.get_confluence_base_url", lambda: None)
+        monkeypatch.setattr("yeaboi.config.get_notion_token", lambda: "tok")
+        monkeypatch.setattr(
+            "yeaboi.tools.notion.notion_recent_pages",
+            lambda days=1: [{"key": "p1", "title": "Empty", "author": "A", "url": "u", "timestamp": "t"}],
+        )
+        monkeypatch.setattr(
+            "yeaboi.tools.notion.notion_read_page_text",
+            lambda page_id, max_chars=0: {"title": "Empty", "text": "   ", "truncated": False, "error": ""},
+        )
+        pages, platforms, coverage = collect_doc_pages("jira", "PROJ")
+        assert pages == []  # blank body dropped
+        assert any("notion: no pages" in c for c in coverage)
+
+
+class TestRunDocQuality:
+    def test_aggregates_collected_pages(self, monkeypatch):
+        monkeypatch.setattr(
+            "yeaboi.analysis.doc_quality.collect_doc_pages",
+            lambda source, project: (
+                [
+                    {"platform": "confluence", "title": "Clear", "text": _CLEAR_TEXT},
+                    {"platform": "notion", "title": "AI", "text": _AI_TELL_TEXT},
+                ],
+                ["confluence", "notion"],
+                [],
+            ),
+        )
+        signal, blob = run_doc_quality("jira", "PROJ")
+        assert signal.pages_scanned == 2
+        assert blob["summary"]["pages_scanned"] == 2
+        # Samples carry titles/scores only — never page bodies.
+        assert blob["samples"]
+        assert all("text" not in s for s in blob["samples"])
+
+    def test_collect_failure_returns_empty_signal(self, monkeypatch):
+        def boom(source, project):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr("yeaboi.analysis.doc_quality.collect_doc_pages", boom)
+        signal, blob = run_doc_quality("jira", "PROJ")
+        assert signal == DocQualitySignal()
+        assert blob["coverage"] == ["doc-quality scan failed"]

--- a/tests/unit/test_standup_activity.py
+++ b/tests/unit/test_standup_activity.py
@@ -663,6 +663,7 @@ class TestAzdoRepoActivity:
                 "author_email": "gina@corp.com",
                 "kind": "commit",
                 "title": "add endpoint (api)",
+                "body": "body",
                 "timestamp": "2026-07-17T08:00:00",
                 "key": "abcdef12",
                 "url": "https://dev.azure.com/org/Proj/_git/api/commit/abcdef1234567890",

--- a/tests/unit/test_team_profile.py
+++ b/tests/unit/test_team_profile.py
@@ -13,6 +13,7 @@ import pytest
 
 from yeaboi.team_profile import (
     DailyScopeSnapshot,
+    DocQualitySignal,
     DoDSignal,
     EpicPattern,
     ScopeChangeEvent,
@@ -404,6 +405,46 @@ class TestExtendedProfileSerialisation:
         )
         assert restored.writing_patterns.subtasks_use_consistent_naming is True
         assert restored.writing_patterns.epic_description_length_avg == 450
+
+    def test_round_trip_doc_quality(self):
+        profile = TeamProfile(
+            team_id="jira-DQ",
+            source="jira",
+            project_key="DQ",
+            doc_quality=DocQualitySignal(
+                pages_scanned=6,
+                platforms_scanned=("confluence", "notion"),
+                avg_clarity=57.5,
+                clear_pages=2,
+                mixed_pages=3,
+                unclear_pages=1,
+                avg_ai_likelihood=48.0,
+                likely_ai_pages=2,
+                ai_marked_pages=1,
+                per_platform=(("confluence", 4), ("notion", 2)),
+                flagged_pages=(("Onboarding guide", "clarity 30/100 — dense or long-winded"),),
+            ),
+        )
+        restored = _json_to_profile(_profile_to_json(profile))
+        dq = restored.doc_quality
+        assert dq.pages_scanned == 6
+        assert dq.platforms_scanned == ("confluence", "notion")
+        assert dq.avg_clarity == 57.5
+        assert (dq.clear_pages, dq.mixed_pages, dq.unclear_pages) == (2, 3, 1)
+        assert dq.avg_ai_likelihood == 48.0
+        assert dq.likely_ai_pages == 2
+        assert dq.ai_marked_pages == 1
+        # Pair lists survive as tuples-of-tuples, not lists-of-lists.
+        assert dq.per_platform == (("confluence", 4), ("notion", 2))
+        assert dq.flagged_pages == (("Onboarding guide", "clarity 30/100 — dense or long-winded"),)
+        assert dq.is_ai_estimate is True
+
+    def test_doc_quality_backward_compat_default(self):
+        """An old profile with no doc_quality key deserializes to an empty signal."""
+        old_json = json.dumps({"team_id": "jira-OLD", "source": "jira", "project_key": "OLD", "sample_sprints": 3})
+        restored = _json_to_profile(old_json)
+        assert restored.doc_quality == DocQualitySignal()
+        assert restored.doc_quality.pages_scanned == 0
 
     def test_round_trip_sprint_counts(self):
         profile = _make_extended_profile()
@@ -1132,6 +1173,56 @@ class TestTeamProfileExporter:
 
         md = build_team_profile_markdown(TeamProfile(team_id="x", source="jira", project_key="X"))
         assert "# Team Profile" in md
+
+    def test_markdown_ai_adoption_source_and_examples(self):
+        from yeaboi.team_profile import AiAdoptionSignal
+        from yeaboi.team_profile_exporter import build_team_profile_markdown
+
+        sig = AiAdoptionSignal(
+            scanned_commits=134,
+            ai_commits=133,
+            footprint_pct=99.0,
+            per_tool=(("claude", 131),),
+            per_source=(("local_git", 133),),
+            repos_scanned=("Local clone: /Users/dinho/repo",),
+            sources_scanned=("local_git",),
+        )
+        profile = TeamProfile(team_id="t", source="jira", project_key="P", ai_adoption=sig)
+        ex = {
+            "ai_adoption": {
+                "coverage": ["github: STANDUP_GITHUB_REPO / GITHUB_TOKEN not set"],
+                "samples": [
+                    {
+                        "tool": "claude",
+                        "title": "Fix login",
+                        "source": "local_git",
+                        "key": "a1b2c3d4",
+                        "url": "https://github.com/o/r/commit/a1b2c3d4",
+                    },
+                ],
+                "insights": {
+                    "start": [
+                        {
+                            "title": "Open PRs",
+                            "detail": "d",
+                            "evidence": "e",
+                            "link": "https://github.com/o/r/commit/a1b2c3d4",
+                        }
+                    ],
+                    "stop": [],
+                    "keep": [],
+                    "try": [],
+                },
+            }
+        }
+        md = build_team_profile_markdown(profile, examples=ex)
+        assert "Local clone (remote)" in md or "Local clone" in md  # friendly source label
+        assert "/Users/dinho/repo" in md  # scanned path
+        assert "**By source:**" in md
+        assert "Not scanned:" in md and "STANDUP_GITHUB_REPO" in md
+        assert "### Examples" in md
+        assert "[Fix login](https://github.com/o/r/commit/a1b2c3d4)" in md  # linked example
+        assert "[↳ example](https://github.com/o/r/commit/a1b2c3d4)" in md  # linked coaching
 
     def test_build_markdown_embeds_velocity_chart(self, tmp_path):
         import pytest

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.24.0"
+version = "2.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## What

Adds two new sub-analyses inside **team-analysis** mode, plus a source-aware / evidence-linked coaching upgrade. Each is a never-raises engine riding on the existing `TeamProfile` / `examples` / coaching plumbing — **no schema bump, no new mode** — surfaced across the TUI card, HTML/Markdown/log exports, the `team_analyze` MCP tool, the `analyze` CLI, and the team-analysis plugin skill.

### 1. AI adoption — "how does my team use AI in their work?"
- Scans recent commits/PRs from **GitHub, the local git clone, and Azure DevOps** for AI-tool markers (`Co-Authored-By: Claude`, Copilot, Cursor, aider, Devin, Codeium, generic trailer) → a detectable footprint, framed everywhere as a **LOWER BOUND** (inline IDE assist leaves no trace).
- **Source-aware:** friendly labels (**Local clone** / **GitHub (remote)** / **Azure DevOps (remote)**), a populated `repos_scanned` "what was scanned" line, a **By source** breakdown, and coverage gaps shown even when data exists — so local-vs-remote is never ambiguous.
- **Evidence-linked coaching:** an **Examples** section from the real scanned items and start/stop/keep/try items that cite a specific commit/PR *with a link* ("here's where you did Y → do X"). LLM-supplied links are accepted only when they match a genuinely scanned item (anti-hallucination).
- `local_git` commits now carry a real short **SHA** (was the constant `"local"`) plus a best-effort web URL derived from the `origin` remote.

### 2. Documentation quality — "is our written knowledge clear, and how does AI show up in it?"
- Reads recently-changed **Notion/Confluence** pages and scores **clarity** (Flesch-style readability) plus a **stylometric AI-likelihood ESTIMATE** (never a detection — prose has no reliable AI marker) and an explicit-AI-marker **lower bound**.
- Same evidence-linked coaching, citing specific pages with links.

## Design notes
- New frozen state `AiAdoptionSignal` (with `per_source`) and `DocQualitySignal` ride in `profile_json` and round-trip; old profiles deserialize to empty defaults.
- Gated by `include_ai_usage` / `include_doc_quality` — both **default-on**, graceful-skip when nothing is configured.
- Honesty framing baked into every surface: footprint = lower bound, clarity = heuristic score, AI-likelihood = estimate.

## Testing
- Full `make test` green except pre-existing environmental failures (contract VCR cassettes + `test_charts` charts dev-extra on Python 3.14 — unrelated to this change). `make lint` clean.
- New unit coverage: marker classifier, aggregation (+ `per_source`), clarity/stylometry heuristics, graceful fan-out, deterministic fallbacks, mocked-LLM happy/fallback + link validation, serialization round-trips, and TUI/export render tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)