### PR TITLE
add retro web board upgrades: author focus/group, top add form, edit fix, timestamps, host admin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.29.0"
+version = "2.30.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,17 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.30.0",
+      "date": "2026-07-23",
+      "summary": "Retro web board gained several quality-of-life features. You can now focus on one team member's cards at a time (useful for turn-taking discussions), group cards by author, add sticky cards at the top of each column so you don't have to scroll on tall boards, and see relative timestamps on each card. The host also gained admin powers: broadcast theme changes and ambient music to all teammates at once, and lock the board during discussions to freeze card editing. Cards can still get reactions and carried-item status updates during a lock. Security tightening removed an information leak in the access log that could have exposed session tokens.",
+      "highlights": [
+        {"text": "Focus and Group controls to filter or cluster cards by author for better turn-taking", "areas": ["retro"]},
+        {"text": "Add-card input at the top of each column; relative timestamps on all cards", "areas": ["retro"]},
+        {"text": "Host admin controls: broadcast theme and music, lock the board during discussions", "areas": ["retro"]},
+        {"text": "Fixed an access-log security regression that leaked session tokens and admin secrets", "areas": ["retro", "general"]}
+      ]
+    },
+    {
       "version": "2.29.0",
       "date": "2026-07-22",
       "summary": "Team analysis got a major rework. It can now run across Jira and Azure DevOps together, and — more importantly — each part of the analysis scans its OWN sources: Delivery (velocity, calibration, contributors) reads your Jira/Azure DevOps boards, Code scans GitHub and Azure Repos, and Docs reads Confluence and Notion. A single grid lets you pick exactly what to analyse — e.g. just Confluence docs, or just one code host — and scope the run to a subset of team members. Delivery is analysed per tracker (never blended, with a side-by-side comparison), while code and docs run once as global scans. Local code scanning was dropped in favour of remote-only.",

--- a/src/yeaboi/retro/board.py
+++ b/src/yeaboi/retro/board.py
@@ -61,6 +61,12 @@ CARRIED_STATUS_LABELS: dict[str, str] = {
 # Statuses that still count as "open" for the Planning/Analysis feed (ceremony_history).
 CARRIED_OPEN_STATUSES: tuple[str, ...] = ("pending", "in_progress", "carried_over")
 
+# Canonical, server-validated theme names. The host (admin) can broadcast one of
+# these to every browser; a name from a LAN peer is rejected unless it's here. These
+# MUST match the [data-theme="…"] blocks in retro/page.py's _CSS (page.py injects
+# this tuple as __THEMES__ so client and server never drift).
+RETRO_THEMES: tuple[str, ...] = ("midnight", "light", "solarized", "synthwave", "forest")
+
 # Canonical, server-validated sets shared with the browser page (retro/page.py
 # injects these so client and server agree). Reactions/avatars from a LAN peer are
 # rejected unless they're in these tuples — bounding what can be stored/rendered.
@@ -135,6 +141,16 @@ class RetroBoard:
         self._card_owner: dict[str, str] = {}  # card_id -> creator pid (edit/delete permission)
         self._presence: dict[str, dict] = {}  # pid -> {name, avatar, typing_grid, last_seen}
         self._timer: dict = {"running": False, "end_epoch": None, "duration": 0}
+        # Host-driven "global" state applied by every browser on its next poll (the
+        # same broadcast-by-polling trick as the timer). Only the admin (host link)
+        # can set these; see server.py's _admin_authed gate. All guarded by _lock.
+        #   _broadcast["theme"]: a RETRO_THEMES name forced on every client, or None.
+        #   _broadcast["music"]: {"playing", "channel", "seq"} — seq lets each client
+        #       apply a given command exactly once (and re-trigger "play"), or None.
+        #   _locked: when True, card add/edit/delete/move are frozen for everyone.
+        self._broadcast: dict = {"theme": None, "music": None}
+        self._music_seq = 0
+        self._locked = False
 
     def add_card(self, *, grid: str, text: str, author: str, origin: str = "web", pid: str = "") -> RetroCard | None:
         """Add one card, validating + capping inputs. Returns the card, or None if invalid.
@@ -157,6 +173,9 @@ class RetroBoard:
             origin=origin,
         )
         with self._lock:
+            if self._locked:  # host froze the board — no new cards from anyone
+                logger.info("retro board: card rejected — board locked")
+                return None
             if len(self._cards) >= _MAX_CARDS:
                 logger.warning("retro board: card rejected — board full (%d cards)", _MAX_CARDS)
                 return None
@@ -312,6 +331,8 @@ class RetroBoard:
         if not text:
             return False
         with self._lock:
+            if self._locked:  # board frozen by the host
+                return False
             if self._card_owner.get(card_id) != pid or not pid:
                 return False
             i = self._index_of_locked(card_id)
@@ -326,6 +347,8 @@ class RetroBoard:
     def delete_card(self, card_id: str, pid: str) -> bool:
         """Delete a card (and its reactions/owner). Author-only. Returns True on success."""
         with self._lock:
+            if self._locked:  # board frozen by the host
+                return False
             if self._card_owner.get(card_id) != pid or not pid:
                 return False
             i = self._index_of_locked(card_id)
@@ -351,6 +374,8 @@ class RetroBoard:
         if to_grid not in RETRO_GRIDS:
             return False
         with self._lock:
+            if self._locked:  # board frozen by the host
+                return False
             i = self._index_of_locked(card_id)
             if i < 0:
                 return False
@@ -485,6 +510,51 @@ class RetroBoard:
         # Include the server clock so clients can compute an offset and tick locally.
         return {**self._timer, "now_epoch": time.time()}
 
+    # ── Host broadcast (theme / music) + board lock ───────────────────────
+    #
+    # These are the "global admin" controls: the host (whoever holds the admin
+    # token — see server.py) sets them and every browser applies them on its next
+    # poll. Enums are server-validated (LAN peers untrusted), like REACTION_EMOJIS.
+
+    def set_broadcast_theme(self, theme: str) -> bool:
+        """Force a theme on every browser. Returns True if accepted (a known theme)."""
+        if theme not in RETRO_THEMES:
+            return False
+        with self._lock:
+            self._broadcast["theme"] = theme
+            self._revision += 1
+        logger.info("retro board: host broadcast theme=%s", theme)
+        return True
+
+    def set_broadcast_music(self, *, playing: bool, channel: int) -> bool:
+        """Broadcast a music command (play/stop + station) to every browser.
+
+        ``channel`` is validated against the shared internet-radio library. A fresh
+        ``seq`` is stamped on each call so clients apply the command exactly once
+        (and can re-trigger "play" even if the play/channel values are unchanged).
+        """
+        from yeaboi.music import CHANNELS
+
+        try:
+            channel = int(channel)
+        except (TypeError, ValueError):
+            return False
+        if not CHANNELS or not (0 <= channel < len(CHANNELS)):
+            return False
+        with self._lock:
+            self._music_seq += 1
+            self._broadcast["music"] = {"playing": bool(playing), "channel": channel, "seq": self._music_seq}
+            self._revision += 1
+        logger.info("retro board: host broadcast music — playing=%s channel=%d", bool(playing), channel)
+        return True
+
+    def set_locked(self, flag: bool) -> None:
+        """Freeze (or unfreeze) card add/edit/delete/move for everyone."""
+        with self._lock:
+            self._locked = bool(flag)
+            self._revision += 1
+        logger.info("retro board: board %s by host", "locked" if flag else "unlocked")
+
     # ── Unified live snapshot (the browser's poll payload) ─────────────────
 
     def state_snapshot(self, viewer_pid: str = "") -> dict:
@@ -522,6 +592,9 @@ class RetroBoard:
                 "typing": typing,
                 "timer": self._timer_locked(),
                 "reaction_events": list(self._reaction_events),
+                # Host-driven globals every browser applies on poll (theme/music/lock).
+                "broadcast": {"theme": self._broadcast["theme"], "music": self._broadcast["music"]},
+                "locked": self._locked,
             }
 
 

--- a/src/yeaboi/retro/page.py
+++ b/src/yeaboi/retro/page.py
@@ -38,6 +38,7 @@ from yeaboi.retro.board import (
     REACTION_EMOJIS,
     RETRO_GRID_LABELS,
     RETRO_GRIDS,
+    RETRO_THEMES,
 )
 
 logger = logging.getLogger(__name__)
@@ -239,6 +240,13 @@ header .spacer { flex:1; }
 .act.danger:hover { color:#f85149; }
 .editbox { width:100%; background:var(--card); color:var(--text); border:1px solid var(--accent);
            border-radius:6px; padding:6px; font:inherit; resize:vertical; }
+.edit-actions { display:flex; gap:8px; margin-top:8px; }
+.btn-save { background:var(--accent); color:var(--ink); border:0; border-radius:7px;
+            padding:6px 18px; font:inherit; font-weight:600; cursor:pointer; }
+.btn-save:hover { filter:brightness(1.08); }
+.btn-cancel { background:transparent; color:var(--text); border:1px solid var(--line);
+              border-radius:7px; padding:6px 14px; font:inherit; cursor:pointer; }
+.btn-cancel:hover { border-color:var(--accent); }
 .rx { display:flex; flex-wrap:wrap; gap:4px; margin-top:7px; }
 .chip { background:transparent; border:1px solid var(--line); border-radius:999px;
         padding:1px 7px; cursor:pointer; font:inherit; font-size:13px; line-height:1.5; color:var(--text); }
@@ -263,6 +271,28 @@ textarea { width:100%; background:var(--card); color:var(--text); border:1px sol
 .addbtn { margin-top:6px; background:var(--accent); color:var(--ink); border:0; border-radius:8px;
           padding:7px 14px; font:inherit; font-weight:600; cursor:pointer; }
 .addbtn:hover { filter:brightness(1.1); }
+.addbtn:disabled, .add textarea:disabled { opacity:.5; cursor:not-allowed; }
+.add { margin-bottom:10px; }  /* input now sits at the top of the column */
+
+/* Small relative timestamp beside the author badge. */
+.card .who .ago { color:var(--muted); font-size:11px; }
+
+/* Group-by-author clusters within a column. */
+.author-group { margin-bottom:10px; }
+.ag-head { font-size:12px; color:var(--muted); margin:2px 0 5px; letter-spacing:.02em; }
+
+/* Header view controls: focus-one-person picker + group-by toggle. */
+.viewctl { display:flex; align-items:center; gap:8px; }
+.viewctl select { background:var(--panel); color:var(--text); border:1px solid var(--line);
+                  border-radius:9px; padding:6px 8px; font:inherit; font-size:13px; cursor:pointer; }
+.viewctl select:hover { border-color:var(--accent); }
+
+/* Host-broadcast banners (autoplay tap-to-listen + board lock). */
+.banner { position:fixed; left:50%; bottom:18px; transform:translateX(-50%); z-index:28;
+          background:var(--panel); color:var(--text); border:1px solid var(--accent);
+          border-radius:999px; padding:9px 18px; font-size:13.5px; cursor:pointer;
+          box-shadow:0 8px 24px rgba(0,0,0,.4); }
+.banner.lock { border-color:#f85149; cursor:default; }
 
 .overlay { position:fixed; inset:0; background:rgba(0,0,0,.75); display:flex;
            align-items:center; justify-content:center; padding:16px; z-index:20; }
@@ -307,6 +337,10 @@ const ADJS = __ADJS__;
 const NOUNS = __NOUNS__;
 
 let TOKEN = new URLSearchParams(location.search).get("token") || sessionStorage.getItem("retro_token") || "";
+// The admin secret only ever rides in the host's private link (server.py appends
+// &admin=…). Whoever has it gets the host controls (music/theme/timer/lock).
+let ADMIN = new URLSearchParams(location.search).get("admin") || sessionStorage.getItem("retro_admin") || "";
+let IS_ADMIN = !!ADMIN;
 let PID = localStorage.getItem("retro_pid");
 if (!PID) { PID = (self.crypto && crypto.randomUUID) ? crypto.randomUUID() : "p" + Math.random().toString(36).slice(2); localStorage.setItem("retro_pid", PID); }
 let NAME = localStorage.getItem("retro_name") || "";
@@ -316,16 +350,24 @@ let JOINED = false, LOOPING = false;
 let TYPING_GRID = "", typingTimer = null;
 let TIMER = { running: false }, OFFSET = 0, firedFor = null;
 let EDITING = null;                          // card id being edited inline
+let LAST_STATE = null;                        // most recent poll payload (for local re-renders)
 const MY_REACTIONS = {};                     // card_id -> Set(emoji) I reacted with
 let lastRxEvent = -1, seededRx = false;       // high-water mark of animated reaction events
 let RX_CARD = null;                           // card whose react-picker is open
 let DRAG_ID = null;
+let FOCUS = "";                               // when set, show only this author's cards (their turn)
+let GROUPED = localStorage.getItem("retro_grouped") === "1";  // cluster cards by author
+let focusSig = null;                          // cached author set so we rebuild the picker only on change
+let lastBcastTheme = null, lastMusicSeq = 0;  // host broadcasts applied once, on change
+let LOCKED = false;                           // board frozen by the host
 
 function esc(s) { const d = document.createElement("div"); d.textContent = s == null ? "" : s; return d.innerHTML; }
 function api(path) { return path + (path.indexOf("?") < 0 ? "?" : "&") + "token=" + encodeURIComponent(TOKEN); }
 function postJSON(path, body) {
+  // `admin` is sent on every POST but only checked by the server on /api/admin/* and
+  // /api/timer — harmless (empty) for teammates who never received the secret.
   return fetch(api(path), { method: "POST", headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(Object.assign({ pid: PID }, body || {})) });
+    body: JSON.stringify(Object.assign({ pid: PID, admin: ADMIN }, body || {})) });
 }
 function randomName() { return ADJS[Math.floor(Math.random()*ADJS.length)] + " " + NOUNS[Math.floor(Math.random()*NOUNS.length)]; }
 function applyTheme(t) { THEME = t; document.documentElement.setAttribute("data-theme", t); localStorage.setItem("retro_theme", t); }
@@ -372,12 +414,14 @@ function paintMe() { document.getElementById("me").innerHTML = (AVATAR || "🙂"
 /* ── Grids + cards ──────────────────────────────────────────── */
 function buildCols() {
   const g = document.getElementById("grids");
+  // Add form sits directly under the heading so you never scroll to the bottom of a
+  // tall column to write a card. Cards then fill below it (newest appended at the end).
   g.innerHTML = GRIDS.map(([k, label]) =>
     '<div class="col"><h2>' + esc(label) + '</h2>' +
-    '<div class="cards" id="cards-' + k + '" data-grid="' + k + '"></div>' +
-    '<div class="typing" id="typing-' + k + '"></div>' +
     '<div class="add"><textarea rows="2" id="in-' + k + '" placeholder="Add a card…"></textarea>' +
-    '<button class="addbtn" data-grid="' + k + '">Add</button></div></div>'
+    '<button class="addbtn" data-grid="' + k + '">Add</button></div>' +
+    '<div class="cards" id="cards-' + k + '" data-grid="' + k + '"></div>' +
+    '<div class="typing" id="typing-' + k + '"></div></div>'
   ).join("");
   g.querySelectorAll("button.addbtn").forEach(b => b.addEventListener("click", () => addCard(b.getAttribute("data-grid"))));
   g.querySelectorAll("textarea").forEach(t => {
@@ -404,20 +448,39 @@ function reactionBar(card) {
   return '<div class="rx">' + chips +
     '<button class="react-btn" data-react="' + card.id + '" title="Add a reaction">😊<span class="plus">+</span></button></div>';
 }
+/* Relative "age" of a card from its ISO-8601 created_at: a live "just now / 3m"
+ * for fresh cards, falling back to a wall-clock HH:MM once past an hour (matches a
+ * retro's short lifespan). Labels refresh for free on each ~1.2s poll re-render. */
+function fmtAgo(iso) {
+  const t = Date.parse(iso);
+  if (!t) return null;
+  const s = Math.max(0, Math.round((Date.now() - t) / 1000));
+  const d = new Date(t);
+  let label;
+  if (s < 10) label = "just now";
+  else if (s < 60) label = s + "s";
+  else if (s < 3600) label = Math.floor(s / 60) + "m";
+  else label = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return { label: label, title: d.toLocaleString() };
+}
 function cardHTML(card, avatarByName) {
   const isAI = card.origin === "ai";
   const badge = isAI ? "🤖 AI" : ((avatarByName[card.author] || "") + " " + esc(card.author)).trim();
+  const t = fmtAgo(card.created_at);
+  const ago = t ? '<span class="ago" title="' + esc(t.title) + '">' + esc(t.label) + "</span>" : "";
   let actions = '<span class="spacer"></span>';
-  if (card.mine && !isAI) {
+  if (card.mine && !isAI && !LOCKED) {  // host lock hides the ✎/✕ controls
     actions += '<button class="act" data-edit="' + card.id + '" title="Edit">✎</button>' +
                '<button class="act danger" data-del="' + card.id + '" title="Delete">✕</button>';
   }
   const body = EDITING === card.id
     ? '<textarea class="editbox" id="edit-' + card.id + '" rows="2">' + esc(card.text) + '</textarea>' +
-      '<button class="act" data-save="' + card.id + '">Save</button><button class="act" data-cancel="1">Cancel</button>'
+      '<div class="edit-actions">' +
+      '<button class="btn-save" data-save="' + card.id + '">Save</button>' +
+      '<button class="btn-cancel" data-cancel="1">Cancel</button></div>'
     : '<div class="body">' + esc(card.text) + '</div>';
   return '<div class="card ' + (isAI ? "ai" : "") + '" draggable="true" data-id="' + card.id + '">' +
-         body + '<div class="who">' + badge + actions + '</div>' + reactionBar(card) + '</div>';
+         body + '<div class="who">' + badge + ago + actions + '</div>' + reactionBar(card) + '</div>';
 }
 
 async function addCard(grid) {
@@ -542,9 +605,72 @@ function paintTimer() {
 }
 setInterval(paintTimer, 250);
 
+/* ── Focus one person / group by author (for turn-by-turn walkthroughs) ─ */
+function gridInner(cards, avatarByName) {
+  let list = FOCUS ? cards.filter(c => c.author === FOCUS) : cards;
+  if (!GROUPED) return list.map(c => cardHTML(c, avatarByName)).join("");
+  // Cluster by author, preserving first-seen order within the grid.
+  const order = [], groups = {};
+  list.forEach(c => { const a = c.origin === "ai" ? "🤖 AI" : c.author; if (!groups[a]) { groups[a] = []; order.push(a); } groups[a].push(c); });
+  return order.map(a => {
+    const av = a === "🤖 AI" ? "" : (avatarByName[a] || "");
+    return '<div class="author-group"><div class="ag-head">' + (av ? esc(av) + " " : "") + esc(a) +
+      "</div>" + groups[a].map(c => cardHTML(c, avatarByName)).join("") + "</div>";
+  }).join("");
+}
+function updateFocusOptions(cards) {
+  // Rebuild the picker only when the human-author set actually changes, so it never
+  // clobbers an open selection mid-poll. Keep FOCUS if that author is still around.
+  const authors = [];
+  (cards || []).forEach(c => { if (c.origin !== "ai" && c.author && authors.indexOf(c.author) < 0) authors.push(c.author); });
+  authors.sort();
+  const sig = authors.join("");
+  if (sig === focusSig) return;
+  focusSig = sig;
+  const sel = document.getElementById("focus-author");
+  if (!sel) return;
+  if (FOCUS && authors.indexOf(FOCUS) < 0) FOCUS = "";
+  sel.innerHTML = '<option value="">Everyone</option>' +
+    authors.map(a => '<option value="' + esc(a) + '">' + esc(a) + "</option>").join("");
+  sel.value = FOCUS;
+}
+function markGroup() { const b = document.getElementById("group-toggle"); if (b) b.classList.toggle("open", GROUPED); }
+
+/* ── Host broadcasts (theme / music) + board lock, applied by every browser ─ */
+function applyBroadcast(state) {
+  const b = state.broadcast || {};
+  // Theme: apply only when the broadcast value *changes* — so a teammate who then
+  // re-picks a theme locally isn't yanked back every poll.
+  if (b.theme && b.theme !== lastBcastTheme) {
+    lastBcastTheme = b.theme;
+    if (b.theme !== THEME) { applyTheme(b.theme); markSwatch(); }
+  }
+  // Music: a fresh seq means a new host command — apply it exactly once.
+  const m = b.music;
+  if (m && m.seq && m.seq > lastMusicSeq) {
+    lastMusicSeq = m.seq;
+    Music.cast(m.channel, m.playing)
+      .then(() => hideMusicBanner())
+      .catch(() => { if (m.playing) showMusicBanner(); });
+  }
+  applyLock(!!state.locked);
+}
+function applyLock(locked) {
+  LOCKED = locked;
+  const banner = document.getElementById("lock-banner");
+  if (banner) banner.classList.toggle("hidden", !locked);
+  document.querySelectorAll(".add textarea, .add .addbtn").forEach(el => { el.disabled = locked; });
+  const lb = document.getElementById("lock-btn");
+  if (lb) { lb.classList.toggle("open", locked); lb.title = locked ? "Unlock the board" : "Lock the board"; }
+}
+function showMusicBanner() { const b = document.getElementById("music-banner"); if (b) b.classList.remove("hidden"); }
+function hideMusicBanner() { const b = document.getElementById("music-banner"); if (b) b.classList.add("hidden"); }
+
 /* ── Render live state ──────────────────────────────────────── */
 function render(state) {
   if (!state) return;
+  LAST_STATE = state;
+  applyBroadcast(state);   // set LOCKED before cards render so cardHTML hides ✎/✕
   if (state.timer) { TIMER = state.timer; OFFSET = state.timer.now_epoch - Date.now() / 1000; }
   // Float any reaction events we haven't shown yet. On the first render we only
   // seed the high-water mark (no backlog burst for someone who just joined).
@@ -563,10 +689,18 @@ function render(state) {
 
   GRIDS.forEach(([k]) => {
     const box = document.getElementById("cards-" + k);
-    if (box) box.innerHTML = (byGrid[k] || []).map(c => cardHTML(c, avatarByName)).join("");
+    if (box) {
+      // Don't clobber an open inline editor (poll fires ~1.2s) — skip re-rendering the
+      // grid that holds the card being edited until Save/Cancel clears EDITING. Keyed
+      // on the id (not live focus) so clicking a toolbar control mid-edit can't wipe
+      // the unsaved text on the next poll; other grids still refresh live.
+      const editingHere = EDITING && (byGrid[k] || []).some(c => c.id === EDITING);
+      if (!editingHere) box.innerHTML = gridInner(byGrid[k] || [], avatarByName);
+    }
     const tl = document.getElementById("typing-" + k);
     if (tl) { const names = (typingByGrid[k] || []).filter(n => n !== NAME); tl.textContent = names.length ? (names.join(", ") + (names.length > 1 ? " are" : " is") + " typing…") : ""; }
   });
+  updateFocusOptions(state.cards || []);
   wireCards();
   renderCarried(state);
 
@@ -601,7 +735,14 @@ function renderRoom(state) {
 function wireCards() {
   document.querySelectorAll(".chip").forEach(ch => ch.onclick = () => react(ch.getAttribute("data-card"), ch.getAttribute("data-emoji")));
   document.querySelectorAll("[data-react]").forEach(b => b.onclick = e => { e.stopPropagation(); openReactPicker(b.getAttribute("data-react"), b); });
-  document.querySelectorAll("[data-edit]").forEach(b => b.onclick = () => { EDITING = b.getAttribute("data-edit"); tick(); });
+  document.querySelectorAll("[data-edit]").forEach(b => b.onclick = () => {
+    // Render the inline editor locally (not via a network tick), then focus it with
+    // the caret at the end. render() then guards this grid from poll-clobbering.
+    EDITING = b.getAttribute("data-edit");
+    if (LAST_STATE) render(LAST_STATE);
+    const t = document.getElementById("edit-" + EDITING);
+    if (t) { t.focus(); t.setSelectionRange(t.value.length, t.value.length); }
+  });
   document.querySelectorAll("[data-del]").forEach(b => b.onclick = () => deleteCard(b.getAttribute("data-del")));
   document.querySelectorAll("[data-save]").forEach(b => b.onclick = () => saveEdit(b.getAttribute("data-save")));
   document.querySelectorAll("[data-cancel]").forEach(b => b.onclick = () => { EDITING = null; tick(); });
@@ -661,7 +802,7 @@ document.addEventListener("click", e => {
 document.addEventListener("keydown", e => { if (e.key === "Escape") { closePops(); closeReactPicker(); } });
 
 /* ── Theme swatches ─────────────────────────────────────────── */
-const THEMES = ["midnight", "light", "solarized", "synthwave", "forest"];
+const THEMES = __THEMES__;   // canonical set, injected from board.RETRO_THEMES
 function buildSwatches() {
   const wrap = document.getElementById("swatches");
   wrap.innerHTML = THEMES.map(t =>
@@ -738,6 +879,13 @@ const Music = (function () {
     setChannel(i) { const wasPlaying = playing || !audio.paused; load(i); if (wasPlaying) play(); },
     playing() { return playing; },
     channels() { return CHANNELS; },
+    channelIndex() { return channel; },
+    // Apply a host broadcast: play the given station, or stop. Returns the audio
+    // play() promise so the caller can show a "tap to listen" banner if autoplay is
+    // blocked (a browser rejects play() without a prior user gesture).
+    cast(i, on) { if (!on) { stop(); return Promise.resolve(); } load(i); return audio.play(); },
+    // Resume after the user taps the autoplay banner (their tap is the gesture).
+    playNow() { if (!audio.src) load(channel); return audio.play(); },
   };
 })();
 
@@ -770,6 +918,14 @@ function alarm() {
   } catch (e) {}
 }
 
+/* ── Host (admin) controls: broadcast to every browser ──────── */
+async function toggleLock() { try { const r = await postJSON("/api/admin/lock", { locked: !LOCKED }); if (r.ok) render((await r.json()).state); } catch (e) {} }
+async function castTheme() { try { const r = await postJSON("/api/admin/broadcast", { theme: THEME }); if (r.ok) render((await r.json()).state); } catch (e) {} }
+async function castMusic() {
+  // Broadcast the host's current play state + station; teammates apply it on poll.
+  try { const r = await postJSON("/api/admin/broadcast", { music: { playing: Music.playing(), channel: Music.channelIndex() } }); if (r.ok) render((await r.json()).state); } catch (e) {}
+}
+
 /* ── Wire up + start ────────────────────────────────────────── */
 applyTheme(THEME);
 buildCols();
@@ -777,6 +933,17 @@ buildAvatars();
 buildSwatches();
 buildChannels();
 paintTimer();
+markGroup();
+// Host controls (music/theme/timer/lock) show only to the admin; teammates see the
+// matching "host controls this" note instead.
+document.querySelectorAll(".admin-only").forEach(el => el.classList.toggle("hidden", !IS_ADMIN));
+document.querySelectorAll(".guest-only").forEach(el => el.classList.toggle("hidden", IS_ADMIN));
+document.getElementById("focus-author").addEventListener("change", e => { FOCUS = e.target.value; if (LAST_STATE) render(LAST_STATE); });
+document.getElementById("group-toggle").addEventListener("click", () => { GROUPED = !GROUPED; localStorage.setItem("retro_grouped", GROUPED ? "1" : "0"); markGroup(); if (LAST_STATE) render(LAST_STATE); });
+document.getElementById("music-banner").addEventListener("click", () => { Music.playNow().then(hideMusicBanner).catch(() => {}); });
+document.getElementById("lock-btn").addEventListener("click", toggleLock);
+document.getElementById("theme-cast").addEventListener("click", castTheme);
+document.getElementById("music-cast").addEventListener("click", castMusic);
 document.getElementById("dice").addEventListener("click", () => { document.getElementById("name-in").value = randomName(); });
 document.getElementById("name-in").addEventListener("keydown", e => { if (e.key === "Enter") saveProfile(); });
 document.getElementById("save-profile").addEventListener("click", saveProfile);
@@ -799,7 +966,9 @@ document.getElementById("invite-close").addEventListener("click", toggleInvite);
 
 function afterToken() {
   // Token known: keep it in sessionStorage (per-tab, survives refresh) and strip
-  // it from the address bar, so copying the URL never leaks access to others.
+  // it (and the admin secret) from the address bar, so copying the URL never leaks
+  // access — or admin — to others.
+  if (ADMIN) sessionStorage.setItem("retro_admin", ADMIN);
   if (TOKEN) { sessionStorage.setItem("retro_token", TOKEN); history.replaceState(null, "", "/"); }
   paintMe();
   if (NAME && localStorage.getItem("retro_avatar")) { JOINED = true; document.getElementById("modal").classList.add("hidden"); startLoop(); }
@@ -822,6 +991,7 @@ def build_board_html() -> str:
         .replace("__CARRIED_STATUSES__", _lit(_CARRIED_STATUS_JS))
         .replace("__EMOJIS__", _lit(list(REACTION_EMOJIS)))
         .replace("__AVATARS__", _lit(list(AVATARS)))
+        .replace("__THEMES__", _lit(list(RETRO_THEMES)))
         .replace("__ADJS__", _lit(_ADJECTIVES))
         .replace("__NOUNS__", _lit(_NOUNS))
         # Same internet-radio library the TUI uses (yeaboi.music.CHANNELS),
@@ -842,8 +1012,14 @@ def build_board_html() -> str:
         '<button class="room-btn" id="room-btn" title="Who\'s in the room">'
         '👥 <span id="roomcount">1</span></button></div>\n'
         '  <span class="spacer"></span>\n'
+        # View controls: focus one person's cards (their turn) / group cards by author.
+        '  <div class="viewctl">\n'
+        '    <select id="focus-author" title="Show only one person\'s cards"><option value="">Everyone</option></select>\n'
+        '    <button class="tbtn" id="group-toggle" title="Group cards by author">⊞ Group</button>\n'
+        "  </div>\n"
         '  <div class="toolbar">\n'
         '    <canvas id="viz" width="34" height="22" title="Now playing"></canvas>\n'
+        '    <button class="tbtn admin-only hidden" id="lock-btn" title="Lock the board"><span class="ico">🔒</span></button>\n'
         '    <button class="tbtn" id="music-btn" title="Music"><span class="ico">♪</span></button>\n'
         '    <button class="tbtn" id="timer-btn" title="Timer"><span class="ico">⏱</span>'
         '<span class="rd" id="timer-readout"></span></button>\n'
@@ -856,24 +1032,32 @@ def build_board_html() -> str:
         '  <button class="playbtn" id="music-play">▶</button>\n'
         '  <input type="range" id="music-vol" min="0" max="1" step="0.05" value="0.35" title="Volume">\n'
         '  <select id="music-mood" title="Station"></select>\n'
-        "</div></div>\n"
-        # Timer popover
+        "</div>\n"
+        '  <div class="row admin-only hidden" style="margin-top:10px">'
+        '<button class="tbtn" id="music-cast" title="Play this for the whole team">📣 Play for everyone</button></div>\n'
+        "</div>\n"
+        # Timer popover — starting/stopping is admin-only; everyone still sees the readout.
         '<div id="timer-pop" class="pop hidden">\n'
         "  <label>Countdown</label>\n"
-        '  <div class="row"><div class="seg">'
+        '  <div class="admin-only hidden">\n'
+        '    <div class="row"><div class="seg">'
         '<button class="preset" data-secs="60">1m</button>'
         '<button class="preset" data-secs="120">2m</button>'
         '<button class="preset" data-secs="180">3m</button>'
         '<button class="preset" data-secs="300">5m</button></div></div>\n'
-        '  <div class="row" style="margin-top:10px">'
+        '    <div class="row" style="margin-top:10px">'
         '<input type="number" id="custom-min" min="1" max="60" placeholder="min">'
         '<button class="tbtn" id="custom-go">Start</button>'
         '<button class="tbtn" id="timer-stop">Stop</button></div>\n'
+        "  </div>\n"
+        '  <p class="sub guest-only hidden" style="margin:6px 0 0">The host controls the timer.</p>\n'
         "</div>\n"
         # Theme popover
         '<div id="theme-pop" class="pop hidden">\n'
         "  <label>Theme</label>\n"
         '  <div class="swatches" id="swatches"></div>\n'
+        '  <div class="row admin-only hidden" style="margin-top:10px">'
+        '<button class="tbtn" id="theme-cast" title="Apply this theme for the whole team">📣 Apply to everyone</button></div>\n'
         "</div>\n"
         # Room roster popover (who's here) — left-anchored under the presence cluster
         '<div id="room-pop" class="pop left hidden">\n'
@@ -892,6 +1076,9 @@ def build_board_html() -> str:
         '<canvas id="confetti"></canvas>\n'
         '<div id="rx-fx"></div>\n'
         '<div id="rx-picker" class="rx-picker hidden"></div>\n'
+        # Host-broadcast banners: tap-to-listen (autoplay fallback) + board-locked notice.
+        '<div id="music-banner" class="banner hidden">▶ The host started music — tap to listen</div>\n'
+        '<div id="lock-banner" class="banner lock hidden">🔒 The host locked the board</div>\n'
         # Code-entry gate (shown when the URL has no token)
         '<div id="code-modal" class="overlay hidden"><div class="box">\n'
         "  <h2>Join a retro</h2>\n"

--- a/src/yeaboi/retro/server.py
+++ b/src/yeaboi/retro/server.py
@@ -167,7 +167,12 @@ class _RetroHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"  # keep-alive; every response sets Content-Length
 
     # Route the default noisy stderr access log into our logger at DEBUG, and never
-    # log the query string (it carries the token).
+    # log the query string — it carries the token AND the admin secret.
+    def log_request(self, code: object = "-", size: object = "-") -> None:  # noqa: N802 - stdlib signature
+        # The default logs ``self.requestline`` (path WITH query) — that would leak
+        # the token/admin secret into the log file at DEBUG. Log method + path only.
+        logger.debug("retro-http %s %s -> %s", self.command, urlparse(self.path).path, code)
+
     def log_message(self, fmt: str, *args: object) -> None:  # noqa: A003 - stdlib signature
         logger.debug("retro-http %s", fmt % args if args else fmt)
 
@@ -178,6 +183,10 @@ class _RetroHandler(BaseHTTPRequestHandler):
     @property
     def _token(self) -> str:
         return self.server.token  # type: ignore[attr-defined]
+
+    @property
+    def _admin_token(self) -> str:
+        return self.server.admin_token  # type: ignore[attr-defined]
 
     @property
     def _join_code(self) -> str:
@@ -192,6 +201,10 @@ class _RetroHandler(BaseHTTPRequestHandler):
 
     def _authed(self) -> bool:
         return secrets.compare_digest(self._query("token"), self._token)
+
+    def _admin_authed(self, admin: str) -> bool:
+        """True iff ``admin`` matches the host's admin secret (constant-time)."""
+        return bool(admin) and secrets.compare_digest(admin, self._admin_token)
 
     def _send(self, code: int, body: bytes, content_type: str) -> None:
         self.send_response(code)
@@ -292,15 +305,47 @@ class _RetroHandler(BaseHTTPRequestHandler):
             "/api/card/delete",
             "/api/card/move",
             "/api/carried/status",
+            "/api/admin/broadcast",
+            "/api/admin/lock",
         )
         if path not in authed_paths or not self._authed():
             self._send_json(403, {"error": "forbidden"})
             return
 
         pid = str(payload.get("pid", ""))
+        admin = str(payload.get("admin", ""))
 
         def _state() -> dict:
             return self._board.state_snapshot(pid)
+
+        # ── Admin-only routes (host link holds the admin secret) ──────────────
+        # /api/timer is admin-only too — the shared countdown belongs to the host.
+        if path in ("/api/admin/broadcast", "/api/admin/lock", "/api/timer"):
+            if not self._admin_authed(admin):
+                self._send_json(403, {"error": "admin only"})
+                return
+
+        if path == "/api/admin/broadcast":
+            ok, applied = True, False
+            if "theme" in payload:
+                ok = self._board.set_broadcast_theme(str(payload.get("theme", ""))) and ok
+                applied = True
+            music = payload.get("music")
+            if isinstance(music, dict):
+                ok = (
+                    self._board.set_broadcast_music(playing=bool(music.get("playing")), channel=music.get("channel", 0))
+                    and ok
+                )
+                applied = True
+            # An empty/malformed broadcast (neither theme nor music) is a client error,
+            # not a silent success.
+            self._send_json(200 if (ok and applied) else 400, {"ok": ok and applied, "state": _state()})
+            return
+
+        if path == "/api/admin/lock":
+            self._board.set_locked(bool(payload.get("locked")))
+            self._send_json(200, {"ok": True, "state": _state()})
+            return
 
         if path == "/api/cards":
             card = self._board.add_card(
@@ -381,6 +426,11 @@ class RetroServer:
     def __init__(self, board: RetroBoard, *, port: int = _DEFAULT_PORT) -> None:
         self.board = board
         self.token = make_token()
+        # A second, stronger secret that ONLY rides in the host's private link
+        # (:attr:`url`). Whoever opens that link becomes the retro's admin (music /
+        # theme / timer / board-lock). It is never in the shared join flow, the
+        # share code, or the tunnel URL — so a join-code teammate is never an admin.
+        self.admin_token = make_token()
         self.join_code = make_join_code()
         self.join_limiter = JoinLimiter()
         self.ip = get_lan_ip()
@@ -393,10 +443,11 @@ class RetroServer:
         """The host's private direct link (carries the token — do not share).
 
         This is the host's own convenience link and the value logged on startup;
-        anyone opening it is let straight in. Teammates get :attr:`share_url`
-        instead and must enter the join code.
+        anyone opening it is let straight in AND granted admin controls (the
+        ``admin`` secret). Teammates get :attr:`share_url` instead and must enter
+        the join code — they never receive the admin secret.
         """
-        return f"http://{self.ip}:{self.port}/?token={self.token}"
+        return f"http://{self.ip}:{self.port}/?token={self.token}&admin={self.admin_token}"
 
     @property
     def share_url(self) -> str:
@@ -435,6 +486,7 @@ class RetroServer:
         # Attach shared state to the server object so the stateless handler can reach it.
         httpd.board = self.board  # type: ignore[attr-defined]
         httpd.token = self.token  # type: ignore[attr-defined]
+        httpd.admin_token = self.admin_token  # type: ignore[attr-defined]
         httpd.join_code = self.join_code  # type: ignore[attr-defined]
         httpd.join_limiter = self.join_limiter  # type: ignore[attr-defined]
         httpd.page_html = page_html  # type: ignore[attr-defined]

--- a/tests/unit/test_retro_board.py
+++ b/tests/unit/test_retro_board.py
@@ -258,7 +258,17 @@ class TestStateSnapshot:
         b.toggle_reaction(c.id, "👍", "p1")
         b.heartbeat("p1", name="Sam", avatar="🤠", typing_grid="went_well")
         snap = b.state_snapshot()
-        assert set(snap) == {"revision", "cards", "carried", "presence", "typing", "timer", "reaction_events"}
+        assert set(snap) == {
+            "revision",
+            "cards",
+            "carried",
+            "presence",
+            "typing",
+            "timer",
+            "reaction_events",
+            "broadcast",
+            "locked",
+        }
         assert snap["cards"][0]["reactions"] == {"👍": 1}
         assert snap["presence"] and snap["typing"][0]["grid"] == "went_well"
 
@@ -369,3 +379,34 @@ class TestCarriedActionItems:
         assert texts == ["ship docs", "new one"]
         carry = [c for c in b.cards_by_grid()["action_items"] if c.origin == "carryover"]
         assert carry and carry[0].text == "new one"
+
+
+class TestHostBroadcast:
+    def test_theme_accepts_known_and_rejects_unknown(self):
+        b = RetroBoard("s")
+        assert b.set_broadcast_theme("synthwave") is True
+        assert b.state_snapshot()["broadcast"]["theme"] == "synthwave"
+        assert b.set_broadcast_theme("chartreuse") is False  # not a real theme
+        assert b.state_snapshot()["broadcast"]["theme"] == "synthwave"  # unchanged
+
+    def test_music_validates_channel_and_bumps_seq(self):
+        b = RetroBoard("s")
+        assert b.set_broadcast_music(playing=True, channel=0) is True
+        first = b.state_snapshot()["broadcast"]["music"]
+        assert first["playing"] is True and first["channel"] == 0 and first["seq"] == 1
+        assert b.set_broadcast_music(playing=False, channel=0) is True
+        assert b.state_snapshot()["broadcast"]["music"]["seq"] == 2  # each command is unique
+        assert b.set_broadcast_music(playing=True, channel=9999) is False  # out of range
+        assert b.set_broadcast_music(playing=True, channel="x") is False  # non-int
+
+    def test_lock_freezes_add_edit_move_delete(self):
+        b = RetroBoard("s")
+        c = b.add_card(grid="went_well", text="ci", author="Sam", pid="p1")
+        b.set_locked(True)
+        assert b.state_snapshot()["locked"] is True
+        assert b.add_card(grid="went_well", text="blocked", author="Sam", pid="p1") is None
+        assert b.edit_card(c.id, "nope", "p1") is False
+        assert b.move_card(c.id, "demos", 0, "p1") is False
+        assert b.delete_card(c.id, "p1") is False
+        b.set_locked(False)
+        assert b.edit_card(c.id, "now ok", "p1") is True

--- a/tests/unit/test_retro_page.py
+++ b/tests/unit/test_retro_page.py
@@ -123,6 +123,41 @@ class TestBuildBoardHtml:
         assert 'sessionStorage.setItem("retro_token"' in html
         assert '"/?token="' not in html  # never rebuild a token'd URL client-side
 
+    def test_timestamps_on_cards(self):
+        html = build_board_html()
+        # Relative "age" helper + the .ago span in the card's who-row.
+        assert "function fmtAgo(" in html and 'class="ago"' in html
+
+    def test_focus_and_group_controls(self):
+        html = build_board_html()
+        assert 'id="focus-author"' in html and 'id="group-toggle"' in html
+        # Grouping/focus render path + persisted group toggle.
+        assert "function gridInner(" in html and "updateFocusOptions" in html
+        assert 'localStorage.setItem("retro_grouped"' in html
+
+    def test_edit_focuses_and_guards_render(self):
+        html = build_board_html()
+        # Entering edit focuses the box and moves the caret to the end…
+        assert "setSelectionRange" in html
+        # …and the poll re-render skips the grid holding the focused editbox.
+        assert "editingHere" in html
+
+    def test_theme_set_injected_from_board(self):
+        html = build_board_html()
+        # THEMES comes from board.RETRO_THEMES (no leftover placeholder).
+        assert "const THEMES = __THEMES__" not in html
+        assert '"midnight"' in html and '"forest"' in html
+
+    def test_admin_controls_present(self):
+        html = build_board_html()
+        # Admin secret read from the host link + the four host controls.
+        assert 'new URLSearchParams(location.search).get("admin")' in html
+        for eid in ("lock-btn", "music-cast", "theme-cast", "music-banner", "lock-banner"):
+            assert f'id="{eid}"' in html
+        # Admin-gated broadcast/lock endpoints + autoplay-fallback banner logic.
+        assert "/api/admin/broadcast" in html and "/api/admin/lock" in html
+        assert "showMusicBanner" in html and "applyLock" in html
+
 
 class TestConfig:
     def test_default_port(self, monkeypatch):

--- a/tests/unit/test_retro_server.py
+++ b/tests/unit/test_retro_server.py
@@ -180,7 +180,17 @@ class TestStateEndpoint:
         srv, b = running_server
         b.add_card(grid="went_well", text="ci", author="Sam")
         data = json.load(_get(f"http://127.0.0.1:{srv.port}/api/state?token={srv.token}"))
-        assert set(data) == {"revision", "cards", "carried", "presence", "typing", "timer", "reaction_events"}
+        assert set(data) == {
+            "revision",
+            "cards",
+            "carried",
+            "presence",
+            "typing",
+            "timer",
+            "reaction_events",
+            "broadcast",
+            "locked",
+        }
 
     def test_state_forbidden_without_token(self, running_server):
         srv, _ = running_server
@@ -252,10 +262,17 @@ class TestPresenceEndpoint:
 class TestTimerEndpoint:
     def test_start_and_stop(self, running_server):
         srv, _ = running_server
-        r = _post(srv, "/api/timer", {"action": "start", "duration": 120, "pid": "p1"})
+        # The shared timer is admin-only — pass the host admin secret.
+        r = _post(srv, "/api/timer", {"action": "start", "duration": 120, "pid": "p1", "admin": srv.admin_token})
         assert r["state"]["timer"]["running"] is True
-        r = _post(srv, "/api/timer", {"action": "stop", "pid": "p1"})
+        r = _post(srv, "/api/timer", {"action": "stop", "pid": "p1", "admin": srv.admin_token})
         assert r["state"]["timer"]["running"] is False
+
+    def test_non_admin_forbidden(self, running_server):
+        srv, _ = running_server
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _post(srv, "/api/timer", {"action": "start", "duration": 60, "pid": "p1"})
+        assert exc.value.code == 403
 
 
 class TestCardsReturnsState:
@@ -348,3 +365,60 @@ class TestLifecycle:
         srv.start()
         srv.stop()
         srv.stop()  # second stop is a no-op, must not raise
+
+
+class TestAdminEndpoints:
+    def test_url_carries_admin_share_url_does_not(self, running_server):
+        srv, _ = running_server
+        assert f"admin={srv.admin_token}" in srv.url
+        assert "admin=" not in srv.share_url and srv.admin_token not in srv.share_url
+
+    def test_broadcast_requires_admin(self, running_server):
+        srv, _ = running_server
+        # Authed teammate (token) but no admin secret → 403.
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _post(srv, "/api/admin/broadcast", {"theme": "synthwave"})
+        assert exc.value.code == 403
+
+    def test_broadcast_theme_and_music_with_admin(self, running_server):
+        srv, _ = running_server
+        r = _post(srv, "/api/admin/broadcast", {"theme": "forest", "admin": srv.admin_token})
+        assert r["ok"] and r["state"]["broadcast"]["theme"] == "forest"
+        r = _post(srv, "/api/admin/broadcast", {"music": {"playing": True, "channel": 0}, "admin": srv.admin_token})
+        assert r["state"]["broadcast"]["music"]["playing"] is True
+
+    def test_lock_requires_admin_and_freezes_board(self, running_server):
+        srv, b = running_server
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _post(srv, "/api/admin/lock", {"locked": True})
+        assert exc.value.code == 403
+        r = _post(srv, "/api/admin/lock", {"locked": True, "admin": srv.admin_token})
+        assert r["ok"] and r["state"]["locked"] is True
+        # A normal card POST is now rejected while locked.
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _post(srv, "/api/cards", {"grid": "demos", "text": "blocked", "author": "Sam"})
+        assert exc.value.code == 400
+
+
+class TestAdminBroadcastValidation:
+    def test_empty_broadcast_is_400(self, running_server):
+        srv, _ = running_server
+        # Neither theme nor music → client error, not a silent 200 no-op.
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _post(srv, "/api/admin/broadcast", {"admin": srv.admin_token})
+        assert exc.value.code == 400
+
+
+class TestNoSecretLogging:
+    def test_query_string_secrets_not_logged(self, running_server, caplog):
+        import logging
+
+        srv, _ = running_server
+        # The host link carries token + admin in the query string; the access log
+        # must never write either to disk (regression: log_request logged the full
+        # request line, leaking the token/admin secret at DEBUG).
+        with caplog.at_level(logging.DEBUG, logger="yeaboi.retro.server"):
+            _get(f"http://127.0.0.1:{srv.port}/api/state?token={srv.token}&admin={srv.admin_token}")
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert srv.token not in blob
+        assert srv.admin_token not in blob


### PR DESCRIPTION
## Summary

Five improvements to how a team runs a retro on the **web board** (`src/yeaboi/retro/`), plus polish. All client UI is inline in `page.py`; live state is the lock-guarded `RetroBoard`; browsers poll ~1.2 s.

1. **Filter / group by author** — a header **Focus** picker (show only one person's cards, for turn-taking) and a **⊞ Group** toggle (cluster cards by author within each column). Client-side only; the picker rebuilds only when the author set changes.
2. **Add-card input at the top** of each column (was at the bottom → users had to scroll on tall columns).
3. **Edit-card fix** — clicking ✎ used to lose focus instantly: the ~1.2 s poll re-rendered the column HTML and destroyed the inline editor. Now `render()` skips re-rendering the grid that holds the card being edited (keyed on `EDITING === card.id`, so clicking a toolbar control mid-edit can't wipe unsaved text either), opens the editor locally, and focuses it with caret-at-end. Save/Cancel restyled as real buttons.
4. **Relative timestamps** on cards ("just now" / "3m" / clock time), formatted client-side from the existing `RetroCard.created_at`.
5. **Global admin (host link = admin)** — `RetroServer` mints a second `admin_token` that rides **only** in the host's private `url` (`&admin=`); teammates (join code) never get it. Admin-gated routes: `/api/admin/broadcast` (force a **theme** / broadcast **music** to every browser), `/api/admin/lock` (freeze card add/edit/delete/move), and `/api/timer` is now host-only. Theme names are server-validated against a new `RETRO_THEMES` tuple; music channel against `yeaboi.music.CHANNELS`. All broadcast/lock/admin state is in-memory, lock-guarded, bumps `_revision`, and rides the existing `state_snapshot()` poll — **no schema/persistence change**, no new dependency (stdlib `http.server` only).

### Design / scope notes
- **Admin model**: whoever opens the host link is admin (chosen with the requester). The admin secret is stripped from the address bar and kept in `sessionStorage`, like the token.
- **Lock scope is deliberately card-authoring only** — reactions and carried-item status stay usable during a locked discussion (parallels the existing "open to anyone" collaborative actions).
- **Music autoplay**: broadcast play is subject to browser autoplay policy; teammates who haven't interacted yet get a dismissible "tap to listen" banner instead of forced audio.

### From independent review
- **Fixed (should-fix)**: the access log (`log_request`) logged the full request line, which would leak the token **and** the new admin secret into the DEBUG log — now logs method + path only, query stripped (regression test added).
- **Fixed (nits)**: empty `/api/admin/broadcast` now returns 400 instead of a silent 200; edit-guard keyed on card id rather than live focus.

## Test plan
- `make test` — **5006 passed, 16 skipped, 0 failed** (unit + integration + contract).
- `make lint` — clean.
- New tests: admin-required 403s, lock-freezes-board (client + server), theme/music validation + `seq`, `url` carries admin while `share_url` does not, empty-broadcast 400, and a no-secret-logging regression.
- **End-to-end in a real browser** (two tabs, admin host link + join-code guest): edit keeps focus across polls and Save persists; add input at top; live timestamps; Focus hides other authors and Group clusters by author; admin theme + lock propagate to the guest tab with server-side enforcement (add-while-locked → 400) and admin controls hidden for guests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)