### PR TITLE
add saved-runs hub with rich per-mode snapshots for standup/retro/reporting/performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.30.0"
+version = "2.31.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,16 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.31.0",
+      "date": "2026-07-23",
+      "summary": "Standup, Retro, Reporting, and Performance modes now surface a browsable saved-runs hub showing the history of past runs alongside the current working session. Instead of jumping straight into a single run, you land on a unified hub with Open, Delete, and Export options for each run — the same experience Planning and Analysis already offer. Saved runs render with rich mode-specific formatting: Standup shows the full meter strip and section drill-in, Reporting displays its indigo card layout, Performance shows the coral metrics grid, and Retro renders the full grid view with a snapshot flag that suppresses the live-only join block. Each mode's own screen builder handles rendering, not flat text, so historical runs read as complete, real snapshots of past work.",
+      "highlights": [
+        {"text": "Saved-runs hub surfaces historical runs with Open / Delete / Export across Standup, Retro, Reporting, and Performance", "areas": ["standup", "retro", "reporting", "performance"]},
+        {"text": "Saved runs render with rich mode-specific formatting: Standup meter strips, Reporting cards, Performance grids, Retro boards", "areas": ["standup", "retro", "reporting", "performance"]},
+        {"text": "Browse, open, delete, or export past runs from one hub; each mode's own screen builder ensures faithful historical rendering", "areas": ["usage", "general"]}
+      ]
+    },
+    {
       "version": "2.30.0",
       "date": "2026-07-23",
       "summary": "Retro web board gained several quality-of-life features. You can now focus on one team member's cards at a time (useful for turn-taking discussions), group cards by author, add sticky cards at the top of each column so you don't have to scroll on tall boards, and see relative timestamps on each card. The host also gained admin powers: broadcast theme changes and ambient music to all teammates at once, and lock the board during discussions to freeze card editing. Cards can still get reactions and carried-item status updates during a lock. Security tightening removed an information leak in the access log that could have exposed session tokens.",

--- a/src/yeaboi/mcp/tools_reporting.py
+++ b/src/yeaboi/mcp/tools_reporting.py
@@ -8,11 +8,52 @@ import logging
 # stringified type hints (PEP 563) of tool functions against this namespace.
 from mcp.server.fastmcp import Context
 
-from yeaboi.mcp.runtime import run_engine
+from yeaboi.mcp.runtime import run_engine, run_readonly, to_jsonable
 
 logger = logging.getLogger(__name__)
 
 _PERIODS = ("last_sprint", "last_month", "quarter")
+
+
+def _reporting_history(session_id: str, limit: int) -> dict:
+    from yeaboi.mcp.tools_sessions import resolve_session_id
+    from yeaboi.paths import get_db_path
+    from yeaboi.reporting.store import ReportingStore
+
+    resolved = resolve_session_id(session_id)
+    with ReportingStore(get_db_path()) as store:
+        history = store.get_history(resolved, limit=limit)
+        latest = store.get_latest_report(resolved)
+    # to_jsonable only unpacks a top-level dataclass; convert the nested report
+    # here so latest_report is a structured dict rather than its str() repr.
+    return {
+        "session_id": resolved,
+        "history": history,
+        "latest_report": to_jsonable(latest) if latest is not None else None,
+    }
+
+
+def _reporting_export(session_id: str) -> dict:
+    from yeaboi.mcp.tools_sessions import resolve_session_id
+    from yeaboi.paths import get_db_path
+    from yeaboi.reporting.export import export_report
+    from yeaboi.reporting.store import ReportingStore
+
+    resolved = resolve_session_id(session_id)
+    with ReportingStore(get_db_path()) as store:
+        report = store.get_latest_report(resolved)
+    if report is None:
+        raise ValueError(
+            f"No delivery report recorded for session {resolved!r} — generate one from the yeaboi TUI first."
+        )
+    paths = export_report(report)
+    logger.info("Delivery report exported via MCP: session=%s period=%s", resolved, report.period_label)
+    return {
+        "session_id": resolved,
+        "period": report.period_label,
+        "markdown": str(paths["markdown"]),
+        "html": str(paths["html"]),
+    }
 
 
 def _report_delivery(
@@ -74,3 +115,15 @@ def register(app) -> None:
             sprint_names,
             period_label_override,
         )
+
+    @app.tool()
+    async def reporting_history(session_id: str = "", limit: int = 30) -> dict:
+        """Get past delivery reports (executive summary, themes, metrics, delivered items) for a
+        session. Blank session_id = most recent session. Generating a new report uses report_delivery."""
+        return await run_readonly(_reporting_history, session_id, limit)
+
+    @app.tool()
+    async def reporting_export(session_id: str = "") -> dict:
+        """Export the most recent delivery report as Markdown + HTML files (under
+        ~/.yeaboi/exports/reporting/) and return their paths. Blank session_id = most recent session."""
+        return await run_readonly(_reporting_export, session_id)

--- a/src/yeaboi/performance/store.py
+++ b/src/yeaboi/performance/store.py
@@ -260,6 +260,36 @@ class PerformanceStore:
             logger.warning("Failed to deserialize latest prep for %s: %s", engineer, exc)
             return None
 
+    def get_one_on_one_by_id(self, run_id: int) -> tuple[str, OneOnOnePrep | OneOnOneRecord] | None:
+        """Return ``(kind, artifact)`` for a single 1:1 row, or None if missing/corrupt.
+
+        The ``performance_one_on_ones`` table holds both preps and completions, so the
+        stored ``kind`` selects which dataclass the JSON deserializes into — the
+        saved-runs hub uses ``kind`` to pick the right formatter.
+        """
+        row = self._conn.execute(
+            "SELECT kind, report_json FROM performance_one_on_ones WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None or not row[1]:
+            return None
+        kind = row[0] or "prep"
+        try:
+            data = json.loads(row[1])
+            artifact = _dict_to_record(data) if kind == "completion" else _dict_to_prep(data)
+            return (kind, artifact)
+        except (json.JSONDecodeError, TypeError, KeyError) as exc:
+            logger.warning("Failed to deserialize 1:1 run id=%s: %s", run_id, exc)
+            return None
+
+    def delete_one_on_one(self, run_id: int) -> bool:
+        """Delete a single 1:1 (prep or completion) row. Returns True if removed."""
+        cursor = self._conn.execute("DELETE FROM performance_one_on_ones WHERE id = ?", (run_id,))
+        deleted = (cursor.rowcount or 0) > 0
+        if deleted:
+            logger.info("Deleted 1:1 run id=%s", run_id)
+        return deleted
+
     # ── 6-month review ────────────────────────────────────────────────────
 
     def record_review(self, review: SixMonthReview, *, session_id: str = "") -> int:
@@ -299,6 +329,28 @@ class PerformanceStore:
             logger.warning("Failed to deserialize latest review for %s: %s", engineer, exc)
             return None
 
+    def get_review_by_id(self, run_id: int) -> SixMonthReview | None:
+        """Return the SixMonthReview for a single review row, or None if missing/corrupt."""
+        row = self._conn.execute(
+            "SELECT report_json FROM performance_reviews WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None or not row[0]:
+            return None
+        try:
+            return _dict_to_review(json.loads(row[0]))
+        except (json.JSONDecodeError, TypeError, KeyError) as exc:
+            logger.warning("Failed to deserialize review run id=%s: %s", run_id, exc)
+            return None
+
+    def delete_review(self, run_id: int) -> bool:
+        """Delete a single 6-month review row. Returns True if removed."""
+        cursor = self._conn.execute("DELETE FROM performance_reviews WHERE id = ?", (run_id,))
+        deleted = (cursor.rowcount or 0) > 0
+        if deleted:
+            logger.info("Deleted review run id=%s", run_id)
+        return deleted
+
     # ── Notes ─────────────────────────────────────────────────────────────
 
     def add_note(self, engineer: str, note_text: str) -> int:
@@ -311,12 +363,60 @@ class PerformanceStore:
         return int(cursor.lastrowid or 0)
 
     def get_notes(self, engineer: str, limit: int = 50) -> list[dict]:
-        """Return the engineer's notes, newest first."""
+        """Return the engineer's notes, newest first (each row carries its ``id``)."""
         rows = self._conn.execute(
-            "SELECT note_text, created_at FROM performance_notes WHERE engineer = ? ORDER BY created_at DESC LIMIT ?",
+            "SELECT id, note_text, created_at FROM performance_notes "
+            "WHERE engineer = ? ORDER BY created_at DESC LIMIT ?",
             (engineer, limit),
         ).fetchall()
-        return [{"note_text": r[0], "created_at": r[1]} for r in rows]
+        return [{"id": r[0], "note_text": r[1], "created_at": r[2]} for r in rows]
+
+    def delete_note(self, note_id: int) -> bool:
+        """Delete a single performance note row. Returns True if removed."""
+        cursor = self._conn.execute("DELETE FROM performance_notes WHERE id = ?", (note_id,))
+        deleted = (cursor.rowcount or 0) > 0
+        if deleted:
+            logger.info("Deleted performance note id=%s", note_id)
+        return deleted
+
+    # ── Per-engineer saved-runs hub ───────────────────────────────────────────
+
+    def get_engineer_history(self, engineer: str, limit: int = 100) -> list[dict]:
+        """Return every saved artifact for an engineer, newest first, for the hub.
+
+        Merges the three per-engineer tables (1:1 preps + completions, 6-month
+        reviews, notes) into one list of lightweight rows. Each row carries a
+        ``kind`` (``prep`` | ``completion`` | ``review`` | ``note``), its table
+        ``id``, ``created_at``, and a short ``title`` — enough for the run-hub list
+        to render and, on open/delete, dispatch to the right getter/deleter by kind.
+        """
+        rows: list[dict] = []
+        for r in self._conn.execute(
+            "SELECT id, kind, on_date, created_at FROM performance_one_on_ones "
+            "WHERE engineer = ? ORDER BY created_at DESC LIMIT ?",
+            (engineer, limit),
+        ).fetchall():
+            kind = r[1] or "prep"
+            label = "1:1 Prep" if kind == "prep" else "1:1 Summary"
+            rows.append({"kind": kind, "id": r[0], "created_at": r[3], "title": f"{label} — {r[2] or r[3][:10]}"})
+        for r in self._conn.execute(
+            "SELECT id, period_start, period_end, created_at FROM performance_reviews "
+            "WHERE engineer = ? ORDER BY created_at DESC LIMIT ?",
+            (engineer, limit),
+        ).fetchall():
+            span = f"{r[1]}..{r[2]}" if (r[1] or r[2]) else r[3][:10]
+            rows.append({"kind": "review", "id": r[0], "created_at": r[3], "title": f"6-Month Review — {span}"})
+        for r in self._conn.execute(
+            "SELECT id, note_text, created_at FROM performance_notes "
+            "WHERE engineer = ? ORDER BY created_at DESC LIMIT ?",
+            (engineer, limit),
+        ).fetchall():
+            snippet = (r[1] or "").strip().replace("\n", " ")
+            if len(snippet) > 48:
+                snippet = snippet[:47] + "…"
+            rows.append({"kind": "note", "id": r[0], "created_at": r[2], "title": f"Note — {snippet or r[2][:10]}"})
+        rows.sort(key=lambda d: d["created_at"], reverse=True)
+        return rows[:limit]
 
     # ── Team-wide (cross-engineer) reads — used by performance/context.py to
     #    feed Planning / Analysis with per-engineer open actions + focus areas.

--- a/src/yeaboi/reporting/store.py
+++ b/src/yeaboi/reporting/store.py
@@ -178,19 +178,70 @@ class ReportingStore:
             return None
 
     def get_history(self, session_id: str = "", limit: int = 30) -> list[dict]:
-        """Return recent delivery-report run metadata (newest first)."""
+        """Return recent delivery-report run metadata (newest first).
+
+        Each row carries its ``id`` so the saved-runs hub can reopen or delete a
+        specific run via ``get_run_by_id`` / ``delete_run``.
+        """
         if session_id:
             rows = self._conn.execute(
-                "SELECT run_at, period, period_end, project_name, item_count FROM reporting_history "
+                "SELECT id, run_at, period, period_end, project_name, item_count FROM reporting_history "
                 "WHERE session_id = ? ORDER BY run_at DESC LIMIT ?",
                 (session_id, limit),
             ).fetchall()
         else:
             rows = self._conn.execute(
-                "SELECT run_at, period, period_end, project_name, item_count FROM reporting_history "
+                "SELECT id, run_at, period, period_end, project_name, item_count FROM reporting_history "
                 "ORDER BY run_at DESC LIMIT ?",
                 (limit,),
             ).fetchall()
         return [
-            {"run_at": r[0], "period": r[1], "period_end": r[2], "project_name": r[3], "item_count": r[4]} for r in rows
+            {"id": r[0], "run_at": r[1], "period": r[2], "period_end": r[3], "project_name": r[4], "item_count": r[5]}
+            for r in rows
         ]
+
+    def get_all_history(self, limit: int = 100) -> list[dict]:
+        """Return recent delivery-report run metadata across ALL sessions (for the hub).
+
+        Reporting piggybacks on the latest planning session, so the hub lists runs
+        across every session (matching how Analysis lists all saved sessions).
+        """
+        rows = self._conn.execute(
+            "SELECT id, session_id, run_at, period, period_end, project_name, item_count FROM reporting_history "
+            "ORDER BY run_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "session_id": r[1],
+                "run_at": r[2],
+                "period": r[3],
+                "period_end": r[4],
+                "project_name": r[5],
+                "item_count": r[6],
+            }
+            for r in rows
+        ]
+
+    def get_run_by_id(self, run_id: int) -> DeliveryReport | None:
+        """Return the DeliveryReport for a single history row, or None if missing/corrupt."""
+        row = self._conn.execute(
+            "SELECT report_json FROM reporting_history WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None or not row[0]:
+            return None
+        try:
+            return _dict_to_report(json.loads(row[0]))
+        except (json.JSONDecodeError, TypeError, KeyError) as exc:
+            logger.warning("Failed to deserialize delivery report run id=%s: %s", run_id, exc)
+            return None
+
+    def delete_run(self, run_id: int) -> bool:
+        """Delete a single delivery-report history row. Returns True if a row was removed."""
+        cursor = self._conn.execute("DELETE FROM reporting_history WHERE id = ?", (run_id,))
+        deleted = (cursor.rowcount or 0) > 0
+        if deleted:
+            logger.info("Deleted delivery report run id=%s", run_id)
+        return deleted

--- a/src/yeaboi/retro/store.py
+++ b/src/yeaboi/retro/store.py
@@ -169,13 +169,41 @@ class RetroStore:
             return None
 
     def get_history(self, session_id: str, limit: int = 30) -> list[dict]:
-        """Return recent retro run metadata (newest first) for a session."""
+        """Return recent retro run metadata (newest first) for a session.
+
+        Each row carries its ``id`` so the saved-runs hub can reopen or delete a
+        specific run via ``get_run_by_id`` / ``delete_run``.
+        """
         rows = self._conn.execute(
-            "SELECT run_at, retro_date, project_name, card_count FROM retro_history "
+            "SELECT id, run_at, retro_date, project_name, card_count FROM retro_history "
             "WHERE session_id = ? ORDER BY run_at DESC LIMIT ?",
             (session_id, limit),
         ).fetchall()
-        return [{"run_at": r[0], "retro_date": r[1], "project_name": r[2], "card_count": r[3]} for r in rows]
+        return [
+            {"id": r[0], "run_at": r[1], "retro_date": r[2], "project_name": r[3], "card_count": r[4]} for r in rows
+        ]
+
+    def get_run_by_id(self, run_id: int) -> RetroReport | None:
+        """Return the RetroReport for a single history row, or None if missing/corrupt."""
+        row = self._conn.execute(
+            "SELECT report_json FROM retro_history WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None or not row[0]:
+            return None
+        try:
+            return _dict_to_retro_report(json.loads(row[0]))
+        except (json.JSONDecodeError, TypeError, KeyError) as exc:
+            logger.warning("Failed to deserialize retro run id=%s: %s", run_id, exc)
+            return None
+
+    def delete_run(self, run_id: int) -> bool:
+        """Delete a single retro history row. Returns True if a row was removed."""
+        cursor = self._conn.execute("DELETE FROM retro_history WHERE id = ?", (run_id,))
+        deleted = (cursor.rowcount or 0) > 0
+        if deleted:
+            logger.info("Deleted retro run id=%s", run_id)
+        return deleted
 
     # ── Team-wide (cross-session) reads — used by ceremony_history to feed
     #    Planning / Analysis with the team's recent retros regardless of which
@@ -209,9 +237,20 @@ class RetroStore:
         return reports
 
     def get_all_history(self, limit: int = 100) -> list[dict]:
-        """Return recent retro run metadata across ALL sessions (for cadence)."""
+        """Return recent retro run metadata across ALL sessions (for cadence + the hub)."""
         rows = self._conn.execute(
-            "SELECT run_at, retro_date, project_name, card_count FROM retro_history ORDER BY run_at DESC LIMIT ?",
+            "SELECT id, session_id, run_at, retro_date, project_name, card_count FROM retro_history "
+            "ORDER BY run_at DESC LIMIT ?",
             (limit,),
         ).fetchall()
-        return [{"run_at": r[0], "retro_date": r[1], "project_name": r[2], "card_count": r[3]} for r in rows]
+        return [
+            {
+                "id": r[0],
+                "session_id": r[1],
+                "run_at": r[2],
+                "retro_date": r[3],
+                "project_name": r[4],
+                "card_count": r[5],
+            }
+            for r in rows
+        ]

--- a/src/yeaboi/standup/store.py
+++ b/src/yeaboi/standup/store.py
@@ -381,22 +381,49 @@ class StandupStore:
             return None
 
     def get_history(self, session_id: str, limit: int = 30) -> list[dict]:
-        """Return recent run metadata (newest first) for a session."""
+        """Return recent run metadata (newest first) for a session.
+
+        Each row carries its ``id`` so callers (the saved-runs hub) can reopen or
+        delete a specific run via ``get_run_by_id`` / ``delete_run``.
+        """
         rows = self._conn.execute(
-            "SELECT run_at, standup_date, sprint_day, confidence_pct, status "
+            "SELECT id, run_at, standup_date, sprint_day, confidence_pct, status "
             "FROM standup_history WHERE session_id = ? ORDER BY run_at DESC LIMIT ?",
             (session_id, limit),
         ).fetchall()
         return [
             {
-                "run_at": r[0],
-                "standup_date": r[1],
-                "sprint_day": r[2],
-                "confidence_pct": r[3],
-                "status": r[4],
+                "id": r[0],
+                "run_at": r[1],
+                "standup_date": r[2],
+                "sprint_day": r[3],
+                "confidence_pct": r[4],
+                "status": r[5],
             }
             for r in rows
         ]
+
+    def get_run_by_id(self, run_id: int) -> StandupReport | None:
+        """Return the StandupReport for a single history row, or None if missing/corrupt."""
+        row = self._conn.execute(
+            "SELECT report_json FROM standup_history WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None or not row[0]:
+            return None
+        try:
+            return _dict_to_standup_report(json.loads(row[0]))
+        except (json.JSONDecodeError, TypeError, KeyError) as exc:
+            logger.warning("Failed to deserialize standup run id=%s: %s", run_id, exc)
+            return None
+
+    def delete_run(self, run_id: int) -> bool:
+        """Delete a single standup history row. Returns True if a row was removed."""
+        cursor = self._conn.execute("DELETE FROM standup_history WHERE id = ?", (run_id,))
+        deleted = (cursor.rowcount or 0) > 0
+        if deleted:
+            logger.info("Deleted standup run id=%s", run_id)
+        return deleted
 
     # ── Team-wide (cross-session) reads — used by ceremony_history to feed
     #    Planning / Analysis with the team's recent standups. standup_history has
@@ -419,13 +446,21 @@ class StandupStore:
         return reports
 
     def get_all_history(self, limit: int = 100) -> list[dict]:
-        """Return recent standup run metadata across ALL sessions (for cadence)."""
+        """Return recent standup run metadata across ALL sessions (for cadence + the hub)."""
         rows = self._conn.execute(
-            "SELECT run_at, standup_date, sprint_day, confidence_pct, status "
+            "SELECT id, session_id, run_at, standup_date, sprint_day, confidence_pct, status "
             "FROM standup_history ORDER BY run_at DESC LIMIT ?",
             (limit,),
         ).fetchall()
         return [
-            {"run_at": r[0], "standup_date": r[1], "sprint_day": r[2], "confidence_pct": r[3], "status": r[4]}
+            {
+                "id": r[0],
+                "session_id": r[1],
+                "run_at": r[2],
+                "standup_date": r[3],
+                "sprint_day": r[4],
+                "confidence_pct": r[5],
+                "status": r[6],
+            }
             for r in rows
         ]

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -2728,6 +2728,741 @@ def _run_feedback_page(console: Console, live, read_key, frame_time: float, supp
         logger.info("feedback: page closed")
 
 
+def _run_mode_hub(
+    console: Console,
+    live,
+    read_key,
+    frame_time: float,
+    supports_timeout: bool,
+    *,
+    mode: str,
+    title_fn,
+    subtitle: str,
+    empty_title: str,
+    empty_subtitle: str,
+    new_label: str,
+    load_runs,
+    files_export,
+    get_document,
+    delete_run,
+    run_new,
+    make_detail=None,
+    open_snapshot=None,
+    new_breaks_out: bool = False,
+) -> None:
+    """Generic saved-runs hub loop shared by standup / retro / reporting.
+
+    Landing screen for a mode: a browsable list of past runs (``load_runs`` →
+    ``RunSummary``s). On a selected run row, Left/Right move focus across
+    [card, Delete, Export]; Enter on the card opens the read-only snapshot, on
+    Delete raises a confirm popup, on Export opens the shared destination picker.
+    The "+ New run" card runs the mode's live page (``run_new``) then reloads. This
+    is the TUI half of the "Saved-Sessions Hub" — the store already kept every run;
+    this makes them openable / deletable / exportable instead of latest-only.
+
+    All the per-mode behaviour is injected as callables so retro/standup/reporting
+    share one loop. Performance uses ``_run_performance_hub`` (per-engineer, mixed
+    artifact kinds) but reuses the same screen builders.
+
+    Opening a saved run renders it through the mode's OWN rich screen builder (the
+    same one its live page uses) so a snapshot looks identical to the live view —
+    themed, with meters / section cards / grids — not flat grey text. ``make_detail``
+    (run) loads the report once and returns a per-frame ``render(scroll, action_sel,
+    actions, scroll_meta, width, height, message, shimmer_tick) -> Panel`` (or None if
+    the run vanished). Standup needs section drill-in beyond plain scroll, so it passes
+    an ``open_snapshot`` override instead; the other three use the shared scroll loop.
+    """
+    from yeaboi.ui.mode_select.screens._run_hub_screen import _build_run_hub_screen
+
+    runs = load_runs()
+    selected = 0
+    focus = 0  # 0 = card, 1 = Delete, 2 = Export (only on a run row)
+    message = ""
+    confirm = False  # delete-confirmation popup showing
+    anim_start = time.monotonic()
+    logger.info("%s hub: opened (%d saved run(s))", mode, len(runs))
+
+    def _reload(msg: str = "") -> None:
+        nonlocal runs, selected, focus, message, confirm
+        runs = load_runs()
+        selected = min(selected, max(0, len(runs)))  # keep within [0, new_idx]
+        focus = 0
+        confirm = False
+        message = msg
+
+    def _render_list() -> None:
+        w, h = console.size
+        tick = time.monotonic() - anim_start
+        on_run = selected < len(runs)
+        live.update(
+            _build_run_hub_screen(
+                runs,
+                selected,
+                title_fn=title_fn,
+                subtitle=subtitle,
+                message=message,
+                width=w,
+                height=max(10, h - 1),
+                focus=focus if on_run else 0,
+                del_fade=1.0 if (on_run and focus == 1) else 0.0,
+                exp_fade=1.0 if (on_run and focus == 2) else 0.0,
+                card_fade=1.0,
+                action_btns_visible=2.0 if on_run else 0.0,
+                delete_popup_name=(runs[selected].title if (confirm and on_run) else ""),
+                delete_popup_t=1.0 if confirm else 0.0,
+                new_label=new_label,
+                empty_title=empty_title,
+                empty_subtitle=empty_subtitle,
+                shimmer_tick=tick,
+            )
+        )
+
+    def _run_action(run, act: str) -> tuple[bool, str | None]:
+        """Perform a snapshot action button. Returns (leave_snapshot, message).
+
+        message is None when nothing should change on screen (e.g. Export cancelled).
+        Shared by the generic scroll loop and the standup section-drill override so the
+        Export / Delete / Run again / Back behaviour stays identical across modes.
+        """
+        if act == "Back":
+            return True, None
+        if act == "Export":
+            return False, _export_via_picker(
+                console,
+                live,
+                read_key,
+                frame_time,
+                supports_timeout,
+                mode=mode,
+                files_export=lambda r=run: files_export(r),
+                get_document=lambda r=run: get_document(r),
+            )
+        if act == "Delete":
+            delete_run(run)
+            _reload("Run deleted.")
+            return True, None
+        if act == "Run again":
+            run_new()
+            _reload("New run recorded.")
+            return True, None
+        return False, None
+
+    def _open_snapshot(run) -> None:
+        """Read-only view of one saved run rendered through the mode's rich builder.
+
+        Standup overrides this (``open_snapshot``) for section drill-in; the other three
+        modes use this shared loop: Up/Down scroll the report, Left/Right move across the
+        [Export, Delete, Run again, Back] buttons, Enter presses one. Scroll is clamped to
+        the geometry the builder publishes into ``scroll_meta`` (the live-page pattern).
+        """
+        if open_snapshot is not None:
+            # The override drives the same actions via a run-bound callable: run_action(act).
+            open_snapshot(run, lambda act, r=run: _run_action(r, act))
+            return
+        render = make_detail(run)
+        if render is None:
+            _reload("That run is no longer available.")
+            return
+        scroll = 0
+        sel = 0
+        actions = ["Export", "Delete", "Run again", "Back"]
+        msg = ""
+        s_anim = time.monotonic()
+        logger.info("%s hub: opened run id=%s", mode, run.run_id)
+
+        def _render_snap() -> None:
+            nonlocal scroll
+            w, h = console.size
+            scroll_meta: dict = {}
+            panel = render(
+                scroll=scroll,
+                action_sel=sel,
+                actions=actions,
+                scroll_meta=scroll_meta,
+                width=w,
+                height=max(10, h - 1),
+                message=msg,
+                shimmer_tick=time.monotonic() - s_anim,
+            )
+            # The builder reports its max scroll only after laying the body out — clamp
+            # here so held Down keys don't run the offset past the end.
+            scroll = max(0, min(scroll, scroll_meta.get("max_scroll", scroll)))
+            live.update(panel)
+
+        _render_snap()
+        while True:
+            k = read_key(timeout=frame_time) if supports_timeout else read_key()
+            if k in SCROLL_KEYS:
+                step = 1 if k in ("down", "scroll_down", "pagedown") else -1
+                scroll = max(0, scroll + step)
+            elif k == "left":
+                sel = max(0, sel - 1)
+            elif k == "right":
+                sel = min(len(actions) - 1, sel + 1)
+            elif k in ("enter", " "):
+                leave, m = _run_action(run, actions[sel])
+                if leave:
+                    return
+                if m is not None:
+                    msg = m
+            elif k in ("esc", "q"):
+                return
+            _render_snap()
+
+    _render_list()
+    while True:
+        k = read_key(timeout=frame_time) if supports_timeout else read_key()
+        n_items = len(runs) + 1
+        on_run = selected < len(runs)
+        if confirm:
+            # Delete-confirmation popup is modal: Enter confirms, Esc cancels.
+            if k in ("enter", " "):
+                run = runs[selected]
+                delete_run(run)
+                _reload("Run deleted.")
+            elif k in ("esc", "q"):
+                confirm = False
+            _render_list()
+            continue
+        if k in SCROLL_KEYS or k in ("up", "down"):
+            step = 1 if k in ("down", "scroll_down", "pagedown") else -1
+            selected = (selected + step) % n_items
+            focus = 0
+        elif k == "left":
+            focus = max(0, focus - 1)
+        elif k == "right":
+            if on_run:
+                focus = min(2, focus + 1)
+        elif k in ("enter", " "):
+            if not on_run:
+                if new_breaks_out:
+                    # Performance: "+ New" hands control back to the roster (where the
+                    # create actions live) instead of running a live page in place.
+                    break
+                # "+ New run" card → run the live page, then reload the list.
+                run_new()
+                _reload("New run recorded.")
+                _render_list()
+                continue
+            run = runs[selected]
+            if focus == 0:
+                _open_snapshot(run)
+            elif focus == 1:
+                confirm = True
+            elif focus == 2:
+                msg = _export_via_picker(
+                    console,
+                    live,
+                    read_key,
+                    frame_time,
+                    supports_timeout,
+                    mode=mode,
+                    files_export=lambda r=run: files_export(r),
+                    get_document=lambda r=run: get_document(r),
+                )
+                if msg is not None:
+                    message = msg
+        elif k in ("esc", "q"):
+            break
+        _render_list()
+    logger.info("%s hub: closed", mode)
+
+
+def _run_standup_hub(console: Console, live, read_key, frame_time: float, supports_timeout: bool) -> None:
+    """Standup saved-runs hub → landing for the Standup card (was: straight into latest)."""
+    from yeaboi.persistence import _relative_time
+    from yeaboi.standup.export import build_standup_markdown, export_standup
+    from yeaboi.standup.store import StandupStore
+    from yeaboi.ui.mode_select.screens._project_cards import RunSummary
+    from yeaboi.ui.mode_select.screens._screens_secondary import _build_standup_screen
+    from yeaboi.ui.mode_select.screens._standup_sections import standup_card_order
+    from yeaboi.ui.shared._components import standup_title
+
+    def _report(run_id: int):
+        with StandupStore(_ana_dbp) as store:
+            return store.get_run_by_id(run_id)
+
+    def load_runs():
+        with StandupStore(_ana_dbp) as store:
+            rows = store.get_all_history(100)
+        out = []
+        for r in rows:
+            date = r.get("standup_date") or ""
+            conf = r.get("confidence_pct", 0)
+            sub = f"Day {r.get('sprint_day', 0)} · {conf}% confident" if conf else "standup"
+            out.append(
+                RunSummary(
+                    "standup",
+                    r["id"],
+                    f"Standup — {date or _relative_time(r['run_at'])}",
+                    sub,
+                    _relative_time(r["run_at"]),
+                    session_id=r.get("session_id", ""),
+                )
+            )
+        return out
+
+    def open_standup_snapshot(run, run_action) -> None:
+        """Read-only standup snapshot with section drill-in (the live overview, replayed).
+
+        The overview is just a section list, so a flat scroll would show less than the
+        markdown did. Instead this replays the live standup screen: ↑/↓ move the section
+        selection, Enter opens that section's detail (or toggles the Team row's inline
+        member rows, matching the live board), Esc returns to the overview. Left/Right +
+        Enter drive the shared [Export, Delete, Run again, Back] actions via ``run_action``.
+        """
+        report = _report(run.run_id)
+        if report is None:
+            return
+        # StandupReport has no project name; the header just reads "Daily standup" for a
+        # saved run (the run row already names the date). my_name drives the "My Update" row.
+        data = {"report": report, "session_name": "", "my_name": report.my_name, "team_expanded": False, "message": ""}
+        order = standup_card_order(data)
+        actions = ["Export", "Delete", "Run again", "Back"]
+        view = "overview"  # "overview" | a section key
+        focus = "sections"  # overview focus zone: "sections" | "buttons"
+        card_idx, scroll, sel = 0, 0, 0
+        s_anim = time.monotonic()
+        logger.info("standup hub: opened run id=%s", run.run_id)
+
+        def _render() -> None:
+            nonlocal scroll
+            w, h = console.size
+            scroll_meta: dict = {}
+            panel = _build_standup_screen(
+                data,
+                scroll_offset=scroll,
+                scroll_meta=scroll_meta,
+                width=w,
+                height=max(10, h - 1),
+                action_sel=sel,
+                shimmer_tick=time.monotonic() - s_anim,
+                view=view,
+                selected_card=card_idx,
+                actions=(actions if view == "overview" else ["← Overview"]),
+            )
+            scroll = max(0, min(scroll, scroll_meta.get("max_scroll", scroll)))
+            live.update(panel)
+
+        _render()
+        while True:
+            k = read_key(timeout=frame_time) if supports_timeout else read_key()
+            if view != "overview":
+                # Drilled into a section: Up/Down scroll it; any exit key returns to overview.
+                if k in SCROLL_KEYS:
+                    scroll = max(0, scroll + (1 if k in ("down", "scroll_down", "pagedown") else -1))
+                elif k in ("enter", " ", "esc", "q", "left", "right"):
+                    view, scroll = "overview", 0
+                _render()
+                continue
+            if k in ("up", "down") or k in SCROLL_KEYS:
+                focus = "sections"
+                card_idx = (card_idx + (1 if k in ("down", "scroll_down", "pagedown") else -1)) % len(order)
+            elif k == "left":
+                focus = "buttons"
+                sel = max(0, sel - 1)
+            elif k == "right":
+                focus = "buttons"
+                sel = min(len(actions) - 1, sel + 1)
+            elif k in ("enter", " "):
+                if focus == "buttons":
+                    leave, m = run_action(actions[sel])
+                    if leave:
+                        return
+                    if m is not None:
+                        data["message"] = m
+                elif order[card_idx] == "team":
+                    # Team row expands inline into member sub-rows (live behaviour), not a detail view.
+                    data["team_expanded"] = not data["team_expanded"]
+                    order = standup_card_order(data)
+                else:
+                    view, scroll = order[card_idx], 0
+            elif k in ("esc", "q"):
+                return
+            _render()
+
+    def files_export(run):
+        report = _report(run.run_id)
+        if report is None:
+            return "That run is no longer available."
+        paths = export_standup(report)
+        return f"Exported to {paths['markdown'].parent}  (Markdown + HTML)"
+
+    def get_document(run):
+        report = _report(run.run_id)
+        return (
+            "That run is no longer available."
+            if report is None
+            else (f"Standup — {report.date}", build_standup_markdown(report))
+        )
+
+    def delete_run(run):
+        with StandupStore(_ana_dbp) as store:
+            store.delete_run(run.run_id)
+
+    _run_mode_hub(
+        console,
+        live,
+        read_key,
+        frame_time,
+        supports_timeout,
+        mode="standup",
+        title_fn=standup_title,
+        subtitle="Saved standups",
+        empty_title="No standups yet",
+        empty_subtitle="Press Enter to run your first standup",
+        new_label="+ New standup",
+        load_runs=load_runs,
+        open_snapshot=open_standup_snapshot,
+        files_export=files_export,
+        get_document=get_document,
+        delete_run=delete_run,
+        run_new=lambda: _run_standup_page(console, live, read_key, frame_time, supports_timeout),
+    )
+
+
+def _run_retro_hub(console: Console, live, read_key, frame_time: float, supports_timeout: bool) -> None:
+    """Retro saved-runs hub → landing for the Retro card.
+
+    Opening a saved retro renders the recorded board as a read-only text snapshot
+    (from ``build_retro_markdown``) rather than resurrecting the live LAN board —
+    "+ New retro" starts a fresh live board via the existing page.
+    """
+    from yeaboi.persistence import _relative_time
+    from yeaboi.retro.export import _title, build_retro_markdown, export_retro
+    from yeaboi.retro.store import RetroStore
+    from yeaboi.ui.mode_select.screens._project_cards import RunSummary
+    from yeaboi.ui.mode_select.screens._screens_secondary import _build_retro_screen
+    from yeaboi.ui.shared._components import retro_title
+
+    def _report(run_id: int):
+        with RetroStore(_ana_dbp) as store:
+            return store.get_run_by_id(run_id)
+
+    def load_runs():
+        with RetroStore(_ana_dbp) as store:
+            rows = store.get_all_history(100)
+        out = []
+        for r in rows:
+            date = r.get("retro_date") or ""
+            proj = r.get("project_name") or ""
+            n = r.get("card_count", 0)
+            sub = " · ".join(p for p in (proj, f"{n} card{'s' if n != 1 else ''}") if p)
+            out.append(
+                RunSummary(
+                    "retro",
+                    r["id"],
+                    f"Retro — {date or _relative_time(r['run_at'])}",
+                    sub,
+                    _relative_time(r["run_at"]),
+                    session_id=r.get("session_id", ""),
+                )
+            )
+        return out
+
+    def make_detail(run):
+        # Replay the saved board through the live Retro screen (structured grids +
+        # card badges + carried-actions review), suppressing the live-only join block.
+        report = _report(run.run_id)
+        if report is None:
+            return None
+        grids = report.by_grid()
+        carried = list(report.carried_action_items)
+        session_name = report.project_name
+
+        def render(*, scroll, action_sel, actions, scroll_meta, width, height, message, shimmer_tick):
+            return _build_retro_screen(
+                {
+                    "grids": grids,
+                    "carried": carried,
+                    "session_name": session_name,
+                    "snapshot": True,
+                    "actions": actions,
+                    "message": message,
+                },
+                scroll_offset=scroll,
+                scroll_meta=scroll_meta,
+                action_sel=action_sel,
+                width=width,
+                height=height,
+                shimmer_tick=shimmer_tick,
+            )
+
+        return render
+
+    def files_export(run):
+        report = _report(run.run_id)
+        if report is None:
+            return "That run is no longer available."
+        paths = export_retro(report)
+        return f"Exported to {paths['markdown'].parent}  (Markdown + HTML)"
+
+    def get_document(run):
+        report = _report(run.run_id)
+        return "That run is no longer available." if report is None else (_title(report), build_retro_markdown(report))
+
+    def delete_run(run):
+        with RetroStore(_ana_dbp) as store:
+            store.delete_run(run.run_id)
+
+    _run_mode_hub(
+        console,
+        live,
+        read_key,
+        frame_time,
+        supports_timeout,
+        mode="retro",
+        title_fn=retro_title,
+        subtitle="Saved retros",
+        empty_title="No retros yet",
+        empty_subtitle="Press Enter to start your first retro board",
+        new_label="+ New retro",
+        load_runs=load_runs,
+        make_detail=make_detail,
+        files_export=files_export,
+        get_document=get_document,
+        delete_run=delete_run,
+        run_new=lambda: _run_retro_page(console, live, read_key, frame_time, supports_timeout),
+    )
+
+
+def _run_reporting_hub(console: Console, live, read_key, frame_time: float, supports_timeout: bool) -> None:
+    """Reporting saved-runs hub → landing for the Reporting card."""
+    from yeaboi.persistence import _relative_time
+    from yeaboi.reporting.export import _title, build_report_markdown, export_report
+    from yeaboi.reporting.render import format_report_lines
+    from yeaboi.reporting.store import ReportingStore
+    from yeaboi.ui.mode_select.screens._project_cards import RunSummary
+    from yeaboi.ui.mode_select.screens._screens_secondary import _build_reporting_screen
+    from yeaboi.ui.shared._components import reporting_title
+
+    def _report(run_id: int):
+        with ReportingStore(_ana_dbp) as store:
+            return store.get_run_by_id(run_id)
+
+    def load_runs():
+        with ReportingStore(_ana_dbp) as store:
+            rows = store.get_all_history(100)
+        out = []
+        for r in rows:
+            period = r.get("period") or ""
+            proj = r.get("project_name") or ""
+            n = r.get("item_count", 0)
+            sub = " · ".join(p for p in (proj, f"{n} item{'s' if n != 1 else ''} delivered") if p)
+            out.append(
+                RunSummary(
+                    "reporting",
+                    r["id"],
+                    f"Report — {period or _relative_time(r['run_at'])}",
+                    sub,
+                    _relative_time(r["run_at"]),
+                    session_id=r.get("session_id", ""),
+                )
+            )
+        return out
+
+    def make_detail(run):
+        # Render the saved report through the live Reporting detail screen (indigo
+        # theme + semantic _styled colouring) instead of flat grey lines.
+        report = _report(run.run_id)
+        if report is None:
+            return None
+        detail_lines = format_report_lines(report)
+        detail_title = f"Delivery Report — {report.period_label}"
+
+        def render(*, scroll, action_sel, actions, scroll_meta, width, height, message, shimmer_tick):
+            return _build_reporting_screen(
+                {
+                    "view": "detail",
+                    "detail_lines": detail_lines,
+                    "detail_title": detail_title,
+                    "actions": actions,
+                    "message": message,
+                },
+                scroll_offset=scroll,
+                scroll_meta=scroll_meta,
+                action_sel=action_sel,
+                width=width,
+                height=height,
+                shimmer_tick=shimmer_tick,
+            )
+
+        return render
+
+    def files_export(run):
+        report = _report(run.run_id)
+        if report is None:
+            return "That run is no longer available."
+        paths = export_report(report)
+        return f"Exported to {paths['markdown'].parent}  (Markdown + HTML + slides)"
+
+    def get_document(run):
+        report = _report(run.run_id)
+        return "That run is no longer available." if report is None else (_title(report), build_report_markdown(report))
+
+    def delete_run(run):
+        with ReportingStore(_ana_dbp) as store:
+            store.delete_run(run.run_id)
+
+    _run_mode_hub(
+        console,
+        live,
+        read_key,
+        frame_time,
+        supports_timeout,
+        mode="reporting",
+        title_fn=reporting_title,
+        subtitle="Saved reports",
+        empty_title="No reports yet",
+        empty_subtitle="Press Enter to generate your first delivery report",
+        new_label="+ New report",
+        load_runs=load_runs,
+        make_detail=make_detail,
+        files_export=files_export,
+        get_document=get_document,
+        delete_run=delete_run,
+        run_new=lambda: _run_reporting_page(console, live, read_key, frame_time, supports_timeout),
+    )
+
+
+def _run_performance_hub(
+    console: Console, live, read_key, frame_time: float, supports_timeout: bool, engineer: str
+) -> None:
+    """Per-engineer saved-artifacts hub (opened from the Performance roster's "History").
+
+    Performance is keyed by engineer, not by a single run, so the hub lists every saved
+    artifact for one engineer — 1:1 preps, completions, 6-month reviews, and notes — with
+    the same Open / Delete / Export experience. "+ New artifact" hands control back to the
+    roster, where the create actions (Prep / Complete / Review / Notes) live.
+    """
+    from yeaboi.performance.export import (
+        build_completion_markdown,
+        build_prep_markdown,
+        build_review_markdown,
+        export_artifact,
+    )
+    from yeaboi.performance.render import format_completion_lines, format_prep_lines, format_review_lines
+    from yeaboi.performance.store import PerformanceStore
+    from yeaboi.persistence import _relative_time
+    from yeaboi.ui.mode_select.screens._project_cards import RunSummary
+    from yeaboi.ui.mode_select.screens._screens_secondary import _build_performance_screen
+    from yeaboi.ui.shared._components import performance_title
+
+    def load_runs():
+        with PerformanceStore(_ana_dbp) as store:
+            rows = store.get_engineer_history(engineer, 100)
+        return [
+            RunSummary(
+                "performance",
+                r["id"],
+                r["title"],
+                r["kind"].capitalize(),
+                _relative_time(r["created_at"]),
+                kind=r["kind"],
+            )
+            for r in rows
+        ]
+
+    def _artifact(run):
+        """Return (artifact_or_text, kind, lines) for a saved row, or None if gone."""
+        with PerformanceStore(_ana_dbp) as store:
+            if run.kind == "review":
+                art = store.get_review_by_id(run.run_id)
+                return None if art is None else (art, "review", format_review_lines(art))
+            if run.kind == "note":
+                for n in store.get_notes(engineer, 200):
+                    if n["id"] == run.run_id:
+                        return (n["note_text"], "note", (n["note_text"] or "").splitlines() or ["(empty note)"])
+                return None
+            pair = store.get_one_on_one_by_id(run.run_id)
+        if pair is None:
+            return None
+        kind, art = pair
+        lines = format_completion_lines(art) if kind == "completion" else format_prep_lines(art)
+        return (art, kind, lines)
+
+    def make_detail(run):
+        # Render the saved artifact through the live Performance detail screen (coral
+        # theme + semantic _styled colouring) instead of flat grey lines.
+        got = _artifact(run)
+        if got is None:
+            return None
+        _art, _kind, lines = got
+        title = run.title
+
+        def render(*, scroll, action_sel, actions, scroll_meta, width, height, message, shimmer_tick):
+            return _build_performance_screen(
+                {
+                    "view": "detail",
+                    "detail_lines": lines,
+                    "detail_title": title,
+                    "actions": actions,
+                    "message": message,
+                },
+                scroll_offset=scroll,
+                scroll_meta=scroll_meta,
+                action_sel=action_sel,
+                width=width,
+                height=height,
+                shimmer_tick=shimmer_tick,
+            )
+
+        return render
+
+    def delete_run(run):
+        with PerformanceStore(_ana_dbp) as store:
+            if run.kind == "review":
+                store.delete_review(run.run_id)
+            elif run.kind == "note":
+                store.delete_note(run.run_id)
+            else:
+                store.delete_one_on_one(run.run_id)
+
+    def files_export(run):
+        got = _artifact(run)
+        if got is None:
+            return "That artifact is no longer available."
+        art, kind, _lines = got
+        if kind == "note":
+            return "Notes aren't exported to files individually — use Copy/Publish."
+        paths = export_artifact(art, engineer=engineer, kind=kind)
+        return f"Exported to {paths['markdown'].parent}  (Markdown + HTML)"
+
+    def get_document(run):
+        got = _artifact(run)
+        if got is None:
+            return "That artifact is no longer available."
+        art, kind, _lines = got
+        if kind == "note":
+            return (f"Note — {engineer}", art if isinstance(art, str) else "")
+        if kind == "completion":
+            return (run.title, build_completion_markdown(art))
+        if kind == "review":
+            return (run.title, build_review_markdown(art))
+        return (run.title, build_prep_markdown(art))
+
+    _run_mode_hub(
+        console,
+        live,
+        read_key,
+        frame_time,
+        supports_timeout,
+        mode="performance",
+        title_fn=performance_title,
+        subtitle=f"Saved artifacts — {engineer}",
+        empty_title=f"No saved artifacts for {engineer}",
+        empty_subtitle="Press Enter to create one from the roster",
+        new_label="+ New artifact",
+        load_runs=load_runs,
+        make_detail=make_detail,
+        files_export=files_export,
+        get_document=get_document,
+        delete_run=delete_run,
+        run_new=lambda: None,
+        new_breaks_out=True,
+    )
+
+
 def _run_standup_page(console: Console, live, read_key, frame_time: float, supports_timeout: bool) -> None:
     """Event loop for the Daily Standup page (overview + expandable sections).
 
@@ -3756,7 +4491,7 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
         "detail_lines": [],
         "detail_title": "",
     }
-    roster_actions = ["1:1 Prep", "1:1 Complete", "6mo Review", "Notes", "Export", "Back"]
+    roster_actions = ["1:1 Prep", "1:1 Complete", "6mo Review", "Notes", "History", "Export", "Back"]
     detail_actions = ["Export", "Anonymize", "Back"]
     # Anonymize state: None = real artifact; an AnonymizedOutput = mask the detail lines.
     anon = None
@@ -3908,7 +4643,11 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
                 else:
                     engineer = roster[state["selected"]]
                     logger.info("performance: %s pressed for engineer=%s", label, engineer)
-                    if label == "Export":
+                    if label == "History":
+                        # Browse this engineer's saved artifacts (open / delete / export).
+                        _run_performance_hub(console, live, read_key, frame_time, supports_timeout, engineer)
+                        roster_hints[:] = _performance_roster_hints(roster)
+                    elif label == "Export":
                         msg = _export_via_picker(
                             console,
                             live,
@@ -6464,7 +7203,7 @@ def select_mode(
                 play_wordmark_intro(console, live, chosen["title"], chosen["color"], frame_time=_FRAME_TIME)
                 # Route all records to logs/standup/standup.log while the page runs.
                 with mode_log("standup"):
-                    _run_standup_page(console, live, read_key, _FRAME_TIME, _supports_timeout)
+                    _run_standup_hub(console, live, read_key, _FRAME_TIME, _supports_timeout)
                 _restart_mode_select = True
                 _skip_fade_in = True
                 continue
@@ -6474,7 +7213,7 @@ def select_mode(
                 logger.info("Retro mode selected")
                 play_wordmark_intro(console, live, chosen["title"], chosen["color"], frame_time=_FRAME_TIME)
                 with mode_log("retro"):
-                    _run_retro_page(console, live, read_key, _FRAME_TIME, _supports_timeout)
+                    _run_retro_hub(console, live, read_key, _FRAME_TIME, _supports_timeout)
                 _restart_mode_select = True
                 _skip_fade_in = True
                 continue
@@ -6494,7 +7233,7 @@ def select_mode(
                 logger.info("Reporting mode selected")
                 play_wordmark_intro(console, live, chosen["title"], chosen["color"], frame_time=_FRAME_TIME)
                 with mode_log("reporting"):
-                    _run_reporting_page(console, live, read_key, _FRAME_TIME, _supports_timeout)
+                    _run_reporting_hub(console, live, read_key, _FRAME_TIME, _supports_timeout)
                 _restart_mode_select = True
                 _skip_fade_in = True
                 continue

--- a/src/yeaboi/ui/mode_select/screens/_project_cards.py
+++ b/src/yeaboi/ui/mode_select/screens/_project_cards.py
@@ -42,6 +42,35 @@ class ProjectSummary:
 
 
 @dataclass
+class RunSummary:
+    """One saved run in a mode's saved-runs hub (standup / retro / reporting / performance).
+
+    A run is a stored report snapshot — not a resumable graph session — so it carries
+    only what the hub list needs: the store row ``run_id`` (+ ``kind`` for performance's
+    mixed artifact table), a ``title``/``subtitle`` for the card, and ``run_at`` for the
+    relative-time line. ``to_project`` maps it onto a ProjectSummary so the existing
+    ``_build_project_card`` renders it identically to a planning/analysis card.
+    """
+
+    mode: str  # "standup" | "retro" | "reporting" | "performance"
+    run_id: int
+    title: str
+    subtitle: str = ""
+    run_at: str = ""  # relative time, e.g. "2 days ago"
+    kind: str = ""  # performance only: "prep" | "completion" | "review" | "note"
+    session_id: str = ""
+
+    def to_project(self) -> ProjectSummary:
+        """Adapt this run to a ProjectSummary for the shared card renderer."""
+        return ProjectSummary(
+            name=self.title,
+            created=self.run_at,
+            progress=self.subtitle,
+            kind="run",  # suppresses the [roadmap] tag; no count metadata
+        )
+
+
+@dataclass
 class ProfileSummary:
     """Lightweight team profile metadata for the project list screen."""
 

--- a/src/yeaboi/ui/mode_select/screens/_run_hub_screen.py
+++ b/src/yeaboi/ui/mode_select/screens/_run_hub_screen.py
@@ -1,0 +1,293 @@
+"""Saved-runs hub screen for the standup / retro / reporting / performance modes.
+
+These modes each append every run to a history table but historically the TUI only
+ever showed the latest one. This screen surfaces that history as a browsable list —
+the same Open / Delete / Export experience Planning and Analysis already offer via
+``_build_project_list_screen`` — so a run is no longer visually overwritten each time.
+
+Design (see the "Saved-Sessions Hub" plan): rather than thread a third ``mode`` value
+through ``_build_project_list_screen`` (which is coupled to projects/profiles, team
+sections, and tracker export), this is a purpose-built sibling that REUSES the same
+low-level primitives (``_build_project_row`` for the card + Delete/Export buttons,
+``_build_new_project_card``, ``_build_empty_state_card``, the viewport peek helpers).
+Each ``RunSummary`` is adapted to a ``ProjectSummary`` (``RunSummary.to_project``) so a
+run card renders identically to a planning/analysis card. Export offers HTML + Markdown
+only (no tracker sync for a point-in-time snapshot), so ``_build_project_row`` is called
+with ``jira_enabled=False, azdevops_enabled=False``.
+
+# See README: "Architecture" — TUI system, shared Panel page structure
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import rich.box
+from rich.console import Group
+from rich.padding import Padding
+from rich.panel import Panel
+from rich.text import Text
+
+from yeaboi.ui.mode_select.screens._project_cards import (
+    _BTN_W,
+    _CARD_H,
+    _CARD_SPACING,
+    _PEEK_H,
+    RunSummary,
+    _build_empty_state_card,
+    _build_new_project_card,
+    _build_peek_above,
+    _build_peek_below,
+    _compute_viewport,
+)
+from yeaboi.ui.mode_select.screens._project_list_screen import _build_project_row
+from yeaboi.ui.shared._animations import BLACK_RGB, lerp_color
+from yeaboi.ui.shared._components import PAD
+
+_PAD = PAD
+
+
+def _build_run_hub_screen(
+    runs: list[RunSummary],
+    selected: int,
+    *,
+    title_fn: Callable[..., Text],
+    subtitle: str = "Saved runs",
+    message: str = "",
+    width: int = 80,
+    height: int = 24,
+    card_opacity: float = 1.0,
+    cards_visible: float = 999.0,
+    show_subtitle: bool = True,
+    focus: int = 0,
+    del_fade: float = 0.0,
+    exp_fade: float = 0.0,
+    card_fade: float = 0.0,
+    pulse: float = 0.0,
+    action_btns_visible: float = 0.0,
+    show_export_submenu: bool = False,
+    submenu_sel: int = 0,
+    submenu_html_fade: float = 0.0,
+    submenu_md_fade: float = 0.0,
+    submenu_visible: float = 0.0,
+    delete_popup_name: str = "",
+    delete_popup_t: float = 0.0,
+    delete_popup_pulse: float = 0.0,
+    delete_popup_flash: float = 0.0,
+    new_label: str = "+ New run",
+    empty_title: str = "No saved runs yet",
+    empty_subtitle: str = "Press Enter to start your first run",
+    shimmer_tick: float | None = None,
+) -> Panel:
+    """Build the saved-runs hub: a scrollable list of past runs + a "+ New run" card.
+
+    The item at index ``len(runs)`` is the "+ New run" card. Selecting a run row and
+    pressing Right reveals its Delete/Export buttons (``focus`` 1/2); ``focus`` 0 = card,
+    where Enter opens the saved snapshot. Mirrors the planning list's key/animation model.
+
+    title_fn: the mode's title function (e.g. ``standup_title``), called with shimmer_tick.
+    """
+    title = title_fn(shimmer_tick)
+
+    sub_color = lerp_color(card_opacity, BLACK_RGB, (100, 100, 100))
+    if message:
+        # A transient toast (export/delete/run-again result) takes the subtitle row so
+        # list-level actions give feedback without disturbing the fixed header height.
+        sub = Text(_PAD + message, style="rgb(120,200,140)", justify="left")
+    elif show_subtitle:
+        sub = Text(_PAD + subtitle, style=sub_color, justify="left")
+    else:
+        sub = Text("")
+
+    # Card width leaves room for two action buttons + gaps to the right (same as planning).
+    box_w = min(56, width - 12 - 2 * _BTN_W)
+    box_w = max(30, box_w)
+    body: list = []
+    body_h = 0
+    _card_pad = (0, 0, 0, len(_PAD))
+
+    inner_h = height - 4
+    header_h = 10  # blank + title(6) + blank + subtitle + blank
+
+    n_items = len(runs) + 1  # runs + "+ New run" card
+    _new_idx = len(runs)
+
+    available_h = inner_h - header_h
+    start, end, show_above, show_below = _compute_viewport(n_items, selected, available_h)
+
+    def _item_title(idx: int) -> str:
+        if idx < len(runs):
+            return runs[idx].title
+        return new_label
+
+    if show_above:
+        body.append(
+            Padding(_build_peek_above(box_w=box_w, opacity=card_opacity, title=_item_title(start - 1)), _card_pad)
+        )
+        body_h += _PEEK_H
+
+    for vi, i in enumerate(range(start, end)):
+        if vi >= cards_visible:
+            break
+        if i < len(runs):
+            is_sel = i == selected
+            row = _build_project_row(
+                runs[i].to_project(),
+                selected=is_sel,
+                focus=focus if is_sel else 0,
+                box_w=box_w,
+                opacity=card_opacity,
+                del_fade=del_fade if is_sel else 0.0,
+                exp_fade=exp_fade if is_sel else 0.0,
+                card_fade=card_fade if is_sel else 0.0,
+                pulse=pulse if is_sel else 0.0,
+                action_btns_visible=action_btns_visible if is_sel else 0.0,
+                show_export_submenu=show_export_submenu if is_sel else False,
+                submenu_sel=submenu_sel if is_sel else 0,
+                submenu_html_fade=submenu_html_fade if is_sel else 0.0,
+                submenu_md_fade=submenu_md_fade if is_sel else 0.0,
+                submenu_visible=submenu_visible if is_sel else 0.0,
+                jira_enabled=False,  # a saved snapshot exports to files only
+                azdevops_enabled=False,
+            )
+            body.append(Padding(row, _card_pad))
+        else:
+            body.append(
+                Padding(
+                    _build_new_project_card(
+                        selected=(i == selected), box_w=box_w, opacity=card_opacity, label_text=new_label
+                    ),
+                    _card_pad,
+                )
+            )
+        body_h += _CARD_H
+        if i < end - 1:
+            body.append(Text(""))
+            body_h += _CARD_SPACING
+
+    if show_below:
+        body.append(Padding(_build_peek_below(box_w=box_w, opacity=card_opacity, title=_item_title(end)), _card_pad))
+        body_h += _PEEK_H
+
+    # Empty state: no runs yet → a hint card above the "+ New run" card.
+    if not runs:
+        body = []
+        body_h = 0
+        body.append(
+            Padding(
+                _build_empty_state_card(
+                    selected=False,
+                    box_w=box_w,
+                    opacity=card_opacity,
+                    title=empty_title,
+                    subtitle=empty_subtitle,
+                ),
+                _card_pad,
+            )
+        )
+        body_h += 6
+        body.append(Text(""))
+        body_h += 1
+        body.append(
+            Padding(
+                _build_new_project_card(
+                    selected=(selected == 0), box_w=box_w, opacity=card_opacity, label_text=new_label
+                ),
+                _card_pad,
+            )
+        )
+        body_h += 3
+
+    remaining = max(0, inner_h - header_h - body_h)
+
+    # Delete confirmation popup — red-bordered overlay sliding up from the bottom.
+    # Ported from _build_project_list_screen so the confirm UX matches exactly.
+    popup_before: list = []
+    popup_mid: list = []
+    popup_after: list = []
+    if delete_popup_name and delete_popup_t > 0:
+        import math as _math
+
+        popup_msg = f'Delete "{delete_popup_name}"?  Enter to confirm'
+        panel_inner_w = width - 6
+        popup_w = min(panel_inner_w, max(40, len(popup_msg) + 8))
+
+        dark_red = (140, 30, 30)
+        bright_red = (255, 90, 90)
+        t = (_math.cos(delete_popup_pulse * 3) + 1) / 2
+        br = int(dark_red[0] + (bright_red[0] - dark_red[0]) * t)
+        bg = int(dark_red[1] + (bright_red[1] - dark_red[1]) * t)
+        bb = int(dark_red[2] + (bright_red[2] - dark_red[2]) * t)
+        if delete_popup_flash > 0:
+            br = int(br + (255 - br) * delete_popup_flash)
+            bg = int(bg + (255 - bg) * delete_popup_flash)
+            bb = int(bb + (255 - bb) * delete_popup_flash)
+        border_style = f"rgb({br},{bg},{bb})"
+        inner_w = popup_w - 2
+
+        msg_pad_l = max(0, (inner_w - len(popup_msg)) // 2)
+        msg_pad_r = max(0, inner_w - len(popup_msg) - msg_pad_l)
+        centered_msg = " " * msg_pad_l + popup_msg + " " * msg_pad_r
+        h_pad = " " * max(0, (panel_inner_w - popup_w) // 2)
+
+        line_top = Text(h_pad, justify="left")
+        line_top.append("╭" + "─" * inner_w + "╮", style=border_style)
+        line_blank1 = Text(h_pad, justify="left")
+        line_blank1.append("│" + " " * inner_w + "│", style=border_style)
+        line_msg = Text(h_pad, justify="left")
+        line_msg.append("│", style=border_style)
+        line_msg.append(centered_msg, style="bold white")
+        line_msg.append("│", style=border_style)
+        line_blank2 = Text(h_pad, justify="left")
+        line_blank2.append("│" + " " * inner_w + "│", style=border_style)
+        line_bot = Text(h_pad, justify="left")
+        line_bot.append("╰" + "─" * inner_w + "╯", style=border_style)
+
+        popup_lines = [line_top, line_blank1, line_msg, line_blank2, line_bot]
+        popup_h = len(popup_lines)
+
+        overflow = popup_h - remaining
+        while overflow > 0 and body and body_h > 0:
+            last = body[-1]
+            if isinstance(last, Text) and not last.plain.strip():
+                item_h = _CARD_SPACING
+            elif isinstance(last, Padding) and isinstance(last.renderable, Group):
+                item_h = _PEEK_H
+            else:
+                item_h = _CARD_H
+            body.pop()
+            body_h -= item_h
+            overflow -= item_h
+        remaining = max(0, inner_h - header_h - body_h)
+
+        resting_above = max(0, remaining - popup_h)
+        start_above = remaining
+        current_above = int(start_above + (resting_above - start_above) * delete_popup_t)
+        current_below = max(0, remaining - current_above - popup_h)
+
+        popup_before = [Text("") for _ in range(current_above)]
+        popup_mid = popup_lines
+        popup_after = [Text("") for _ in range(current_below)]
+    else:
+        popup_before = [Text("") for _ in range(remaining)]
+
+    content = Group(
+        Text(""),
+        title,
+        Text(""),
+        sub,
+        Text(""),
+        *body,
+        *popup_before,
+        *popup_mid,
+        *popup_after,
+    )
+
+    return Panel(
+        content,
+        border_style="white",
+        box=rich.box.ROUNDED,
+        expand=True,
+        height=height,
+        padding=(0, 2),
+    )

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -2055,8 +2055,13 @@ def _build_standup_screen(
     elif warnings:
         n = len(warnings)
         prefix = f"⚠ {n} notice{'s' if n != 1 else ''} · "
-        # Panel border (2) + padding (4) leave width-6 columns for content.
-        room = max(16, (width - 6) - len(_PAD) - len(prefix) - 1)
+        # Panel border (2) + padding (4) leave width-6 columns. Keep a 3-col safety
+        # margin so an ambiguous-width glyph (⚠ / — count as 1 cell to Rich but often
+        # render as 2 in the terminal) can't nudge the line past the right border, and
+        # cap the gist so this stays a readable teaser instead of stretching edge-to-edge
+        # on ultra-wide terminals — the full warning list lives in the Notices section.
+        avail = (width - 6) - len(_PAD) - len(prefix) - 3
+        room = max(16, min(avail, 90))
         gist = warnings[0]
         if len(gist) > room:
             gist = gist[: room - 1] + "…"
@@ -3420,18 +3425,22 @@ def _build_retro_screen(
         body_lines.append(Text(_PAD + "  " + message, style=theme.accent_bright, justify="left"))
 
     # ── Join info ─────────────────────────────────────────────────
-    _heading("Join this retro")
-    _row("Share code", retro_data.get("display_code", "—"), f"bold {theme.accent_bright}")
-    _row("LAN URL", retro_data.get("url", "—"), theme.value)
-    _line("Teammates on the same Wi-Fi open the LAN URL, then enter the Share code above.", theme.muted)
-    public_url = retro_data.get("public_url", "")
-    if public_url:
-        _row("Remote URL", public_url, f"bold {theme.accent_bright}")
-        _line("Off-network teammates open the Remote URL (public HTTPS link), then enter the code.", theme.muted)
-    host_url = retro_data.get("host_url", "")
-    if host_url:
-        _row("Host link (private)", host_url, theme.muted)
-        _line("For you only — this link skips the code. Don't share it.", theme.muted)
+    # Live-board only: a saved-run snapshot has no share code / LAN URL, so the
+    # hub passes snapshot=True to suppress this whole block (the report replays
+    # the grids + carried actions, not a resumable board).
+    if not retro_data.get("snapshot"):
+        _heading("Join this retro")
+        _row("Share code", retro_data.get("display_code", "—"), f"bold {theme.accent_bright}")
+        _row("LAN URL", retro_data.get("url", "—"), theme.value)
+        _line("Teammates on the same Wi-Fi open the LAN URL, then enter the Share code above.", theme.muted)
+        public_url = retro_data.get("public_url", "")
+        if public_url:
+            _row("Remote URL", public_url, f"bold {theme.accent_bright}")
+            _line("Off-network teammates open the Remote URL (public HTTPS link), then enter the code.", theme.muted)
+        host_url = retro_data.get("host_url", "")
+        if host_url:
+            _row("Host link (private)", host_url, theme.muted)
+            _line("For you only — this link skips the code. Don't share it.", theme.muted)
 
     # ── Last sprint's actions (progress review) ───────────────────
     # Set from teammates' browsers (the review column); the host view is read-only,

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -128,6 +128,10 @@ _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
     "Anonymize": ("rgb(120,110,170)", "rgb(165,150,220)", "rgb(44,42,54)", "rgb(54,52,64)"),
     "Copy": ("rgb(120,110,170)", "rgb(165,150,220)", "rgb(44,42,54)", "rgb(54,52,64)"),
     "Adjust": ("rgb(100,100,120)", "rgb(140,140,160)", "rgb(40,40,50)", "rgb(50,50,60)"),
+    # Saved-runs hub actions (standup / retro / reporting / performance history).
+    "Delete": ("rgb(220,60,60)", "rgb(240,90,90)", "rgb(52,38,38)", "rgb(62,48,48)"),
+    "Run again": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),
+    "History": ("rgb(160,160,180)", "rgb(200,200,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
 }
 _BTN_DEFAULT = ("rgb(100,100,120)", "rgb(140,140,160)", "rgb(40,40,50)", "rgb(50,50,60)")
 _BTN_MIN_W = 12

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -36,6 +36,8 @@ EXPECTED_TOOLS = {
     "standup_config_get",
     "standup_config_set",
     "report_delivery",
+    "reporting_history",
+    "reporting_export",
     "perf_roster",
     "perf_one_on_one_prep",
     "perf_one_on_one_complete",
@@ -206,6 +208,28 @@ class TestHistoryTools:
         payload = call_tool("retro_history")
         assert payload["ok"] is True
         assert payload["data"]["history"] == []
+
+    def test_reporting_history_empty(self, seeded_session):
+        payload = call_tool("reporting_history")
+        assert payload["ok"] is True
+        assert payload["data"]["history"] == []
+        assert payload["data"]["latest_report"] is None
+
+    def test_reporting_history_after_run(self, seeded_session, tmp_db):
+        from yeaboi.agent.state import DeliveryReport
+        from yeaboi.reporting.store import ReportingStore
+
+        with ReportingStore(tmp_db) as store:
+            store.record_run(DeliveryReport(period_label="Last month", headline="Shipped."), session_id=seeded_session)
+        payload = call_tool("reporting_history", {"session_id": seeded_session})
+        assert payload["ok"] is True
+        assert len(payload["data"]["history"]) == 1
+        assert payload["data"]["latest_report"]["headline"] == "Shipped."
+
+    def test_reporting_export_no_report(self, seeded_session):
+        payload = call_tool("reporting_export")
+        # No report recorded → the tool raises, surfaced as ok=False in the envelope.
+        assert payload["ok"] is False
 
     def test_team_profile_get_no_db(self, tmp_db):
         payload = call_tool("team_profile_get")

--- a/tests/unit/test_performance_store.py
+++ b/tests/unit/test_performance_store.py
@@ -78,6 +78,56 @@ class TestNotes:
             store.add_note("Ada", "second")
             notes = store.get_notes("Ada")
         assert [n["note_text"] for n in notes] == ["second", "first"]
+        assert all("id" in n for n in notes)  # saved-runs hub needs per-note id
+
+    def test_delete_note(self, db_path):
+        with PerformanceStore(db_path) as store:
+            nid = store.add_note("Ada", "gone")
+            store.add_note("Ada", "kept")
+            assert store.delete_note(nid) is True
+            assert [n["note_text"] for n in store.get_notes("Ada")] == ["kept"]
+
+
+class TestSavedRunsHub:
+    """Per-id getters/deletes + merged history — power the per-engineer saved-artifacts hub."""
+
+    def test_get_engineer_history_merges_all_kinds(self, db_path):
+        with PerformanceStore(db_path) as store:
+            store.record_prep(OneOnOnePrep(engineer="Ada", date="2026-07-01"))
+            store.record_completion(OneOnOneRecord(engineer="Ada", date="2026-07-05"))
+            store.record_review(SixMonthReview(engineer="Ada", overall="x"))
+            store.add_note("Ada", "a note")
+            store.record_prep(OneOnOnePrep(engineer="Bob", date="2026-07-01"))
+            rows = store.get_engineer_history("Ada")
+        kinds = sorted(r["kind"] for r in rows)
+        assert kinds == ["completion", "note", "prep", "review"]
+        assert all({"id", "created_at", "title"} <= set(r) for r in rows)
+
+    def test_one_on_one_by_id_dispatches_on_kind(self, db_path):
+        with PerformanceStore(db_path) as store:
+            pid = store.record_prep(OneOnOnePrep(engineer="Ada", date="2026-07-01", goals=("g",)))
+            cid = store.record_completion(OneOnOneRecord(engineer="Ada", date="2026-07-05", highlights=("h",)))
+            pk, prep = store.get_one_on_one_by_id(pid)
+            ck, comp = store.get_one_on_one_by_id(cid)
+        assert pk == "prep" and prep.goals == ("g",)
+        assert ck == "completion" and comp.highlights == ("h",)
+
+    def test_get_by_id_missing_and_corrupt(self, db_path):
+        with PerformanceStore(db_path) as store:
+            rid = store.record_review(SixMonthReview(engineer="Ada", overall="x"))
+            assert store.get_review_by_id(rid) is not None
+            assert store.get_review_by_id(999) is None
+            assert store.get_one_on_one_by_id(999) is None
+            store._conn.execute("UPDATE performance_reviews SET report_json='{bad' WHERE id=?", (rid,))
+            assert store.get_review_by_id(rid) is None
+
+    def test_delete_one_on_one_and_review(self, db_path):
+        with PerformanceStore(db_path) as store:
+            pid = store.record_prep(OneOnOnePrep(engineer="Ada", date="2026-07-01"))
+            rid = store.record_review(SixMonthReview(engineer="Ada", overall="x"))
+            assert store.delete_one_on_one(pid) is True
+            assert store.delete_review(rid) is True
+            assert store.get_engineer_history("Ada") == []
 
 
 class TestTeamWide:

--- a/tests/unit/test_reporting_store.py
+++ b/tests/unit/test_reporting_store.py
@@ -61,6 +61,42 @@ class TestStore:
             assert len(hist) == 1
             assert hist[0]["item_count"] == 1
             assert hist[0]["period"] == "Last sprint"
+            assert "id" in hist[0]  # saved-runs hub needs the row id to open/delete
+
+
+class TestSavedRunsHub:
+    """get_all_history / get_run_by_id / delete_run — power the TUI saved-runs hub."""
+
+    def test_get_all_history_spans_sessions(self, db_path):
+        with ReportingStore(db_path) as store:
+            store.record_run(_report(), session_id="s1")
+            store.record_run(_report(), session_id="s2")
+            rows = store.get_all_history()
+            assert len(rows) == 2
+            assert {r["session_id"] for r in rows} == {"s1", "s2"}
+            assert all("id" in r for r in rows)
+
+    def test_get_run_by_id_round_trips(self, db_path):
+        with ReportingStore(db_path) as store:
+            rid = store.record_run(_report(), session_id="s1")
+            got = store.get_run_by_id(rid)
+            assert got is not None and got.headline == "Shipped."
+            assert store.get_run_by_id(999) is None  # missing id
+
+    def test_get_run_by_id_corrupt_returns_none(self, db_path):
+        with ReportingStore(db_path) as store:
+            rid = store.record_run(_report(), session_id="s1")
+            store._conn.execute("UPDATE reporting_history SET report_json='{bad' WHERE id=?", (rid,))
+            assert store.get_run_by_id(rid) is None  # corrupt json → None, no raise
+
+    def test_delete_run_removes_only_that_row(self, db_path):
+        with ReportingStore(db_path) as store:
+            keep = store.record_run(_report(), session_id="s1")
+            drop = store.record_run(_report(), session_id="s2")
+            assert store.delete_run(drop) is True
+            assert store.delete_run(drop) is False  # already gone → no-op
+            remaining = {r["id"] for r in store.get_all_history()}
+            assert remaining == {keep}
 
 
 class TestSchemaMigration:

--- a/tests/unit/test_retro_store.py
+++ b/tests/unit/test_retro_store.py
@@ -103,3 +103,35 @@ class TestStore:
             store.record_run(_report())
             hist = store.get_history("sess-1")
         assert hist and hist[0]["card_count"] == 2 and hist[0]["project_name"] == "Demo"
+        assert "id" in hist[0]  # saved-runs hub needs the row id
+
+
+class TestSavedRunsHub:
+    """get_all_history / get_run_by_id / delete_run — power the TUI saved-runs hub."""
+
+    def test_get_all_history_carries_id_and_session(self, tmp_path):
+        with RetroStore(tmp_path / "sessions.db") as store:
+            store.record_run(_report())
+            rows = store.get_all_history()
+        assert rows and "id" in rows[0] and rows[0]["session_id"] == "sess-1"
+
+    def test_get_run_by_id_round_trips_and_missing(self, tmp_path):
+        with RetroStore(tmp_path / "sessions.db") as store:
+            rid = store.record_run(_report())
+            got = store.get_run_by_id(rid)
+            assert got is not None and len(got.cards) == 2
+            assert store.get_run_by_id(999) is None
+
+    def test_get_run_by_id_corrupt_returns_none(self, tmp_path):
+        with RetroStore(tmp_path / "sessions.db") as store:
+            rid = store.record_run(_report())
+            store._conn.execute("UPDATE retro_history SET report_json='{bad' WHERE id=?", (rid,))
+            assert store.get_run_by_id(rid) is None
+
+    def test_delete_run_removes_only_that_row(self, tmp_path):
+        with RetroStore(tmp_path / "sessions.db") as store:
+            keep = store.record_run(_report())
+            drop = store.record_run(RetroReport(session_id="sess-2", date="2026-07-12", cards=(RetroCard(text="x"),)))
+            assert store.delete_run(drop) is True
+            assert store.delete_run(drop) is False
+            assert {r["id"] for r in store.get_all_history()} == {keep}

--- a/tests/unit/test_run_hub_screen.py
+++ b/tests/unit/test_run_hub_screen.py
@@ -1,0 +1,240 @@
+"""Render tests for the saved-runs hub.
+
+The hub is the standup/retro/reporting/performance landing that lists past runs with
+Open/Delete/Export — the list render (`_build_run_hub_screen`) must not crash at any size
+or state (populated list, empty state, focused row with buttons, delete popup). Opening a
+saved run renders it through the mode's OWN rich builder (not a flat text view), so
+`TestSnapshotRendering` checks each mode's snapshot data shape drives its themed screen.
+"""
+
+import io
+
+from rich.console import Console
+from rich.panel import Panel
+
+from yeaboi.ui.mode_select.screens._project_cards import RunSummary
+from yeaboi.ui.mode_select.screens._run_hub_screen import _build_run_hub_screen
+from yeaboi.ui.shared._components import reporting_title, standup_title
+
+
+def _text(panel: Panel, width: int = 100, height: int = 30) -> str:
+    console = Console(file=io.StringIO(), width=width, height=height, legacy_windows=False)
+    console.print(panel)
+    return console.file.getvalue()
+
+
+def _runs(n: int = 4) -> list[RunSummary]:
+    return [
+        RunSummary("standup", i, f"Standup — 2026-07-0{i}", f"Day {i} · 80% confident", "2 days ago")
+        for i in range(1, n + 1)
+    ]
+
+
+class TestHubList:
+    def test_populated_list_renders(self):
+        out = _text(_build_run_hub_screen(_runs(), 0, title_fn=standup_title, subtitle="Saved standups"))
+        assert "Saved standups" in out
+        assert "Standup — 2026-07-01" in out
+
+    def test_empty_state_uses_custom_text(self):
+        panel = _build_run_hub_screen(
+            [], 0, title_fn=standup_title, empty_title="No standups yet", empty_subtitle="Press Enter to run one"
+        )
+        out = _text(panel)
+        assert "No standups yet" in out
+        assert "+ New run" in out
+
+    def test_selected_row_shows_action_buttons(self):
+        panel = _build_run_hub_screen(
+            _runs(), 1, title_fn=standup_title, focus=2, action_btns_visible=2.0, card_fade=1.0
+        )
+        out = _text(panel)
+        assert "Delete" in out and "Export" in out
+
+    def test_delete_popup_renders(self):
+        panel = _build_run_hub_screen(
+            _runs(), 2, title_fn=standup_title, delete_popup_name="Standup — 2026-07-03", delete_popup_t=1.0
+        )
+        out = _text(panel)
+        assert "Delete" in out and "Enter to confirm" in out
+
+    def test_small_terminal_does_not_crash(self):
+        # Just needs to render without raising at a cramped size.
+        _text(_build_run_hub_screen(_runs(8), 5, title_fn=reporting_title), width=60, height=16)
+
+
+_SNAP_ACTIONS = ["Export", "Delete", "Run again", "Back"]
+
+
+class TestSnapshotRendering:
+    """Opening a saved run feeds the report into the mode's real rich screen builder.
+
+    These mirror the data shape each ``make_detail`` / ``open_snapshot`` in
+    ``mode_select/__init__`` passes, so the snapshot looks like the live screen
+    (themed, meters/grids/cards) rather than flat grey markdown.
+    """
+
+    def test_reporting_detail_renders_rich(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_reporting_screen
+
+        panel = _build_reporting_screen(
+            {
+                "view": "detail",
+                "detail_lines": ["Executive summary:", "• shipped auth"],
+                "detail_title": "Delivery Report — Last month",
+                "actions": _SNAP_ACTIONS,
+            },
+            action_sel=0,
+            width=100,
+            height=30,
+        )
+        out = _text(panel)
+        assert "Delivery Report — Last month" in out
+        assert "shipped auth" in out and "Run again" in out
+
+    def test_performance_detail_renders_rich(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_performance_screen
+
+        panel = _build_performance_screen(
+            {
+                "view": "detail",
+                "detail_lines": ["Strengths:", "• ownership"],
+                "detail_title": "6-month review — Ada",
+                "actions": _SNAP_ACTIONS,
+            },
+            action_sel=0,
+            width=100,
+            height=30,
+        )
+        out = _text(panel)
+        assert "6-month review — Ada" in out
+        assert "ownership" in out
+
+    def test_retro_snapshot_shows_grids_and_hides_join(self):
+        from yeaboi.agent.state import RetroCard, RetroReport
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_retro_screen
+
+        report = RetroReport(
+            session_id="s",
+            project_name="Demo",
+            cards=(RetroCard(id="a", grid="went_well", text="ci is green", author="Sam", origin="web"),),
+        )
+        panel = _build_retro_screen(
+            {
+                "grids": report.by_grid(),
+                "carried": list(report.carried_action_items),
+                "session_name": report.project_name,
+                "snapshot": True,
+                "actions": _SNAP_ACTIONS,
+            },
+            action_sel=0,
+            width=100,
+            height=40,
+        )
+        out = _text(panel)
+        assert "ci is green" in out
+        assert "Join this retro" not in out  # live-only join block suppressed for a saved run
+
+    def test_retro_live_still_shows_join(self):
+        # Guard sanity: without the snapshot flag the live board still renders the join block.
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_retro_screen
+
+        panel = _build_retro_screen(
+            {"grids": {}, "display_code": "ABC123", "actions": ["Generate Action Items", "Export", "Close"]},
+            action_sel=0,
+            width=100,
+            height=40,
+        )
+        assert "Join this retro" in _text(panel)
+
+    def test_standup_overview_shows_meter_strip(self):
+        from yeaboi.agent.state import StandupReport
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_standup_screen
+
+        report = StandupReport(
+            date="2026-07-01",
+            sprint_name="Sprint 5",
+            sprint_day=3,
+            sprint_total_days=10,
+            confidence_label="On track",
+            confidence_pct=80,
+            team_summary="All green.",
+        )
+        # Build the dict exactly as open_standup_snapshot does (reading report attrs) so a
+        # missing/renamed field — StandupReport has no project_name — fails here, not at runtime.
+        data = {"report": report, "session_name": "", "my_name": report.my_name, "team_expanded": False}
+        panel = _build_standup_screen(
+            data,
+            view="overview",
+            selected_card=0,
+            action_sel=0,
+            actions=_SNAP_ACTIONS,
+            width=100,
+            height=30,
+        )
+        out = _text(panel)
+        assert "Sprint 5" in out and "On track" in out  # pinned meter strip, not flat text
+
+    def test_standup_section_detail_renders(self):
+        from yeaboi.agent.state import StandupReport
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_standup_screen
+
+        report = StandupReport(date="2026-07-01", sprint_name="Sprint 5", team_summary="All systems green.")
+        panel = _build_standup_screen(
+            {"report": report, "session_name": "Demo"},
+            view="summary",
+            action_sel=0,
+            actions=["← Overview"],
+            width=100,
+            height=30,
+        )
+        assert "green" in _text(panel).lower()
+
+
+class TestStandupSnapshotLoop:
+    """Regression: opening a saved standup and pressing an action button must not crash.
+
+    The standup snapshot uses an ``open_snapshot`` override that drives the shared
+    [Export, Delete, Run again, Back] actions through a run-bound callback. A wiring bug
+    once passed the two-arg ``_run_action`` and then called it with one arg, so every
+    button raised ``TypeError`` inside the live loop. This drives the loop headlessly to
+    the Back button — the exact dispatch that used to crash.
+    """
+
+    def test_open_snapshot_and_press_back_does_not_crash(self, tmp_path, monkeypatch):
+        import yeaboi.ui.mode_select as ms
+        from yeaboi.agent.state import StandupReport
+        from yeaboi.standup.store import StandupStore
+
+        db = tmp_path / "sessions.db"
+        with StandupStore(db) as store:
+            store.record_run(
+                StandupReport(
+                    date="2026-07-01",
+                    session_id="s1",
+                    sprint_name="Sprint 5",
+                    sprint_day=3,
+                    sprint_total_days=10,
+                    team_summary="all good",
+                )
+            )
+        monkeypatch.setattr(ms, "_ana_dbp", db)
+
+        class _Console:
+            size = (120, 40)
+
+            def print(self, *a, **k):
+                pass
+
+        class _Live:
+            def update(self, *a, **k):
+                pass
+
+        # Enter opens the run's snapshot; three Rights move focus to the Back button;
+        # Enter presses Back (the dispatch that used to raise); q exits the hub.
+        keys = iter(["enter", "right", "right", "right", "enter", "q"])
+
+        def read_key(timeout=None):
+            return next(keys, "q")
+
+        ms._run_standup_hub(_Console(), _Live(), read_key, 0.05, True)  # must not raise

--- a/tests/unit/test_standup_screen.py
+++ b/tests/unit/test_standup_screen.py
@@ -126,6 +126,28 @@ class TestBuildStandupScreen:
         out = cap.get()
         assert "⚠ 2 notices · Jira: authentication failed" in out
 
+    def test_long_notice_capped_and_stays_within_border(self):
+        # A long run-on warning must not stretch edge-to-edge on a wide terminal nor push
+        # the notice past the panel's right border (ambiguous-width ⚠/— safety margin).
+        import re
+
+        from rich.console import Console
+
+        long_warn = (
+            "Not scanned: Azure Devops (AZURE_DEVOPS_PROJECT not set), Github (STANDUP_GITHUB_REPO not set), "
+            "Local Git (no repo path configured), Notion (NOTION_ROOT_PAGE_ID not set) — connect these in Settings"
+        )
+        width = 220
+        panel = _build_standup_screen({"report": StandupReport(warnings=(long_warn,))}, width=width, height=40)
+        console = Console(width=width, file=open("/dev/null", "w"))
+        with console.capture() as cap:
+            console.print(panel)
+        notice = next(ln for ln in cap.get().splitlines() if "notice" in ln)
+        vis = re.sub(r"\x1b\[[0-9;]*m", "", notice).rstrip()
+        assert vis.endswith("│")  # right border intact
+        assert vis.endswith("…   │") or "…" in vis  # truncated, not full text
+        assert len(vis[:-1].rstrip()) < 130  # capped teaser, not stretched across 220 cols
+
     def test_banner_message_wins_over_warnings(self):
         from rich.console import Console
 

--- a/tests/unit/test_standup_store.py
+++ b/tests/unit/test_standup_store.py
@@ -201,12 +201,44 @@ class TestRunHistory:
         assert len(history) == 2
         assert history[0]["standup_date"] == "2026-07-10"  # newest first
         assert history[0]["confidence_pct"] == 82
+        assert "id" in history[0]  # saved-runs hub needs the row id
 
     def test_corrupt_report_json_returns_none(self, db_path):
         with StandupStore(db_path) as store:
             store.record_run(_make_report())
             store._conn.execute("UPDATE standup_history SET report_json = 'garbage'")
             assert store.get_latest_report("s1") is None
+
+
+class TestSavedRunsHub:
+    """get_all_history / get_run_by_id / delete_run — power the TUI saved-runs hub."""
+
+    def test_get_all_history_carries_id_and_session(self, db_path):
+        with StandupStore(db_path) as store:
+            store.record_run(_make_report(date="2026-07-09"))
+            rows = store.get_all_history()
+        assert rows and "id" in rows[0] and rows[0]["session_id"] == "s1"
+
+    def test_get_run_by_id_round_trips_and_missing(self, db_path):
+        report = _make_report(date="2026-07-10")
+        with StandupStore(db_path) as store:
+            rid = store.record_run(report)
+            assert store.get_run_by_id(rid) == report
+            assert store.get_run_by_id(999) is None
+
+    def test_get_run_by_id_corrupt_returns_none(self, db_path):
+        with StandupStore(db_path) as store:
+            rid = store.record_run(_make_report())
+            store._conn.execute("UPDATE standup_history SET report_json='{bad' WHERE id=?", (rid,))
+            assert store.get_run_by_id(rid) is None
+
+    def test_delete_run_removes_only_that_row(self, db_path):
+        with StandupStore(db_path) as store:
+            keep = store.record_run(_make_report(date="2026-07-09"))
+            drop = store.record_run(_make_report(date="2026-07-10"))
+            assert store.delete_run(drop) is True
+            assert store.delete_run(drop) is False
+            assert {r["id"] for r in store.get_all_history()} == {keep}
 
     def test_self_report_round_trips(self, db_path):
         report = _make_report(

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -99,7 +99,9 @@ CAPABILITIES: dict[str, dict] = {
     },
     "reporting": {
         "engines": {("yeaboi.reporting.engine", "run_delivery_report")},
-        "mcp_tools": {"report_delivery"},
+        # reporting_history / reporting_export are read-only store/export wrappers
+        # (no pipeline) — the saved-runs hub surfaces them; parity with retro-board.
+        "mcp_tools": {"report_delivery", "reporting_history", "reporting_export"},
         "tui_mode": "reporting",
         "cli": {"report"},
         "skill": "delivery-report",

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.29.0"
+version = "2.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

Standup, Retro, Reporting, and Performance previously jumped straight into a single working page that only ever showed the **latest** run. Every run was already persisted to a per-mode history table, but the TUI never listed them — so each new run appeared to overwrite the last, with no way to reopen, delete, or export a past one.

This branch surfaces that history as a browsable **saved-runs hub**, giving all four modes the same Open / Delete / Export experience Planning and Analysis already offer.

**Store layer** (no schema migration — the rows already existed):
- `get_run_by_id` / `delete_run` across the four stores (+ `id` in history dicts)
- reporting gains `get_all_history`; performance gains per-id getters/deletes and a merged `get_engineer_history` (preps / completions / reviews / notes)

**MCP + parity:**
- new read-only `reporting_history` / `reporting_export` tools, closing reporting's MCP gap
- surface-parity registry updated (`CAPABILITIES["reporting"]`)

**TUI — rich snapshots (the main win):**
- a generic saved-runs hub loop (`_run_mode_hub`) lists past runs with the planning-card look
- opening a run renders through the mode's **own rich screen builder**, not flat grey text: magenta standup with the pinned meter strip + section drill-in, indigo reporting detail, coral performance detail, retro grids with card badges
- `_build_retro_screen` gains a `snapshot` flag that suppresses the live-only "Join this retro" share-code block
- the standup notice banner is capped so a long run-on warning can't overflow the panel on wide terminals

## Review

An independent `code-reviewer` pass flagged one blocker and one should-fix, both resolved:
- **blocker** — the standup snapshot's action buttons called the run-bound callback with the wrong arity (`TypeError` on Export/Delete/Run again/Back). Fixed, and covered by a new headless loop-drive regression test (`TestStandupSnapshotLoop`, verified to fail without the fix).
- **should-fix** — list-level Export feedback was written to `message` but never rendered; `_build_run_hub_screen` now shows it as a subtitle-row toast.
- plus two nits (dead `_new_idx` helper removed; delete-popup corner glyph corrected).

## Test plan

- `make lint` — clean
- `make test` — **5039 passed, 16 skipped** (unit + integration + contract)
- New coverage: store per-id/delete/round-trip/corrupt tests, MCP tool tests, per-mode snapshot render tests, retro join-suppression both-ways test, standup banner-overflow test, and the standup snapshot action-dispatch regression test
- Planning/Analysis untouched (`_build_project_list_screen` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)