### PR TITLE
Improve All Tips page layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.31.0"
+version = "2.31.1"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,16 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.31.1",
+      "date": "2026-07-24",
+      "summary": "The All Tips screen now displays better, with tips grouped into logical sections (Modes, More Workflows, and Shortcuts & Setup), improved spacing and text wrapping, colored metadata badges, and scrollbar gutters that prevent layout fragmentation. The gallery preserves emoji in copied tip text while avoiding terminal-unsafe characters in the displayed view.",
+      "highlights": [
+        {"text": "All Tips screen reorganized into logical sections with better spacing and layout", "areas": ["general"]},
+        {"text": "Improved text wrapping, colored metadata badges, and scrollbar gutters prevent layout fragmentation", "areas": ["general"]},
+        {"text": "Emoji preserved in copied text while terminal display stays safe", "areas": ["general"]}
+      ]
+    },
+    {
       "version": "2.31.0",
       "date": "2026-07-23",
       "summary": "Standup, Retro, Reporting, and Performance modes now surface a browsable saved-runs hub showing the history of past runs alongside the current working session. Instead of jumping straight into a single run, you land on a unified hub with Open, Delete, and Export options for each run — the same experience Planning and Analysis already offer. Saved runs render with rich mode-specific formatting: Standup shows the full meter strip and section drill-in, Reporting displays its indigo card layout, Performance shows the coral metrics grid, and Retro renders the full grid view with a snapshot flag that suppresses the live-only join block. Each mode's own screen builder handles rendering, not flat text, so historical runs read as complete, real snapshots of past work.",

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -2316,10 +2316,11 @@ def _build_all_tips_screen(
     """Build the All Tips gallery page: every discoverability tip in one scroll.
 
     Same scrollable Panel skeleton as :func:`_build_changelog_screen`. Content is
-    the live ``get_tips()`` list, so it always reflects the current tips. Each tip
-    is one bullet; freshly-shipped features get a gold ``NEW`` badge and tips that
-    map to a home card note the mode they open. The ``Copy all`` action copies the
-    whole list to the clipboard (see the run loop in mode_select/__init__.py).
+    the live ``get_tips()`` list, grouped into modes, workflows, and setup so the
+    gallery scans like the other sectioned pages. Freshly-shipped features get a
+    gold ``NEW`` badge and tips that map to a home card note the mode they open.
+    The ``Copy all`` action copies the whole list to the clipboard (see the run
+    loop in mode_select/__init__.py).
     """
     import textwrap
 
@@ -2330,28 +2331,82 @@ def _build_all_tips_screen(
     theme = CHANGELOG_THEME
     title = tips_title(shimmer_tick, width=width)
     sub = build_reveal_subtitle("Everything yeaboi can do", sub_reveal, pad=PAD)
-    titles = {card["key"]: card["title"] for card in _MODE_CARDS}
+    cards = {card["key"]: card for card in _MODE_CARDS}
     gold = f"rgb({_TIP_DOT_ON[0]},{_TIP_DOT_ON[1]},{_TIP_DOT_ON[2]})"
 
     body_lines: list = []
     if message:
         body_lines.append(Text(PAD + "  " + message, style=theme.accent_bright, justify="left"))
         body_lines.append(Text(""))
-    wrap_w = max(24, width - len(PAD) - 12)
 
-    for tip in get_tips():
-        chunks = textwrap.wrap(tip.text, width=max(24, wrap_w - 3)) or [""]
-        for i, chunk in enumerate(chunks):
-            prefix = "  •  " if i == 0 else "     "
-            line = Text(PAD + prefix + chunk, style=theme.value, justify="left")
-            if i == len(chunks) - 1:  # append badges to the tip's last line
+    # Account explicitly for the frame, horizontal panel padding, scrollbar,
+    # and the gutter beside it. Keeping wrapping inside this budget prevents
+    # wide glyphs or metadata from visually colliding with the right frame.
+    panel_inner_w = max(20, width - 2 - 4)
+    viewport_body_w = max(18, panel_inner_w - 3)
+    bullet_prefix = PAD + "    •  "
+    continuation_prefix = PAD + "       "
+    tip_wrap_w = max(16, viewport_body_w - len(bullet_prefix) - 1)
+    separator_w = max(8, min(viewport_body_w - len(PAD) - 2, 40))
+
+    tips = get_tips()
+    grouped_tips = (
+        ("Modes", [tip for tip in tips if tip.mode_key]),
+        (
+            "More workflows",
+            [
+                tip
+                for tip in tips
+                if not tip.mode_key and tip.key not in {"voice", "music"} and not tip.key.startswith("meta:")
+            ],
+        ),
+        (
+            "Shortcuts & setup",
+            [tip for tip in tips if tip.key in {"voice", "music"} or tip.key.startswith("meta:")],
+        ),
+    )
+
+    rendered_section = False
+    for section, section_tips in grouped_tips:
+        if not section_tips:
+            continue
+        if rendered_section:
+            body_lines.append(Text(""))
+        rendered_section = True
+        heading = Text(PAD + "  ", justify="left")
+        heading.append(section, style=f"bold {theme.accent_bright}")
+        body_lines.append(heading)
+        body_lines.append(Text(PAD + "  " + "─" * separator_w, style=theme.sep, justify="left"))
+
+        for tip in section_tips:
+            # Emoji variation selectors are not measured consistently across
+            # terminals. On a full-width panel that disagreement shifts Rich's
+            # final frame cell and makes the right border appear fragmented.
+            # The gallery already has a bullet and colour-coded mode metadata,
+            # so omit the decorative "<emoji> Tip:" prefix here. The canonical
+            # tip text (and therefore Copy all) remains unchanged.
+            _prefix, marker, display_text = tip.text.partition("Tip: ")
+            if not marker:
+                display_text = tip.text
+            chunks = textwrap.wrap(display_text, width=tip_wrap_w) or [""]
+            for i, chunk in enumerate(chunks):
+                prefix = bullet_prefix if i == 0 else continuation_prefix
+                body_lines.append(Text(prefix + chunk, style=theme.value, justify="left"))
+
+            if tip.is_new or (tip.mode_key and tip.mode_key in cards):
+                metadata = Text(continuation_prefix, justify="left")
                 if tip.is_new:
-                    line.append("  ")
-                    line.append("NEW", style=f"bold {gold}")
-                if tip.mode_key and tip.mode_key in titles:
-                    line.append("  → opens ", style=theme.muted)
-                    line.append(titles[tip.mode_key], style=theme.desc)
-            body_lines.append(line)
+                    metadata.append("NEW", style=f"bold {gold}")
+                if tip.mode_key and tip.mode_key in cards:
+                    if tip.is_new:
+                        metadata.append("  ·  ", style=theme.sep)
+                    metadata.append("opens ", style=theme.muted)
+                    card = cards[tip.mode_key]
+                    metadata.append(card["title"], style=f"bold {card['color']}")
+                body_lines.append(metadata)
+
+            # A deliberate spacer makes each wrapped record read as one unit.
+            body_lines.append(Text(""))
 
     # ── Layout using shared components (identical to the changelog page) ──
     viewport_h = calc_viewport(height, header_h=10, action_h=4)
@@ -2381,7 +2436,9 @@ def _build_all_tips_screen(
         )
         _vp_table.add_column(ratio=1)
         _vp_table.add_column(width=1)
-        _vp_table.add_row(Group(*padded_lines), _sb_text)
+        _vp_table.add_column(width=1)
+        _vp_table.add_column(width=1)
+        _vp_table.add_row(Group(*padded_lines), Text(""), _sb_text, Text(""))
         viewport_renderable = _vp_table
     else:
         viewport_renderable = Group(*padded_lines)

--- a/tests/unit/test_tips_ui.py
+++ b/tests/unit/test_tips_ui.py
@@ -197,6 +197,64 @@ def test_all_tips_screen_shows_a_tip_and_new_badge(monkeypatch):
     _tips.get_tips.cache_clear()
 
 
+def test_all_tips_screen_groups_every_tip_once(monkeypatch):
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr(
+        "yeaboi.ui.mode_select.screens._screens_secondary.build_scrollbar",
+        lambda *_args, **_kwargs: None,
+    )
+    _tips.get_tips.cache_clear()
+    tips = _tips.get_tips()
+    out = _all_tips_rendered(height=200, shimmer_tick=0.0, sub_reveal=99)
+    assert out.index("Modes") < out.index("More workflows") < out.index("Shortcuts & setup")
+    content_lines = [line.strip().strip("│").strip() for line in out.splitlines()[1:-1]]
+    normalized_out = " ".join(" ".join(content_lines).split())
+    for tip in tips:
+        _prefix, marker, display_text = tip.text.partition("Tip: ")
+        expected = display_text if marker else tip.text
+        assert normalized_out.count(" ".join(expected.split())) == 1
+    _tips.get_tips.cache_clear()
+
+
+def test_all_tips_screen_omits_terminal_unsafe_emoji_prefixes(monkeypatch):
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    _tips.get_tips.cache_clear()
+    out = _all_tips_rendered(height=200, shimmer_tick=0.0, sub_reveal=99)
+    assert "Analysis reads your board" in out
+    assert "🔍" not in out
+    assert "🗺️" not in out
+    assert "Tip:" not in out
+    _tips.get_tips.cache_clear()
+
+
+def test_all_tips_screen_keeps_full_frame_at_common_widths(monkeypatch):
+    import io
+
+    from rich.cells import cell_len
+    from rich.console import Console
+
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    _tips.get_tips.cache_clear()
+    for width, height in ((60, 20), (80, 24), (100, 30)):
+        buf = io.StringIO()
+        console = Console(file=buf, width=width, height=height, color_system=None)
+        console.print(
+            _build_all_tips_screen(
+                width=width,
+                height=height,
+                shimmer_tick=0.0,
+                sub_reveal=99,
+            )
+        )
+        lines = buf.getvalue().splitlines()
+        assert len(lines) == height
+        assert lines[0].startswith("╭") and lines[0].endswith("╮")
+        assert lines[-1].startswith("╰") and lines[-1].endswith("╯")
+        assert all(cell_len(line) == width for line in lines)
+        assert all(line.startswith("│") and line.endswith("│") for line in lines[1:-1])
+    _tips.get_tips.cache_clear()
+
+
 def test_all_tips_screen_shows_status_message(monkeypatch):
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
     _tips.get_tips.cache_clear()


### PR DESCRIPTION
## Summary

- group tips into Modes, More workflows, and Shortcuts & setup sections
- add consistent spacing, wrapping, colored metadata, and scrollbar gutters
- prevent right-border fragmentation by omitting terminal-unsafe emoji prefixes from the gallery while preserving copied tip text
- add responsive frame and catalogue coverage tests

## Validation

- `.venv/bin/ruff check src/yeaboi/ui/mode_select/screens/_screens_secondary.py tests/unit/test_tips_ui.py`
- `.venv/bin/pytest -q tests/unit/test_tips_ui.py tests/unit/test_copy_clipboard.py tests/unit/test_version_row.py` — 47 passed
- full pre-commit suite — 4,479 passed, 16 skipped, with one unrelated existing failure in `TestFormView.test_area_chip_uses_mode_color`
