### PR TITLE
Add online sharing across output modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1254,6 +1254,23 @@ Self-contained single-file HTML report with embedded CSS, collapsible sections, 
 yeaboi --non-interactive --description "Build a todo app" --output html
 ```
 
+### Temporary online sharing
+
+Generated Planning, Analysis, Standup, Performance, Reporting, Roadmap, and saved-run
+outputs can be opened from their result screen with **Share Online**. yeaboi serves the
+same self-contained HTML from your machine and exposes it through a Cloudflare quick
+tunnel—no Cloudflare account or token required.
+
+- The public URL shows an access-code gate; share the displayed `XXXX-XXXX` code separately.
+- The link exists only while the sharing screen is open. **Back** or **Stop Sharing**
+  terminates both the tunnel and local server.
+- Sharing publishes the version currently under review. Run **Anonymize** first when
+  you want the masked version online.
+- The first share may download the pinned, checksum-verified `cloudflared` binary
+  (about 40 MB). Set `CLOUDFLARED_PATH` to use an existing installation.
+- The output is internet-reachable while active. Treat the URL and access code as
+  temporary credentials and avoid sharing sensitive Performance outputs unnecessarily.
+
 ### Notion & Confluence
 
 Every Export button can publish straight to Notion or Confluence with **native, first-class formatting** — not a markdown dump:
@@ -2345,6 +2362,7 @@ src/yeaboi/
 | `NOTION_ROOT_PAGE_ID` | No | Default parent for created Notion pages; enables the Notion standup source; Notion exports fall back here |
 | `NOTION_EXPORT_PARENT_PAGE_ID` | No | Optional dedicated page the Export buttons publish under (blank = grouped under an auto-created 🤙 yeaboi page in `NOTION_ROOT_PAGE_ID`) |
 | `ANONYMIZE_MASK_TERMS` | No | Comma-separated company terms the Anonymize action always masks (e.g. `YouLend,YL`); redacted even without an AI provider |
+| `CLOUDFLARED_PATH` | No | Path to an existing `cloudflared` binary used by Retro and temporary output sharing (otherwise a pinned copy is downloaded and cached) |
 | `YEABOI_HOME` | No | Data home for everything yeaboi writes — exports, logs, sessions DB (default: `~/.yeaboi`; `.env` always stays at `~/.yeaboi/.env`; editable in Settings → Data Dir) |
 | `LANGSMITH_TRACING` | No | Enable LangSmith tracing (`true`) |
 | `LANGSMITH_API_KEY` | No | LangSmith API key |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.31.1"
+version = "2.32.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,18 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.32.0",
+      "date": "2026-07-24",
+      "summary": "Share your yeaboi output publicly without exposing anything private. Every mode's result screen — planning, analysis, standups, retros, performance, reporting, and roadmaps — now has a Share Online button: press it and a local artifact server starts up, exchanges a short access code for a strong token with rate limiting, and opens a public Cloudflare tunnel URL you can send to teammates or stakeholders. The browser displays your rich output in full fidelity (cards, tables, meters, grids, all styled exactly as you see it in the app), and the link stays active only while the sharing screen is open. Security is baked in: the local server binds to loopback only, tokens carry no-store headers, and logs never expose URLs, codes, or artifact content.",
+      "highlights": [
+        {"text": "Share Online button on every mode's result screen — planning, analysis, standup, retro, performance, reporting, roadmap", "areas": ["planning", "analysis", "standup", "retro", "performance", "reporting"]},
+        {"text": "Cloudflare tunnel with rate-limited token exchange and secure access codes — no long-lived URLs", "areas": ["general"]},
+        {"text": "Rich rendering in the browser: same cards, tables, and grids you see in the app, fully styled", "areas": ["general"]},
+        {"text": "Local artifact server bound to loopback only; link stays active only while sharing screen is open", "areas": ["general"]},
+        {"text": "Works with both raw and anonymized documents, retro's interactive sharing flow preserved", "areas": ["retro", "general"]}
+      ]
+    },
+    {
       "version": "2.31.1",
       "date": "2026-07-24",
       "summary": "The All Tips screen now displays better, with tips grouped into logical sections (Modes, More Workflows, and Shortcuts & Setup), improved spacing and text wrapping, colored metadata badges, and scrollbar gutters that prevent layout fragmentation. The gallery preserves emoji in copied tip text while avoiding terminal-unsafe characters in the displayed view.",

--- a/src/yeaboi/retro/server.py
+++ b/src/yeaboi/retro/server.py
@@ -43,12 +43,23 @@ from urllib.parse import parse_qs, urlparse
 
 from yeaboi.retro.board import RetroBoard
 from yeaboi.retro.page import build_board_html
+from yeaboi.sharing.access import JoinLimiter as _SharedJoinLimiter
+from yeaboi.sharing.access import make_join_code, make_token
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 5173
 _PORT_WALK = 20  # try _DEFAULT_PORT .. _DEFAULT_PORT + _PORT_WALK on conflict
 _MAX_BODY = 4096  # POST body cap (bytes) — blunt DoS
+
+
+class JoinLimiter(_SharedJoinLimiter):
+    """Retro-compatible wrapper over the shared failed-code limiter."""
+
+    def __init__(self) -> None:
+        # Keep the clock lookup late so existing tests and callers can replace
+        # ``retro.server.time.monotonic`` deterministically.
+        super().__init__(clock=lambda: time.monotonic())
 
 
 # ---------------------------------------------------------------------------
@@ -72,69 +83,6 @@ def get_lan_ip() -> str:
         return "127.0.0.1"
     finally:
         s.close()
-
-
-def make_token() -> str:
-    """Return a fresh ~128-bit url-safe access token for one retro session."""
-    return secrets.token_urlsafe(16)
-
-
-# Human-typable join code: unambiguous alphabet (no 0/O/1/I) grouped XXXX-XXXX.
-_JOIN_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
-
-
-def make_join_code() -> str:
-    """Return a short, human-typable join code (e.g. ``A3F9-1B2C``).
-
-    This is a LAN-trust convenience credential the server resolves to the strong
-    token (see ``/api/join``); the 128-bit token still guards direct URLs/QR.
-    """
-    raw = "".join(secrets.choice(_JOIN_ALPHABET) for _ in range(8))
-    return f"{raw[:4]}-{raw[4:]}"
-
-
-class JoinLimiter:
-    """Thread-safe failed-``/api/join`` throttle to stop brute-forcing the join code.
-
-    The join code is a ~40-bit LAN convenience credential; once the Cloudflare
-    tunnel is up, ``/api/join`` is internet-reachable, so unlimited guessing must
-    be stopped. After ``_MAX_FAILS`` wrong codes a source IP is locked out for
-    ``_LOCKOUT_S`` seconds (``429``); a correct code clears that IP's counter.
-    Uses the same ``threading.Lock`` discipline as the board — the background HTTP
-    threads mutate it concurrently.
-    """
-
-    _MAX_FAILS = 8
-    _LOCKOUT_S = 300.0
-
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        # ip -> (fail_count, window_start_monotonic)
-        self._fails: dict[str, tuple[int, float]] = {}
-
-    def blocked(self, ip: str) -> bool:
-        with self._lock:
-            entry = self._fails.get(ip)
-            if entry is None:
-                return False
-            count, first = entry
-            if count < self._MAX_FAILS:
-                return False
-            if time.monotonic() - first < self._LOCKOUT_S:
-                return True
-            del self._fails[ip]  # lockout window elapsed — forgive
-            return False
-
-    def record_failure(self, ip: str) -> None:
-        with self._lock:
-            count, first = self._fails.get(ip, (0, time.monotonic()))
-            if time.monotonic() - first >= self._LOCKOUT_S:
-                count, first = 0, time.monotonic()  # stale window — restart
-            self._fails[ip] = (count + 1, first)
-
-    def record_success(self, ip: str) -> None:
-        with self._lock:
-            self._fails.pop(ip, None)
 
 
 def encode_share_code(ip: str, port: int, token: str) -> str:

--- a/src/yeaboi/retro/tunnel.py
+++ b/src/yeaboi/retro/tunnel.py
@@ -271,7 +271,7 @@ class CloudflareTunnel:
         # globally resolvable before declaring the tunnel ready.
         host = self._url.split("://", 1)[-1].split("/", 1)[0]
         self._wait_dns_live(host, deadline=time.monotonic() + 30.0)
-        logger.info("retro: tunnel ready at %s", self._url)
+        logger.info("cloudflare quick tunnel ready (local_port=%d)", self.port)
         return self._url
 
     def _dns_query(self, base: str, host: str) -> bool | None:
@@ -315,7 +315,7 @@ class CloudflareTunnel:
         while time.monotonic() < deadline:
             ext = self._dns_query(google, host)
             if ext:  # an ordinary public resolver sees it → joining teammates will too
-                logger.info("retro: tunnel DNS propagated for %s", host)
+                logger.info("cloudflare quick tunnel DNS propagated")
                 time.sleep(3.0)  # small settle for slower downstream resolvers
                 return True
             if ext is not None:  # reachable (just NXDOMAIN for now) — keep waiting on Google
@@ -325,14 +325,13 @@ class CloudflareTunnel:
             # which would forfeit the external-propagation guarantee and re-poison caches.
             elif not google_reachable and (time.monotonic() - start) > (deadline - start) * 0.5:
                 if self._dns_query(cloudflare, host):
-                    logger.info("retro: tunnel DNS live for %s (cloudflare resolver; google unreachable)", host)
+                    logger.info("cloudflare quick tunnel DNS live (cloudflare resolver; google unreachable)")
                     time.sleep(3.0)
                     return True
             time.sleep(1.5)
         logger.warning(
-            "retro: tunnel host %s not resolvable via public DNS yet — give it a few more "
+            "cloudflare quick tunnel host not resolvable via public DNS yet — give it a few more "
             "seconds, or the joining network may block/slow trycloudflare.com (NXDOMAIN).",
-            host,
         )
         return False
 

--- a/src/yeaboi/sharing/__init__.py
+++ b/src/yeaboi/sharing/__init__.py
@@ -1,0 +1,6 @@
+"""Temporary, code-gated sharing for generated yeaboi HTML artifacts."""
+
+from yeaboi.sharing.server import OutputShareServer, ShareDocument
+from yeaboi.sharing.tunnel import CloudflareTunnel, ensure_cloudflared
+
+__all__ = ["CloudflareTunnel", "OutputShareServer", "ShareDocument", "ensure_cloudflared"]

--- a/src/yeaboi/sharing/access.py
+++ b/src/yeaboi/sharing/access.py
@@ -1,0 +1,57 @@
+"""Shared access credentials and brute-force protection for browser sharing."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from collections.abc import Callable
+
+_JOIN_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+
+def make_token() -> str:
+    """Return a fresh ~128-bit URL-safe access token."""
+    return secrets.token_urlsafe(16)
+
+
+def make_join_code() -> str:
+    """Return an unambiguous, human-typable ``XXXX-XXXX`` access code."""
+    raw = "".join(secrets.choice(_JOIN_ALPHABET) for _ in range(8))
+    return f"{raw[:4]}-{raw[4:]}"
+
+
+class JoinLimiter:
+    """Thread-safe failed-code throttle shared by Retro and static output sharing."""
+
+    _MAX_FAILS = 8
+    _LOCKOUT_S = 300.0
+
+    def __init__(self, *, clock: Callable[[], float] = time.monotonic) -> None:
+        self._lock = threading.Lock()
+        self._fails: dict[str, tuple[int, float]] = {}
+        self._clock = clock
+
+    def blocked(self, ip: str) -> bool:
+        with self._lock:
+            entry = self._fails.get(ip)
+            if entry is None:
+                return False
+            count, first = entry
+            if count < self._MAX_FAILS:
+                return False
+            if self._clock() - first < self._LOCKOUT_S:
+                return True
+            del self._fails[ip]
+            return False
+
+    def record_failure(self, ip: str) -> None:
+        with self._lock:
+            count, first = self._fails.get(ip, (0, self._clock()))
+            if self._clock() - first >= self._LOCKOUT_S:
+                count, first = 0, self._clock()
+            self._fails[ip] = (count + 1, first)
+
+    def record_success(self, ip: str) -> None:
+        with self._lock:
+            self._fails.pop(ip, None)

--- a/src/yeaboi/sharing/documents.py
+++ b/src/yeaboi/sharing/documents.py
@@ -1,0 +1,95 @@
+"""Mode adapters that turn generated artifacts into immutable share documents."""
+
+from __future__ import annotations
+
+from yeaboi.sharing.server import ShareDocument
+
+
+def _masked_document(anon, title: str, mode: str) -> ShareDocument:
+    from yeaboi.anonymize.export import build_anonymized_html
+
+    return ShareDocument(title=title, html=build_anonymized_html(anon, title=title), source_mode=mode)
+
+
+def planning_document(graph_state: dict, *, stage: str = "complete", anon=None) -> ShareDocument:
+    analysis = graph_state.get("project_analysis")
+    name = getattr(analysis, "project_name", "") if analysis is not None else ""
+    title = f"Sprint Plan — {name}" if name else "Sprint Plan"
+    if anon is not None:
+        return _masked_document(anon, title, "planning")
+    from yeaboi.html_exporter import build_export_html
+
+    return ShareDocument(title=title, html=build_export_html(graph_state, stage=stage), source_mode="planning")
+
+
+def analysis_document(
+    profile,
+    *,
+    examples: dict | None = None,
+    sprint_names: list[str] | None = None,
+    ceremony=None,
+    anon=None,
+) -> ShareDocument:
+    title = f"Team Profile — {profile.source}/{profile.project_key}"
+    if anon is not None:
+        return _masked_document(anon, title, "analysis")
+    from yeaboi.team_profile_exporter import build_team_profile_html
+
+    html = build_team_profile_html(
+        profile,
+        examples=examples,
+        sprint_names=sprint_names,
+        ceremony=ceremony,
+    )
+    return ShareDocument(title=title, html=html, source_mode="analysis")
+
+
+def standup_document(report, *, anon=None) -> ShareDocument:
+    title = f"Daily Standup — {report.date}"
+    if anon is not None:
+        return _masked_document(anon, title, "standup")
+    from yeaboi.standup.export import build_standup_html
+
+    return ShareDocument(title=title, html=build_standup_html(report), source_mode="standup")
+
+
+def retro_document(report, *, anon=None) -> ShareDocument:
+    title = f"Retro — {report.sprint_name or report.date}"
+    if anon is not None:
+        return _masked_document(anon, title, "retro")
+    from yeaboi.retro.export import build_retro_html
+
+    return ShareDocument(title=title, html=build_retro_html(report), source_mode="retro")
+
+
+def performance_document(artifact, *, kind: str, anon=None) -> ShareDocument:
+    from yeaboi.performance import export
+
+    labels = {"prep": "1:1 Prep", "completion": "1:1 Summary", "review": "6-Month Review"}
+    title = f"{labels[kind]} — {artifact.engineer}"
+    if anon is not None:
+        return _masked_document(anon, title, "performance")
+    builders = {
+        "prep": export.build_prep_html,
+        "completion": export.build_completion_html,
+        "review": export.build_review_html,
+    }
+    return ShareDocument(title=title, html=builders[kind](artifact), source_mode="performance")
+
+
+def reporting_document(report, *, anon=None) -> ShareDocument:
+    title = f"Delivery Report — {report.period_label}"
+    if anon is not None:
+        return _masked_document(anon, title, "reporting")
+    from yeaboi.reporting.export import build_report_html
+
+    return ShareDocument(title=title, html=build_report_html(report), source_mode="reporting")
+
+
+def roadmap_document(analysis, *, anon=None) -> ShareDocument:
+    title = f"Roadmap — {analysis.source_label or 'Analysis'}"
+    if anon is not None:
+        return _masked_document(anon, title, "roadmap")
+    from yeaboi.roadmap.export import build_roadmap_html
+
+    return ShareDocument(title=title, html=build_roadmap_html(analysis), source_mode="roadmap")

--- a/src/yeaboi/sharing/server.py
+++ b/src/yeaboi/sharing/server.py
@@ -1,0 +1,202 @@
+"""Code-gated HTTP server for one immutable, self-contained HTML artifact.
+
+The server binds loopback only: it is not a LAN file server. A Cloudflare quick
+tunnel forwards the public HTTPS URL to it while the TUI's sharing view is open.
+The public root initially serves a harmless code gate; the artifact is returned
+only when the browser presents the strong token obtained from ``/api/join``.
+
+# See README: "Guardrails" — access control and untrusted browser input
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+from yeaboi.sharing.access import JoinLimiter, make_join_code, make_token
+
+logger = logging.getLogger(__name__)
+
+_MAX_BODY = 1024
+
+_GATE_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shared with yeaboi</title>
+  <style>
+    :root{color-scheme:dark}*{box-sizing:border-box}body{margin:0;min-height:100vh;
+    display:grid;place-items:center;background:#090d14;color:#e6edf3;font:16px system-ui,sans-serif}
+    main{width:min(92vw,430px);padding:2rem;border:1px solid #30363d;border-radius:14px;
+    background:#111722;box-shadow:0 20px 70px #0008}h1{margin:.2rem 0 .5rem;font-size:1.45rem}
+    p{color:#9da7b3;line-height:1.5}label{display:block;margin:1.4rem 0 .45rem;font-weight:650}
+    input{width:100%;padding:.85rem 1rem;border:1px solid #465166;border-radius:9px;background:#090d14;
+    color:#fff;font:700 1.15rem ui-monospace,monospace;text-transform:uppercase;letter-spacing:.12em}
+    button{width:100%;margin-top:.8rem;padding:.8rem;border:0;border-radius:9px;background:#648cff;
+    color:#fff;font-weight:750;cursor:pointer}#status{min-height:1.4rem;color:#ff9b9b;font-size:.9rem}
+  </style>
+</head>
+<body><main><div>🤙 yeaboi.ai</div><h1>Someone shared an output with you</h1>
+<p>Enter the access code shown by the host. This temporary page disappears when they stop sharing.</p>
+<form id="join"><label for="code">Access code</label><input id="code" maxlength="9"
+placeholder="XXXX-XXXX" autocomplete="one-time-code" autofocus><button>View output</button>
+<p id="status" role="alert"></p></form></main>
+<script>
+const form=document.getElementById('join'),status=document.getElementById('status');
+form.addEventListener('submit',async e=>{e.preventDefault();status.textContent='Checking…';
+try{const r=await fetch('/api/join',{method:'POST',headers:{'Content-Type':'application/json'},
+body:JSON.stringify({code:document.getElementById('code').value})});
+const d=await r.json();
+if(!r.ok)throw new Error(r.status===429?'Too many attempts — try again later.':'That code did not match.');
+location.replace('/?token='+encodeURIComponent(d.token));}
+catch(err){status.textContent=err.message||'Could not join.';}});
+</script></body></html>"""
+
+
+@dataclass(frozen=True)
+class ShareDocument:
+    """One immutable HTML snapshot exposed by :class:`OutputShareServer`."""
+
+    title: str
+    html: str
+    source_mode: str
+
+
+class _OutputHandler(BaseHTTPRequestHandler):
+    server_version = "YeaboiShare/1"
+    protocol_version = "HTTP/1.1"
+
+    def log_request(self, code: object = "-", size: object = "-") -> None:  # noqa: N802
+        logger.debug("output-share-http %s %s -> %s", self.command, urlparse(self.path).path, code)
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        logger.debug("output-share-http %s", fmt % args if args else fmt)
+
+    def _query(self, key: str) -> str:
+        return parse_qs(urlparse(self.path).query).get(key, [""])[0]
+
+    def _authed(self) -> bool:
+        supplied = self._query("token")
+        token = self.server.token  # type: ignore[attr-defined]
+        return bool(supplied) and secrets.compare_digest(supplied, token)
+
+    def _send(self, code: int, body: bytes, content_type: str, *, artifact: bool = False) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store, max-age=0")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        if artifact:
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'none'; img-src data:; style-src 'unsafe-inline'; "
+                "script-src 'unsafe-inline'; font-src data:; connect-src 'none'",
+            )
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json(self, code: int, payload: dict) -> None:
+        self._send(code, json.dumps(payload).encode(), "application/json")
+
+    def do_GET(self) -> None:  # noqa: N802
+        if urlparse(self.path).path not in ("/", "/index.html"):
+            self._json(404, {"error": "not found"})
+            return
+        if self._authed():
+            document = self.server.document  # type: ignore[attr-defined]
+            self._send(200, document.html.encode(), "text/html; charset=utf-8", artifact=True)
+            return
+        self._send(200, _GATE_HTML.encode(), "text/html; charset=utf-8")
+
+    def do_POST(self) -> None:  # noqa: N802
+        if urlparse(self.path).path != "/api/join":
+            self._json(404, {"error": "not found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            length = 0
+        if length > _MAX_BODY:
+            self._json(413, {"error": "too large"})
+            return
+        try:
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except (json.JSONDecodeError, ValueError):
+            self._json(400, {"error": "bad json"})
+            return
+        if not isinstance(payload, dict):
+            self._json(400, {"error": "bad json"})
+            return
+        ip = self.client_address[0]
+        limiter = self.server.join_limiter  # type: ignore[attr-defined]
+        if limiter.blocked(ip):
+            self._json(429, {"error": "too many attempts"})
+            return
+        code = str(payload.get("code", "")).strip().upper()
+        expected = self.server.join_code  # type: ignore[attr-defined]
+        if code and secrets.compare_digest(code, expected):
+            limiter.record_success(ip)
+            self._json(200, {"ok": True, "token": self.server.token})  # type: ignore[attr-defined]
+            return
+        limiter.record_failure(ip)
+        self._json(403, {"error": "bad code"})
+
+
+class OutputShareServer:
+    """Own a loopback HTTP server and background thread for one HTML snapshot."""
+
+    def __init__(self, document: ShareDocument, *, port: int = 0) -> None:
+        self.document = document
+        self.port = port
+        self.token = make_token()
+        self.join_code = make_join_code()
+        self.join_limiter = JoinLimiter()
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def local_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/"
+
+    @property
+    def display_code(self) -> str:
+        return self.join_code
+
+    def start(self) -> None:
+        """Bind loopback, choosing an ephemeral port by default, and start serving."""
+        if self._httpd is not None:
+            return
+        httpd = ThreadingHTTPServer(("127.0.0.1", self.port), _OutputHandler)
+        httpd.daemon_threads = True
+        self.port = int(httpd.server_address[1])
+        httpd.document = self.document  # type: ignore[attr-defined]
+        httpd.token = self.token  # type: ignore[attr-defined]
+        httpd.join_code = self.join_code  # type: ignore[attr-defined]
+        httpd.join_limiter = self.join_limiter  # type: ignore[attr-defined]
+        self._httpd = httpd
+        self._thread = threading.Thread(target=httpd.serve_forever, name="output-share-http", daemon=True)
+        self._thread.start()
+        logger.info("output share server started (mode=%s, port=%d)", self.document.source_mode, self.port)
+
+    def stop(self) -> None:
+        """Stop serving and release the socket; safe and idempotent."""
+        if self._httpd is None:
+            return
+        try:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+        finally:
+            self._httpd = None
+        if self._thread is not None:
+            self._thread.join(timeout=3)
+            self._thread = None
+        logger.info("output share server stopped (mode=%s)", self.document.source_mode)

--- a/src/yeaboi/sharing/tunnel.py
+++ b/src/yeaboi/sharing/tunnel.py
@@ -1,0 +1,10 @@
+"""Shared Cloudflare quick-tunnel API.
+
+The implementation remains in :mod:`yeaboi.retro.tunnel` for compatibility with
+existing installations and imports. New output-sharing code imports it through
+this mode-neutral module, leaving one pinned/download-verified implementation.
+"""
+
+from yeaboi.retro.tunnel import CloudflareTunnel, ensure_cloudflared
+
+__all__ = ["CloudflareTunnel", "ensure_cloudflared"]

--- a/src/yeaboi/team_profile_exporter.py
+++ b/src/yeaboi/team_profile_exporter.py
@@ -199,26 +199,20 @@ def _ceremony_md(ceremony) -> list[str]:
     return lines
 
 
-def export_team_profile_html(
+def build_team_profile_html(
     profile: TeamProfile,
-    output_dir: Path | None = None,
     *,
     examples: dict | None = None,
     sprint_names: list[str] | None = None,
     ceremony=None,
-) -> Path:
-    """Generate a self-contained HTML report matching the TUI results screen.
+    charts_dir: Path | None = None,
+) -> str:
+    """Build a self-contained HTML report matching the TUI results screen.
 
     ``ceremony`` is an optional CeremonyContext (agent/ceremony_history.py). When
     present and non-empty, a "Ceremony Cadence & Trends" section is added.
-
-    Returns the path to the generated file.
     """
     from yeaboi.html_exporter import _CSS
-
-    out_dir = _project_export_dir(profile.project_key, output_dir)
-    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-    out_path = out_dir / f"team-profile-{ts}.html"
 
     ex = examples or {}
     sections: list[str] = []
@@ -516,7 +510,7 @@ def export_team_profile_html(
                 for sd in sp_details
                 if isinstance(sd, dict)
             ]
-            chart = velocity_chart(chart_rows, out_dir / "velocity.png")
+            chart = velocity_chart(chart_rows, charts_dir / "velocity.png") if charts_dir is not None else None
             chart_html = img_b64_tag(chart, "Sprint velocity") if chart else ""
             sprint_content = chart_html + (
                 f'<div class="card" style="padding:0;overflow:hidden;">'
@@ -1523,6 +1517,28 @@ def export_team_profile_html(
 </body>
 </html>"""
 
+    return page
+
+
+def export_team_profile_html(
+    profile: TeamProfile,
+    output_dir: Path | None = None,
+    *,
+    examples: dict | None = None,
+    sprint_names: list[str] | None = None,
+    ceremony=None,
+) -> Path:
+    """Write the self-contained team-profile HTML report and return its path."""
+    out_dir = _project_export_dir(profile.project_key, output_dir)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out_path = out_dir / f"team-profile-{ts}.html"
+    page = build_team_profile_html(
+        profile,
+        examples=examples,
+        sprint_names=sprint_names,
+        ceremony=ceremony,
+        charts_dir=out_dir,
+    )
     out_path.write_text(page, encoding="utf-8")
     logger.info("Exported team profile HTML to %s", out_path)
     return out_path

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -81,6 +81,32 @@ _HEADER_SUB_SPEED = 45  # characters per second for the page subtitle typewriter
 _FRAME_TIME = FRAME_TIME_60FPS
 
 
+def _run_output_share_flow(
+    console,
+    live,
+    read_key,
+    frame_time: float,
+    supports_timeout: bool,
+    *,
+    document,
+    theme,
+    title_fn,
+) -> None:
+    """Open the shared temporary-output publishing view."""
+    from yeaboi.ui.shared._output_share import run_output_share
+
+    run_output_share(
+        console,
+        live,
+        read_key,
+        frame_time,
+        supports_timeout,
+        document=document,
+        theme=theme,
+        title_fn=title_fn,
+    )
+
+
 def _next_log_level(current: str) -> str:
     """Return the next level in the Settings cycle: DEBUG → INFO → WARNING → ERROR → DEBUG.
 
@@ -1832,6 +1858,22 @@ def _export_roadmap_via_picker(
 
         return (f"Roadmap — {label}", build_roadmap_markdown(analysis))
 
+    def _share() -> str:
+        from yeaboi.sharing.documents import roadmap_document
+        from yeaboi.ui.shared._components import PLANNING_THEME, planning_title
+
+        _run_output_share_flow(
+            console,
+            live,
+            read_key,
+            frame_time,
+            supports_timeout,
+            document=roadmap_document(analysis),
+            theme=PLANNING_THEME,
+            title_fn=planning_title,
+        )
+        return "Online share closed."
+
     return _export_via_picker(
         console,
         live,
@@ -1841,6 +1883,8 @@ def _export_roadmap_via_picker(
         mode="planning",
         files_export=_files,
         get_document=_doc,
+        extra_options=["Share Online"],
+        extra_handlers={"shareonline": _share},
     )
 
 
@@ -2748,6 +2792,8 @@ def _run_mode_hub(
     run_new,
     make_detail=None,
     open_snapshot=None,
+    get_share_document=None,
+    share_theme=None,
     new_breaks_out: bool = False,
 ) -> None:
     """Generic saved-runs hub loop shared by standup / retro / reporting.
@@ -2837,6 +2883,21 @@ def _run_mode_hub(
                 files_export=lambda r=run: files_export(r),
                 get_document=lambda r=run: get_document(r),
             )
+        if act == "Share Online" and get_share_document is not None:
+            document = get_share_document(run)
+            if document is None:
+                return False, "That artifact cannot be shared."
+            _run_output_share_flow(
+                console,
+                live,
+                read_key,
+                frame_time,
+                supports_timeout,
+                document=document,
+                theme=share_theme,
+                title_fn=title_fn,
+            )
+            return False, None
         if act == "Delete":
             delete_run(run)
             _reload("Run deleted.")
@@ -2865,7 +2926,10 @@ def _run_mode_hub(
             return
         scroll = 0
         sel = 0
-        actions = ["Export", "Delete", "Run again", "Back"]
+        actions = ["Export"]
+        if get_share_document is not None and get_share_document(run) is not None:
+            actions.append("Share Online")
+        actions.extend(["Delete", "Run again", "Back"])
         msg = ""
         s_anim = time.monotonic()
         logger.info("%s hub: opened run id=%s", mode, run.run_id)
@@ -2976,7 +3040,7 @@ def _run_standup_hub(console: Console, live, read_key, frame_time: float, suppor
     from yeaboi.ui.mode_select.screens._project_cards import RunSummary
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_standup_screen
     from yeaboi.ui.mode_select.screens._standup_sections import standup_card_order
-    from yeaboi.ui.shared._components import standup_title
+    from yeaboi.ui.shared._components import STANDUP_THEME, standup_title
 
     def _report(run_id: int):
         with StandupStore(_ana_dbp) as store:
@@ -3018,7 +3082,7 @@ def _run_standup_hub(console: Console, live, read_key, frame_time: float, suppor
         # saved run (the run row already names the date). my_name drives the "My Update" row.
         data = {"report": report, "session_name": "", "my_name": report.my_name, "team_expanded": False, "message": ""}
         order = standup_card_order(data)
-        actions = ["Export", "Delete", "Run again", "Back"]
+        actions = ["Export", "Share Online", "Delete", "Run again", "Back"]
         view = "overview"  # "overview" | a section key
         focus = "sections"  # overview focus zone: "sections" | "buttons"
         card_idx, scroll, sel = 0, 0, 0
@@ -3096,6 +3160,14 @@ def _run_standup_hub(console: Console, live, read_key, frame_time: float, suppor
             else (f"Standup — {report.date}", build_standup_markdown(report))
         )
 
+    def get_share_document(run):
+        report = _report(run.run_id)
+        if report is None:
+            return None
+        from yeaboi.sharing.documents import standup_document
+
+        return standup_document(report)
+
     def delete_run(run):
         with StandupStore(_ana_dbp) as store:
             store.delete_run(run.run_id)
@@ -3116,6 +3188,8 @@ def _run_standup_hub(console: Console, live, read_key, frame_time: float, suppor
         open_snapshot=open_standup_snapshot,
         files_export=files_export,
         get_document=get_document,
+        get_share_document=get_share_document,
+        share_theme=STANDUP_THEME,
         delete_run=delete_run,
         run_new=lambda: _run_standup_page(console, live, read_key, frame_time, supports_timeout),
     )
@@ -3133,7 +3207,7 @@ def _run_retro_hub(console: Console, live, read_key, frame_time: float, supports
     from yeaboi.retro.store import RetroStore
     from yeaboi.ui.mode_select.screens._project_cards import RunSummary
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_retro_screen
-    from yeaboi.ui.shared._components import retro_title
+    from yeaboi.ui.shared._components import RETRO_THEME, retro_title
 
     def _report(run_id: int):
         with RetroStore(_ana_dbp) as store:
@@ -3201,6 +3275,14 @@ def _run_retro_hub(console: Console, live, read_key, frame_time: float, supports
         report = _report(run.run_id)
         return "That run is no longer available." if report is None else (_title(report), build_retro_markdown(report))
 
+    def get_share_document(run):
+        report = _report(run.run_id)
+        if report is None:
+            return None
+        from yeaboi.sharing.documents import retro_document
+
+        return retro_document(report)
+
     def delete_run(run):
         with RetroStore(_ana_dbp) as store:
             store.delete_run(run.run_id)
@@ -3221,6 +3303,8 @@ def _run_retro_hub(console: Console, live, read_key, frame_time: float, supports
         make_detail=make_detail,
         files_export=files_export,
         get_document=get_document,
+        get_share_document=get_share_document,
+        share_theme=RETRO_THEME,
         delete_run=delete_run,
         run_new=lambda: _run_retro_page(console, live, read_key, frame_time, supports_timeout),
     )
@@ -3234,7 +3318,7 @@ def _run_reporting_hub(console: Console, live, read_key, frame_time: float, supp
     from yeaboi.reporting.store import ReportingStore
     from yeaboi.ui.mode_select.screens._project_cards import RunSummary
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_reporting_screen
-    from yeaboi.ui.shared._components import reporting_title
+    from yeaboi.ui.shared._components import REPORTING_THEME, reporting_title
 
     def _report(run_id: int):
         with ReportingStore(_ana_dbp) as store:
@@ -3300,6 +3384,14 @@ def _run_reporting_hub(console: Console, live, read_key, frame_time: float, supp
         report = _report(run.run_id)
         return "That run is no longer available." if report is None else (_title(report), build_report_markdown(report))
 
+    def get_share_document(run):
+        report = _report(run.run_id)
+        if report is None:
+            return None
+        from yeaboi.sharing.documents import reporting_document
+
+        return reporting_document(report)
+
     def delete_run(run):
         with ReportingStore(_ana_dbp) as store:
             store.delete_run(run.run_id)
@@ -3320,6 +3412,8 @@ def _run_reporting_hub(console: Console, live, read_key, frame_time: float, supp
         make_detail=make_detail,
         files_export=files_export,
         get_document=get_document,
+        get_share_document=get_share_document,
+        share_theme=REPORTING_THEME,
         delete_run=delete_run,
         run_new=lambda: _run_reporting_page(console, live, read_key, frame_time, supports_timeout),
     )
@@ -3346,7 +3440,7 @@ def _run_performance_hub(
     from yeaboi.persistence import _relative_time
     from yeaboi.ui.mode_select.screens._project_cards import RunSummary
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_performance_screen
-    from yeaboi.ui.shared._components import performance_title
+    from yeaboi.ui.shared._components import PERFORMANCE_THEME, performance_title
 
     def load_runs():
         with PerformanceStore(_ana_dbp) as store:
@@ -3441,6 +3535,17 @@ def _run_performance_hub(
             return (run.title, build_review_markdown(art))
         return (run.title, build_prep_markdown(art))
 
+    def get_share_document(run):
+        got = _artifact(run)
+        if got is None:
+            return None
+        art, kind, _lines = got
+        if kind == "note":
+            return None
+        from yeaboi.sharing.documents import performance_document
+
+        return performance_document(art, kind=kind)
+
     _run_mode_hub(
         console,
         live,
@@ -3457,6 +3562,8 @@ def _run_performance_hub(
         make_detail=make_detail,
         files_export=files_export,
         get_document=get_document,
+        get_share_document=get_share_document,
+        share_theme=PERFORMANCE_THEME,
         delete_run=delete_run,
         run_new=lambda: None,
         new_breaks_out=True,
@@ -3499,6 +3606,8 @@ def _run_standup_page(console: Console, live, read_key, frame_time: float, suppo
             base = ["Generate", "Anonymize", "Configure", "Back"]
         else:
             base = ["Back", "Export", "Anonymize"]
+        if data.get("report") is not None:
+            base.insert(-1, "Share Online")
         if anon is not None:  # swap Anonymize → Adjust + Revert while masked
             i = base.index("Anonymize")
             base[i : i + 1] = ["Adjust", "Revert"]
@@ -3644,6 +3753,23 @@ def _run_standup_page(console: Console, live, read_key, frame_time: float, suppo
                     )
                 if msg is not None:  # None = user backed out of the picker
                     data = _collect_standup_data(message=msg)
+                _reset_to_overview()
+            elif act == "Share Online":
+                report = data.get("report")
+                if report is not None:
+                    from yeaboi.sharing.documents import standup_document
+                    from yeaboi.ui.shared._components import STANDUP_THEME, standup_title
+
+                    _run_output_share_flow(
+                        console,
+                        live,
+                        read_key,
+                        frame_time,
+                        supports_timeout,
+                        document=standup_document(report, anon=anon),
+                        theme=STANDUP_THEME,
+                        title_fn=standup_title,
+                    )
                 _reset_to_overview()
             elif act == "Anonymize":  # mask the report in place for public sharing
                 logger.info("standup: Anonymize pressed (session=%s)", session_id)
@@ -4122,9 +4248,9 @@ def _run_team_analysis_results(
             actions = ["Open"] if view == "overview" else ["Back"]
         else:
             actions = (
-                ["Open", "Export", "Anonymize", "Continue"]
+                ["Open", "Export", "Share Online", "Anonymize", "Continue"]
                 if view == "overview"
-                else ["Back", "Export", "Anonymize", "Continue"]
+                else ["Back", "Export", "Share Online", "Anonymize", "Continue"]
             )
         if anon is not None and "Anonymize" in actions:  # swap Anonymize → Adjust + Revert while masked
             i = actions.index("Anonymize")
@@ -4233,6 +4359,25 @@ def _run_team_analysis_results(
                         examples=examples,
                         sprint_names=sprint_names,
                     )
+            elif act == "Share Online":
+                from yeaboi.sharing.documents import analysis_document
+                from yeaboi.ui.shared._components import ANALYSIS_THEME, analysis_title
+
+                _run_output_share_flow(
+                    console,
+                    live,
+                    read_key,
+                    frame_time,
+                    supports_timeout,
+                    document=analysis_document(
+                        profile,
+                        examples=examples,
+                        sprint_names=sprint_names,
+                        anon=anon,
+                    ),
+                    theme=ANALYSIS_THEME,
+                    title_fn=analysis_title,
+                )
             elif act == "Anonymize":
                 logger.info("Analysis results: Anonymize pressed (view=%s)", view)
                 from yeaboi.ui.shared._components import ANALYSIS_THEME, analysis_title
@@ -4492,7 +4637,7 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
         "detail_title": "",
     }
     roster_actions = ["1:1 Prep", "1:1 Complete", "6mo Review", "Notes", "History", "Export", "Back"]
-    detail_actions = ["Export", "Anonymize", "Back"]
+    detail_actions = ["Export", "Share Online", "Anonymize", "Back"]
     # Anonymize state: None = real artifact; an AnonymizedOutput = mask the detail lines.
     anon = None
     anon_instruction = ""
@@ -4718,6 +4863,26 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
                         )
                     if msg is not None:
                         state["message"] = msg
+                elif label == "Share Online" and roster:
+                    engineer = roster[state["selected"]]
+                    found = _performance_latest_artifact(engineer)
+                    if found is None:
+                        state["message"] = "Nothing to share yet."
+                    else:
+                        artifact, kind = found
+                        from yeaboi.sharing.documents import performance_document
+                        from yeaboi.ui.shared._components import PERFORMANCE_THEME, performance_title
+
+                        _run_output_share_flow(
+                            console,
+                            live,
+                            read_key,
+                            frame_time,
+                            supports_timeout,
+                            document=performance_document(artifact, kind=kind, anon=anon),
+                            theme=PERFORMANCE_THEME,
+                            title_fn=performance_title,
+                        )
                 elif label == "Anonymize" and roster:
                     engineer = roster[state["selected"]]
                     logger.info("performance: Anonymize pressed in detail view for engineer=%s", engineer)
@@ -4867,7 +5032,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
         "sprint_checked": set(),
     }
     picker_actions = ["Generate Report", "Theme", "Back"]
-    detail_actions = ["Export", "Anonymize", "Theme", "Back"]
+    detail_actions = ["Export", "Share Online", "Anonymize", "Theme", "Back"]
     sprint_actions = ["Generate Report", "Back"]
     # Anonymize state: None = real report; an AnonymizedOutput = mask the detail lines.
     anon = None
@@ -5168,6 +5333,22 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
                     anon, anon_instruction = None, ""  # leaving the report drops the mask
                 elif label == "Export":
                     _export()
+                elif label == "Share Online":
+                    report = state.get("report")
+                    if report is not None:
+                        from yeaboi.sharing.documents import reporting_document
+                        from yeaboi.ui.shared._components import REPORTING_THEME, reporting_title
+
+                        _run_output_share_flow(
+                            console,
+                            live,
+                            read_key,
+                            frame_time,
+                            supports_timeout,
+                            document=reporting_document(report, anon=anon),
+                            theme=REPORTING_THEME,
+                            title_fn=reporting_title,
+                        )
                 elif label == "Anonymize":
                     report = state.get("report")
                     if report is None:
@@ -5403,7 +5584,7 @@ def _run_roadmap_page(
         "busy": False,  # True while the analysis worker runs (spinner-only screen)
     }
     source_actions = ["Select", "Back"]
-    results_actions = ["Plan This", "Re-analyze", "Change Source", "Anonymize", "Back"]
+    results_actions = ["Plan This", "Re-analyze", "Change Source", "Share Online", "Anonymize", "Back"]
     # Anonymize state: None = real analysis; an AnonymizedOutput = mask it in place.
     # Roadmap has no Export button normally, so anonymizing adds one (to share the masked copy).
     anon = None
@@ -5672,6 +5853,22 @@ def _run_roadmap_page(
                     anon, anon_instruction = None, ""
                     state["view"] = "source"
                     state["sel"], state["message"] = 0, ""
+                elif label == "Share Online":
+                    analysis = state.get("analysis")
+                    if analysis is not None:
+                        from yeaboi.sharing.documents import roadmap_document
+                        from yeaboi.ui.shared._components import PLANNING_THEME, planning_title
+
+                        _run_output_share_flow(
+                            console,
+                            live,
+                            read_key,
+                            frame_time,
+                            supports_timeout,
+                            document=roadmap_document(analysis, anon=anon),
+                            theme=PLANNING_THEME,
+                            title_fn=planning_title,
+                        )
                 elif label == "Anonymize":
                     if state["analysis"] is None:
                         state["message"] = "Analyze this roadmap before anonymizing."
@@ -5890,7 +6087,7 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
     def _start_remote() -> None:
         def _worker() -> None:
             try:
-                from yeaboi.retro.tunnel import CloudflareTunnel, ensure_cloudflared
+                from yeaboi.sharing.tunnel import CloudflareTunnel, ensure_cloudflared
 
                 remote["status"] = "Setting up remote link — fetching cloudflared (first use, ~40MB)…"
                 binary = ensure_cloudflared()
@@ -7617,7 +7814,8 @@ def select_mode(
                             exp_fade_target = 1.0  # restore Export highlight
 
                         elif focus == 2 and _is_project_row():
-                            _extra = (["Jira"] if _jira_ok else []) + (["Azure DevOps"] if _azdevops_ok else [])
+                            _extra = ["Share Online"]
+                            _extra += (["Jira"] if _jira_ok else []) + (["Azure DevOps"] if _azdevops_ok else [])
                             _dest = _pick_dest(
                                 console,
                                 live,
@@ -7649,6 +7847,26 @@ def select_mode(
                                         project.id,
                                         _dest,
                                     )
+                                elif _dest == "shareonline":
+                                    from yeaboi.persistence import load_graph_state
+                                    from yeaboi.sharing.documents import planning_document
+                                    from yeaboi.ui.shared._components import PLANNING_THEME, planning_title
+
+                                    _gs = load_graph_state(project.id)
+                                    if not _gs:
+                                        path = "No saved state for this project"
+                                    else:
+                                        _run_output_share_flow(
+                                            console,
+                                            live,
+                                            read_key,
+                                            _FRAME_TIME,
+                                            _supports_timeout,
+                                            document=planning_document(_gs),
+                                            theme=PLANNING_THEME,
+                                            title_fn=planning_title,
+                                        )
+                                        path = "Online share closed."
                                 elif _dest == "copy":
                                     from yeaboi.clipboard import copy_markdown_status
                                     from yeaboi.persistence import load_graph_state

--- a/src/yeaboi/ui/session/phases/_phases.py
+++ b/src/yeaboi/ui/session/phases/_phases.py
@@ -1250,6 +1250,7 @@ def _phase_pipeline(
             # so offer Anonymize there — a masked copy for public sharing. While masked,
             # swap it for Adjust (refine) + Revert (restore real names).
             if is_sprint_stage:
+                acts.append("Share Online")
                 acts.extend(["Adjust", "Revert"] if anon is not None else ["Anonymize"])
             if _active_trackers and (is_story_stage or is_task_stage or is_sprint_stage):
                 for _trk in _active_trackers:
@@ -1587,6 +1588,22 @@ def _phase_pipeline(
                             warning_text=_anon_banner(),
                             scroll_meta=_scroll_meta,
                         )
+                    )
+                elif action == "Share Online":
+                    logger.info("Review decision: Share Online for %s", pending)
+                    from yeaboi.sharing.documents import planning_document
+                    from yeaboi.ui.shared._components import PLANNING_THEME, planning_title
+                    from yeaboi.ui.shared._output_share import run_output_share
+
+                    run_output_share(
+                        console,
+                        live,
+                        _key,
+                        0.05,
+                        True,
+                        document=planning_document(graph_state, stage=pending, anon=anon),
+                        theme=PLANNING_THEME,
+                        title_fn=planning_title,
                     )
                 elif action in ("Anonymize", "Adjust"):
                     # In-place mask (or refine): re-render the SAME pipeline with only the

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -98,6 +98,8 @@ _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
     "Generate Action Items": ("rgb(50,170,170)", "rgb(90,220,220)", "rgb(40,52,52)", "rgb(50,62,62)"),
     "Close": ("rgb(100,100,120)", "rgb(140,140,160)", "rgb(40,40,50)", "rgb(50,50,60)"),
     "Share Remotely": ("rgb(50,170,170)", "rgb(90,220,220)", "rgb(40,52,52)", "rgb(50,62,62)"),
+    "Share Online": ("rgb(70,100,180)", "rgb(100,140,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
+    "Copy Invite": ("rgb(70,100,180)", "rgb(100,140,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
     "Stop Sharing": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
     # Quit-time popup: stop the local Ollama server before exiting.
     "Stop": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),

--- a/src/yeaboi/ui/shared/_export_picker.py
+++ b/src/yeaboi/ui/shared/_export_picker.py
@@ -126,6 +126,8 @@ def _dest_description(key: str, label: str, mode: str) -> str:
         return "Needs a Confluence space key — press Enter to set it up"
     if key == "back":
         return "Return without exporting"
+    if key == "shareonline":
+        return "Publish this saved HTML temporarily behind an access code"
     return f"Send to {label}"
 
 

--- a/src/yeaboi/ui/shared/_output_share.py
+++ b/src/yeaboi/ui/shared/_output_share.py
@@ -1,0 +1,273 @@
+"""Shared TUI flow for temporarily publishing one generated HTML artifact."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.text import Text
+
+from yeaboi.sharing.server import OutputShareServer, ShareDocument
+from yeaboi.ui.shared._animations import loading_border_color
+from yeaboi.ui.shared._components import PAD, Theme, build_action_buttons
+
+logger = logging.getLogger(__name__)
+
+
+def _build_output_share_screen(
+    *,
+    title_fn: Callable,
+    theme: Theme,
+    document_title: str,
+    status: str,
+    public_url: str = "",
+    join_code: str = "",
+    message: str = "",
+    actions: list[str] | None = None,
+    action_sel: int = 0,
+    width: int = 100,
+    height: int = 30,
+    shimmer_tick: float | None = None,
+    loading: bool = False,
+) -> Panel:
+    """Render the shared output-sharing lifecycle screen.
+
+    # See README: "Architecture" — shared TUI components and fixed page structure
+    """
+    actions = actions or ["Back"]
+    try:
+        title = title_fn(shimmer_tick, width=width)
+    except TypeError:
+        title = title_fn(shimmer_tick)
+
+    body: list = [
+        Text(PAD + "Share this output online", style=f"bold {theme.accent_bright}"),
+        Text(PAD + document_title, style=theme.value),
+        Text(""),
+        Text(
+            PAD + "Anyone with the temporary URL and access code can view this output while this screen is open.",
+            style=theme.warn,
+        ),
+        Text(""),
+    ]
+    if loading:
+        tick = shimmer_tick or 0.0
+        spinners = ("◐", "◓", "◑", "◒")
+        spinner = spinners[int(tick * 5) % len(spinners)]
+        dots = "." * (int(tick * 2.5) % 4)
+        elapsed = int(tick)
+        body.extend(
+            [
+                Text(
+                    PAD + f"{spinner}  Establishing secure share{dots}",
+                    style=f"bold {theme.accent_bright}",
+                ),
+                Text(PAD + f"   {status}", style=theme.muted),
+                Text(PAD + f"   Elapsed: {elapsed}s  ·  Esc cancels", style=theme.dim),
+            ]
+        )
+    else:
+        body.append(Text(PAD + status, style=theme.muted))
+    if public_url:
+        body.extend(
+            [
+                Text(""),
+                Text(PAD + "Public URL", style=f"bold {theme.accent}"),
+                Text(PAD + public_url, style=theme.value, overflow="fold"),
+                Text(""),
+                Text(PAD + "Access code", style=f"bold {theme.accent}"),
+                Text(PAD + join_code, style=f"bold {theme.accent_bright}"),
+                Text(""),
+                Text(PAD + "Copy Invite includes both values. Back or Stop Sharing closes the link.", style=theme.dim),
+            ]
+        )
+    if message:
+        body.extend([Text(""), Text(PAD + message, style=theme.good if message.startswith("Copied") else theme.warn)])
+
+    # Keep the action bar pinned at the bottom while the status body gets the
+    # remaining rows, matching every other shared screen.
+    reserved = 18
+    body_rows = max(4, height - reserved)
+    visible = body[:body_rows]
+    while len(visible) < body_rows:
+        visible.append(Text(""))
+    btn_top, btn_mid, btn_bot = build_action_buttons(actions, action_sel)
+    return Panel(
+        Group(
+            Text(""),
+            title,
+            Text(""),
+            Text(PAD + "Temporary, code-gated Cloudflare share", style=theme.muted),
+            Text(""),
+            *visible,
+            Text(""),
+            btn_top,
+            btn_mid,
+            btn_bot,
+        ),
+        height=height,
+        padding=(1, 2),
+        border_style=loading_border_color(shimmer_tick or 0.0) if loading else theme.sep,
+    )
+
+
+def run_output_share(
+    console,
+    live,
+    read_key,
+    frame_time: float,
+    supports_timeout: bool,
+    *,
+    document: ShareDocument,
+    theme: Theme,
+    title_fn: Callable,
+) -> None:
+    """Start a code-gated server+tunnel and own them until the user leaves."""
+    from yeaboi.sharing.tunnel import CloudflareTunnel, ensure_cloudflared
+
+    state: dict[str, object] = {
+        "status": "Preparing a protected local snapshot…",
+        "public_url": "",
+        "error": "",
+        "done": False,
+        "active": False,
+        "server": None,
+        "tunnel": None,
+    }
+    lock = threading.Lock()
+    cancel = threading.Event()
+
+    def _set(**values) -> None:
+        with lock:
+            state.update(values)
+
+    def _worker() -> None:
+        server: OutputShareServer | None = None
+        tunnel: CloudflareTunnel | None = None
+        try:
+            server = OutputShareServer(document)
+            server.start()
+            _set(server=server, status="Setting up Cloudflare sharing (first use may download ~40 MB)…")
+            binary = ensure_cloudflared()
+            if binary is None:
+                _set(error="Could not obtain cloudflared. The output was not published.", done=True)
+                return
+            if cancel.is_set():
+                _set(done=True)
+                return
+            _set(status="Starting the secure tunnel and checking public DNS…")
+            tunnel = CloudflareTunnel(server.port, binary=binary)
+            _set(tunnel=tunnel)
+            public_url = tunnel.start(timeout=45)
+            if not public_url:
+                _set(error="Cloudflare did not provide a reachable URL. See the logs for details.", done=True)
+                return
+            if cancel.is_set():
+                tunnel.stop()
+                _set(done=True)
+                return
+            _set(
+                public_url=public_url.rstrip("/") + "/",
+                status="Sharing is live.",
+                active=True,
+                done=True,
+            )
+            logger.info("output sharing ready (mode=%s, port=%d)", document.source_mode, server.port)
+        except Exception as exc:
+            logger.error("output sharing failed (mode=%s): %s", document.source_mode, exc, exc_info=True)
+            _set(error="Could not start online sharing. See the logs for details.", done=True)
+
+    logger.info("Share Online pressed (mode=%s)", document.source_mode)
+    worker = threading.Thread(target=_worker, name="output-share-setup", daemon=True)
+    worker.start()
+    sel = 0
+    message = ""
+    started = time.monotonic()
+    leaving = False
+
+    try:
+        while True:
+            with lock:
+                snapshot = dict(state)
+            active = bool(snapshot["active"])
+            error = str(snapshot["error"])
+            done = bool(snapshot["done"])
+            if active:
+                actions = ["Copy Invite", "Stop Sharing", "Back"]
+            else:
+                actions = ["Back"]
+                sel = 0
+            status = error or str(snapshot["status"])
+            if leaving and not done:
+                status = "Cancelling setup and cleaning up…"
+
+            w, h = console.size
+            live.update(
+                _build_output_share_screen(
+                    title_fn=title_fn,
+                    theme=theme,
+                    document_title=document.title,
+                    status=status,
+                    public_url=str(snapshot["public_url"]),
+                    join_code=(
+                        snapshot["server"].display_code if snapshot.get("server") is not None and active else ""  # type: ignore[union-attr]
+                    ),
+                    message=message,
+                    actions=actions,
+                    action_sel=sel,
+                    width=w,
+                    height=max(16, h - 1),
+                    shimmer_tick=time.monotonic() - started,
+                    loading=not done,
+                )
+            )
+            if leaving and done:
+                break
+
+            key = read_key(timeout=frame_time) if supports_timeout else read_key()
+            if key == "left":
+                sel = max(0, sel - 1)
+            elif key == "right":
+                sel = min(len(actions) - 1, sel + 1)
+            elif key in ("esc", "q"):
+                cancel.set()
+                leaving = True
+            elif key in ("enter", " "):
+                action = actions[sel]
+                if action == "Copy Invite" and active:
+                    from yeaboi.clipboard import copy_text
+
+                    server = snapshot["server"]
+                    invite = f"{snapshot['public_url']}\nAccess code: {server.display_code}"  # type: ignore[union-attr]
+                    message = "Copied invite to clipboard." if copy_text(invite) else "Couldn't copy — see logs."
+                    logger.info("output sharing invite copy requested (mode=%s)", document.source_mode)
+                elif action in ("Stop Sharing", "Back"):
+                    cancel.set()
+                    leaving = True
+                    if done:
+                        break
+    finally:
+        cancel.set()
+        # Tear down already-published resources before waiting. A first-use
+        # binary download is not cancellable, but the worker checks ``cancel``
+        # before it can launch cloudflared afterwards.
+        with lock:
+            early_tunnel = state.get("tunnel")
+            early_server = state.get("server")
+        if early_tunnel is not None:
+            early_tunnel.stop()  # type: ignore[union-attr]
+        if early_server is not None:
+            early_server.stop()  # type: ignore[union-attr]
+        worker.join(timeout=50)
+        with lock:
+            tunnel = state.get("tunnel")
+            server = state.get("server")
+        if tunnel is not None:
+            tunnel.stop()  # type: ignore[union-attr]
+        if server is not None:
+            server.stop()  # type: ignore[union-attr]
+        logger.info("output sharing closed (mode=%s)", document.source_mode)

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -116,6 +116,11 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
         "anonymize",
         "\U0001f576️ Tip: press Anonymize on any result screen to mask names before sharing",
     ),
+    FeatureTip(
+        "output-sharing",
+        "🌐 Tip: Share Online publishes any generated output behind a temporary access code",
+        is_new=True,
+    ),
 )
 
 # Ambient tips — not tied to a capability, so exempt from parity. The generic

--- a/tests/unit/test_output_share_screen.py
+++ b/tests/unit/test_output_share_screen.py
@@ -1,0 +1,135 @@
+"""Render coverage for the shared online-output screen."""
+
+import time
+
+from rich.console import Console
+
+from yeaboi.sharing.server import ShareDocument
+from yeaboi.ui.shared._components import STANDUP_THEME, standup_title
+from yeaboi.ui.shared._output_share import _build_output_share_screen, run_output_share
+
+
+def _text(panel) -> str:
+    console = Console(width=100, record=True)
+    console.print(panel)
+    return console.export_text()
+
+
+def test_starting_state_renders_warning_and_back():
+    panel = _build_output_share_screen(
+        title_fn=standup_title,
+        theme=STANDUP_THEME,
+        document_title="Daily Standup",
+        status="Starting…",
+        loading=True,
+        shimmer_tick=2.5,
+        width=100,
+        height=30,
+    )
+    out = _text(panel)
+    assert "Share this output online" in out
+    assert "Anyone with the temporary URL" in out
+    assert "Establishing secure share" in out
+    assert "Elapsed: 2s" in out
+    assert "Esc cancels" in out
+    assert "Back" in out
+
+
+def test_starting_animation_changes_between_frames():
+    def render(tick: float) -> str:
+        return _text(
+            _build_output_share_screen(
+                title_fn=standup_title,
+                theme=STANDUP_THEME,
+                document_title="Daily Standup",
+                status="Starting the secure tunnel…",
+                loading=True,
+                shimmer_tick=tick,
+                width=100,
+                height=30,
+            )
+        )
+
+    first = render(0.0)
+    second = render(0.25)
+    assert "◐  Establishing secure share" in first
+    assert "◓  Establishing secure share" in second
+    assert first != second
+
+
+def test_ready_state_renders_url_code_and_actions():
+    panel = _build_output_share_screen(
+        title_fn=standup_title,
+        theme=STANDUP_THEME,
+        document_title="Daily Standup",
+        status="Sharing is live.",
+        public_url="https://example.trycloudflare.com/",
+        join_code="ABCD-2345",
+        actions=["Copy Invite", "Stop Sharing", "Back"],
+        width=100,
+        height=34,
+    )
+    out = _text(panel)
+    assert "example.trycloudflare.com" in out
+    assert "ABCD-2345" in out
+    assert "Copy Invite" in out
+    assert "Stop Sharing" in out
+
+
+def test_runner_stops_server_and_tunnel(monkeypatch):
+    events: list[str] = []
+
+    class FakeServer:
+        port = 54321
+        display_code = "ABCD-2345"
+
+        def __init__(self, document):
+            self.document = document
+
+        def start(self):
+            events.append("server-start")
+
+        def stop(self):
+            events.append("server-stop")
+
+    class FakeTunnel:
+        def __init__(self, port, *, binary):
+            assert port == 54321
+
+        def start(self, *, timeout):
+            events.append("tunnel-start")
+            return "https://example.trycloudflare.com"
+
+        def stop(self):
+            events.append("tunnel-stop")
+
+    class FakeConsole:
+        size = (100, 34)
+
+    class FakeLive:
+        def update(self, _panel):
+            pass
+
+    keys = iter(("right", "enter"))
+
+    def read_key(timeout=None):
+        time.sleep(0.01)
+        return next(keys, "enter")
+
+    monkeypatch.setattr("yeaboi.ui.shared._output_share.OutputShareServer", FakeServer)
+    monkeypatch.setattr("yeaboi.sharing.tunnel.ensure_cloudflared", lambda: "/bin/cloudflared")
+    monkeypatch.setattr("yeaboi.sharing.tunnel.CloudflareTunnel", FakeTunnel)
+
+    run_output_share(
+        FakeConsole(),
+        FakeLive(),
+        read_key,
+        0.001,
+        True,
+        document=ShareDocument("Daily Standup", "<html></html>", "standup"),
+        theme=STANDUP_THEME,
+        title_fn=standup_title,
+    )
+    assert events[:2] == ["server-start", "tunnel-start"]
+    assert "tunnel-stop" in events
+    assert "server-stop" in events

--- a/tests/unit/test_output_share_server.py
+++ b/tests/unit/test_output_share_server.py
@@ -1,0 +1,72 @@
+"""Tests for the temporary code-gated output server."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from yeaboi.sharing.server import OutputShareServer, ShareDocument
+
+
+@pytest.fixture
+def share_server():
+    server = OutputShareServer(
+        ShareDocument(title="Sprint plan", html="<html><body>SECRET OUTPUT</body></html>", source_mode="planning")
+    )
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def _post(server, code: str):
+    request = urllib.request.Request(
+        server.local_url + "api/join",
+        data=json.dumps({"code": code}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return urllib.request.urlopen(request, timeout=2)  # noqa: S310 - loopback test server
+
+
+def test_gate_hides_artifact_until_code_is_exchanged(share_server):
+    with urllib.request.urlopen(share_server.local_url, timeout=2) as response:  # noqa: S310
+        gate = response.read().decode()
+    assert "Enter the access code" in gate
+    assert "SECRET OUTPUT" not in gate
+
+    with _post(share_server, share_server.display_code) as response:
+        token = json.loads(response.read())["token"]
+    with urllib.request.urlopen(f"{share_server.local_url}?token={token}", timeout=2) as response:  # noqa: S310
+        assert "SECRET OUTPUT" in response.read().decode()
+        assert response.headers["Cache-Control"].startswith("no-store")
+        assert response.headers["X-Frame-Options"] == "DENY"
+        assert "default-src 'none'" in response.headers["Content-Security-Policy"]
+
+
+def test_wrong_code_is_rejected(share_server):
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post(share_server, "AAAA-BBBB")
+    assert exc.value.code == 403
+
+
+def test_failed_code_attempts_are_rate_limited(share_server):
+    for _ in range(8):
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _post(share_server, "AAAA-BBBB")
+        assert exc.value.code == 403
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post(share_server, share_server.display_code)
+    assert exc.value.code == 429
+
+
+def test_stop_is_idempotent():
+    server = OutputShareServer(ShareDocument("t", "<html></html>", "analysis"))
+    server.start()
+    assert server.port > 0
+    server.stop()
+    server.stop()

--- a/tests/unit/test_sharing_documents.py
+++ b/tests/unit/test_sharing_documents.py
@@ -1,0 +1,73 @@
+"""Every generated artifact has a self-contained HTML sharing adapter."""
+
+from yeaboi.agent.state import (
+    AnonymizedOutput,
+    DeliveryReport,
+    OneOnOnePrep,
+    ProjectAnalysis,
+    RetroReport,
+    RoadmapAnalysis,
+    StandupReport,
+)
+from yeaboi.sharing.documents import (
+    analysis_document,
+    performance_document,
+    planning_document,
+    reporting_document,
+    retro_document,
+    roadmap_document,
+    standup_document,
+)
+from yeaboi.team_profile import TeamProfile
+
+
+def _project_analysis():
+    return ProjectAnalysis(
+        project_name="Acme",
+        project_description="Plan",
+        project_type="greenfield",
+        goals=(),
+        end_users=(),
+        target_state="Done",
+        tech_stack=(),
+        integrations=(),
+        constraints=(),
+        sprint_length_weeks=2,
+        target_sprints=1,
+        risks=(),
+        out_of_scope=(),
+        assumptions=(),
+    )
+
+
+def test_all_raw_mode_adapters_return_html():
+    documents = [
+        planning_document({"project_analysis": _project_analysis()}),
+        analysis_document(TeamProfile(team_id="t", source="jira", project_key="ACME")),
+        standup_document(StandupReport(date="2026-07-24")),
+        retro_document(RetroReport(date="2026-07-24", sprint_name="Sprint 1")),
+        performance_document(OneOnOnePrep(engineer="Ada"), kind="prep"),
+        reporting_document(DeliveryReport(period_label="Last sprint")),
+        roadmap_document(RoadmapAnalysis(source_label="Q3")),
+    ]
+    assert {d.source_mode for d in documents} == {
+        "planning",
+        "analysis",
+        "standup",
+        "retro",
+        "performance",
+        "reporting",
+        "roadmap",
+    }
+    assert all(d.html.startswith("<!DOCTYPE html>") for d in documents)
+
+
+def test_anonymized_adapter_uses_masked_output_only():
+    anon = AnonymizedOutput(
+        anonymized_text="# [PROJECT]\n\nSafe summary",
+        replacements=(("Acme", "[PROJECT]"),),
+        source_mode="standup",
+    )
+    document = standup_document(StandupReport(date="2026-07-24", team_summary="Acme secret"), anon=anon)
+    assert "[PROJECT]" in document.html
+    assert "Acme secret" not in document.html

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -175,6 +175,15 @@ CAPABILITIES: dict[str, dict] = {
         "cli": Exempt("headless callers anonymize via the anonymize_text MCP tool"),
         "skill": Exempt("post-processing action, not a guided workflow"),
     },
+    "output-sharing": {
+        "engines": Exempt("transport over already-generated HTML artifacts, not an artifact-generation pipeline"),
+        "mcp_tools": Exempt(
+            "a stdio tool cannot safely own an interactive host process and temporary tunnel lifecycle"
+        ),
+        "tui_mode": Exempt("a Share Online action on existing result screens, not a dedicated mode card"),
+        "cli": Exempt("temporary shares intentionally remain visible and cancellable in the interactive TUI"),
+        "skill": Exempt("local process and access-code ownership belongs to the human host in the TUI"),
+    },
     "usage": {
         "engines": Exempt("TUI utility page — reads the local token_usage table"),
         "mcp_tools": {"usage_get"},


### PR DESCRIPTION
<h2>Summary</h2><ul><li>add reusable code-gated Cloudflare sharing for generated HTML artifacts</li><li>roll Share Online out across live and saved planning, analysis, standup, performance, reporting, roadmap, and retro outputs</li><li>support raw and anonymized documents while preserving retro's interactive sharing flow</li><li>add an animated tunnel-starting state with spinner, elapsed time, cancellation hint, and pulsing border</li></ul><h2>Security and lifecycle</h2><ul><li>bind the local artifact server to loopback only</li><li>exchange a short access code for a strong token with rate limiting and no-store security headers</li><li>keep the public link active only while the sharing screen is open</li><li>avoid logging URLs, access codes, tokens, or artifact content</li></ul><h2>Verification</h2><ul><li>full suite: 5,048 passed, 16 skipped</li><li>pre-commit unit suite after animation update: 4,487 passed, 16 skipped</li><li>lint, formatting, secret scanning, and patch-integrity checks passed</li></ul>