### PR TITLE
Add animated idle screensaver

### DIFF
--- a/src/yeaboi/ui/provider_select/__init__.py
+++ b/src/yeaboi/ui/provider_select/__init__.py
@@ -357,18 +357,21 @@ def select_provider(
                 def _do() -> None:
                     result.append(pull_ollama_model(api_key_val, model_id, _on_progress, cancel_event=cancel))
 
-                thread = threading.Thread(target=_do, daemon=True)
-                thread.start()
-                while thread.is_alive():
-                    frac = prog["frac"]
-                    pct = f"{frac * 100:3.0f}% · " if frac is not None else ""
-                    render_progress(f"⬇ Downloading {model_id} — {pct}{prog['status']}  ·  Esc cancels")
-                    if _supports_timeout:
-                        if read_key(timeout=FRAME_TIME_30FPS) == "esc":
-                            cancel.set()
-                    else:
-                        time.sleep(FRAME_TIME_30FPS)
-                thread.join()
+                from yeaboi.ui.shared._screensaver import suppress_screensaver
+
+                with suppress_screensaver():
+                    thread = threading.Thread(target=_do, daemon=True)
+                    thread.start()
+                    while thread.is_alive():
+                        frac = prog["frac"]
+                        pct = f"{frac * 100:3.0f}% · " if frac is not None else ""
+                        render_progress(f"⬇ Downloading {model_id} — {pct}{prog['status']}  ·  Esc cancels")
+                        if _supports_timeout:
+                            if read_key(timeout=FRAME_TIME_30FPS) == "esc":
+                                cancel.set()
+                        else:
+                            time.sleep(FRAME_TIME_30FPS)
+                    thread.join()
                 return result[0] if result else (False, "Download failed")
 
             def _run_custom_input() -> str | None:

--- a/src/yeaboi/ui/session/_utils.py
+++ b/src/yeaboi/ui/session/_utils.py
@@ -20,6 +20,7 @@ from rich.table import Table
 from rich.text import Text
 
 from yeaboi.ui.shared._animations import FRAME_TIME_30FPS, loading_border_color
+from yeaboi.ui.shared._screensaver import suppress_during_call
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -294,6 +295,7 @@ def _handle_rate_limit_tui(graph, invoke_state: dict, result_box: list) -> bool:
 # ---------------------------------------------------------------------------
 
 
+@suppress_during_call
 def _invoke_with_animation(
     live,
     console: Console,

--- a/src/yeaboi/ui/shared/_input.py
+++ b/src/yeaboi/ui/shared/_input.py
@@ -18,6 +18,9 @@ import tty
 # by the next read_key() call, so no keypress is ever lost. Single-threaded input,
 # so a plain module list is safe. See coalesce_scroll() in _scroll.py.
 _pushback: list[str] = []
+# Set by _read_key_impl so the public wrapper can distinguish a real terminal
+# event that decoded to "" (for example a consumed mouse click) from a timeout.
+_last_read_had_input = False
 
 
 def push_back_key(key: str) -> None:
@@ -25,7 +28,7 @@ def push_back_key(key: str) -> None:
     _pushback.append(key)
 
 
-def read_key(stdin=None, timeout: float | None = None) -> str:
+def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
     """Read a single keypress from the terminal in raw mode.
 
     If timeout is given, returns "" if no key is pressed within that time.
@@ -48,7 +51,11 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
     """
     import select as _select
 
+    global _last_read_had_input
+    _last_read_had_input = False
+
     if _pushback:
+        _last_read_had_input = True
         return _pushback.pop()
 
     fd = (stdin or sys.stdin).fileno()
@@ -91,6 +98,7 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
             return buf
 
         ch = _read1()
+        _last_read_had_input = True
         if ch == "\x1b":
             # Non-blocking check for the second byte — if nothing arrives
             # within 100ms, this is a bare Escape keypress (not an arrow
@@ -283,27 +291,57 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
             # ui/shared/_attachments.py. Note: Cmd+V on macOS stays a terminal
             # *text* paste; Ctrl+V is the image binding, like Claude Code.
             return "ctrl+v"
-        # Ctrl+P / Ctrl+O — global background-music controls. Handled here (the one
-        # input chokepoint every screen's loop reads through) so music works app-wide
-        # with no per-loop changes, and works even inside text fields because these
-        # control bytes are never printable text. The action mutates music state and
-        # nudges the status bar; we return "" (idle) so loops just re-render.
-        # # See README: "Music (ffplay)"
+        # Return global music controls as internal key names. The public wrapper
+        # performs the action only after giving an active screensaver first chance
+        # to consume the event as its wake-only key.
         if ch in ("\x10", "\x0f"):
-            from yeaboi import music
-
-            if ch == "\x10":
-                music.toggle()  # Ctrl+P → play/pause
-            else:
-                music.cycle_channel()  # Ctrl+O → next channel
-            return ""
+            return "ctrl+p" if ch == "\x10" else "ctrl+o"
+        if ch == "\x19":
+            return "ctrl+y"
         if ch == "\x03":
-            raise KeyboardInterrupt
+            return "ctrl+c"
         if ch.isprintable():
             return ch
         return ch
     finally:
         termios.tcsetattr(fd, termios.TCSANOW, old_settings)
+
+
+def read_key(stdin=None, timeout: float | None = None) -> str:
+    """Read one standardized key, with app-wide idle and wake handling.
+
+    A real event wakes the screensaver before any global shortcut or underlying
+    screen action runs. Timed polls that return no input leave the idle baseline
+    untouched.
+    """
+    from yeaboi.ui.shared._screensaver import begin_input_wait, handle_input_event, show_screensaver_now
+
+    begin_input_wait()
+    key = _read_key_impl(stdin=stdin, timeout=timeout)
+    if _last_read_had_input and handle_input_event():
+        return ""
+
+    if key == "ctrl+c":
+        raise KeyboardInterrupt
+
+    # Hidden app-wide preview shortcut: Y for Yeaboi. It deliberately has no
+    # on-screen hint, but uses the same rendering/wake path as genuine idleness.
+    if key == "ctrl+y":
+        show_screensaver_now()
+        return ""
+
+    # Ctrl+P / Ctrl+O are global background-music controls. Keeping them after
+    # wake handling prevents the key that dismisses the saver from also changing
+    # playback state.
+    if key in ("ctrl+p", "ctrl+o"):
+        from yeaboi import music
+
+        if key == "ctrl+p":
+            music.toggle()
+        else:
+            music.cycle_channel()
+        return ""
+    return key
 
 
 # Terminal settings saved by enter_raw_mode(), restored by exit_raw_mode().

--- a/src/yeaboi/ui/shared/_music_bar.py
+++ b/src/yeaboi/ui/shared/_music_bar.py
@@ -114,7 +114,7 @@ def build_music_subtitle(theme: Theme = PLANNING_THEME) -> Text:
 
 
 class MusicLive(Live):
-    """A Rich ``Live`` that stamps the music status onto every Panel it renders."""
+    """App-wide ``Live`` with music chrome and idle-screensaver rendering."""
 
     def __init__(self, *args, **kwargs) -> None:
         # Default vertical_overflow to "crop". The TUI is a hand-rolled scroller:
@@ -136,6 +136,15 @@ class MusicLive(Live):
         self._last_renderable = renderable
         self._stamp(renderable)
         super().update(renderable, refresh=refresh)
+
+    def get_renderable(self):
+        """Return the saver while idle, otherwise the preserved app screen."""
+        from yeaboi.ui.shared._screensaver import build_screensaver, idle_controller
+
+        if idle_controller.should_show():
+            width, height = self.console.size
+            return build_screensaver(width=width, height=height)
+        return super().get_renderable()
 
     def refresh(self) -> None:
         # Re-stamp before every auto-refresh tick so the equalizer keeps animating

--- a/src/yeaboi/ui/shared/_screensaver.py
+++ b/src/yeaboi/ui/shared/_screensaver.py
@@ -1,0 +1,377 @@
+"""Application-wide idle tracking and animated Yeaboi screensaver.
+
+The TUI is made of many small Rich frame loops.  Keeping the idle state here
+lets the shared input reader say when the application is waiting for a person,
+while the shared Live wrapper decides which renderable should be visible.
+"""
+
+from __future__ import annotations
+
+import functools
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import ParamSpec, TypeVar
+
+from rich.align import Align
+from rich.console import Group, RenderableType
+from rich.text import Text
+
+IDLE_SECONDS = 5 * 60
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+class IdleController:
+    """Thread-safe idle state shared by terminal input and Rich's refresh thread."""
+
+    def __init__(self, *, idle_seconds: float = IDLE_SECONDS, clock: Callable[[], float] = time.monotonic) -> None:
+        self.idle_seconds = idle_seconds
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._last_activity = clock()
+        self._animation_started = self._last_activity
+        self._waiting_for_input = False
+        self._suppression_depth = 0
+        self._active = False
+
+    def begin_input_wait(self) -> None:
+        """Declare that the current screen is ready for user input.
+
+        Repeated timed polls keep the original baseline.  Transitioning back
+        from processing starts a fresh idle period so work time never counts.
+        """
+        now = self._clock()
+        with self._lock:
+            if self._suppression_depth:
+                return
+            if not self._waiting_for_input:
+                self._last_activity = now
+            self._waiting_for_input = True
+
+    def handle_input_event(self) -> bool:
+        """Record a real terminal event; return True when it is a wake-only event."""
+        now = self._clock()
+        with self._lock:
+            self._last_activity = now
+            if self._active:
+                self._active = False
+                self._animation_started = now
+                # The wake key is swallowed, so the screen remains in its input wait.
+                self._waiting_for_input = True
+                return True
+            # The caller is about to act on the key.  Its next read starts a new
+            # waiting interval; any processing in between is therefore excluded.
+            self._waiting_for_input = False
+            return False
+
+    def should_show(self) -> bool:
+        """Return whether the saver should replace the current renderable."""
+        now = self._clock()
+        with self._lock:
+            if self._suppression_depth or not self._waiting_for_input:
+                self._active = False
+                return False
+            if not self._active and now - self._last_activity >= self.idle_seconds:
+                self._active = True
+                self._animation_started = now
+            return self._active
+
+    def animation_elapsed(self) -> float:
+        with self._lock:
+            return max(0.0, self._clock() - self._animation_started)
+
+    def show_now(self) -> bool:
+        """Activate immediately for the hidden preview shortcut.
+
+        Returns False while processing is suppressing the saver.
+        """
+        now = self._clock()
+        with self._lock:
+            if self._suppression_depth:
+                return False
+            self._waiting_for_input = True
+            self._active = True
+            self._animation_started = now
+            return True
+
+    def push_suppression(self) -> None:
+        with self._lock:
+            self._suppression_depth += 1
+            self._waiting_for_input = False
+            self._active = False
+
+    def pop_suppression(self) -> None:
+        now = self._clock()
+        with self._lock:
+            self._suppression_depth = max(0, self._suppression_depth - 1)
+            if self._suppression_depth == 0:
+                self._last_activity = now
+                self._waiting_for_input = False
+                self._active = False
+
+
+idle_controller = IdleController()
+
+
+def begin_input_wait() -> None:
+    idle_controller.begin_input_wait()
+
+
+def handle_input_event() -> bool:
+    return idle_controller.handle_input_event()
+
+
+def show_screensaver_now() -> bool:
+    return idle_controller.show_now()
+
+
+@contextmanager
+def suppress_screensaver() -> Iterator[None]:
+    """Exclude a worker/agent operation from idle tracking."""
+    idle_controller.push_suppression()
+    try:
+        yield
+    finally:
+        idle_controller.pop_suppression()
+
+
+def suppress_during_call(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+    """Decorator form of :func:`suppress_screensaver` for processing helpers."""
+
+    @functools.wraps(fn)
+    def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        with suppress_screensaver():
+            return fn(*args, **kwargs)
+
+    return wrapped
+
+
+_PALETTE = {
+    "K": "rgb(3,8,11)",  # outline / sunglasses frame
+    "S": "rgb(22,31,37)",  # subtly lighter sunglasses lenses
+    "G": "rgb(42,170,105)",  # mallard green
+    "g": "rgb(30,125,112)",  # teal shadow
+    "W": "rgb(225,245,241)",  # wing / glasses glint
+    "C": "rgb(105,220,235)",  # cool highlight
+    "B": "rgb(132,184,186)",  # blue-grey body
+    "b": "rgb(74,139,145)",  # body shadow
+    "O": "rgb(255,165,15)",  # bill / feet
+    "R": "rgb(235,65,12)",  # warm orange shadow
+    "D": "rgb(55,58,72)",  # ground shadow
+}
+
+# Each source cell is rendered as a two-column pixel, giving the full duck a
+# deliberately chunky ANSI/pixel-art silhouette close to the Yeaboi icon.
+_FULL_DUCK = (
+    "........KKKKK..........",
+    "......KKGGGGGKK.........",
+    ".....KGGGGGGGGGK........",
+    "....KGGKKKKKKKKGGK......",
+    "...KGGKSSKKSSKGGGK......",
+    "OOKGGGKSWKKSWKGGGGK.....",
+    "OOOOOKGKKKKKKKKGGGGK....",
+    ".RRROKGGGGGGGGGGGGK.....",
+    ".....KGGGWWWWWWGGGKKK...",
+    ".....KGGWWCWWWWWGGGGGK..",
+    "......KGGGGggGGGGGGGGK..",
+    ".......KKKKKKKKKKKKKKK..",
+    "..........O.....O........",
+    ".........OOO...OOO.......",
+)
+
+_COMPACT_DUCK = (
+    "...KKK.....",
+    "..KGGGKK...",
+    ".KGKKKGGK..",
+    "OKKSKSKGGK.",
+    "OOOKKKGGGK.",
+    "..KGWWWGKK.",
+    "...KGGGGGK.",
+    "....KKKKK..",
+    ".....O.O...",
+)
+
+
+def _fill_ellipse(canvas: list[list[str | None]], cx: int, cy: int, rx: int, ry: int, color: str) -> None:
+    for y in range(max(0, cy - ry), min(len(canvas), cy + ry + 1)):
+        for x in range(max(0, cx - rx), min(len(canvas[0]), cx + rx + 1)):
+            if ((x - cx) / max(rx, 1)) ** 2 + ((y - cy) / max(ry, 1)) ** 2 <= 1:
+                canvas[y][x] = color
+
+
+def _inside_polygon(x: float, y: float, points: tuple[tuple[int, int], ...]) -> bool:
+    inside = False
+    previous = points[-1]
+    for current in points:
+        x1, y1 = previous
+        x2, y2 = current
+        if (y1 > y) != (y2 > y):
+            crossing = (x2 - x1) * (y - y1) / (y2 - y1) + x1
+            if x < crossing:
+                inside = not inside
+        previous = current
+    return inside
+
+
+def _fill_polygon(canvas: list[list[str | None]], points: tuple[tuple[int, int], ...], color: str) -> None:
+    min_x = max(0, min(x for x, _ in points))
+    max_x = min(len(canvas[0]) - 1, max(x for x, _ in points))
+    min_y = max(0, min(y for _, y in points))
+    max_y = min(len(canvas) - 1, max(y for _, y in points))
+    for y in range(min_y, max_y + 1):
+        for x in range(min_x, max_x + 1):
+            if _inside_polygon(x + 0.5, y + 0.5, points):
+                canvas[y][x] = color
+
+
+def _half_block_rows(canvas: list[list[str | None]]) -> list[Text]:
+    """Compress two colour pixels into each terminal row using ▀/▄ blocks."""
+    rows: list[Text] = []
+    for y in range(0, len(canvas), 2):
+        row = Text()
+        lower_y = y + 1
+        for x, top in enumerate(canvas[y]):
+            bottom = canvas[lower_y][x] if lower_y < len(canvas) else None
+            if top is None and bottom is None:
+                row.append(" ")
+            elif top == bottom:
+                row.append("█", style=_PALETTE[top])
+            elif top is not None and bottom is not None:
+                row.append("▀", style=f"{_PALETTE[top]} on {_PALETTE[bottom]}")
+            elif top is not None:
+                row.append("▀", style=_PALETTE[top])
+            else:
+                row.append("▄", style=_PALETTE[bottom])
+        rows.append(row)
+    return rows
+
+
+def _high_resolution_duck(frame: int) -> Group:
+    """Draw the full duck on a 42×30 pixel canvas, then pack it into 15 rows."""
+    width, height = 42, 30
+    canvas: list[list[str | None]] = [[None for _ in range(width)] for _ in range(height)]
+
+    # Ground shadow and feet sit behind the body.
+    _fill_ellipse(canvas, 22, 28, 14, 1, "D")
+    foot_shift = 1 if frame in (1, 5) else 0
+    _fill_polygon(canvas, ((12 + foot_shift, 26), (20 + foot_shift, 26), (21 + foot_shift, 29), (11, 29)), "K")
+    _fill_polygon(canvas, ((13 + foot_shift, 26), (18 + foot_shift, 26), (19 + foot_shift, 28), (12, 28)), "O")
+    _fill_polygon(canvas, ((26, 26), (34, 26), (35, 29), (25, 29)), "K")
+    _fill_polygon(canvas, ((27, 26), (32, 26), (33, 28), (26, 28)), "O")
+    for x in (16 + foot_shift, 30):
+        for y in range(22, 27):
+            canvas[y][x] = "K"
+        for y in range(23, 27):
+            canvas[y][x] = "O"
+
+    # Raised tail, rounded body, lower shadow, and a clearly separate pale wing.
+    _fill_polygon(canvas, ((32, 14), (39, 9), (41, 10), (40, 20), (35, 22)), "K")
+    _fill_polygon(canvas, ((33, 15), (38, 11), (39, 11), (39, 19), (35, 20)), "B")
+    _fill_ellipse(canvas, 25, 19, 15, 8, "K")
+    _fill_ellipse(canvas, 25, 19, 14, 7, "B")
+    _fill_ellipse(canvas, 26, 22, 12, 4, "b")
+    _fill_polygon(canvas, ((18, 14), (34, 14), (36, 18), (32, 23), (22, 24), (16, 19)), "K")
+    _fill_polygon(canvas, ((19, 15), (33, 15), (34, 18), (31, 22), (23, 23), (17, 19)), "W")
+    _fill_polygon(canvas, ((30, 20), (34, 18), (32, 22), (24, 23)), "C")
+
+    # Green chest/neck visually joins the head to the body without swallowing
+    # the wing silhouette.
+    _fill_ellipse(canvas, 14, 18, 7, 8, "K")
+    _fill_ellipse(canvas, 15, 18, 6, 7, "G")
+    _fill_polygon(canvas, ((15, 17), (20, 15), (22, 24), (16, 24)), "g")
+
+    # Rounded mallard head.
+    _fill_ellipse(canvas, 13, 9, 10, 9, "K")
+    _fill_ellipse(canvas, 14, 9, 9, 8, "G")
+    _fill_ellipse(canvas, 17, 6, 5, 5, "G")
+
+    # Orange bill with a red lower edge and a black attachment/outline.
+    _fill_polygon(canvas, ((0, 8), (7, 6), (11, 8), (11, 13), (6, 15), (0, 13)), "K")
+    _fill_polygon(canvas, ((1, 9), (7, 7), (10, 9), (10, 12), (6, 13), (1, 12)), "O")
+    _fill_polygon(canvas, ((2, 12), (10, 11), (9, 13), (3, 14)), "R")
+
+    # Two discrete sunglass lenses, frames, bridge, and temple arm.
+    left_frame = ((5, 5), (12, 5), (13, 10), (11, 12), (5, 11), (4, 7))
+    right_frame = ((13, 5), (20, 5), (21, 7), (20, 11), (14, 12), (12, 10))
+    _fill_polygon(canvas, left_frame, "K")
+    _fill_polygon(canvas, right_frame, "K")
+    _fill_polygon(canvas, ((6, 6), (11, 6), (12, 9), (10, 10), (6, 10), (5, 7)), "S")
+    _fill_polygon(canvas, ((14, 6), (19, 6), (20, 7), (19, 10), (15, 11), (13, 9)), "S")
+    for x in range(11, 15):
+        canvas[7][x] = "K"
+    for x in range(20, 24):
+        canvas[7][x] = "K"
+
+    # The shine crosses the left lens, bridge, then right lens over the loop.
+    shine_positions = ((6, 6), (7, 6), (9, 7), (14, 6), (16, 7), (18, 8), None, None)
+    shine = shine_positions[frame]
+    if shine is not None:
+        sx, sy = shine
+        canvas[sy][sx] = "W"
+        if sx + 1 < width:
+            canvas[sy][sx + 1] = "W"
+
+    rows = _half_block_rows(canvas)
+    if frame in (2, 3, 4):
+        rows.insert(0, Text(""))
+    return Group(*rows)
+
+
+def _pixel_line(source: str, *, glint_column: int | None = None) -> Text:
+    line = Text()
+    for column, pixel in enumerate(source.rstrip(".")):
+        if pixel == ".":
+            line.append("  ")
+            continue
+        if pixel == "S" and glint_column is not None and column == glint_column:
+            pixel = "W"
+        line.append("██", style=_PALETTE[pixel])
+    return line
+
+
+def _duck_art(source: tuple[str, ...], frame: int, *, full: bool) -> Group:
+    glint_columns = (None, 7, 8, 11, 12, None, None, None)
+    glint = glint_columns[frame] if full else ({2: 3, 3: 5}.get(frame))
+    bob = 1 if frame in (2, 3, 4) else 0
+    rows: list[Text] = [Text("")] * bob
+
+    for row_index, row in enumerate(source):
+        # The last two rows are feet in the full sprite. Shift one foot by a
+        # pixel on alternating frames to give the duck a relaxed little shuffle.
+        if full and row_index >= len(source) - 2 and frame in (1, 5):
+            row = "." + row[:-1]
+        rows.append(_pixel_line(row, glint_column=glint))
+
+    shadow_width = 9 + (frame % 3)
+    shadow = Text("  " * max(0, (len(source[0]) - shadow_width) // 2))
+    shadow.append("▄" * (shadow_width * 2), style=_PALETTE["D"])
+    rows.append(shadow)
+    return Group(*rows)
+
+
+def build_screensaver(*, width: int, height: int, elapsed: float | None = None) -> RenderableType:
+    """Build a size-aware animated saver frame without mutating app content."""
+    elapsed = idle_controller.animation_elapsed() if elapsed is None else elapsed
+    frame = int(elapsed * 8) % 8
+
+    if width >= 46 and height >= 19:
+        art = _high_resolution_duck(frame)
+    elif width >= 22 and height >= 13:
+        art = _duck_art(_COMPACT_DUCK, frame, full=False)
+    else:
+        if width >= 20:
+            label = "<(o )___ YEABOI"
+        elif width >= 12:
+            label = "<(o )_ YEABOI"
+        else:
+            label = "YEABOI"[:width]
+        line = Text(label, style="bold rgb(42,170,105)")
+        return Align.center(line, vertical="middle", height=max(1, height))
+
+    caption = Text("YEABOI · chilling", style="bold rgb(105,220,235)", justify="center")
+    hint = Text("press any key", style="rgb(95,105,115)", justify="center")
+    content = Group(art, caption, hint)
+    return Align.center(content, vertical="middle", height=max(1, height))

--- a/tests/unit/test_input_raw_mode.py
+++ b/tests/unit/test_input_raw_mode.py
@@ -110,6 +110,23 @@ def test_ctrl_v_decodes_to_paste_image_key(pty_pair):
         t.cancel()
 
 
+def test_ctrl_y_decodes_to_hidden_screensaver_key(pty_pair):
+    import threading
+
+    master, slave = pty_pair
+
+    class _Stdin:
+        def fileno(self):
+            return slave
+
+    t = threading.Timer(0.2, os.write, args=(master, b"\x19"))
+    t.start()
+    try:
+        assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0) == "ctrl+y"
+    finally:
+        t.cancel()
+
+
 def test_enter_raw_mode_on_non_tty_is_safe(monkeypatch):
     # A pipe fd is not a terminal — enter_raw_mode must swallow the error.
     r, w = os.pipe()

--- a/tests/unit/test_screensaver.py
+++ b/tests/unit/test_screensaver.py
@@ -1,0 +1,143 @@
+"""Tests for app-wide idle tracking and the animated ANSI screensaver."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.text import Text
+
+from yeaboi.ui.shared import _input, _screensaver
+from yeaboi.ui.shared._music_bar import make_live
+from yeaboi.ui.shared._screensaver import IdleController, build_screensaver
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _controller(seconds: float = 300) -> tuple[IdleController, FakeClock]:
+    clock = FakeClock()
+    return IdleController(idle_seconds=seconds, clock=clock), clock
+
+
+def test_activates_at_idle_boundary_and_polling_does_not_reset():
+    controller, clock = _controller()
+    controller.begin_input_wait()
+    clock.advance(299)
+    controller.begin_input_wait()  # another timed input poll, not activity
+    assert controller.should_show() is False
+    clock.advance(1)
+    assert controller.should_show() is True
+
+
+def test_first_event_wakes_only_then_next_event_is_actionable():
+    controller, clock = _controller(seconds=5)
+    controller.begin_input_wait()
+    clock.advance(5)
+    assert controller.should_show() is True
+    assert controller.handle_input_event() is True
+    assert controller.should_show() is False
+    assert controller.handle_input_event() is False
+
+
+def test_processing_is_excluded_and_idle_restarts_afterward(monkeypatch):
+    controller, clock = _controller(seconds=10)
+    monkeypatch.setattr(_screensaver, "idle_controller", controller)
+    controller.begin_input_wait()
+    clock.advance(9)
+
+    with _screensaver.suppress_screensaver():
+        clock.advance(1000)
+        controller.begin_input_wait()
+        assert controller.should_show() is False
+
+    controller.begin_input_wait()
+    clock.advance(9)
+    assert controller.should_show() is False
+    clock.advance(1)
+    assert controller.should_show() is True
+
+
+def test_read_key_consumes_wake_before_music_shortcut(monkeypatch):
+    controller, clock = _controller(seconds=1)
+    monkeypatch.setattr(_screensaver, "idle_controller", controller)
+    controller.begin_input_wait()
+    clock.advance(1)
+    assert controller.should_show() is True
+
+    def fake_read(**_kwargs):
+        _input._last_read_had_input = True
+        return "ctrl+p"
+
+    toggles: list[bool] = []
+    monkeypatch.setattr(_input, "_read_key_impl", fake_read)
+    monkeypatch.setattr("yeaboi.music.toggle", lambda: toggles.append(True))
+
+    assert _input.read_key(timeout=0) == ""
+    assert toggles == []
+
+    # The same shortcut is actionable after the saver has been dismissed.
+    assert _input.read_key(timeout=0) == ""
+    assert toggles == [True]
+
+
+def test_ctrl_y_previews_saver_and_ctrl_y_again_only_wakes(monkeypatch):
+    controller, _clock = _controller()
+    monkeypatch.setattr(_screensaver, "idle_controller", controller)
+
+    def fake_read(**_kwargs):
+        _input._last_read_had_input = True
+        return "ctrl+y"
+
+    monkeypatch.setattr(_input, "_read_key_impl", fake_read)
+
+    assert _input.read_key(timeout=0) == ""
+    assert controller.should_show() is True
+    assert _input.read_key(timeout=0) == ""
+    assert controller.should_show() is False
+
+
+def test_ctrl_y_preview_is_ignored_during_processing(monkeypatch):
+    controller, _clock = _controller()
+    monkeypatch.setattr(_screensaver, "idle_controller", controller)
+
+    def fake_read(**_kwargs):
+        _input._last_read_had_input = True
+        return "ctrl+y"
+
+    monkeypatch.setattr(_input, "_read_key_impl", fake_read)
+    with _screensaver.suppress_screensaver():
+        assert _input.read_key(timeout=0) == ""
+        assert controller.should_show() is False
+
+
+def test_live_swaps_saver_without_losing_underlying_renderable(monkeypatch):
+    controller, clock = _controller(seconds=1)
+    monkeypatch.setattr(_screensaver, "idle_controller", controller)
+    underlying = Text("underlying")
+    live = make_live(underlying, console=Console(width=80, height=24))
+
+    controller.begin_input_wait()
+    clock.advance(1)
+    assert live.get_renderable() is not underlying
+
+    assert controller.handle_input_event() is True
+    assert live.get_renderable() is underlying
+
+
+def test_full_compact_and_tiny_layouts_fit_the_terminal():
+    for width, height in ((80, 24), (30, 14), (18, 5)):
+        console = Console(width=width, height=height, color_system=None)
+        lines = console.render_lines(
+            build_screensaver(width=width, height=height, elapsed=0.25),
+            console.options.update(width=width, height=height),
+            pad=False,
+        )
+        assert len(lines) <= height
+        assert all(sum(segment.cell_length for segment in line) <= width for line in lines)


### PR DESCRIPTION
## Summary
- add an app-wide five-minute idle screensaver with a high-resolution ANSI Yeaboi duck
- preserve the underlying TUI state and consume the first wake key
- suppress activation while agents, workers, syncs, or model downloads are running
- add the hidden Ctrl+Y preview shortcut and responsive compact fallbacks

## Testing
- 4,486 passed, 16 skipped in the full unit suite
- pseudo-terminal TUI smoke test passed
- Ruff and pre-commit formatting/secret checks passed