### PR TITLE
Speed up team analysis with Quick and Deep modes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.33.0"
+version = "2.34.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/analysis/engine.py
+++ b/src/yeaboi/analysis/engine.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 logger = logging.getLogger(__name__)
 
@@ -264,6 +265,7 @@ def run_team_analysis(
     components: dict[str, list[str]] | None = None,
     members: dict[str, list[str]] | None = None,
     *,
+    analysis_depth: str = "quick",
     progress: list | None = None,
     db_path=None,
 ) -> dict:
@@ -293,6 +295,9 @@ def run_team_analysis(
             None — scan commits/PRs for AI-tool markers (Code component).
         include_doc_quality: legacy toggle folded into ``components`` when None — read
             recent Notion/Confluence pages (Docs component).
+        analysis_depth: ``quick`` makes no LLM calls and uses deterministic
+            explanations; ``deep`` adds cached ticket classification and AI-written
+            enrichments. Defaults to ``quick``.
         components: component → sub-source map, e.g.
             ``{"delivery": ["jira"], "code": ["github", "azdo"], "docs": ["confluence"]}``.
             Each component runs over ONLY its listed sub-sources; an absent/empty
@@ -310,6 +315,13 @@ def run_team_analysis(
     Raises ValueError when nothing at all can be analysed (no tracker/component
     configured); per-tracker board errors degrade to a ``warnings`` entry.
     """
+    if analysis_depth not in ("quick", "deep"):
+        raise ValueError(f"analysis_depth must be 'quick' or 'deep' — got {analysis_depth!r}")
+    if analysis_depth == "quick" and generate_samples:
+        raise ValueError("generate_samples requires analysis_depth='deep' because sample generation uses the LLM.")
+    from yeaboi.paths import get_db_path
+
+    effective_db_path = db_path or get_db_path()
     comps = _resolve_components(source, components, include_ai_usage, include_doc_quality)
     members = members or {}
     warnings: list[str] = []
@@ -322,45 +334,105 @@ def run_team_analysis(
         members or "all",
     )
 
-    # Delivery — one TeamProfile per selected tracker (never blended).
-    delivery: dict[str, dict] = {}
+    # Build one independent top-level job per delivery tracker plus one global Code
+    # and Docs job.  Delivery's own four-worker analysis remains unchanged; this
+    # outer pool removes the serial wait between otherwise unrelated components.
+    delivery_results: dict[str, dict] = {}
     single = len(comps["delivery"]) == 1
-    for tracker in comps["delivery"]:
-        try:
-            delivery[tracker] = _run_delivery(
-                tracker,
-                project_key if single else "",
-                team_name if single else "",
-                members.get(tracker),
-                sprint_count,
-                generate_samples,
-                include_insights,
-                progress_list,
-            )
-        except Exception as exc:  # a per-tracker failure degrades to a warning, not a crash
-            logger.warning("Delivery analysis failed for %s: %s", tracker, exc)
-            warnings.append(f"{_SOURCE_NAMES.get(tracker, tracker)} delivery analysis failed: {exc}")
-
-    # Code + Docs — one global scan each, over their selected sub-sources.
     union_members = sorted({m for names in members.values() for m in (names or [])}) or None
-    code = None
+    jobs: list[tuple[str, str, tuple, dict]] = []
+    for tracker in comps["delivery"]:
+        jobs.append(
+            (
+                "delivery",
+                tracker,
+                (
+                    tracker,
+                    project_key if single else "",
+                    team_name if single else "",
+                    members.get(tracker),
+                    sprint_count,
+                    generate_samples,
+                    include_insights,
+                    analysis_depth,
+                    progress_list,
+                    effective_db_path,
+                ),
+                {},
+            )
+        )
+
     if comps["code"]:
         from yeaboi.tools.team_learning import _run_ai_usage_component
 
-        signal, blob = _run_ai_usage_component("", "", [], [], union_members, progress_list, sub_sources=comps["code"])
-        if signal is not None:
-            code = {"signal": signal, "examples": blob}
-    docs = None
+        jobs.append(
+            (
+                "code",
+                "code",
+                ("", "", [], [], union_members, progress_list),
+                {"sub_sources": comps["code"], "analysis_depth": analysis_depth},
+            )
+        )
     if comps["docs"]:
         from yeaboi.tools.team_learning import _run_doc_quality_component
 
-        signal, blob = _run_doc_quality_component("", "", progress_list, sub_sources=comps["docs"])
-        if signal is not None:
-            docs = {"signal": signal, "examples": blob}
+        jobs.append(
+            (
+                "docs",
+                "docs",
+                ("", "", progress_list),
+                {"sub_sources": comps["docs"], "analysis_depth": analysis_depth},
+            )
+        )
+
+    code = None
+    docs = None
+    if jobs:
+        max_workers = min(4, len(jobs))
+        logger.info("Running %d top-level analysis job(s) with %d worker(s)", len(jobs), max_workers)
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="team-analysis") as executor:
+            futures = {}
+            for kind, key, args, kwargs in jobs:
+                if kind == "delivery":
+                    future = executor.submit(_run_delivery, *args, **kwargs)
+                elif kind == "code":
+                    future = executor.submit(_run_ai_usage_component, *args, **kwargs)
+                else:
+                    future = executor.submit(_run_doc_quality_component, *args, **kwargs)
+                futures[future] = (kind, key)
+
+            for future in as_completed(futures):
+                kind, key = futures[future]
+                try:
+                    result = future.result()
+                except Exception as exc:
+                    if kind == "delivery":
+                        logger.warning("Delivery analysis failed for %s: %s", key, exc)
+                        warnings.append(f"{_SOURCE_NAMES.get(key, key)} delivery analysis failed: {exc}")
+                    else:
+                        label = "Code" if kind == "code" else "Docs"
+                        logger.warning("%s analysis failed: %s", label, exc)
+                        warnings.append(f"{label} analysis failed: {exc}")
+                    continue
+
+                if kind == "delivery":
+                    delivery_results[key] = result
+                elif kind == "code":
+                    signal, blob = result
+                    if signal is not None:
+                        code = {"signal": signal, "examples": blob}
+                else:
+                    signal, blob = result
+                    if signal is not None:
+                        docs = {"signal": signal, "examples": blob}
+
+    # Futures complete in arbitrary order. Rebuild delivery in configured order so
+    # the comparison table and TUI's initial tracker stay deterministic.
+    delivery = {tracker: delivery_results[tracker] for tracker in comps["delivery"] if tracker in delivery_results}
 
     # Attach the global code/docs signals to every delivery profile, then persist.
     if delivery:
-        _persist_delivery(delivery, code, docs, db_path)
+        _persist_delivery(delivery, code, docs, effective_db_path)
     for sub in delivery.values():
         warnings.extend(sub.get("warnings", []))
 
@@ -378,6 +450,7 @@ def run_team_analysis(
         "docs": docs,
         "comparison": _build_comparison(delivery) if len(ran) >= 2 else [],
         "components": comps,
+        "analysis_depth": analysis_depth,
         "warnings": warnings,
     }
 
@@ -390,7 +463,9 @@ def _run_delivery(
     sprint_count: int,
     generate_samples: bool,
     include_insights: bool,
+    analysis_depth: str,
     progress: list,
+    db_path,
 ) -> dict:
     """Run the Delivery component for one tracker → a per-tracker result sub-dict.
 
@@ -415,12 +490,16 @@ def _run_delivery(
         sprint_count,
         members or "all",
     )
+    fetch_started = time.monotonic()
     fetch = _fetch_jira_history if resolved_source == "jira" else _fetch_azdevops_history
     sprint_data = fetch(resolved_project, sprint_count)
+    fetch_secs = time.monotonic() - fetch_started
     if not sprint_data:
         raise ValueError("No closed sprints found on the board — nothing to analyse.")
     sprint_names = [sd.get("sprint_name", "") for sd in sprint_data]
 
+    analysis_started = time.monotonic()
+    cache_updates: dict[str, tuple[str, dict]] = {}
     profile, examples = _run_parallel_analysis(
         resolved_source,
         resolved_project or "unknown",
@@ -430,14 +509,20 @@ def _run_delivery(
         include_doc_quality=False,
         members=members,
         warnings=warnings,
+        analysis_depth=analysis_depth,
+        include_insights=include_insights,
+        db_path=db_path,
+        cache_updates=cache_updates,
     )
+    analysis_secs = time.monotonic() - analysis_started
     if resolved_team and not profile.team_name:
         from dataclasses import replace
 
         profile = replace(profile, team_name=resolved_team)
 
     duration = time.monotonic() - started
-    insights = _generate_team_insights_safe(profile, examples) if include_insights else None
+    examples["analysis_depth"] = analysis_depth
+    insights = examples.get("insights") if include_insights else None
     samples = _generate_samples(profile, examples or {}, warnings) if generate_samples else None
     return {
         "source": resolved_source,
@@ -449,15 +534,16 @@ def _run_delivery(
         "headline_stats": compute_headline_stats(profile, examples),
         "insights": insights,
         "samples": samples,
+        "analysis_depth": analysis_depth,
+        "stage_timings": {
+            "fetch_secs": round(fetch_secs, 1),
+            "analysis_secs": round(analysis_secs, 1),
+            "total_secs": round(duration, 1),
+        },
+        "_ticket_cache_updates": cache_updates,
         "log_path": "",
         "warnings": warnings,
     }
-
-
-def _generate_team_insights_safe(profile, examples):
-    from yeaboi.tools.team_learning import _generate_team_insights
-
-    return _generate_team_insights(profile, examples)  # never raises — deterministic fallback inside
 
 
 def _persist_delivery(delivery: dict, code: dict | None, docs: dict | None, db_path) -> None:
@@ -476,6 +562,9 @@ def _persist_delivery(delivery: dict, code: dict | None, docs: dict | None, db_p
         for sub in delivery.values():
             profile = sub["profile"]
             examples = sub["examples"]
+            cache_updates = sub.pop("_ticket_cache_updates", {})
+            if cache_updates:
+                store.save_ticket_parse_cache(profile.source, profile.project_key, cache_updates)
             if code_sig is not None:
                 profile = replace(profile, ai_adoption=code_sig)
                 examples["ai_adoption"] = code["examples"]

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,18 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.34.0",
+      "date": "2026-07-24",
+      "summary": "Team analysis now offers two speed tiers. Quick mode runs instantly with deterministic summaries and no LLM calls—perfect for fast iterations during planning sessions. Deep mode activates AI-enriched analysis with larger ticket batches and parallel processing of all three analysis components (delivery, code, and documentation) for comprehensive insights. The Quick/Deep choice appears right before analysis starts in both the TUI workflow and CLI, with mode details and stage timings visible throughout the run. All three components now run concurrently instead of serially, cutting analysis wall-clock time significantly. The choice is exposed through CLI flags and MCP tools so teammates and AI agents can pick the right depth for their workflow.",
+      "highlights": [
+        {"text": "Quick mode: instant, deterministic analysis with no LLM calls; perfect for fast iterations", "areas": ["analysis"]},
+        {"text": "Deep mode: AI-enriched with larger ticket batches and parallel processing of delivery, code, and docs components", "areas": ["analysis"]},
+        {"text": "Choose Quick or Deep right before analysis starts; mode details and stage timings shown during the run", "areas": ["analysis"]},
+        {"text": "Concurrent component analysis cuts wall-clock time; delivery, code, and documentation run in parallel", "areas": ["analysis"]},
+        {"text": "Analysis depth exposed through CLI flags and MCP tools for programmatic control", "areas": ["analysis"]}
+      ]
+    },
+    {
       "version": "2.33.0",
       "date": "2026-07-24",
       "summary": "Analysis mode gained significantly improved insights dashboards. AI Adoption and Documentation sections now display as evidence-led dashboards with metric tiles, meters, ranked member breakdowns, evidence tables, and actionable cards — replacing a flat text layout with data-forward visualization. Team Insights was reorganized into consistent Focus Now, Keep Working, and Experiments sections, each with category badges for quick scanning. Member selection was redesigned: every team member starts pre-selected in the analysis scope picker, you can toggle one at a time or press A to select or deselect all, and the app prevents running with nobody selected. Overall scrolling and navigation improved for better usability with rich content.",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -572,7 +572,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     analyze_p.add_argument("--project", default="", metavar="KEY", help="Project key (default: configured)")
     analyze_p.add_argument("--sprints", type=int, default=8, help="Closed sprints to analyse (default 8)")
-    analyze_p.add_argument("--samples", action="store_true", help="Also generate sample tickets (extra LLM calls)")
+    analyze_p.add_argument(
+        "--depth",
+        choices=["quick", "deep"],
+        default="quick",
+        help="Analysis depth: quick uses no LLM calls; deep adds cached AI enrichment (default quick)",
+    )
+    analyze_p.add_argument(
+        "--samples",
+        action="store_true",
+        help="Also generate sample tickets (requires --depth deep; extra LLM calls)",
+    )
     analyze_p.add_argument("--no-insights", action="store_true", help="Skip the coaching-insights LLM call")
     analyze_p.add_argument(
         "--no-ai-usage",
@@ -1340,6 +1350,7 @@ def _cmd_analyze(args: argparse.Namespace, console: "Console") -> int:
         include_insights=not args.no_insights,
         include_ai_usage=args.include_ai_usage,
         include_doc_quality=args.include_doc_quality,
+        analysis_depth=args.depth,
         components=components or None,
         members=members,
     )

--- a/src/yeaboi/mcp/tools_team.py
+++ b/src/yeaboi/mcp/tools_team.py
@@ -43,12 +43,15 @@ def _team_analyze(
     include_insights: bool,
     include_ai_usage: bool,
     include_doc_quality: bool,
+    analysis_depth: str,
     components=None,
     members=None,
     progress=None,
 ):
     if source not in ("", "jira", "azdevops", "both"):
         raise ValueError(f"source must be 'jira', 'azdevops', or 'both' (blank auto-detects) — got {source!r}")
+    if analysis_depth not in ("quick", "deep"):
+        raise ValueError(f"analysis_depth must be 'quick' or 'deep' — got {analysis_depth!r}")
     allowed = {"delivery": ("jira", "azdevops"), "code": ("github", "azdo"), "docs": ("confluence", "notion")}
     if components:
         for comp, subs in components.items():
@@ -67,6 +70,7 @@ def _team_analyze(
         include_insights=include_insights,
         include_ai_usage=include_ai_usage,
         include_doc_quality=include_doc_quality,
+        analysis_depth=analysis_depth,
         components=components,
         members=members,
         progress=progress,
@@ -118,13 +122,14 @@ def register(app) -> None:
         include_insights: bool = True,
         include_ai_usage: bool = True,
         include_doc_quality: bool = True,
+        analysis_depth: str = "quick",
         components: dict[str, list[str]] | None = None,
         members: dict[str, list[str]] | None = None,
     ) -> dict:
         """Analyse the team's tracker history (closed sprints) into a calibration profile:
         velocity, story-point calibration, writing style, DoD signals, plus coaching insights
-        and headline stats. The profile is saved and feeds future planning. HEAVY: several LLM
-        calls plus tracker API paging — takes minutes; warn the user before running.
+        and headline stats. The profile is saved and feeds future planning. Quick depth
+        performs tracker paging but no LLM calls; Deep may take minutes on a cold cache.
         source: 'jira', 'azdevops', or 'both' (blank auto-detects a single tracker). With 'both'
         the analysis runs once per configured tracker and returns a combined result
         {source:'both', results:{jira:..., azdevops:...}, comparison:[[label,jira,azdevops],...]} —
@@ -137,6 +142,8 @@ def register(app) -> None:
         the team's recent Notion/Confluence pages and reports a documentation clarity score plus a
         stylometric AI-likelihood ESTIMATE (not a detection); set False to skip those doc-platform
         network calls.
+        analysis_depth is "quick" (default, zero LLM calls) or "deep" (cached AI ticket
+        classification and AI-written explanations).
         components selects which parts run, each over its OWN sub-sources:
         {"delivery": ["jira","azdevops"], "code": ["github","azdo"], "docs": ["confluence","notion"]}.
         Delivery runs one velocity profile PER selected tracker; code and docs are each ONE global
@@ -161,6 +168,7 @@ def register(app) -> None:
             include_insights,
             include_ai_usage,
             include_doc_quality,
+            analysis_depth,
             components,
             members,
             progress,

--- a/src/yeaboi/sessions.py
+++ b/src/yeaboi/sessions.py
@@ -128,7 +128,7 @@ CREATE TABLE IF NOT EXISTS sessions_meta (
 #   stored < current → run migrations, UPDATE to current
 #   stored == current → schema_mismatch=False
 # See README: "Memory & State" — session persistence
-CURRENT_SCHEMA_VERSION = 12  # v1=8A, v2=8B, v3=team_profiles, v4=session_mode, v5=token_usage, v6=standup, v7=retro, v8=performance, v9=reporting, v10=roadmap, v11=roadmap list, v12=token_usage perf columns  # noqa: E501
+CURRENT_SCHEMA_VERSION = 13  # v1=8A, v2=8B, v3=team_profiles, v4=session_mode, v5=token_usage, v6=standup, v7=retro, v8=performance, v9=reporting, v10=roadmap, v11=roadmap list, v12=token usage perf, v13=analysis ticket cache  # noqa: E501
 
 _SCHEMA_INFO = """\
 CREATE TABLE IF NOT EXISTS schema_info (
@@ -587,6 +587,12 @@ class SessionStore:
                 except sqlite3.OperationalError:
                     pass  # column already exists
             logger.info("Migration v12: added token_usage performance columns")
+
+        if from_version < 13:
+            from yeaboi.team_profile import _ANALYSIS_TICKET_CACHE_SCHEMA
+
+            self._conn.execute(_ANALYSIS_TICKET_CACHE_SCHEMA)
+            logger.info("Migration v13: created analysis ticket parse cache")
 
     # ── Token usage persistence ──────────────────────────────────────────
 

--- a/src/yeaboi/team_profile.py
+++ b/src/yeaboi/team_profile.py
@@ -385,6 +385,17 @@ _ADD_EXAMPLES_COL = """\
 ALTER TABLE team_profiles ADD COLUMN examples_json TEXT;
 """
 
+_ANALYSIS_TICKET_CACHE_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS analysis_ticket_cache (
+    source         TEXT NOT NULL,
+    project_key    TEXT NOT NULL,
+    issue_key      TEXT NOT NULL,
+    content_hash   TEXT NOT NULL,
+    parsed_json    TEXT NOT NULL,
+    last_used_at   TEXT NOT NULL,
+    PRIMARY KEY (source, project_key, issue_key)
+);"""
+
 
 # ---------------------------------------------------------------------------
 # Serialisation helpers — same pattern as sessions.py
@@ -665,6 +676,7 @@ class TeamProfileStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.isolation_level = None
         self._conn.execute(_TEAM_PROFILES_SCHEMA)
+        self._conn.execute(_ANALYSIS_TICKET_CACHE_SCHEMA)
         # Migrate: add examples_json column if missing
         try:
             self._conn.execute(_ADD_EXAMPLES_COL)
@@ -709,6 +721,56 @@ class TeamProfileStore:
             (profile.team_id, profile.project_key, profile.source, json_str, ex_str, now, now),
         )
         logger.info("Saved team profile: %s", profile.team_id)
+
+    def load_ticket_parse_cache(
+        self,
+        source: str,
+        project_key: str,
+        content_hashes: dict[str, str],
+    ) -> dict[str, dict]:
+        """Return cached ticket parses whose stored hash matches current content."""
+        if not content_hashes:
+            return {}
+        rows = self._conn.execute(
+            """SELECT issue_key, content_hash, parsed_json
+               FROM analysis_ticket_cache
+               WHERE source = ? AND project_key = ?""",
+            (source, project_key),
+        ).fetchall()
+        out: dict[str, dict] = {}
+        for issue_key, content_hash, parsed_json in rows:
+            if content_hashes.get(issue_key) != content_hash:
+                continue
+            try:
+                parsed = json.loads(parsed_json)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(parsed, dict):
+                out[issue_key] = parsed
+        return out
+
+    def save_ticket_parse_cache(
+        self,
+        source: str,
+        project_key: str,
+        entries: dict[str, tuple[str, dict]],
+    ) -> None:
+        """Upsert valid Deep-analysis ticket parses and prune stale cache rows."""
+        now = datetime.now(UTC).isoformat()
+        for issue_key, (content_hash, parsed) in entries.items():
+            self._conn.execute(
+                """INSERT INTO analysis_ticket_cache
+                       (source, project_key, issue_key, content_hash, parsed_json, last_used_at)
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(source, project_key, issue_key) DO UPDATE SET
+                       content_hash = excluded.content_hash,
+                       parsed_json = excluded.parsed_json,
+                       last_used_at = excluded.last_used_at""",
+                (source, project_key, issue_key, content_hash, json.dumps(parsed, ensure_ascii=False), now),
+            )
+        self._conn.execute(
+            "DELETE FROM analysis_ticket_cache WHERE julianday(last_used_at) < julianday('now', '-90 days')"
+        )
 
     def delete(self, team_id: str) -> bool:
         """Delete a team profile by ID and clean up associated exports/logs.

--- a/src/yeaboi/team_profile_exporter.py
+++ b/src/yeaboi/team_profile_exporter.py
@@ -217,6 +217,11 @@ def build_team_profile_html(
     ex = examples or {}
     sections: list[str] = []
     nav_links: list[str] = []
+    depth = str(ex.get("analysis_depth", "")).strip().lower()
+    if depth in ("quick", "deep"):
+        _depth_html = f"<p><strong>Analysis depth:</strong> {_e(depth.capitalize())}</p>"
+    else:
+        _depth_html = ""
 
     def _nav(id_: str, label: str) -> None:
         nav_links.append(f'<a href="#{id_}">{_e(label)}</a>')
@@ -224,7 +229,7 @@ def build_team_profile_html(
     # ── Executive Summary (AI narrative, generated at analysis time) ─
     narrative = ex.get("narrative", {})
     if isinstance(narrative, dict) and narrative.get("executive_summary"):
-        n_html = f"<p>{_e(str(narrative['executive_summary']))}</p>"
+        n_html = _depth_html + f"<p>{_e(str(narrative['executive_summary']))}</p>"
         n_sections = narrative.get("sections", {})
         if isinstance(n_sections, dict):
             n_items = "".join(
@@ -1596,6 +1601,9 @@ def build_team_profile_markdown(
         "",
         f"*{profile.sample_sprints} sprints · {profile.sample_stories} stories · Generated {gen_ts}*",
     ]
+    depth = str(ex.get("analysis_depth", "")).strip().lower()
+    if depth in ("quick", "deep"):
+        lines.extend(["", f"**Analysis depth:** {depth.capitalize()}"])
     if sprint_names:
         lines.append(f"\nSprints: {', '.join(sprint_names)}")
     lines.append("")

--- a/src/yeaboi/tools/team_learning.py
+++ b/src/yeaboi/tools/team_learning.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
@@ -44,7 +45,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _llm_invoke(prompt: str, *, temperature: float = 0.0):
+def _llm_invoke(prompt: str, *, temperature: float = 0.0, max_reasks: int = 1):
     """Invoke the LLM expecting a JSON reply; tracks token usage internally.
 
     Every caller of this wrapper parses the response as JSON, so it routes
@@ -53,7 +54,7 @@ def _llm_invoke(prompt: str, *, temperature: float = 0.0):
     """
     from yeaboi.agent.llm import invoke_json
 
-    return invoke_json(prompt, temperature=temperature)
+    return invoke_json(prompt, temperature=temperature, max_reasks=max_reasks)
 
 
 def _safe_float(val: object) -> float:
@@ -638,13 +639,9 @@ _TICKET_PARSE_SCHEMA = """\
 [
   {
     "key": "ISSUE-123",
-    "description": "The actual problem/feature description",
     "acceptance_criteria": ["AC item 1", "AC item 2"],
     "ac_specificity": "precise",
-    "risks": ["Risk 1"],
-    "justification": "Why this matters",
     "dod_signals": ["Code reviewed", "Deployed to staging"],
-    "personas": ["developer", "admin"],
     "gwt": false,
     "discipline": "backend",
     "work_type": "create/build",
@@ -662,12 +659,8 @@ Return a JSON array with one object per work item matching this schema:
 {schema}
 
 Section extraction — look for these patterns in the description:
-- "What is this about?" / "Description" / problem statement → description
 - "What does done look like?" / "Acceptance criteria" / "AC" → acceptance_criteria
-- "Are there any risks?" / "Blockers" / "Dependencies" → risks
-- "Why does it matter?" / "Business value" / "Impact" → justification
 - Definition of done items (testing, review, deployment steps) → dod_signals
-- User personas ("As a developer...", "As an admin...") → personas
 
 Classification fields:
 - discipline: infer the primary discipline from the content. Common values include \
@@ -712,7 +705,12 @@ def _strip_html(text: str) -> str:
 def _parse_tickets_with_llm(
     stories: list[dict],
     progress: list[str],
-    batch_size: int = 6,
+    batch_size: int = 12,
+    *,
+    source: str = "",
+    project_key: str = "",
+    db_path=None,
+    cache_updates: dict[str, tuple[str, dict]] | None = None,
 ) -> dict[str, dict]:
     """Parse tickets using LLM in batches. Returns {issue_key: parsed_dict}.
 
@@ -721,18 +719,43 @@ def _parse_tickets_with_llm(
     if not stories:
         return {}
 
-    try:
-        pass
-    except Exception:
-        logger.debug("LLM not available for ticket parsing, using regex fallback")
-        return {}
+    parser_version = "compact-v1"
 
-    # Build batches
-    batches: list[list[dict]] = []
-    for i in range(0, len(stories), batch_size):
-        batches.append(stories[i : i + batch_size])
+    def _content_hash(story: dict) -> str:
+        material = {
+            "parser": parser_version,
+            "summary": story.get("summary", ""),
+            "description": _strip_html(story.get("description", "") or ""),
+            "points": story.get("points", 0),
+            "task_count": story.get("task_count", 0),
+            "carried_over": bool(story.get("carried_over")),
+        }
+        raw = json.dumps(material, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
+    content_hashes = {str(s.get("issue_key", "")): _content_hash(s) for s in stories if str(s.get("issue_key", ""))}
     results: dict[str, dict] = {}
+    if source and project_key and db_path and content_hashes:
+        try:
+            from yeaboi.team_profile import TeamProfileStore
+
+            with TeamProfileStore(db_path) as store:
+                results.update(store.load_ticket_parse_cache(source, project_key, content_hashes))
+        except Exception:
+            logger.debug("Ticket parse cache read failed", exc_info=True)
+
+    uncached = [s for s in stories if str(s.get("issue_key", "")) not in results]
+    if results:
+        logger.info("Ticket parse cache: %d hit(s), %d miss(es)", len(results), len(uncached))
+    if not uncached:
+        if cache_updates is not None:
+            cache_updates.update({key: (content_hashes[key], value) for key, value in results.items()})
+        return results
+
+    # Build batches from cache misses only.
+    batches: list[list[dict]] = []
+    for i in range(0, len(uncached), batch_size):
+        batches.append(uncached[i : i + batch_size])
 
     def _parse_batch(batch: list[dict]) -> dict[str, dict]:
         """Parse a single batch of stories."""
@@ -755,7 +778,10 @@ def _parse_tickets_with_llm(
         prompt = _TICKET_PARSE_PROMPT.format(schema=_TICKET_PARSE_SCHEMA, items=items_block)
 
         try:
-            response = _llm_invoke(prompt, temperature=0.0)
+            # A malformed batch falls back deterministically. Repair re-asks can
+            # double the dominant cost on large boards, so ticket parsing does not
+            # retry; narrative/insight calls retain the shared repair behaviour.
+            response = _llm_invoke(prompt, temperature=0.0, max_reasks=0)
             text = response.content if hasattr(response, "content") else str(response)
             # Extract JSON from response (handle markdown fences)
             text = text.strip()
@@ -777,7 +803,7 @@ def _parse_tickets_with_llm(
     # Run batches in parallel
     progress.append("Parsing ticket structure\u2026")
     try:
-        with ThreadPoolExecutor(max_workers=3) as executor:
+        with ThreadPoolExecutor(max_workers=min(4, len(batches))) as executor:
             futures = {executor.submit(_parse_batch, b): i for i, b in enumerate(batches)}
             for future in as_completed(futures):
                 try:
@@ -789,7 +815,11 @@ def _parse_tickets_with_llm(
         logger.warning("LLM ticket parsing failed entirely: %s", exc)
         return {}
 
-    logger.info("LLM parsed %d/%d stories", len(results), len(stories))
+    if cache_updates is not None:
+        cache_updates.update(
+            {key: (content_hashes[key], value) for key, value in results.items() if key in content_hashes}
+        )
+    logger.info("Deep parser resolved %d/%d stories", len(results), len(stories))
     return results
 
 
@@ -2280,6 +2310,7 @@ def _run_ai_usage_component(
     members: list[str] | None,
     progress: list[str],
     sub_sources: list[str] | None = None,
+    analysis_depth: str = "deep",
 ) -> tuple[object | None, dict | None]:
     """Run the AI-adoption ('code') sub-analysis over ``sub_sources`` (github/azdo;
     None = all). Returns ``(signal, blob)`` or ``(None, None)`` on failure. Best-effort
@@ -2294,8 +2325,12 @@ def _run_ai_usage_component(
         )
         # Only spend an LLM call on coaching when something was actually scanned;
         # an empty footprint (no repos/creds) coaches deterministically.
-        if signal.scanned_commits + signal.scanned_prs > 0:
+        if analysis_depth == "deep" and signal.scanned_commits + signal.scanned_prs > 0:
             ai_examples["insights"] = generate_ai_adoption_insights(signal, ai_examples)
+        else:
+            from yeaboi.analysis.ai_usage import _fallback_ai_adoption_insights
+
+            ai_examples["insights"] = _fallback_ai_adoption_insights(signal, ai_examples.get("samples"))
         return signal, ai_examples
     except Exception:  # pragma: no cover - defensive; run_ai_adoption already guards
         logger.exception("AI-adoption analysis failed; continuing without it")
@@ -2307,6 +2342,7 @@ def _run_doc_quality_component(
     project_key: str,
     progress: list[str],
     sub_sources: list[str] | None = None,
+    analysis_depth: str = "deep",
 ) -> tuple[object | None, dict | None]:
     """Run the documentation-quality ('docs') sub-analysis over ``sub_sources``
     (confluence/notion; None = all). Returns ``(signal, blob)`` or ``(None, None)`` on
@@ -2317,8 +2353,12 @@ def _run_doc_quality_component(
 
         dq_signal, dq_examples = run_doc_quality(source, project_key, sub_sources=sub_sources)
         # Only spend an LLM call on coaching when pages were actually read.
-        if dq_signal.pages_scanned > 0:
+        if analysis_depth == "deep" and dq_signal.pages_scanned > 0:
             dq_examples["insights"] = generate_doc_quality_insights(dq_signal, dq_examples)
+        else:
+            from yeaboi.analysis.doc_quality import _fallback_doc_quality_insights
+
+            dq_examples["insights"] = _fallback_doc_quality_insights(dq_signal, dq_examples.get("samples"))
         return dq_signal, dq_examples
     except Exception:  # pragma: no cover - defensive; run_doc_quality already guards
         logger.exception("Doc-quality analysis failed; continuing without it")
@@ -2334,7 +2374,11 @@ def _run_parallel_analysis(
     include_doc_quality: bool = True,
     members: list[str] | None = None,
     warnings: list[str] | None = None,
-) -> TeamProfile:
+    analysis_depth: str = "deep",
+    include_insights: bool = True,
+    db_path=None,
+    cache_updates: dict[str, tuple[str, dict]] | None = None,
+) -> tuple[TeamProfile, dict]:
     """Run the 4-worker parallel analysis and merge results into a TeamProfile.
 
     ``progress`` is a shared list the TUI can read to display live status messages.
@@ -2399,11 +2443,20 @@ def _run_parallel_analysis(
         len(sprint_data),
     )
 
-    # LLM-powered ticket structure parsing — enriches story dicts with
-    # extracted acceptance criteria, DoD signals, risks, personas.
-    # Runs BEFORE workers so they all get enriched data.
-    # Falls back silently to regex if LLM is unavailable.
-    _parsed_tickets = _parse_tickets_with_llm(delivery_stories, progress)
+    # Deep mode enriches tickets with cached/batched LLM classification. Quick
+    # mode deliberately stays zero-LLM and uses the existing deterministic fields.
+    if analysis_depth == "deep":
+        _parsed_tickets = _parse_tickets_with_llm(
+            delivery_stories,
+            progress,
+            source=source,
+            project_key=project_key,
+            db_path=db_path,
+            cache_updates=cache_updates,
+        )
+    else:
+        progress.append("Using fast ticket parsing…")
+        _parsed_tickets = {}
     _enrich_stories_with_parsed(delivery_stories, _parsed_tickets)
 
     # Re-filter: LLM may have flagged additional stories as recurring
@@ -2625,8 +2678,9 @@ def _run_parallel_analysis(
     }
     examples["spillover_correlation"] = spillover_correlation  # type: ignore[assignment]
 
-    # LLM-generated point value descriptions
-    examples["point_descriptions"] = _generate_point_descriptions(  # type: ignore[assignment]
+    # Inputs for point descriptions are retained until the final enrichment
+    # phase, where Deep mode runs this alongside narrative and coaching.
+    point_description_args = (
         delivery_stories,
         cal.get("calibrations", ()),
         discipline_calibration,
@@ -2830,7 +2884,13 @@ def _run_parallel_analysis(
     # engine's global scans.
     if include_ai_usage:
         signal, ai_examples = _run_ai_usage_component(
-            source, project_key, delivery_stories, all_stories, members, progress
+            source,
+            project_key,
+            delivery_stories,
+            all_stories,
+            members,
+            progress,
+            analysis_depth=analysis_depth,
         )
         if signal is not None:
             from dataclasses import replace
@@ -2839,23 +2899,47 @@ def _run_parallel_analysis(
             examples["ai_adoption"] = ai_examples  # type: ignore[assignment]
 
     if include_doc_quality:
-        dq_signal, dq_examples = _run_doc_quality_component(source, project_key, progress)
+        dq_signal, dq_examples = _run_doc_quality_component(
+            source,
+            project_key,
+            progress,
+            analysis_depth=analysis_depth,
+        )
         if dq_signal is not None:
             from dataclasses import replace
 
             profile = replace(profile, doc_quality=dq_signal)
             examples["doc_quality"] = dq_examples  # type: ignore[assignment]
 
-    # Plain-English narrative — one LLM call explaining what the numbers mean
-    # per section card. Falls back to deterministic text; never raises.
-    progress.append("Writing plain-English summary…")
-    examples["narrative"] = _generate_analysis_narrative(profile, examples)
-
-    # Coaching insights — one LLM call turning the same digest into
-    # start/stop/keep/try advice for the team lead. Falls back to
-    # deterministic insights; never raises.
-    progress.append("Coaching insights…")
-    examples["insights"] = _generate_team_insights(profile, examples)
+    if analysis_depth == "quick":
+        progress.append("Building fast summaries…")
+        examples["point_descriptions"] = _fallback_point_descriptions(point_description_args[1])
+        examples["narrative"] = _fallback_narrative(profile, examples)
+        if include_insights:
+            examples["insights"] = _fallback_team_insights(profile, examples)
+    else:
+        progress.append("Generating AI enrichments in parallel…")
+        enrichment: dict[str, object] = {}
+        with ThreadPoolExecutor(max_workers=3 if include_insights else 2) as executor:
+            futures = {
+                executor.submit(_generate_point_descriptions, *point_description_args): "point_descriptions",
+                executor.submit(_generate_analysis_narrative, profile, examples): "narrative",
+            }
+            if include_insights:
+                futures[executor.submit(_generate_team_insights, profile, examples)] = "insights"
+            for future in as_completed(futures):
+                key = futures[future]
+                try:
+                    enrichment[key] = future.result()
+                except Exception:
+                    logger.exception("Final analysis enrichment %s failed", key)
+        examples["point_descriptions"] = enrichment.get(
+            "point_descriptions",
+            _fallback_point_descriptions(point_description_args[1]),
+        )
+        examples["narrative"] = enrichment.get("narrative", _fallback_narrative(profile, examples))
+        if include_insights:
+            examples["insights"] = enrichment.get("insights", _fallback_team_insights(profile, examples))
 
     return profile, examples
 

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -4084,6 +4084,25 @@ def _run_component_select(live, console: Console, read_key, frame_time: float, s
             return "cancel"
 
 
+def _run_analysis_depth_select(live, console: Console, read_key, frame_time: float, supports_timeout: bool):
+    """Choose Quick/Deep analysis. Quick is preselected; Esc returns ``cancel``."""
+    from yeaboi.ui.mode_select.screens._screens_secondary import _build_analysis_depth_screen
+
+    selected = 0
+    while True:
+        w, h = console.size
+        live.update(_build_analysis_depth_screen(selected, width=w, height=h))
+        key = read_key(timeout=frame_time) if supports_timeout else read_key()
+        if key in ("up", "left", "scroll_up"):
+            selected = (selected - 1) % 2
+        elif key in ("down", "right", "scroll_down"):
+            selected = (selected + 1) % 2
+        elif key == "enter":
+            return ("quick", "deep")[selected]
+        elif key in ("esc", "q"):
+            return "cancel"
+
+
 def _run_member_select(live, console: Console, read_key, frame_time: float, supports_timeout: bool, roster: list):
     """Blocking roster picker.
 
@@ -4123,6 +4142,7 @@ def _prefetch_roster(live, console: Console, sources: list, project_key: str, db
     showing a progress screen while the lookup runs. Returns a sorted name list ([] on
     any failure — the caller can then skip member selection)."""
     import threading
+    from concurrent.futures import ThreadPoolExecutor, as_completed
 
     from yeaboi.analysis import get_team_roster
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_analysis_progress_screen
@@ -4131,11 +4151,26 @@ def _prefetch_roster(live, console: Console, sources: list, project_key: str, db
 
     def _work():
         found: set[str] = set()
-        for s in sources:
-            try:
-                found.update(get_team_roster(s, project_key if len(sources) == 1 else "", db_path=db_path))
-            except Exception as exc:  # best-effort — a failed roster just means "no subset offered"
-                logger.warning("Roster prefetch failed for %s: %s", s, exc)
+        if sources:
+            with ThreadPoolExecutor(
+                max_workers=min(2, len(sources)),
+                thread_name_prefix="analysis-roster",
+            ) as executor:
+                futures = {
+                    executor.submit(
+                        get_team_roster,
+                        source,
+                        project_key if len(sources) == 1 else "",
+                        db_path=db_path,
+                    ): source
+                    for source in sources
+                }
+                for future in as_completed(futures):
+                    source = futures[future]
+                    try:
+                        found.update(future.result())
+                    except Exception as exc:  # best-effort — a failed roster just means "no subset offered"
+                        logger.warning("Roster prefetch failed for %s: %s", source, exc)
         names_box[0] = sorted(found)
 
     done = threading.Event()
@@ -7082,6 +7117,11 @@ def select_mode(
                             _team_popup_result = ""
                             continue
 
+                        _ta_depth = _run_analysis_depth_select(live, console, read_key, _FRAME_TIME, _supports_timeout)
+                        if _ta_depth == "cancel":
+                            _team_popup_result = ""
+                            continue
+
                         # Member subset \u2014 only meaningful for delivery (velocity) or code
                         # (authors). Prefetch the roster over the selected delivery trackers.
                         _ta_dlv = _ta_components.get("delivery") or []
@@ -7112,7 +7152,7 @@ def select_mode(
                                 # One code path with CLI/MCP: the engine fetches,
                                 # analyses, saves the profile, and writes the log.
                                 _res = run_team_analysis(
-                                    include_insights=False,
+                                    analysis_depth=_ta_depth,
                                     components=_ta_components,
                                     members=_ta_members_map,
                                     progress=_ta_progress,
@@ -8351,6 +8391,11 @@ def select_mode(
                     except Exception:
                         pass
 
+                    _ta_depth = _run_analysis_depth_select(live, console, read_key, _FRAME_TIME, _supports_timeout)
+                    if _ta_depth == "cancel":
+                        _team_popup_result = ""
+                        continue
+
                     _ta_progress: list[str] = ["Fetching sprint history\u2026"]
                     _ta_profile_box: list = [None]
                     _ta_examples_box: list = [None]
@@ -8367,7 +8412,7 @@ def select_mode(
                                 source=_ta_source,
                                 project_key=_ta_project_key,
                                 team_name=_ta_team_name,
-                                include_insights=False,
+                                analysis_depth=_ta_depth,
                                 progress=_ta_progress,
                                 db_path=_ana_dbp,
                             )

--- a/src/yeaboi/ui/mode_select/screens/_analysis_sections.py
+++ b/src/yeaboi/ui/mode_select/screens/_analysis_sections.py
@@ -2199,6 +2199,9 @@ def _ta_overview(ctx: _TaCtx, profile, selected_card: int) -> None:
     # active tracker; a code/docs-only view leads straight into its cards.
     if profile is not None:
         ctx.heading("At a Glance")
+        depth = str(ctx.ex.get("analysis_depth", "")).strip().lower()
+        if depth in ("quick", "deep"):
+            ctx.kv("Analysis", f"{depth.capitalize()} mode")
         if stats.get("team_size"):
             ctx.kv("Team size", f"{stats['team_size']} contributors")
         if stats.get("velocity"):

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -514,7 +514,7 @@ def _build_component_select_screen(
     title = analysis_title()
     sub = Text(_PAD + "Choose what to analyse — each part scans its own sources", style="bold white", justify="left")
     crumb = Text(
-        _PAD + "↑/↓ · ←/→ · Space toggle · Enter run · Esc cancel",
+        _PAD + "↑/↓ · ←/→ · Space toggle · Enter continue · Esc cancel",
         style="rgb(120,120,140)",
         justify="left",
     )
@@ -584,6 +584,46 @@ def _build_component_select_screen(
         padded.append(Text(""))
 
     content = Group(Text(""), title, Text(""), sub, crumb, Text(""), Group(*padded))
+    return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+
+
+def _build_analysis_depth_screen(selected: int = 0, *, width: int = 80, height: int = 24) -> Panel:
+    """Choose Quick (zero LLM calls) or Deep (cached AI enrichment)."""
+    from yeaboi.ui.shared._components import analysis_title
+
+    theme = ANALYSIS_THEME
+    options = (
+        (
+            "QUICK",
+            "Recommended · fastest",
+            "Computed metrics, deterministic summaries and coaching. No LLM wait.",
+        ),
+        (
+            "DEEP",
+            "Richer AI enrichment",
+            "Classifies ticket structure and writes AI explanations. Cached, but slower.",
+        ),
+    )
+    lines: list[Text] = []
+    for idx, (name, label, detail) in enumerate(options):
+        focused = idx == selected
+        line = Text(_PAD + "  ", justify="left")
+        line.append("› " if focused else "  ", style=theme.accent_bright)
+        line.append(name, style=f"bold {theme.accent_bright if focused else theme.accent}")
+        line.append(f"  {label}", style="bold white" if focused else theme.muted)
+        lines.append(line)
+        lines.append(Text(_PAD + "    " + detail, style=theme.dim, justify="left"))
+        lines.append(Text(""))
+
+    content = Group(
+        Text(""),
+        analysis_title(),
+        Text(""),
+        Text(_PAD + "Choose analysis depth", style="bold white", justify="left"),
+        Text(_PAD + "↑/↓ or ←/→ · Enter continue · Esc cancel", style=theme.muted, justify="left"),
+        Text(""),
+        Group(*lines),
+    )
     return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
 
 

--- a/tests/unit/test_analysis_engine.py
+++ b/tests/unit/test_analysis_engine.py
@@ -56,6 +56,10 @@ def wired(monkeypatch, db, tmp_path):
         include_doc_quality=True,
         members=None,
         warnings=None,
+        analysis_depth="deep",
+        include_insights=True,
+        db_path=None,
+        cache_updates=None,
     ):
         progress.append("Analysing…")
         captured["parallel"] = (source, project, len(sprint_data))
@@ -63,7 +67,11 @@ def wired(monkeypatch, db, tmp_path):
         captured["inline_ai"] = include_ai_usage
         captured["inline_docs"] = include_doc_quality
         captured["members"][source] = members
-        return _profile(team_id=f"{source}:{project}", source=source, project_key=project), {"sprint_details": []}
+        examples = {"sprint_details": []}
+        if include_insights:
+            examples["insights"] = {"start": [], "stop": [], "keep": [], "try": []}
+        captured["analysis_depth"] = analysis_depth
+        return _profile(team_id=f"{source}:{project}", source=source, project_key=project), examples
 
     monkeypatch.setattr("yeaboi.tools.team_learning._run_parallel_analysis", fake_parallel)
     monkeypatch.setattr(
@@ -154,6 +162,23 @@ class TestDelivery:
         with pytest.raises(ValueError, match="No tracker configured"):
             run_team_analysis(components={"delivery": [], "code": [], "docs": []}, db_path=db)
 
+    def test_quick_is_default_and_metadata_is_persisted(self, wired, db):
+        result = run_team_analysis(components={"delivery": ["jira"]}, db_path=db)
+        sub = result["delivery"]["jira"]
+        assert result["analysis_depth"] == "quick"
+        assert sub["analysis_depth"] == "quick"
+        assert sub["examples"]["analysis_depth"] == "quick"
+        assert set(sub["stage_timings"]) == {"fetch_secs", "analysis_secs", "total_secs"}
+        assert wired["analysis_depth"] == "quick"
+
+    def test_rejects_unknown_analysis_depth(self, db):
+        with pytest.raises(ValueError, match="analysis_depth"):
+            run_team_analysis(analysis_depth="turbo", components={"delivery": []}, db_path=db)
+
+    def test_quick_rejects_llm_generated_samples(self, db):
+        with pytest.raises(ValueError, match="requires analysis_depth='deep'"):
+            run_team_analysis(generate_samples=True, components={"delivery": []}, db_path=db)
+
 
 class TestGlobalCodeDocs:
     def test_code_and_docs_run_once_and_attach(self, wired, db):
@@ -192,6 +217,121 @@ class TestGlobalCodeDocs:
         r = run_team_analysis(components={"docs": ["confluence"]}, db_path=db)
         assert r["delivery"] == {} and r["code"] is None
         assert r["docs"]["signal"].avg_clarity == 70.0
+
+
+class TestTopLevelConcurrency:
+    def test_all_four_component_jobs_overlap_and_persist_after_completion(self, monkeypatch, db):
+        import threading
+
+        barrier = threading.Barrier(4)
+        state = {"active": 0, "peak": 0, "completed": set()}
+        lock = threading.Lock()
+
+        def overlap(label, result):
+            with lock:
+                state["active"] += 1
+                state["peak"] = max(state["peak"], state["active"])
+            try:
+                barrier.wait(timeout=2)
+                return result
+            finally:
+                with lock:
+                    state["active"] -= 1
+                    state["completed"].add(label)
+
+        def delivery(tracker, *args, **kwargs):
+            profile = _profile(
+                team_id=f"{tracker}:PROJ",
+                source=tracker,
+                project_key="PROJ",
+            )
+            return overlap(
+                tracker,
+                {
+                    "profile": profile,
+                    "examples": {},
+                    "warnings": [],
+                },
+            )
+
+        monkeypatch.setattr("yeaboi.analysis.engine._run_delivery", delivery)
+        monkeypatch.setattr(
+            "yeaboi.tools.team_learning._run_ai_usage_component",
+            lambda *a, **k: overlap(
+                "code",
+                (AiAdoptionSignal(scanned_commits=1), {}),
+            ),
+        )
+        monkeypatch.setattr(
+            "yeaboi.tools.team_learning._run_doc_quality_component",
+            lambda *a, **k: overlap(
+                "docs",
+                (DocQualitySignal(pages_scanned=1), {}),
+            ),
+        )
+
+        def persist(delivery_results, code, docs, path):
+            assert state["completed"] == {"jira", "azdevops", "code", "docs"}
+
+        monkeypatch.setattr("yeaboi.analysis.engine._persist_delivery", persist)
+
+        result = run_team_analysis(
+            components={
+                "delivery": ["jira", "azdevops"],
+                "code": ["github"],
+                "docs": ["confluence"],
+            },
+            include_insights=False,
+            db_path=db,
+        )
+
+        assert state["peak"] == 4
+        assert list(result["delivery"]) == ["jira", "azdevops"]
+        assert result["code"] is not None and result["docs"] is not None
+
+    def test_delivery_order_is_configured_order_not_completion_order(self, monkeypatch, db):
+        import threading
+
+        azdo_finished = threading.Event()
+
+        def delivery(tracker, *args, **kwargs):
+            if tracker == "jira":
+                assert azdo_finished.wait(timeout=2)
+            else:
+                azdo_finished.set()
+            return {
+                "profile": _profile(
+                    team_id=f"{tracker}:PROJ",
+                    source=tracker,
+                    project_key="PROJ",
+                ),
+                "examples": {},
+                "warnings": [],
+            }
+
+        monkeypatch.setattr("yeaboi.analysis.engine._run_delivery", delivery)
+        monkeypatch.setattr("yeaboi.analysis.engine._persist_delivery", lambda *a, **k: None)
+
+        result = run_team_analysis(
+            components={"delivery": ["jira", "azdevops"]},
+            include_insights=False,
+            db_path=db,
+        )
+
+        assert list(result["delivery"]) == ["jira", "azdevops"]
+
+    def test_unexpected_component_failure_does_not_cancel_other_jobs(self, wired, monkeypatch, db):
+        monkeypatch.setattr(
+            "yeaboi.tools.team_learning._run_ai_usage_component",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("rate limited")),
+        )
+
+        result = run_team_analysis(components=_ALL, db_path=db)
+
+        assert result["delivery"]["jira"]["profile"] is not None
+        assert result["docs"] is not None
+        assert result["code"] is None
+        assert "Code analysis failed: rate limited" in result["warnings"]
 
 
 def _configure(monkeypatch, *, jira=True, azdevops=True):

--- a/tests/unit/test_analysis_screens.py
+++ b/tests/unit/test_analysis_screens.py
@@ -24,6 +24,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from yeaboi.ui.mode_select.screens._screens_secondary import (
+    _build_analysis_depth_screen,
     _build_analysis_progress_screen,
     _build_analysis_review_screen,
     _build_component_select_screen,
@@ -1201,6 +1202,17 @@ class TestComponentSelectScreen:
         )
 
 
+class TestAnalysisDepthScreen:
+    def test_quick_is_rendered_as_recommended(self):
+        out = _render(_build_analysis_depth_screen(0, width=100, height=30), width=100)
+        assert "QUICK" in out and "Recommended" in out
+        assert "DEEP" in out and "cached" in out.lower()
+
+    def test_deep_can_be_focused(self):
+        out = _render(_build_analysis_depth_screen(1, width=100, height=30), width=100)
+        assert "› DEEP" in out
+
+
 class TestMemberSelectScreen:
     def test_roster_render(self):
         out = _render(_build_member_select_screen(["Alice", "Bob"], {0}, 0, width=100, height=30), width=100)
@@ -1252,6 +1264,11 @@ class TestComponentAndMemberLoops:
 
         return _run_member_select(self._FakeLive(), self._console(), self._reader(keys), 0.01, True, roster)
 
+    def _depth(self, keys):
+        from yeaboi.ui.mode_select import _run_analysis_depth_select
+
+        return _run_analysis_depth_select(self._FakeLive(), self._console(), self._reader(keys), 0.01, True)
+
     def test_all_checked_returns_full_map(self):
         # Everything checked by default → Enter returns the full component→sub-source map.
         assert self._components(["enter"]) == {
@@ -1259,6 +1276,13 @@ class TestComponentAndMemberLoops:
             "code": ["github", "azdo"],
             "docs": ["confluence"],
         }
+
+    def test_depth_defaults_to_quick(self):
+        assert self._depth(["enter"]) == "quick"
+
+    def test_depth_can_select_deep_or_cancel(self):
+        assert self._depth(["right", "enter"]) == "deep"
+        assert self._depth(["esc"]) == "cancel"
 
     def test_deselecting_a_subsource(self):
         # Toggle off delivery[0]=jira → delivery keeps only azdevops.
@@ -1318,6 +1342,32 @@ class TestComponentAndMemberLoops:
         monkeypatch.setattr("yeaboi.analysis.get_team_roster", lambda s, p, db_path=None: rosters[s])
         names = _prefetch_roster(self._FakeLive(), self._console(), ["jira", "azdevops"], "", None)
         assert names == ["Alice", "Bob", "Zoe"]  # sorted union across both trackers
+
+    def test_prefetch_roster_fetches_sources_concurrently(self, monkeypatch):
+        import threading
+
+        from yeaboi.ui.mode_select import _prefetch_roster
+
+        barrier = threading.Barrier(2)
+        state = {"active": 0, "peak": 0}
+        lock = threading.Lock()
+
+        def roster(source, project, db_path=None):
+            with lock:
+                state["active"] += 1
+                state["peak"] = max(state["peak"], state["active"])
+            try:
+                barrier.wait(timeout=2)
+                return [source]
+            finally:
+                with lock:
+                    state["active"] -= 1
+
+        monkeypatch.setattr("yeaboi.analysis.get_team_roster", roster)
+        names = _prefetch_roster(self._FakeLive(), self._console(), ["jira", "azdevops"], "", None)
+
+        assert state["peak"] == 2
+        assert names == ["azdevops", "jira"]
 
     def test_prefetch_roster_swallows_errors(self, monkeypatch):
         from yeaboi.ui.mode_select import _prefetch_roster

--- a/tests/unit/test_analysis_sessions.py
+++ b/tests/unit/test_analysis_sessions.py
@@ -42,8 +42,9 @@ class TestSchemaVersion:
         # Reporting table (reporting_history); v10 added the Roadmap tables
         # (roadmap_config, roadmap_history); v11 added the multi-row roadmaps
         # list; v12 added the token_usage performance columns (duration_ms /
-        # eval_duration_ms / load_duration_ms / tokens_per_sec) for local metrics.
-        assert CURRENT_SCHEMA_VERSION == 12
+        # eval_duration_ms / load_duration_ms / tokens_per_sec) for local metrics;
+        # v13 added the Deep-analysis ticket parse cache.
+        assert CURRENT_SCHEMA_VERSION == 13
 
     def test_new_db_has_session_mode_column(self, store: SessionStore):
         """A freshly created DB should have the session_mode column."""
@@ -52,6 +53,31 @@ class TestSchemaVersion:
         row = store._conn.execute("SELECT session_mode FROM sessions_meta WHERE session_id = ?", (sid,)).fetchone()
         assert row is not None
         assert row[0] == "analysis"
+
+    def test_new_db_has_analysis_ticket_cache(self, store: SessionStore):
+        row = store._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='analysis_ticket_cache'"
+        ).fetchone()
+        assert row == ("analysis_ticket_cache",)
+
+    def test_v12_db_migrates_analysis_ticket_cache(self, tmp_path: Path):
+        import sqlite3
+
+        db_path = tmp_path / "v12.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE schema_info (schema_version INT NOT NULL)")
+        conn.execute("INSERT INTO schema_info (schema_version) VALUES (12)")
+        conn.commit()
+        conn.close()
+
+        with SessionStore(db_path) as migrated:
+            row = migrated._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='analysis_ticket_cache'"
+            ).fetchone()
+            version = migrated._conn.execute("SELECT schema_version FROM schema_info").fetchone()[0]
+
+        assert row == ("analysis_ticket_cache",)
+        assert version == CURRENT_SCHEMA_VERSION
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -147,6 +147,7 @@ class TestParsing:
         assert args.sprints == 4
         assert args.samples is True
         assert args.no_insights is False
+        assert args.depth == "quick"
 
 
 class TestReportCommand:
@@ -453,6 +454,18 @@ class TestAnalyzeCommand:
         assert captured["source"] == "jira"
         assert captured["sprint_count"] == 4
         assert captured["include_insights"] is False
+        assert captured["analysis_depth"] == "quick"
+
+    def test_depth_deep_passthrough(self, monkeypatch):
+        captured: dict = {}
+
+        monkeypatch.setattr(
+            "yeaboi.analysis.run_team_analysis",
+            lambda **kwargs: captured.update(kwargs) or {"delivery": {}, "code": None, "docs": None, "warnings": []},
+        )
+        args = build_parser().parse_args(["analyze", "--depth", "deep", "--delivery", "jira"])
+        assert _cmd_analyze(args, _console()) == 0
+        assert captured["analysis_depth"] == "deep"
 
     def test_delivery_banners_and_comparison(self, monkeypatch):
         import io

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -423,6 +423,18 @@ class TestEngineTools:
         assert payload["warnings"] == ["log skipped"]
         assert captured["sprint_count"] == 4
         assert captured["generate_samples"] is True
+        assert captured["analysis_depth"] == "quick"
+
+    def test_team_analyze_deep_passthrough(self, tmp_db, provider_mode, monkeypatch):
+        captured: dict = {}
+
+        monkeypatch.setattr(
+            "yeaboi.analysis.run_team_analysis",
+            lambda **kwargs: captured.update(kwargs) or {"warnings": []},
+        )
+        payload = call_tool("team_analyze", {"analysis_depth": "deep"})
+        assert payload["ok"] is True
+        assert captured["analysis_depth"] == "deep"
 
     def test_anonymize_text(self, tmp_db, provider_mode, monkeypatch):
         captured: dict = {}

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -273,6 +273,7 @@ CLI_RENAMES: dict[str, dict[str, str]] = {
     "analyze": {
         "project": "project_key",
         "sprints": "sprint_count",
+        "depth": "analysis_depth",
         "samples": "generate_samples",
         "no_insights": "include_insights",  # inverted store_true flag
     },

--- a/tests/unit/test_team_profile.py
+++ b/tests/unit/test_team_profile.py
@@ -1633,7 +1633,7 @@ class TestNarrativeInParallelAnalysis:
         assert isinstance(narrative, dict)
         assert narrative["executive_summary"]
         assert len(narrative["sections"]) == 7
-        assert "Writing plain-English summary…" in progress
+        assert "Generating AI enrichments in parallel…" in progress
 
 
 class TestInsightsPersistenceAndExport:
@@ -1761,4 +1761,192 @@ class TestInsightsInParallelAnalysis:
         insights = examples.get("insights")
         assert isinstance(insights, dict)
         assert all(insights[k] for k in ("start", "stop", "keep", "try"))
-        assert "Coaching insights…" in progress
+        assert "Generating AI enrichments in parallel…" in progress
+
+
+class TestAnalysisDepth:
+    @staticmethod
+    def _sprint_data(summary: str = "Story A"):
+        return [
+            {
+                "sprint_name": "Sprint 1",
+                "completed_points": 3.0,
+                "planned_count": 1,
+                "completed_count": 1,
+                "stories": [
+                    {
+                        "points": 3,
+                        "cycle_time_days": 2.0,
+                        "discipline": "backend",
+                        "task_count": 2,
+                        "ac_count": 2,
+                        "epic_key": "EP-1",
+                        "point_changed": False,
+                        "issue_key": "P-1",
+                        "description": "Acceptance Criteria: returns HTTP 200",
+                        "summary": summary,
+                    }
+                ],
+            }
+        ]
+
+    def test_quick_mode_makes_no_llm_calls(self, monkeypatch):
+        from yeaboi.tools.team_learning import _run_parallel_analysis
+
+        monkeypatch.setattr(
+            "yeaboi.tools.team_learning._llm_invoke",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("Quick must not invoke an LLM")),
+        )
+        progress: list[str] = []
+        _profile, examples = _run_parallel_analysis(
+            "jira",
+            "PROJ",
+            self._sprint_data(),
+            progress,
+            include_ai_usage=False,
+            include_doc_quality=False,
+            analysis_depth="quick",
+        )
+
+        assert "Building fast summaries…" in progress
+        assert examples["narrative"]["executive_summary"]
+        assert examples["point_descriptions"]
+        assert all(examples["insights"][key] for key in ("start", "stop", "keep", "try"))
+
+    def test_quick_mode_can_omit_insights(self):
+        from yeaboi.tools.team_learning import _run_parallel_analysis
+
+        _profile, examples = _run_parallel_analysis(
+            "jira",
+            "PROJ",
+            self._sprint_data(),
+            include_ai_usage=False,
+            include_doc_quality=False,
+            analysis_depth="quick",
+            include_insights=False,
+        )
+        assert "insights" not in examples
+
+    def test_deep_final_enrichments_overlap(self, monkeypatch):
+        import threading
+
+        from yeaboi.tools.team_learning import _run_parallel_analysis
+
+        barrier = threading.Barrier(3)
+        active = {"value": 0, "peak": 0}
+        lock = threading.Lock()
+
+        def overlap(result):
+            with lock:
+                active["value"] += 1
+                active["peak"] = max(active["peak"], active["value"])
+            try:
+                barrier.wait(timeout=2)
+                return result
+            finally:
+                with lock:
+                    active["value"] -= 1
+
+        monkeypatch.setattr("yeaboi.tools.team_learning._parse_tickets_with_llm", lambda *a, **k: {})
+        monkeypatch.setattr(
+            "yeaboi.tools.team_learning._generate_point_descriptions",
+            lambda *a, **k: overlap({"3": "Three points"}),
+        )
+        monkeypatch.setattr(
+            "yeaboi.tools.team_learning._generate_analysis_narrative",
+            lambda *a, **k: overlap({"executive_summary": "Summary", "sections": {}}),
+        )
+        monkeypatch.setattr(
+            "yeaboi.tools.team_learning._generate_team_insights",
+            lambda *a, **k: overlap({"start": [], "stop": [], "keep": [], "try": []}),
+        )
+
+        _run_parallel_analysis(
+            "jira",
+            "PROJ",
+            self._sprint_data(),
+            include_ai_usage=False,
+            include_doc_quality=False,
+            analysis_depth="deep",
+        )
+        assert active["peak"] == 3
+
+
+class TestTicketParseCache:
+    @staticmethod
+    def _story(description: str = "Acceptance Criteria: returns HTTP 200"):
+        return {
+            "issue_key": "P-1",
+            "summary": "Build endpoint",
+            "description": description,
+            "points": 3,
+            "task_count": 2,
+            "carried_over": False,
+        }
+
+    def test_cache_hit_skips_llm_and_content_change_invalidates(self, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+
+        from yeaboi.tools.team_learning import _parse_tickets_with_llm
+
+        calls = {"count": 0}
+
+        def invoke(*args, **kwargs):
+            calls["count"] += 1
+            return SimpleNamespace(content='[{"key":"P-1","discipline":"backend"}]')
+
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", invoke)
+        db = tmp_path / "sessions.db"
+        updates: dict = {}
+        first = _parse_tickets_with_llm(
+            [self._story()],
+            [],
+            source="jira",
+            project_key="PROJ",
+            db_path=db,
+            cache_updates=updates,
+        )
+        with TeamProfileStore(db) as store:
+            store.save_ticket_parse_cache("jira", "PROJ", updates)
+
+        second_updates: dict = {}
+        second = _parse_tickets_with_llm(
+            [self._story()],
+            [],
+            source="jira",
+            project_key="PROJ",
+            db_path=db,
+            cache_updates=second_updates,
+        )
+        changed = _parse_tickets_with_llm(
+            [self._story("Acceptance Criteria: returns HTTP 201")],
+            [],
+            source="jira",
+            project_key="PROJ",
+            db_path=db,
+            cache_updates={},
+        )
+
+        assert first == second
+        assert changed["P-1"]["discipline"] == "backend"
+        assert calls["count"] == 2
+
+    def test_deep_parser_uses_compact_twelve_ticket_batches(self, monkeypatch):
+        import re
+        from types import SimpleNamespace
+
+        from yeaboi.tools.team_learning import _parse_tickets_with_llm
+
+        calls = {"count": 0}
+
+        def invoke(prompt, **kwargs):
+            calls["count"] += 1
+            keys = re.findall(r"--- ([A-Z]+-\d+):", prompt)
+            return SimpleNamespace(content=json.dumps([{"key": key} for key in keys]))
+
+        monkeypatch.setattr("yeaboi.tools.team_learning._llm_invoke", invoke)
+        stories = [{**self._story(), "issue_key": f"P-{idx}", "summary": f"Story {idx}"} for idx in range(25)]
+        result = _parse_tickets_with_llm(stories, [])
+
+        assert len(result) == 25
+        assert calls["count"] == 3


### PR DESCRIPTION
## Summary
- add a default Quick analysis mode with deterministic summaries and no LLM calls
- add a cached Deep mode with larger ticket batches and parallel AI enrichments
- run delivery, code, and documentation components concurrently
- show the Quick/Deep choice before analysis in both TUI flows
- expose analysis depth through CLI and MCP, with mode metadata and stage timings

## Validation
- 583 focused analysis, CLI, MCP, persistence, and UI tests passed after rebasing
- Ruff and diff checks passed
- full pre-commit suite: 4,496 passed, 16 skipped; one unrelated ANSI-color assertion failed in the non-interactive terminal environment