### PR TITLE
make the claude review resilient to fast merges and large diffs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -50,10 +50,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Open OR already-merged: fast merges land seconds after CI goes green,
+          # which used to race this resolve step ("no open PR") and silently drop
+          # the review. A post-merge advisory comment is still the product here.
+          # Closed-without-merge PRs stay excluded — nothing to advise on.
           pr=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
-            --jq '[.[] | select(.state == "open")][0]')
+            --jq '[.[] | select(.state == "open" or .merged_at != null)][0]')
           if [ -z "$pr" ] || [ "$pr" = "null" ]; then
-            echo "No open PR for this run — skipping review."
+            echo "No open or merged PR for this run — skipping review."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -109,6 +113,16 @@ jobs:
             If there are no significant findings, post one line saying the review passed.
             Do not comment on style that ruff already enforces. Do not request changes on
             nitpicks. This review is advisory — never attempt to approve, merge, or block.
+
+            Budget your turns: posting the comment is the one non-negotiable step.
+            On a large diff, skim breadth-first and go deep only on the riskiest
+            files rather than reading everything — an 80% review that posts beats
+            a 100% review that runs out of turns. If you notice you are close to
+            the turn limit, stop investigating and post what you have.
           # Review stays on the default (Opus-tier) model — judgment quality is
           # the point, and volume is already gated to green PRs by workflow_run.
-          claude_args: '--max-turns 25 --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment ${{ steps.pr.outputs.number }}:*),Bash(gh run view:*),Read,Grep,Glob"'
+          # --max-turns was 25; large PRs (skills to read + a big diff) burned all
+          # 25 on investigation and died before posting ("Reached maximum number
+          # of turns"), dropping the review entirely on exactly the PRs that most
+          # needed one.
+          claude_args: '--max-turns 60 --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment ${{ steps.pr.outputs.number }}:*),Bash(gh run view:*),Read,Grep,Glob"'


### PR DESCRIPTION
## Summary

The post-CI Claude review comment (`claude-review.yml`) has been silently missing on several recent PRs (#96, #98, #101). Two distinct failure modes, both confirmed from the workflow run logs:

1. **Merged before the review could resolve the PR.** The review triggers on CI success, but fast merges land seconds later — PR #96 was merged 3 seconds after CI went green, so the resolve step found no *open* PR and skipped. The resolve step now also accepts already-merged PRs (a post-merge advisory comment is still the product; closed-without-merge PRs stay excluded).
2. **`--max-turns 25` exhaustion on large PRs.** Four recent runs died with `Reached maximum number of turns (25)` — the reviewer burned every turn reading skills and a big diff and never got to post (that's what dropped #98 and #101). The limit is now 60, and the prompt instructs the reviewer to budget turns: skim breadth-first on large diffs and always post, even a partial review.

Workflow-only change — no `src/` files touched, so the auto-version guard correctly skips a release bump.

## Test plan

- `yaml.safe_load` parses the workflow cleanly
- jq filter change verified against the `commits/{sha}/pulls` API shape (`merged_at` present on PR objects)
- Diagnosis verified from run logs: runs 30153800942 / 30092552521 / 30145335745 / 30098338086 all failed with the max-turns error; run 30090731789 logged 'No open PR for this run' 3 s after #96 merged
- Observable check after merge: the next few merged PRs should each carry exactly one Claude review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)