### PR TITLE
paint every tui screen with its mode's background tint

### DIFF
--- a/.claude/skills/tui-standards/SKILL.md
+++ b/.claude/skills/tui-standards/SKILL.md
@@ -11,7 +11,8 @@ All TUI screens MUST use the shared component system in `src/yeaboi/ui/shared/_c
 
 | Component | Function | Purpose |
 |-----------|----------|---------|
-| `Theme` | `ANALYSIS_THEME`, `PLANNING_THEME`, `USAGE_THEME`, `SETTINGS_THEME` | Colour palette per mode |
+| `Theme` | `ANALYSIS_THEME`, `PLANNING_THEME`, `USAGE_THEME`, `SETTINGS_THEME` | Colour palette per mode (incl. `bg` page tint) |
+| Page panel | `build_page_panel(content, theme=, height=)` | The full-screen root Panel every page returns |
 | Buttons | `build_action_buttons(actions, selected)` | Consistent button row (Accept/Edit/Export/Back etc.) |
 | Scrollbar | `build_scrollbar(viewport_h, total, offset, max_scroll)` | Right-side scroll indicator |
 | Progress | `build_progress_dots(stages, current, theme=)` | Stage indicator (● ● ○ ○ ○) |
@@ -23,7 +24,7 @@ All TUI screens MUST use the shared component system in `src/yeaboi/ui/shared/_c
 ## Page Structure (every `_build_*_screen` function MUST follow)
 
 ```
-Panel(height=height, padding=(1,2))
+build_page_panel(content, theme=<MODE_THEME>, height=height)   # NEVER a raw full-screen Panel(...)
   ├── Text("")                    # blank
   ├── title                       # ASCII art from *_title()
   ├── Text("")                    # blank
@@ -40,9 +41,10 @@ Panel(height=height, padding=(1,2))
 
 1. **DRY** — Never inline button rendering, scrollbar math, or viewport calculations. Always use shared functions.
 2. **Themes** — Never hardcode colour values (`"rgb(100,180,100)"`). Use `theme.accent`, `theme.muted`, etc. from the appropriate Theme constant.
-3. **New pages** — Adding a new mode/page requires: a Theme constant, a `*_title()` function, a colour entry in `COLOR_RGB`, an entry in `_MODE_CARDS` (if it's a main menu item), and a `FeatureTip` in `ui/shared/_tips.py` keyed by the capability (with `mode_key` = the card key so the welcome-screen `g` key jumps in; `is_new=True` for a release or two). `TestTips` enforces this.
+3. **New pages** — Adding a new mode/page requires: a Theme constant (including a dark `bg` tint of the accent hue), a `*_title()` function, a colour entry in `COLOR_RGB`, an entry in `_MODE_CARDS` (if it's a main menu item), and a `FeatureTip` in `ui/shared/_tips.py` keyed by the capability (with `mode_key` = the card key so the welcome-screen `g` key jumps in; `is_new=True` for a release or two). `TestTips` enforces this.
 4. **Consistency** — All pages use the same Panel structure (title → subtitle → viewport → buttons). No exceptions.
-5. **Scrollbar** — Content that can overflow MUST use `build_scrollbar()`. Use `always_show=True` for pages where the track should always be visible.
-6. **Buttons** — Register new button labels in `_BTN_COLORS` dict in `_components.py` with accent/grey colour tuples.
-7. **No `_PAD` aliases** — Import `PAD` directly from `yeaboi.ui.shared._components`. Legacy `_PAD = PAD` aliases exist but should not be added to new files.
-8. **Never log in per-frame code** — `_build_*_screen` builders and render paths run every frame (~60 fps); `logger.info` belongs in key-handling branches of runner loops and one-shot functions only (see the `logging` skill).
+5. **Page background** — Every page paints its own background so all users see the same TUI regardless of terminal theme. `build_page_panel` applies `theme.bg` (a dark tint of the mode accent; `NEUTRAL_BG` for home/setup/settings pages) as the Panel style, and Rich cascades it onto every child segment — content rows, spacers, scroll filler, padding. Never return a raw full-screen `Panel` from a builder; `tests/unit/test_screen_backgrounds.py` fails the build if one appears. `MusicLive._stamp` back-fills `NEUTRAL_BG` on any unstyled Panel as a safety net, and non-Panel surfaces (screensaver, splash) set their own `on NEUTRAL_BG` style. Keep tints dark (channel values ≤ 40) — foreground styles assume dark backgrounds.
+6. **Scrollbar** — Content that can overflow MUST use `build_scrollbar()`. Use `always_show=True` for pages where the track should always be visible.
+7. **Buttons** — Register new button labels in `_BTN_COLORS` dict in `_components.py` with accent/grey colour tuples.
+8. **No `_PAD` aliases** — Import `PAD` directly from `yeaboi.ui.shared._components`. Legacy `_PAD = PAD` aliases exist but should not be added to new files.
+9. **Never log in per-frame code** — `_build_*_screen` builders and render paths run every frame (~60 fps); `logger.info` belongs in key-handling branches of runner loops and one-shot functions only (see the `logging` skill).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.37.0"
+version = "2.38.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,17 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.38.0",
+      "date": "2026-07-27",
+      "summary": "Every TUI screen now displays with its mode's signature background color — a dark tint of the accent (analysis green, planning blue, standup magenta, retro teal, poker gold, performance rust, reporting violet, usage amber) instead of your terminal's default, ensuring the app looks identical and polished across any terminal theme. Home, splash, provider select, settings, changelog, and feedback use a neutral dark base. The change includes a shared root-panel helper, full-screen AST guards to prevent regressions, and new truecolor rendering tests.",
+      "highlights": [
+        {"text": "Every mode-specific TUI screen now displays with its mode's background tint for a polished, consistent look", "areas": ["general"]},
+        {"text": "Neutral dark base for home, splash, settings, and other cross-mode screens", "areas": ["general"]},
+        {"text": "Appearance is now identical across all terminal themes thanks to baked-in backgrounds", "areas": ["general"]},
+        {"text": "New AST guard + truecolor tests prevent raw full-screen Panels from merging in the future", "areas": ["general"]}
+      ]
+    },
+    {
       "version": "2.37.0",
       "date": "2026-07-27",
       "summary": "Team analysis evolved into a comprehensive, member-scoped investigation of how your team works. The AI Usage card now leads with an engineering-practices table scoring tests-with-changes, documentation clarity, ticket references, and PR description quality across all attributed work — honest denominators, small-sample transparency, and a recomputed team row. The same table appears in markdown and HTML exports. Performance overhaul adds pooled tracker fetching, a schema v19 model-keyed analysis cache, cold-run lookup caps with disclosed truncation, activity-targeted repo scanning, and fan-out dedup. Scope controls let you pick sources per component (delivery reads Jira/Azure DevOps, code scans GitHub/Azure Repos, docs reads Confluence/Notion), pick specific members, run dual-source analyses, and persist analysis features per run. Doc quality now reads page content for clarity and AI usage estimates with evidence links. Default analysis depth is now `deep` on all surfaces. UX gains include wizard Esc back-stepping, Ctrl-C cooperative cancel, AzDO SDK clients pinned to the configured org URL, and render-side caps preventing oversized tables from rendering blank.",

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -1374,13 +1374,13 @@ def _confirm_move_data(console: Console, live, read_key, frame_time, supports_ti
     """Move/Leave popup shown after the data directory changes; True = move."""
     from rich.align import Align
     from rich.console import Group
-    from rich.panel import Panel
     from rich.text import Text
 
     from yeaboi.ui.shared._components import (
         PAD,
         SETTINGS_THEME,
         build_action_buttons,
+        build_page_panel,
         build_popup,
         settings_title,
     )
@@ -1405,7 +1405,7 @@ def _confirm_move_data(console: Console, live, read_key, frame_time, supports_ti
         lines.append(Text(""))
         btn_top, btn_mid, btn_bot = build_action_buttons(["Move", "Leave"], sel)
         lines += [btn_top, btn_mid, btn_bot]
-        live.update(Panel(Group(*lines), height=h, padding=(1, 2), border_style=SETTINGS_THEME.sep))
+        live.update(build_page_panel(Group(*lines), theme=SETTINGS_THEME, border_style=SETTINGS_THEME.sep, height=h))
         try:
             k = read_key(timeout=frame_time) if supports_timeout else read_key()
         except TypeError:
@@ -1430,10 +1430,9 @@ def _confirm_stop_ollama(console: Console, live, read_key, frame_time, supports_
     """
     from rich.align import Align
     from rich.console import Group
-    from rich.panel import Panel
     from rich.text import Text
 
-    from yeaboi.ui.shared._components import SETTINGS_THEME, build_action_buttons, build_popup
+    from yeaboi.ui.shared._components import SETTINGS_THEME, build_action_buttons, build_page_panel, build_popup
 
     sel = 0
     while True:
@@ -1451,7 +1450,7 @@ def _confirm_stop_ollama(console: Console, live, read_key, frame_time, supports_
         lines.append(Text(""))
         btn_top, btn_mid, btn_bot = build_action_buttons(["Stop", "Leave"], sel)
         lines += [btn_top, btn_mid, btn_bot]
-        live.update(Panel(Group(*lines), height=h, padding=(1, 2), border_style=SETTINGS_THEME.sep))
+        live.update(build_page_panel(Group(*lines), theme=SETTINGS_THEME, border_style=SETTINGS_THEME.sep, height=h))
         try:
             k = read_key(timeout=frame_time) if supports_timeout else read_key()
         except TypeError:
@@ -3064,7 +3063,7 @@ def _run_feedback_page(console: Console, live, read_key, frame_time: float, supp
     from yeaboi.feedback import FEEDBACK_AREAS, FEEDBACK_TYPES, polish_feedback, submit_feedback
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_feedback_screen
     from yeaboi.ui.shared._attachments import referenced_images
-    from yeaboi.ui.shared._components import FEEDBACK_THEME, build_popup, feedback_title
+    from yeaboi.ui.shared._components import FEEDBACK_THEME, build_page_panel, build_popup, feedback_title
 
     with mode_log("feedback"):
         logger.info("feedback: page opened")
@@ -3130,7 +3129,6 @@ def _run_feedback_page(console: Console, live, read_key, frame_time: float, supp
             """Popup guard so Esc can't silently destroy a long draft."""
             from rich.align import Align
             from rich.console import Group
-            from rich.panel import Panel
             from rich.text import Text
 
             while True:
@@ -3145,7 +3143,7 @@ def _run_feedback_page(console: Console, live, read_key, frame_time: float, supp
                         )
                     )
                 )
-                live.update(Panel(Group(*lines), height=max(10, h - 1), padding=(1, 2)))
+                live.update(build_page_panel(Group(*lines), theme=FEEDBACK_THEME, height=max(10, h - 1)))
                 k = read_key(timeout=frame_time) if supports_timeout else read_key()
                 if not k:
                     continue
@@ -3403,6 +3401,7 @@ def _run_mode_hub(
                 runs,
                 selected,
                 title_fn=title_fn,
+                theme=share_theme,
                 subtitle=subtitle,
                 message=message,
                 width=w,
@@ -5186,6 +5185,8 @@ def _run_analysis_roster_lookup(
     from rich.panel import Panel
     from rich.text import Text
 
+    from yeaboi.ui.shared._components import ANALYSIS_THEME, build_page_panel
+
     while True:
         result = _prefetch_roster_result(live, console, sources, project_key, db_path)
         if result.status != "failed":
@@ -5194,8 +5195,20 @@ def _run_analysis_roster_lookup(
         body.append("Team members could not be loaded.\n\n", style="bold")
         body.append("\n".join(result.warnings) or "The selected tracker did not return a roster.")
         body.append("\n\nEnter / R  Retry     Esc  Back", style="dim")
-        w, _ = console.size
-        live.update(Align.center(Panel(body, title="Analysis · Team members", width=min(76, max(40, w - 4)))))
+        w, h = console.size
+        # Wrap the dialog in a full-screen page panel: with an Align root,
+        # MusicLive's unstyled-Panel safety net never fires, so the terminal's
+        # own background would bleed through around the popup.
+        live.update(
+            build_page_panel(
+                Align.center(
+                    Panel(body, title="Analysis · Team members", width=min(76, max(40, w - 4))),
+                    vertical="middle",
+                ),
+                theme=ANALYSIS_THEME,
+                height=max(10, h - 1),
+            )
+        )
         key = read_key()
         if key in ("enter", "r", "R"):
             continue

--- a/src/yeaboi/ui/mode_select/screens/_project_list_screen.py
+++ b/src/yeaboi/ui/mode_select/screens/_project_list_screen.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-import rich.box
 from rich.console import Group
 from rich.padding import Padding
 from rich.panel import Panel
@@ -32,7 +31,14 @@ from yeaboi.ui.mode_select.screens._project_cards import (
     _compute_viewport,
 )
 from yeaboi.ui.shared._animations import BLACK_RGB, lerp_color
-from yeaboi.ui.shared._components import PAD, analysis_title, planning_title
+from yeaboi.ui.shared._components import (
+    ANALYSIS_THEME,
+    PAD,
+    PLANNING_THEME,
+    analysis_title,
+    build_page_panel,
+    planning_title,
+)
 
 _PAD = PAD  # alias for backward compatibility within this module
 
@@ -760,11 +766,8 @@ def _build_project_list_screen(
         *popup_after,
     )
 
-    return Panel(
+    return build_page_panel(
         content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
+        theme=ANALYSIS_THEME if mode == "analysis" else PLANNING_THEME,
         height=height,
-        padding=(1, 2),
     )

--- a/src/yeaboi/ui/mode_select/screens/_run_hub_screen.py
+++ b/src/yeaboi/ui/mode_select/screens/_run_hub_screen.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import rich.box
 from rich.console import Group
 from rich.padding import Padding
 from rich.panel import Panel
@@ -42,7 +41,7 @@ from yeaboi.ui.mode_select.screens._project_cards import (
 )
 from yeaboi.ui.mode_select.screens._project_list_screen import _build_project_row
 from yeaboi.ui.shared._animations import BLACK_RGB, lerp_color
-from yeaboi.ui.shared._components import PAD
+from yeaboi.ui.shared._components import PAD, Theme, build_page_panel
 
 _PAD = PAD
 
@@ -78,6 +77,7 @@ def _build_run_hub_screen(
     empty_title: str = "No saved runs yet",
     empty_subtitle: str = "Press Enter to start your first run",
     shimmer_tick: float | None = None,
+    theme: Theme | None = None,
 ) -> Panel:
     """Build the saved-runs hub: a scrollable list of past runs + a "+ New run" card.
 
@@ -86,6 +86,7 @@ def _build_run_hub_screen(
     where Enter opens the saved snapshot. Mirrors the planning list's key/animation model.
 
     title_fn: the mode's title function (e.g. ``standup_title``), called with shimmer_tick.
+    theme: the mode's Theme — its ``bg`` tints the whole page (None → neutral dark base).
     """
     title = title_fn(shimmer_tick)
 
@@ -283,11 +284,4 @@ def _build_run_hub_screen(
         *popup_after,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(0, 2),
-    )
+    return build_page_panel(content, theme=theme, height=height, padding=(0, 2))

--- a/src/yeaboi/ui/mode_select/screens/_screens.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens.py
@@ -9,14 +9,13 @@ from __future__ import annotations
 
 from typing import Any
 
-import rich.box
 from rich.console import Group
 from rich.panel import Panel
 from rich.text import Text
 
 from yeaboi.ui.shared._animations import COLOR_RGB, shimmer_style
 from yeaboi.ui.shared._ascii_font import render_ascii_text
-from yeaboi.ui.shared._components import PAD
+from yeaboi.ui.shared._components import PAD, build_page_panel
 
 # ---------------------------------------------------------------------------
 # Mode definitions
@@ -419,14 +418,7 @@ def _build_mode_screen(
         version_row,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, height=height)
 
 
 # ---------------------------------------------------------------------------
@@ -465,11 +457,4 @@ def _build_slide_frame(
         *[Text("") for _ in range(below)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, height=height)

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -30,6 +30,7 @@ from yeaboi.ui.shared._components import (
     PAD,
     PLANNING_THEME,
     build_action_buttons,
+    build_page_panel,
     build_progress_dots,
     build_scrollbar,
     calc_viewport,
@@ -146,14 +147,7 @@ def _build_analysis_review_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=ANALYSIS_THEME, height=height)
 
 
 _PAD = PAD  # alias for backward compatibility within this module
@@ -485,19 +479,9 @@ def _build_team_analysis_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        # Rich cascades a Panel's style onto every child segment without an
-        # explicit bgcolor, so one background here tints content rows, heading
-        # spacers, scroll filler lines and card interiors alike — no dark seams
-        # between cards regardless of the terminal's own background.
-        style=_ANALYSIS_CARD_BG,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    # The results page keeps the proven card colour (slightly lighter than the
+    # analysis page tint) so its dense card layout reads as one elevated surface.
+    return build_page_panel(content, theme=ANALYSIS_THEME, bg=_ANALYSIS_CARD_BG_RGB, height=height)
 
 
 # Component picker — order + friendly labels. Each component runs over its OWN
@@ -532,9 +516,12 @@ _ANALYSIS_FEATURE_LABELS: dict[str, tuple[str, str]] = {
     "documentation": ("Documentation", "clarity, usefulness, structure, and ownership"),
 }
 
-# The only background style in the app: used on the analysis setup/review cards
-# and on the whole analysis results viewport (see _build_team_analysis_screen).
-_ANALYSIS_CARD_BG = "on rgb(13,31,27)"
+# Elevated-surface background for the analysis setup/review cards and the whole
+# analysis results viewport (see _build_team_analysis_screen) — a touch lighter
+# than ANALYSIS_THEME.bg so cards read as raised above the page tint. Page-wide
+# backgrounds now come from Theme.bg via build_page_panel.
+_ANALYSIS_CARD_BG_RGB = "rgb(13,31,27)"
+_ANALYSIS_CARD_BG = f"on {_ANALYSIS_CARD_BG_RGB}"
 
 
 def _analysis_toggle_row(
@@ -681,7 +668,7 @@ def _build_analysis_feature_screen(
         _analysis_toggle_viewport(rows, cursor, height=height),
         Text(_PAD + f"{footer}  ·  Enter ⏎", style=theme.accent_bright),
     )
-    return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+    return build_page_panel(content, theme=ANALYSIS_THEME, height=height)
 
 
 def _build_component_select_screen(
@@ -758,7 +745,7 @@ def _build_component_select_screen(
         counts = "  ·  ".join(f"{name} {count}" for name, count in per_component)
         sections.insert(0, Text(_PAD + counts, style=theme.muted))
     content = Group(Text(""), title, Text(""), *header, Group(*sections), footer)
-    return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+    return build_page_panel(content, theme=ANALYSIS_THEME, height=height)
 
 
 def _build_analysis_depth_screen(selected: int = 0, *, width: int = 80, height: int = 24) -> Panel:
@@ -795,7 +782,7 @@ def _build_analysis_depth_screen(selected: int = 0, *, width: int = 80, height: 
         *_analysis_setup_header("Depth", "←/→ or ↑/↓ choose · Enter continue · Esc cancel"),
         Group(*rows),
     )
-    return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+    return build_page_panel(content, theme=ANALYSIS_THEME, height=height)
 
 
 def _build_analysis_model_offer_screen(
@@ -841,7 +828,7 @@ def _build_analysis_model_offer_screen(
         Text(""),
         Group(*rows),
     )
-    return Panel(content, border_style=theme.accent, box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+    return build_page_panel(content, theme=ANALYSIS_THEME, border_style=theme.accent, height=height)
 
 
 def _build_analysis_window_screen(selected: int = 2, *, width: int = 80, height: int = 24) -> Panel:
@@ -866,7 +853,7 @@ def _build_analysis_window_screen(selected: int = 2, *, width: int = 80, height:
         *_analysis_setup_header("Time window", "←/→ and ↑/↓ choose · Enter continue · Esc cancel"),
         Group(*rows),
     )
-    return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+    return build_page_panel(content, theme=ANALYSIS_THEME, height=height)
 
 
 def _build_member_select_screen(
@@ -917,7 +904,7 @@ def _build_member_select_screen(
         Text(""),
         viewport_renderable,
     )
-    return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+    return build_page_panel(content, theme=ANALYSIS_THEME, height=height)
 
 
 def _build_code_project_select_screen(
@@ -946,7 +933,7 @@ def _build_code_project_select_screen(
         "Arrows move · Space selects · A selects all · Enter continues",
         message=message,
     )
-    return Panel(
+    return build_page_panel(
         Group(
             Text(""),
             _analysis_setup_title(width, height),
@@ -956,11 +943,8 @@ def _build_code_project_select_screen(
             Text(""),
             _analysis_toggle_viewport(rows, cursor, height=height, header_h=12),
         ),
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
+        theme=ANALYSIS_THEME,
         height=height,
-        padding=(1, 2),
     )
 
 
@@ -1063,14 +1047,7 @@ def _build_analysis_setup_review_screen(
             btn_mid,
             btn_bot,
         )
-    return Panel(
-        content,
-        border_style=theme.accent,
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=ANALYSIS_THEME, border_style=theme.accent, height=height)
 
 
 def _build_instructions_review_screen(
@@ -1836,14 +1813,7 @@ def _build_intake_screen(
         *[Text("") for _ in range(remaining)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 def _build_offline_screen(
@@ -1901,14 +1871,7 @@ def _build_offline_screen(
         *[Text("") for _ in range(remaining)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 def _build_export_success_screen(
@@ -1955,14 +1918,7 @@ def _build_export_success_screen(
         *[Text("") for _ in range(remaining)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 def _build_import_screen(
@@ -2051,14 +2007,7 @@ def _build_import_screen(
         *[Text("") for _ in range(remaining)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 def _build_activity_progress_rows(
@@ -2209,14 +2158,7 @@ def _build_analysis_progress_screen(
 
     content = Group(Text(""), title, Text(""), *body)
 
-    return Panel(
-        content,
-        border_style=theme.accent,
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=theme, border_style=theme.accent, height=height)
 
 
 def _build_project_export_success_screen(
@@ -2270,14 +2212,7 @@ def _build_project_export_success_screen(
         *[Text("") for _ in range(remaining)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 # ---------------------------------------------------------------------------
@@ -2468,14 +2403,7 @@ def _build_usage_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=USAGE_THEME, height=height)
 
 
 def _build_standup_screen(
@@ -2672,14 +2600,7 @@ def _build_standup_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=STANDUP_THEME, height=height)
 
 
 def _build_standup_team_source_screen(
@@ -2722,7 +2643,7 @@ def _build_standup_team_source_screen(
         Text(""),
         Group(*rows[:viewport_h]),
     )
-    return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+    return build_page_panel(content, theme=STANDUP_THEME, height=height)
 
 
 def _build_standup_team_member_screen(
@@ -2787,7 +2708,7 @@ def _build_standup_team_member_screen(
         Text(""),
         viewport,
     )
-    return Panel(content, border_style="white", box=rich.box.ROUNDED, expand=True, height=height, padding=(1, 2))
+    return build_page_panel(content, theme=STANDUP_THEME, height=height)
 
 
 def _build_changelog_screen(
@@ -2925,14 +2846,7 @@ def _build_changelog_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=CHANGELOG_THEME, height=height)
 
 
 def _build_all_tips_screen(
@@ -3090,14 +3004,7 @@ def _build_all_tips_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=CHANGELOG_THEME, height=height)
 
 
 def _build_feedback_screen(
@@ -3311,14 +3218,7 @@ def _build_feedback_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style=border_style or "white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=FEEDBACK_THEME, border_style=border_style or "white", height=height)
 
 
 def _performance_roster_window(selected: int, n: int, budget: int) -> tuple[int, int]:
@@ -3467,14 +3367,7 @@ def _build_performance_screen(
             btn_mid,
             btn_bot,
         )
-        return Panel(
-            content,
-            border_style="white",
-            box=rich.box.ROUNDED,
-            expand=True,
-            height=height,
-            padding=(1, 2),
-        )
+        return build_page_panel(content, theme=PERFORMANCE_THEME, height=height)
 
     # ── Detail view — the produced artifact, scrollable ──────────────────────────
     body_lines: list = []
@@ -3520,14 +3413,7 @@ def _build_performance_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PERFORMANCE_THEME, height=height)
 
 
 def _build_reporting_screen(
@@ -3650,14 +3536,7 @@ def _build_reporting_screen(
             btn_mid,
             btn_bot,
         )
-        return Panel(
-            content,
-            border_style="white",
-            box=rich.box.ROUNDED,
-            expand=True,
-            height=height,
-            padding=(1, 2),
-        )
+        return build_page_panel(content, theme=REPORTING_THEME, height=height)
 
     # ── Picker view — choose the reporting period ────────────────────────────────
     if view != "detail":
@@ -3694,14 +3573,7 @@ def _build_reporting_screen(
             btn_mid,
             btn_bot,
         )
-        return Panel(
-            content,
-            border_style="white",
-            box=rich.box.ROUNDED,
-            expand=True,
-            height=height,
-            padding=(1, 2),
-        )
+        return build_page_panel(content, theme=REPORTING_THEME, height=height)
 
     # ── Detail view — the generated report, scrollable ───────────────────────────
     def _styled(line: str) -> Text:
@@ -3759,14 +3631,7 @@ def _build_reporting_screen(
         btn_mid,
         btn_bot,
     )
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=REPORTING_THEME, height=height)
 
 
 def _build_roadmap_screen(
@@ -3830,13 +3695,10 @@ def _build_roadmap_screen(
     # the source options / buttons underneath don't confuse the user. ─────────────
     if busy:
         spinner = Text(PAD + message, style=theme.accent_bright, justify="left") if message else Text("")
-        return Panel(
+        return build_page_panel(
             Group(Text(""), title, Text(""), sub, Text(""), Text(""), spinner),
-            border_style="white",
-            box=rich.box.ROUNDED,
-            expand=True,
+            theme=PLANNING_THEME,
             height=height,
-            padding=(1, 2),
         )
 
     # ── Source view — pick where the roadmap lives ───────────────────────────────
@@ -3873,14 +3735,7 @@ def _build_roadmap_screen(
             btn_mid,
             btn_bot,
         )
-        return Panel(
-            content,
-            border_style="white",
-            box=rich.box.ROUNDED,
-            expand=True,
-            height=height,
-            padding=(1, 2),
-        )
+        return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
     # ── Results view — summary + bordered project cards (selected expands) ────
     # Mirrors the list branch above: _Padding-wrapped rounded cards with peek
@@ -4036,14 +3891,7 @@ def _build_roadmap_screen(
         btn_mid,
         btn_bot,
     )
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 def _build_retro_screen(
@@ -4218,14 +4066,7 @@ def _build_retro_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=RETRO_THEME, height=height)
 
 
 _voice_hint_cache: str | None = None
@@ -4548,14 +4389,7 @@ def _build_poker_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=POKER_THEME, height=height)
 
 
 def _build_standup_progress_screen(
@@ -4604,14 +4438,9 @@ def _build_standup_progress_screen(
     body.extend(Text("") for _ in range(remaining))
 
     content = Group(Text(""), title, Text(""), *body)
-    return Panel(
-        content,
-        border_style=theme.accent,
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    # theme, not STANDUP_THEME: this loading screen is shared — poker ticket
+    # fetch and the anonymize pass reuse it with their own mode's theme.
+    return build_page_panel(content, theme=theme, border_style=theme.accent, height=height)
 
 
 def _build_standup_input_screen(
@@ -4711,14 +4540,7 @@ def _build_standup_input_screen(
     body.extend(Text("") for _ in range(pad_rows))
 
     content = Group(Text(""), title, Text(""), sub, Text(""), *body)
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=STANDUP_THEME, height=height)
 
 
 # ---------------------------------------------------------------------------
@@ -4867,14 +4689,7 @@ def _build_profile_picker_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 # ---------------------------------------------------------------------------
@@ -5091,11 +4906,4 @@ def _build_settings_screen(
         btn_bot,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=SETTINGS_THEME, height=height)

--- a/src/yeaboi/ui/provider_select/screens/_screens.py
+++ b/src/yeaboi/ui/provider_select/screens/_screens.py
@@ -18,6 +18,7 @@ from yeaboi.ui.provider_select._constants import _PROVIDER_CARDS, TOKEN_HELP
 from yeaboi.ui.provider_select._verification import _validate_key
 from yeaboi.ui.shared._animations import shimmer_style
 from yeaboi.ui.shared._ascii_font import render_ascii_text
+from yeaboi.ui.shared._components import build_page_panel
 from yeaboi.ui.shared._wordmarks import get_shadow_wordmark
 
 # ---------------------------------------------------------------------------
@@ -187,7 +188,6 @@ def _build_screen_frame(
     title_text: text to render as ASCII art title. Defaults to "Setup". Rendered
     in the tall ANSI-Shadow font (brand blue) to match the app's mode screens.
     """
-    import rich.box
     from rich.console import Group
 
     display_title = title_text or "Setup"
@@ -221,14 +221,7 @@ def _build_screen_frame(
         Align.center(progress),
     )
 
-    return Panel(
-        content,
-        border_style=_ACCENT,
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, border_style=_ACCENT, height=height)
 
 
 def _build_select_screen(

--- a/src/yeaboi/ui/session/editor/_editor.py
+++ b/src/yeaboi/ui/session/editor/_editor.py
@@ -42,7 +42,7 @@ from yeaboi.ui.session.editor._editor_core import (
     _wrap_indent,
 )
 from yeaboi.ui.shared._animations import lerp_color
-from yeaboi.ui.shared._components import PAD, planning_title
+from yeaboi.ui.shared._components import PAD, PLANNING_THEME, build_page_panel, planning_title
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -317,9 +317,7 @@ def _render_editor(
     Complex renderer with DoD button grid and AC markers — story-specific.
     shimmer_tick: if set, animates the title's travelling highlight.
     """
-    import rich.box
     from rich.console import Group
-    from rich.panel import Panel
 
     title = planning_title(shimmer_tick)
     sub = Text(justify="left")
@@ -457,14 +455,7 @@ def _render_editor(
         text_content.append("\n")
 
     content = Group(Text(""), title, Text(""), sub, Text(""), text_content)
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    ), scroll_offset
+    return build_page_panel(content, theme=PLANNING_THEME, height=height), scroll_offset
 
 
 # ---------------------------------------------------------------------------

--- a/src/yeaboi/ui/session/editor/_editor_core.py
+++ b/src/yeaboi/ui/session/editor/_editor_core.py
@@ -20,13 +20,12 @@ import re
 import time
 from collections.abc import Callable
 
-import rich.box
 from rich.console import Console, Group
 from rich.live import Live
 from rich.panel import Panel
 from rich.text import Text
 
-from yeaboi.ui.shared._components import PAD, planning_title
+from yeaboi.ui.shared._components import PAD, PLANNING_THEME, build_page_panel, planning_title
 
 # ---------------------------------------------------------------------------
 # Shared field label pattern for all editors (story, task, sprint, etc.)
@@ -288,14 +287,7 @@ def render_editor_panel(
         text_content,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    ), scroll_offset
+    return build_page_panel(content, theme=PLANNING_THEME, height=height), scroll_offset
 
 
 # ---------------------------------------------------------------------------

--- a/src/yeaboi/ui/session/screens/_accordion.py
+++ b/src/yeaboi/ui/session/screens/_accordion.py
@@ -27,6 +27,7 @@ from yeaboi.agent.state import TOTAL_QUESTIONS, QuestionnaireState
 from yeaboi.prompts.intake import QUESTION_SHORT_LABELS
 from yeaboi.ui.session._utils import _pad_left, _wrap_text
 from yeaboi.ui.session.screens._screens import _INPUT_BOX_W_MAX, _PAD, _planning_title
+from yeaboi.ui.shared._components import PLANNING_THEME, build_page_panel
 
 # ---------------------------------------------------------------------------
 # Accordion item renderers
@@ -498,11 +499,4 @@ def _build_accordion_question_screen(
         *pad_lines,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)

--- a/src/yeaboi/ui/session/screens/_screens.py
+++ b/src/yeaboi/ui/session/screens/_screens.py
@@ -7,14 +7,13 @@
 
 from __future__ import annotations
 
-import rich.box
 from rich.console import Group
 from rich.panel import Panel
 from rich.text import Text
 
 from yeaboi.ui.shared._animations import lerp_color as _shared_lerp_color
 from yeaboi.ui.shared._animations import scrollbar_column
-from yeaboi.ui.shared._components import PAD, planning_title
+from yeaboi.ui.shared._components import PAD, PLANNING_THEME, build_page_panel, planning_title
 from yeaboi.ui.shared._scroll import publish_geometry
 
 # ---------------------------------------------------------------------------
@@ -202,11 +201,4 @@ def _build_summary_screen(
         *body,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)

--- a/src/yeaboi/ui/session/screens/_screens_input.py
+++ b/src/yeaboi/ui/session/screens/_screens_input.py
@@ -15,7 +15,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from yeaboi.ui.session._utils import _pad_left, _wrap_text
-from yeaboi.ui.shared._components import PAD, planning_title
+from yeaboi.ui.shared._components import PAD, PLANNING_THEME, build_page_panel, planning_title
 
 _PAD = PAD
 
@@ -205,14 +205,7 @@ def _build_description_screen(
         *[Text("") for _ in range(remaining_h)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 # ---------------------------------------------------------------------------
@@ -398,11 +391,4 @@ def _build_question_screen(
         *[Text("") for _ in range(remaining_h)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)

--- a/src/yeaboi/ui/session/screens/_screens_pipeline.py
+++ b/src/yeaboi/ui/session/screens/_screens_pipeline.py
@@ -18,7 +18,7 @@ from yeaboi.ui.session._utils import _pad_left, _wrap_text
 from yeaboi.ui.session.screens._screens import _build_action_bar, _planning_title
 from yeaboi.ui.session.screens._screens_input import _image_hint
 from yeaboi.ui.shared._animations import scrollbar_column
-from yeaboi.ui.shared._components import PAD
+from yeaboi.ui.shared._components import PAD, PLANNING_THEME, build_page_panel
 from yeaboi.ui.shared._scroll import publish_geometry
 
 _PAD = PAD
@@ -273,14 +273,7 @@ def _build_pipeline_screen(
         *popup_rendered,
     )
 
-    return Panel(
-        content,
-        border_style=border_style,
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, border_style=border_style, height=height)
 
 
 def _build_popup_overlay(
@@ -484,14 +477,7 @@ def _build_chat_screen(
         *body,
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)
 
 
 # ---------------------------------------------------------------------------
@@ -557,11 +543,4 @@ def _build_edit_prompt_screen(
         *[Text("") for _ in range(remaining_h)],
     )
 
-    return Panel(
-        content,
-        border_style="white",
-        box=rich.box.ROUNDED,
-        expand=True,
-        height=height,
-        padding=(1, 2),
-    )
+    return build_page_panel(content, theme=PLANNING_THEME, height=height)

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -34,6 +34,12 @@ PAD = "    "
 # Theme — centralised color palette for both modes
 # ---------------------------------------------------------------------------
 
+# Neutral dark page background for screens that don't belong to a tinted mode
+# (home, splash, provider select, settings/changelog/feedback). Every page paints
+# its own background so all users see the same TUI regardless of their
+# terminal's color scheme.
+NEUTRAL_BG = "rgb(16,16,20)"
+
 
 @dataclass(frozen=True)
 class Theme:
@@ -50,19 +56,23 @@ class Theme:
     sep: str = "rgb(50,60,80)"
     id: str = "cyan"
     desc: str = "rgb(160,160,160)"
+    # Page background: a dark tint of the mode's accent hue, applied by
+    # build_page_panel as "on {bg}" so the whole terminal shows the mode's
+    # colour instead of the user's terminal background.
+    bg: str = NEUTRAL_BG
 
 
-ANALYSIS_THEME = Theme()
-PLANNING_THEME = Theme(accent="rgb(110,140,220)", accent_bright="rgb(140,170,255)")
-USAGE_THEME = Theme(accent="rgb(220,160,60)", accent_bright="rgb(255,200,80)")
+ANALYSIS_THEME = Theme(bg="rgb(9,23,19)")
+PLANNING_THEME = Theme(accent="rgb(110,140,220)", accent_bright="rgb(140,170,255)", bg="rgb(13,17,30)")
+USAGE_THEME = Theme(accent="rgb(220,160,60)", accent_bright="rgb(255,200,80)", bg="rgb(29,21,9)")
 SETTINGS_THEME = Theme(accent="rgb(160,160,180)", accent_bright="rgb(200,200,220)")
-STANDUP_THEME = Theme(accent="rgb(200,100,180)", accent_bright="rgb(255,150,220)")
-RETRO_THEME = Theme(accent="rgb(80,190,190)", accent_bright="rgb(120,230,230)")
+STANDUP_THEME = Theme(accent="rgb(200,100,180)", accent_bright="rgb(255,150,220)", bg="rgb(26,13,23)")
+RETRO_THEME = Theme(accent="rgb(80,190,190)", accent_bright="rgb(120,230,230)", bg="rgb(10,25,25)")
 # Gold, not table-felt green — analysis owns green, and the two cards sat side
 # by side looking like twins. Gold keeps the casino identity (chips) instead.
-POKER_THEME = Theme(accent="rgb(230,200,70)", accent_bright="rgb(255,235,110)")
-PERFORMANCE_THEME = Theme(accent="rgb(220,110,90)", accent_bright="rgb(255,150,120)")
-REPORTING_THEME = Theme(accent="rgb(140,120,230)", accent_bright="rgb(180,160,255)")
+POKER_THEME = Theme(accent="rgb(230,200,70)", accent_bright="rgb(255,235,110)", bg="rgb(27,24,10)")
+PERFORMANCE_THEME = Theme(accent="rgb(220,110,90)", accent_bright="rgb(255,150,120)", bg="rgb(29,15,12)")
+REPORTING_THEME = Theme(accent="rgb(140,120,230)", accent_bright="rgb(180,160,255)", bg="rgb(19,16,30)")
 # Silver chrome on purpose — the changelog page's per-feature area tags carry the
 # colour (each tag uses its mode's accent), so the page frame stays neutral.
 CHANGELOG_THEME = Theme(accent="rgb(160,160,180)", accent_bright="rgb(200,200,220)")
@@ -150,6 +160,41 @@ _BTN_GAP = 2
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
+
+def build_page_panel(
+    content,
+    *,
+    theme: Theme | None = None,
+    bg: str | None = None,
+    border_style: str = "white",
+    height: int,
+    padding: tuple[int, int] = (1, 2),
+    **panel_kwargs,
+) -> Panel:
+    """Build the full-screen root Panel every TUI page must return.
+
+    Rich cascades a Panel's ``style`` onto every child segment that has no
+    explicit background of its own, so setting ``style="on {bg}"`` here tints
+    content rows, heading spacers, scroll filler lines and padding alike — the
+    whole terminal shows the mode's background colour with no seams, instead of
+    the user's terminal default.
+
+    ``bg`` overrides ``theme.bg``; with neither, the neutral dark base is used.
+    Never return a raw full-screen ``Panel`` from a screen builder — a unit test
+    (tests/unit/test_screen_backgrounds.py) enforces this.
+    """
+    color = bg or (theme.bg if theme is not None else NEUTRAL_BG)
+    return Panel(
+        content,
+        style=f"on {color}",
+        border_style=border_style,
+        box=rich.box.ROUNDED,
+        expand=True,
+        height=height,
+        padding=padding,
+        **panel_kwargs,
+    )
 
 
 def center_label(label: str, width: int) -> str:

--- a/src/yeaboi/ui/shared/_export_picker.py
+++ b/src/yeaboi/ui/shared/_export_picker.py
@@ -49,6 +49,7 @@ from yeaboi.ui.shared._components import (
     STANDUP_THEME,
     analysis_title,
     build_action_buttons,
+    build_page_panel,
     build_popup,
     performance_title,
     planning_title,
@@ -188,12 +189,7 @@ def _build_export_picker_screen(
         btn_top, btn_mid, btn_bot = build_action_buttons(labels, selected)
     lines += [btn_top, btn_mid, btn_bot]
 
-    return Panel(
-        Group(*lines),
-        height=height,
-        padding=(1, 2),
-        border_style=theme.sep,
-    )
+    return build_page_panel(Group(*lines), theme=theme, border_style=theme.sep, height=height)
 
 
 def pick_export_destination(

--- a/src/yeaboi/ui/shared/_music_bar.py
+++ b/src/yeaboi/ui/shared/_music_bar.py
@@ -30,7 +30,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from yeaboi import music
-from yeaboi.ui.shared._components import PLANNING_THEME, Theme
+from yeaboi.ui.shared._components import NEUTRAL_BG, PLANNING_THEME, Theme
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +160,12 @@ class MusicLive(Live):
         if not isinstance(renderable, Panel):
             self._stamped = False
             return
+        # Safety net: no screen may ever show the terminal's own background. A
+        # Panel whose builder didn't set a style (i.e. bypassed build_page_panel)
+        # gets the neutral dark base; styled Panels are left untouched. Rich's
+        # Panel defaults ``style`` to the string "none", not an empty value.
+        if not renderable.style or str(renderable.style) == "none":
+            renderable.style = f"on {NEUTRAL_BG}"
         # A subtitle we didn't set (a popup's own status) is meaningful — don't
         # clobber it. Our own previous stamp is tagged so we can refresh it.
         if getattr(renderable, "subtitle", None) and not getattr(renderable, "_music_stamped", False):

--- a/src/yeaboi/ui/shared/_output_share.py
+++ b/src/yeaboi/ui/shared/_output_share.py
@@ -13,7 +13,7 @@ from rich.text import Text
 
 from yeaboi.sharing.server import OutputShareServer, ShareDocument
 from yeaboi.ui.shared._animations import loading_border_color
-from yeaboi.ui.shared._components import PAD, Theme, build_action_buttons
+from yeaboi.ui.shared._components import PAD, Theme, build_action_buttons, build_page_panel
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ def _build_output_share_screen(
     while len(visible) < body_rows:
         visible.append(Text(""))
     btn_top, btn_mid, btn_bot = build_action_buttons(actions, action_sel)
-    return Panel(
+    return build_page_panel(
         Group(
             Text(""),
             title,
@@ -109,9 +109,9 @@ def _build_output_share_screen(
             btn_mid,
             btn_bot,
         ),
-        height=height,
-        padding=(1, 2),
+        theme=theme,
         border_style=loading_border_color(shimmer_tick or 0.0) if loading else theme.sep,
+        height=height,
     )
 
 

--- a/src/yeaboi/ui/shared/_screensaver.py
+++ b/src/yeaboi/ui/shared/_screensaver.py
@@ -18,6 +18,8 @@ from rich.align import Align
 from rich.console import Group, RenderableType
 from rich.text import Text
 
+from yeaboi.ui.shared._components import NEUTRAL_BG
+
 IDLE_SECONDS = 5 * 60
 
 _P = ParamSpec("_P")
@@ -369,9 +371,9 @@ def build_screensaver(*, width: int, height: int, elapsed: float | None = None) 
         else:
             label = "YEABOI"[:width]
         line = Text(label, style="bold rgb(42,170,105)")
-        return Align.center(line, vertical="middle", height=max(1, height))
+        return Align.center(line, vertical="middle", height=max(1, height), style=f"on {NEUTRAL_BG}")
 
     caption = Text("YEABOI · chilling", style="bold rgb(105,220,235)", justify="center")
     hint = Text("press any key", style="rgb(95,105,115)", justify="center")
     content = Group(art, caption, hint)
-    return Align.center(content, vertical="middle", height=max(1, height))
+    return Align.center(content, vertical="middle", height=max(1, height), style=f"on {NEUTRAL_BG}")

--- a/src/yeaboi/ui/splash.py
+++ b/src/yeaboi/ui/splash.py
@@ -24,6 +24,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from yeaboi.ui.shared._ascii_font import render_ascii_text
+from yeaboi.ui.shared._components import NEUTRAL_BG
 from yeaboi.ui.shared._wordmarks import get_shadow_wordmark
 
 logger = logging.getLogger(__name__)
@@ -83,8 +84,11 @@ def _center_in_panel(rendered: Text, *, width: int, height: int, block_h: int) -
         *[Text("") for _ in range(bot_pad)],
     )
 
+    # Neutral dark base — the splash owns its background like every other page,
+    # so all users see the same boot screen regardless of terminal theme.
     return Panel(
         content,
+        style=f"on {NEUTRAL_BG}",
         border_style="white",
         box=rich.box.ROUNDED,
         expand=True,

--- a/tests/unit/test_music_bar.py
+++ b/tests/unit/test_music_bar.py
@@ -125,6 +125,22 @@ def test_ignores_non_panel_renderables():
     assert ml._stamped is False
 
 
+def test_unstyled_panel_gains_neutral_background():
+    from yeaboi.ui.shared._components import NEUTRAL_BG
+
+    ml = make_live(Text(""))
+    panel = Panel(Text("body"))  # a screen that bypassed build_page_panel
+    ml._stamp(panel)
+    assert panel.style == f"on {NEUTRAL_BG}"
+
+
+def test_styled_panel_background_is_left_untouched():
+    ml = make_live(Text(""))
+    panel = Panel(Text("body"), style="on rgb(9,23,19)")  # build_page_panel output
+    ml._stamp(panel)
+    assert panel.style == "on rgb(9,23,19)"
+
+
 def test_install_hint_when_unavailable(monkeypatch):
     monkeypatch.setattr(music, "is_music_available", lambda: (False, "no ffplay"))
     text = build_music_subtitle().plain

--- a/tests/unit/test_screen_backgrounds.py
+++ b/tests/unit/test_screen_backgrounds.py
@@ -1,0 +1,192 @@
+"""Every TUI page paints its own mode-tinted background (no terminal bleed-through).
+
+Two layers of protection:
+- Render tests: representative screens emit the truecolor background SGR escape
+  (``48;2;R;G;B``) for their mode's ``Theme.bg`` when captured with a truecolor
+  console, so the whole terminal shows the mode's colour.
+- An AST scan: no full-screen ``Panel`` under ``src/yeaboi/ui`` may bypass
+  ``build_page_panel`` (which is what applies the background style).
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import pathlib
+import re
+
+import pytest
+from rich.console import Console
+from rich.text import Text
+
+from yeaboi.ui.shared._components import (
+    ANALYSIS_THEME,
+    CHANGELOG_THEME,
+    FEEDBACK_THEME,
+    NEUTRAL_BG,
+    PERFORMANCE_THEME,
+    PLANNING_THEME,
+    POKER_THEME,
+    REPORTING_THEME,
+    RETRO_THEME,
+    SETTINGS_THEME,
+    STANDUP_THEME,
+    USAGE_THEME,
+    build_page_panel,
+    standup_title,
+)
+
+UI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "yeaboi" / "ui"
+
+
+def _render(renderable, *, width: int = 100, height: int = 30) -> str:
+    """Render with escapes emitted so background SGR codes appear in the capture."""
+    console = Console(
+        file=io.StringIO(),
+        width=width,
+        height=height,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    console.print(renderable)
+    return console.file.getvalue()
+
+
+def _bg_escape(rgb: str) -> str:
+    """Truecolor background SGR fragment for an "rgb(r,g,b)" style string."""
+    r, g, b = re.fullmatch(r"rgb\((\d+),(\d+),(\d+)\)", rgb).groups()
+    return f"48;2;{r};{g};{b}"
+
+
+class TestThemeBackgrounds:
+    """Each mode's Theme carries a dark tint and build_page_panel emits it."""
+
+    MODE_THEMES = {
+        "analysis": ANALYSIS_THEME,
+        "planning": PLANNING_THEME,
+        "usage": USAGE_THEME,
+        "standup": STANDUP_THEME,
+        "retro": RETRO_THEME,
+        "poker": POKER_THEME,
+        "performance": PERFORMANCE_THEME,
+        "reporting": REPORTING_THEME,
+    }
+
+    @pytest.mark.parametrize("name", sorted(MODE_THEMES))
+    def test_mode_theme_bg_renders(self, name):
+        theme = self.MODE_THEMES[name]
+        out = _render(build_page_panel(Text("hello"), theme=theme, height=10))
+        assert _bg_escape(theme.bg) in out
+
+    def test_mode_tints_are_distinct(self):
+        bgs = [t.bg for t in self.MODE_THEMES.values()]
+        assert len(set(bgs)) == len(bgs)
+        assert NEUTRAL_BG not in bgs  # every mode overrides the neutral base
+
+    def test_mode_tints_are_dark(self):
+        # Foreground styles are designed for dark backgrounds; keep tints deep.
+        for theme in self.MODE_THEMES.values():
+            r, g, b = (int(v) for v in re.findall(r"\d+", theme.bg))
+            assert max(r, g, b) <= 40, theme.bg
+
+    def test_neutral_pages_use_neutral_base(self):
+        for theme in (SETTINGS_THEME, CHANGELOG_THEME, FEEDBACK_THEME):
+            assert theme.bg == NEUTRAL_BG
+        out = _render(build_page_panel(Text("hello"), height=10))
+        assert _bg_escape(NEUTRAL_BG) in out
+
+
+class TestRepresentativeScreens:
+    """Real screen builders route through build_page_panel and emit their tint."""
+
+    def test_mode_home_uses_neutral_base(self):
+        from yeaboi.ui.mode_select.screens._screens import _build_mode_screen
+
+        out = _render(_build_mode_screen(0, width=100, height=30))
+        assert _bg_escape(NEUTRAL_BG) in out
+
+    def test_analysis_setup_screen_uses_analysis_tint(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_analysis_depth_screen
+
+        out = _render(_build_analysis_depth_screen(0, width=100, height=30))
+        assert _bg_escape(ANALYSIS_THEME.bg) in out
+
+    def test_run_hub_uses_mode_theme(self):
+        from yeaboi.ui.mode_select.screens._run_hub_screen import _build_run_hub_screen
+
+        out = _render(_build_run_hub_screen([], 0, title_fn=standup_title, theme=STANDUP_THEME))
+        assert _bg_escape(STANDUP_THEME.bg) in out
+
+    def test_run_hub_without_theme_falls_back_to_neutral(self):
+        from yeaboi.ui.mode_select.screens._run_hub_screen import _build_run_hub_screen
+
+        out = _render(_build_run_hub_screen([], 0, title_fn=standup_title))
+        assert _bg_escape(NEUTRAL_BG) in out
+
+    def test_provider_select_frame_uses_neutral_base(self):
+        from yeaboi.ui.provider_select.screens._screens import _build_screen_frame
+
+        out = _render(
+            _build_screen_frame(subtitle="s", step=0, body_items=[Text("body")], body_height=1, width=100, height=30)
+        )
+        assert _bg_escape(NEUTRAL_BG) in out
+
+    def test_splash_frame_uses_neutral_base(self):
+        from yeaboi.ui.splash import _build_splash_frame
+
+        out = _render(_build_splash_frame(["YEABOI"], width=100, height=30))
+        assert _bg_escape(NEUTRAL_BG) in out
+
+    def test_screensaver_uses_neutral_base(self):
+        from yeaboi.ui.shared._screensaver import build_screensaver
+
+        out = _render(build_screensaver(width=80, height=24, elapsed=0.0))
+        assert _bg_escape(NEUTRAL_BG) in out
+
+    def test_screensaver_tiny_terminal_uses_neutral_base(self):
+        from yeaboi.ui.shared._screensaver import build_screensaver
+
+        out = _render(build_screensaver(width=18, height=6, elapsed=0.0), width=18, height=6)
+        assert _bg_escape(NEUTRAL_BG) in out
+
+
+class TestNoRawFullScreenPanels:
+    """AST guard: full-screen Panels must be built via build_page_panel.
+
+    A "full-screen" Panel is one with a ``height=`` kwarg, no ``width=`` kwarg
+    and ``expand`` not explicitly False — it fills the terminal, so an unstyled
+    one would show the user's terminal background through padding and blank
+    rows. Adding a new screen? Return ``build_page_panel(...)`` with the mode's
+    Theme (see .claude/skills/tui-standards).
+    """
+
+    # Files allowed to construct a styled full-screen Panel directly.
+    ALLOWED = {
+        "shared/_components.py",  # build_page_panel itself
+        "splash.py",  # pre-Live boot screen, styles itself with NEUTRAL_BG
+    }
+
+    def test_no_unstyled_full_screen_panel(self):
+        offenders: list[str] = []
+        for path in sorted(UI_ROOT.rglob("*.py")):
+            rel = path.relative_to(UI_ROOT).as_posix()
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = getattr(node.func, "id", getattr(node.func, "attr", ""))
+                if name != "Panel":
+                    continue
+                kw = {k.arg: k.value for k in node.keywords if k.arg}
+                expand_false = isinstance(kw.get("expand"), ast.Constant) and kw["expand"].value is False
+                if "height" not in kw or "width" in kw or expand_false:
+                    continue  # inner card / chip / popup — inherits the page bg
+                if "style" in kw and rel in self.ALLOWED:
+                    continue
+                offenders.append(f"{rel}:{node.lineno}")
+        assert not offenders, (
+            "Full-screen Panel(s) bypass build_page_panel — return "
+            f"build_page_panel(..., theme=<mode theme>) instead: {offenders}"
+        )

--- a/tests/unit/test_shared_components.py
+++ b/tests/unit/test_shared_components.py
@@ -11,6 +11,7 @@ from yeaboi.ui.shared._components import (
     Theme,
     build_action_buttons,
     build_meter,
+    build_page_panel,
     build_progress_dots,
     build_scrollbar,
     calc_viewport,
@@ -50,6 +51,38 @@ class TestTheme:
 
         with pytest.raises(AttributeError):
             ANALYSIS_THEME.accent = "red"  # type: ignore[misc]
+
+    def test_bg_defaults_to_neutral(self):
+        from yeaboi.ui.shared._components import NEUTRAL_BG
+
+        assert Theme().bg == NEUTRAL_BG
+
+    def test_mode_themes_carry_dark_tints(self):
+        assert ANALYSIS_THEME.bg == "rgb(9,23,19)"
+        assert PLANNING_THEME.bg == "rgb(13,17,30)"
+
+
+class TestBuildPagePanel:
+    def test_applies_theme_bg_as_panel_style(self):
+        panel = build_page_panel(Text("x"), theme=ANALYSIS_THEME, height=10)
+        assert panel.style == f"on {ANALYSIS_THEME.bg}"
+        assert panel.height == 10
+        assert panel.expand is True
+
+    def test_no_theme_uses_neutral_base(self):
+        from yeaboi.ui.shared._components import NEUTRAL_BG
+
+        panel = build_page_panel(Text("x"), height=10)
+        assert panel.style == f"on {NEUTRAL_BG}"
+
+    def test_explicit_bg_overrides_theme(self):
+        panel = build_page_panel(Text("x"), theme=ANALYSIS_THEME, bg="rgb(1,2,3)", height=10)
+        assert panel.style == "on rgb(1,2,3)"
+
+    def test_passes_border_style_and_extra_kwargs(self):
+        panel = build_page_panel(Text("x"), theme=PLANNING_THEME, border_style="red", height=8, title="T")
+        assert panel.border_style == "red"
+        assert panel.title == "T"
 
 
 class TestBuildActionButtons:

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.36.0"
+version = "2.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

The TUI now takes control of its own background instead of inheriting the terminal's: every screen paints a dark tint of its mode's accent colour, so all users get the same visual experience regardless of their terminal theme. Analysis is deep green (`rgb(9,23,19)`), Planning deep blue, Standup deep magenta, Retro deep teal, Poker deep gold, Performance deep rust, Reporting deep violet, Usage deep amber. Home, splash, provider select, settings, changelog, and feedback screens use a neutral dark base (`rgb(16,16,20)`). Tints are deliberately dark (channel values ≤ 40) because the existing foreground palette is designed for dark backgrounds.

How it works:

- `Theme` gains a `bg` field, and a new `build_page_panel()` helper in `ui/shared/_components.py` builds the full-screen root Panel with `style="on {theme.bg}"`. Rich cascades that style onto every child segment — content rows, spacers, scroll filler, padding — the mechanism already proven by the analysis results screen's card background. All ~55 full-screen Panel sites now route through it.
- `MusicLive._stamp` back-fills the neutral base on any Panel that slips through unstyled (Rich's default Panel style is the string `"none"`, not empty). The screensaver and splash, which bypass that path, style themselves.
- The analysis results page keeps its original `rgb(13,31,27)` (now `_ANALYSIS_CARD_BG_RGB`) as a slightly-lighter elevated surface over the darker analysis page tint.
- The shared loading screen (`_build_standup_progress_screen`) and the generic run hub take the calling mode's theme, so poker/retro/reporting/performance reuse renders with the right tint.
- An AST-scan test (`tests/unit/test_screen_backgrounds.py`) fails the build if a raw full-screen `Panel(` reappears under `ui/`, plus truecolor render tests assert the background SGR escape per mode and for representative screens. The `tui-standards` skill documents `build_page_panel` as the mandatory page root.

Notes: an independent review flagged (and this branch fixes) the shared loading screen hardcoding the standup theme and the analysis roster-retry dialog bleeding terminal background around its popup. One deliberate small visual change: the feedback draft-guard popup page now has the standard white rounded border like every other page. Accepted limitation: a single refresh-tick flash of the terminal's own background when the alt screen first opens (fixing it would require OSC 11, which mutates the user's terminal).

## Test plan

- `make test` — full suite, 5786 passed / 16 skipped
- `make lint` — clean
- New tests: `tests/unit/test_screen_backgrounds.py` (per-mode tint rendering, distinctness + darkness invariants, representative screens incl. splash/screensaver/run-hub, AST guard), `test_music_bar.py` safety-net cases, `test_shared_components.py` `Theme.bg` + `build_page_panel` cases
- Independent fresh-context code review; both should-fix findings resolved in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)