### PR TITLE
deflake concurrent roster test with a barrier

### DIFF
--- a/tests/unit/test_team_roster.py
+++ b/tests/unit/test_team_roster.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import time
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -66,19 +66,24 @@ def test_stale_cache_is_returned_when_refresh_fails(monkeypatch, tmp_path):
 
 
 def test_sources_are_queried_concurrently(monkeypatch, tmp_path):
+    # A Barrier(2) only releases once BOTH fetchers have reached it. If the sources
+    # were queried sequentially the first fetcher would block until the timeout and
+    # trip BrokenBarrierError, so a clean pass proves they ran concurrently — with no
+    # wall-clock threshold to flake on a slow/loaded CI runner (the old `< 0.27s`
+    # assertion failed there despite correct concurrency).
+    barrier = threading.Barrier(2, timeout=5)
+
     def slow(name):
         def fetch(project, days=30):
-            time.sleep(0.15)
+            barrier.wait()
             return [{"name": name, "identity": name}]
 
         return fetch
 
     monkeypatch.setattr("yeaboi.tools.jira.jira_assignee_roster", slow("Ada"))
     monkeypatch.setattr("yeaboi.tools.azure_devops.azdevops_assignee_roster", slow("Bob"))
-    started = time.monotonic()
     result = fetch_roster_result(jira_project="J", azdo_project="A", db_path=tmp_path / "db")
 
-    assert time.monotonic() - started < 0.27
     assert [member.name for member in result.members] == ["Ada", "Bob"]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.39.0"
+version = "2.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

The PyPI publish pipeline (`publish.yml`) runs the full test suite before building/publishing, and that gate was intermittently failing on a **flaky timing test** — not on anything packaging-related. [Run 30286773683](https://github.com/dinho149/yeaboi.ai/actions/runs/30286773683/job/90046446223) died with:

```
FAILED tests/unit/test_team_roster.py::test_sources_are_queried_concurrently
  assert (188.188290606 - 187.804928713) < 0.27   # 0.383 < 0.27 → False
```

`test_sources_are_queried_concurrently` proved concurrency by wall clock: two fetchers each `sleep(0.15)`, then it asserted total elapsed `< 0.27s` (below the ~0.30s sequential floor). The code *is* concurrent (`ThreadPoolExecutor` in `team_roster.py`), but on a loaded CI runner thread-scheduling/GIL overhead pushed even the concurrent run to 0.383s — so the threshold flaked and blocked releases.

**Fix:** replace the wall-clock assertion with a deterministic `threading.Barrier(2, timeout=5)`. Each fetcher waits on the barrier, which only releases once *both* have arrived — so a clean pass proves concurrency with no timing threshold to flake. A sequential regression blocks the first fetcher until the timeout, trips `BrokenBarrierError`, and yields empty `members`, failing the `== ["Ada", "Bob"]` assertion. The 5s timeout is deliberately generous (the original flake was a *slow* runner; the timeout only matters on a genuine regression).

Also syncs `uv.lock` (yeaboi `2.39.0 → 2.40.0`) to match the already-bumped `pyproject.toml`.

## Test plan

- `make test` — full suite green (6198 passed, 16 skipped)
- `make lint` — clean
- Independent fresh-context review (code-reviewer): no blockers/should-fixes; confirmed the barrier still catches a sequential regression
- Pre-commit hooks (ruff, secrets, unit tests) all passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)