### PR TITLE
repair automation pipelines: restore dropped reviews, fix dead triage workflows

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -7,8 +7,12 @@ name: Auto Version Bump
 # to choose the semver level when the change actually ships code.
 #
 # The bump lands on the PR *branch* (not main) on purpose: the human merge is what
-# pushes to main and triggers publish.yml. A workflow pushing to main with the
-# default GITHUB_TOKEN would NOT re-trigger publish.yml, so this avoids needing a PAT.
+# pushes to main and triggers publish.yml — so nothing here has to push to main.
+#
+# The bump push DOES need a real identity, though (see the checkout step): pushing
+# it as the default GITHUB_TOKEN makes the resulting CI run bot-actored, and GitHub
+# then suppresses that run's `workflow_run` event — which silently killed
+# claude-review.yml and dependabot-auto.yml on every bumped PR.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
@@ -31,11 +35,52 @@ jobs:
       pull-requests: write # post the explanation comment
       id-token: write # claude-code-action OIDC
     steps:
+      # The `|| github.token` fallback below keeps the bump working when the
+      # secret is absent, but that silently restores the review-dropping
+      # behaviour this workflow exists to prevent. Make the degraded mode
+      # visible instead of invisible. (`secrets` is not available in a step
+      # `if:`, so this tests a materialized env var rather than branching.)
+      - name: Warn if the review-restoring PAT is missing
+        env:
+          HAS_PAT: ${{ secrets.AUTO_VERSION_PAT != '' }}
+        run: |
+          if [ "$HAS_PAT" != "true" ]; then
+            echo "::warning::AUTO_VERSION_PAT is not set — the bump will be pushed as GITHUB_TOKEN, so the bump commit's CI run will emit no workflow_run and Claude Review will NOT run on this PR."
+          fi
+
       - name: Checkout PR branch
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          # These persisted credentials are what Claude's `git push` of the
+          # `chore: bump version` commit uses. With the default GITHUB_TOKEN that
+          # push produces a bot-actored CI run, and GitHub's recursive-run guard
+          # then emits NO `workflow_run` event when it completes — so Claude
+          # Review and Dependabot verify never fired on a bumped PR (and never
+          # showed up as skipped either: there was simply no run). A PAT makes the
+          # push a real identity, so the event fires normally.
+          #
+          # AUTO_VERSION_PAT MUST be a *fine-grained* PAT scoped to this single
+          # repository with `Contents: read and write` and nothing else. Do not
+          # substitute a classic `repo`-scoped token on rotation: the steps below
+          # run `claude-code-action` with unrestricted `Bash` against code checked
+          # out FROM THE PR BRANCH (including `scripts/bump_version.py`), and
+          # checkout persists this credential into `.git/config`. A fine-grained
+          # token bounds a leak to this repo's contents; a classic one would
+          # expose the whole account, and the job's `permissions:` block does not
+          # constrain a PAT the way it constrains github.token.
+          #
+          # Falls back to github.token so the workflow still works before the
+          # secret exists — that just restores the old (review-dropping) behaviour
+          # rather than failing the bump outright. The step above warns when that
+          # fallback is in effect.
+          #
+          # This re-triggers auto-version itself, exactly as the GITHUB_TOKEN push
+          # already did; the "already bumped in this PR" branch of the guards step
+          # below short-circuits the second run (that guard is pure git/grep over
+          # pyproject.toml + changelog_data.json, so it is token-independent).
+          token: ${{ secrets.AUTO_VERSION_PAT || github.token }}
 
       - name: Deterministic guards
         id: guard

--- a/.github/workflows/backlog-groomer.yml
+++ b/.github/workflows/backlog-groomer.yml
@@ -18,7 +18,7 @@ name: Backlog Groomer
 
 on:
   schedule:
-    - cron: "0 8 * * 1" # Mondays 08:00 UTC
+    - cron: "43 8 * * 1" # Mondays 08:43 UTC (off the hour — ":00" queues ~3h late)
   workflow_dispatch: {}
 
 concurrency:
@@ -34,7 +34,23 @@ jobs:
   groom:
     name: Groom the open backlog
     runs-on: ubuntu-latest
+    env:
+      # `gh` infers the repo from a git remote; make it explicit so this job never
+      # depends on checkout ordering. Job-level so it reaches both the collect step
+      # and the shells claude-code-action spawns for its own `gh` calls. (Safe
+      # here — this job only ever runs `gh issue`, never `gh pr create`, which is
+      # the one command GH_REPO interferes with.)
+      GH_REPO: ${{ github.repository }}
     steps:
+      # Shallow checkout purely so claude-code-action runs in a real repo, as it
+      # does in every other Claude job here. This job reads no source files, but
+      # it had never once got past the step below, so its Claude step is entirely
+      # unexercised — don't also make it the only one running in a bare workspace.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
       - name: Collect open issues (exclude bots + own report)
         id: collect
         env:

--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -50,6 +50,14 @@ jobs:
         id: dedupe
         env:
           GH_TOKEN: ${{ github.token }}
+          # This step runs BEFORE the checkout below, so `gh` has no git remote to
+          # infer the repo from and would die with "fatal: not a git repository".
+          # Deliberately step-scoped, NOT job-level: every later `gh` call runs
+          # after the checkout and resolves from `origin` on its own, and the
+          # Claude step's main output path is `gh pr create`, which misbehaves
+          # when GH_REPO is set (it can no longer infer the head branch from the
+          # local repo and demands an explicit --head).
+          GH_REPO: ${{ github.repository }}
         run: |
           set -uo pipefail
           open_pr=$(gh pr list --label ci-sentinel --state open --json number --jq 'length')

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,6 +20,15 @@
 # entirely. Reviewing it is correct anyway: `gh pr diff` shows the whole PR
 # (feature changes + the one version line), and the per-branch
 # `cancel-in-progress` below guarantees exactly one review, on the final head.
+#
+# The above is necessary but was NOT sufficient. Because auto-version originally
+# pushed the bump with the default GITHUB_TOKEN, the bump commit's CI run was
+# bot-actored, and GitHub's recursive-run guard emitted no `workflow_run` event
+# for it at all. So the one CI run that reaches `success` on a bumped PR was
+# precisely the one this workflow could never see — no run, no skip, no signal,
+# and 7 of 12 merged PRs went unreviewed. auto-version.yml now pushes with
+# `secrets.AUTO_VERSION_PAT` so the event fires; if that secret is ever removed,
+# reviews silently stop again.
 
 name: Claude Review
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,9 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: "0 7 * * 2" # Tuesdays 07:00 UTC — offset from security-scan.yml's Monday sweep
+    # Tuesdays, offset from security-scan.yml's Monday sweep and off the hour
+    # (":00" is the most contended slot and queues these ~3h late).
+    - cron: "29 7 * * 2" # Tuesdays 07:29 UTC
 
 concurrency:
   group: codeql-${{ github.ref }}

--- a/.github/workflows/feedback-remediation.yml
+++ b/.github/workflows/feedback-remediation.yml
@@ -21,7 +21,9 @@ name: Feedback Remediation
 
 on:
   schedule:
-    - cron: "0 2 * * *" # nightly 02:00 UTC
+    # Nightly, deliberately off the hour: GitHub queues scheduled runs on shared
+    # capacity and ":00" is the most contended slot — these were firing ~3h late.
+    - cron: "17 2 * * *" # nightly 02:17 UTC
   workflow_dispatch:
     inputs:
       dry_run:
@@ -46,7 +48,22 @@ jobs:
     env:
       # Scheduled runs act for real; manual runs default to dry-run.
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+      # `gh` infers the repo from a git remote; make it explicit so this job never
+      # depends on checkout ordering. Job-level so it reaches both the collect step
+      # and the shells claude-code-action spawns for its own `gh` calls. (Safe
+      # here — this job only ever runs `gh issue`, never `gh pr create`, which is
+      # the one command GH_REPO interferes with.)
+      GH_REPO: ${{ github.repository }}
     steps:
+      # Shallow checkout purely so claude-code-action runs in a real repo, as it
+      # does in every other Claude job here. This job reads no source files, but
+      # it had never once got past the step below, so its Claude step is entirely
+      # unexercised — don't also make it the only one running in a bare workspace.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
       - name: Collect fresh issues (exclude bots + already-triaged)
         id: collect
         env:
@@ -76,12 +93,16 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # In a dry run, hand Claude ONLY read tools — it physically cannot edit,
           # comment, or create, so "log the plan" is enforced, not just requested.
-          # A real run adds the issue-write verbs.
+          # A real run adds the issue-write verbs, plus `date`: the DIGEST
+          # instruction below tells Claude to check the weekday with `date -u +%u`,
+          # which was previously denied outright. It stays OUT of the dry-run list
+          # — the digest is skipped on a dry run, so `date` is unreachable there,
+          # and the "hand Claude ONLY read tools" invariant stays literally true.
           claude_args: >-
             --model claude-sonnet-5 --max-turns 30 --allowedTools
             "${{ env.DRY_RUN == 'true'
               && 'Bash(gh issue list:*),Bash(gh issue view:*),Read'
-              || 'Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh issue create:*),Read' }}"
+              || 'Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh issue create:*),Bash(date:*),Read' }}"
           prompt: |
             You are the feedback-remediation triager. The fresh open issues to
             triage are in `issues.json` at the repo root (bot-authored and

--- a/.github/workflows/flaky-test-hunter.yml
+++ b/.github/workflows/flaky-test-hunter.yml
@@ -20,7 +20,7 @@ name: Flaky Test Hunter
 
 on:
   schedule:
-    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+    - cron: "23 6 * * 1" # Mondays 06:23 UTC (off the hour — ":00" queues ~3h late)
   workflow_dispatch:
     inputs:
       reruns:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -10,7 +10,7 @@ name: Scheduled Security Scan
 # (anthropics/claude-code-action@v1 authenticated with CLAUDE_CODE_OAUTH_TOKEN).
 on:
   schedule:
-    - cron: "0 7 * * 1" # Mondays 07:00 UTC
+    - cron: "37 7 * * 1" # Mondays 07:37 UTC (off the hour — ":00" queues ~3h late)
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,9 +1,10 @@
 name: Smoke Tests
 
 on:
-  schedule:
-    # Every Monday at 06:00 UTC
-    - cron: "0 6 * * 1"
+  # No `schedule:` while the job below is disabled — a weekly cron on an
+  # `if: false` job just logs a skipped run every Monday forever, which buries
+  # real signal in the Actions list. Restore the cron at the same time as
+  # re-enabling the job, off the hour like the others: "23 6 * * 1".
   workflow_dispatch: # Allow manual trigger from GitHub UI
 
 # Least-privilege token — this job only checks out code and runs tests.

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.40.0"
+version = "2.41.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

Investigating why `Feedback Remediation` was failing and three workflows were showing as skipped turned up three real defects. The visible skips were the least of it.

**The three skipped runs were correct behaviour** — they're `workflow_run` responses to the CI run on a `main` push. Claude Review and Dependabot Auto require `workflow_run.event == 'pull_request'`; CI Sentinel requires `conclusion == 'failure'`. A green main-push CI matches none. Not touched.

**1. Reviews were being silently dropped (highest impact).** `auto-version.yml` checked out with no `token:` override, so Claude's `git push` of `chore: bump version` used the default `GITHUB_TOKEN`. That makes the bump commit's CI run bot-actored, and GitHub's recursive-run guard then emits **no `workflow_run` event at all** when it completes. Since `ci.yml`'s `cancel-in-progress` cancels the pre-bump run (cancelled ≠ `success`), a bumped PR had no CI run capable of triggering anything. The correlation is exact — CI run `actor` is the only differing variable:

| PR | head commit | `workflow_run` | review |
|---|---|---|---|
| #109 | `claude[bot]` bump | none emitted | ✗ |
| #107 | `claude[bot]` bump | none emitted | ✗ |
| #108 | human commit | fired 3s later | ✓ |

**7 of the last 12 merged PRs shipped unreviewed**, with no failure and no skip visible anywhere. Now pushes with `AUTO_VERSION_PAT` (secret created), and a warning step flags the `|| github.token` fallback so the degraded mode can't be silent again.

**2. Two workflows had never done any work.** `Feedback Remediation` (failed 4/4 nights) and `Backlog Groomer` both die on their first step — neither checks out nor sets `GH_REPO`, so bare `gh issue list` exits 1 with `fatal: not a git repository`. `ci-sentinel.yml` had the same bug latent, its dedupe step calling `gh pr list` before its checkout; it only survived because `main` CI has never gone red.

**3.** The triager's prompt calls `date -u +%u` for its Monday digest, but `date` wasn't in `--allowedTools`.

Plus: crons moved off `:00` (they were firing 3–4h late), and `smoke.yml`'s cron dropped since its only job is `if: false`.

## Review findings addressed

An independent review raised 6 `should-fix` items; 5 applied, 1 rejected with evidence:

- **PAT blast radius** — comment now mandates a *fine-grained* token scoped to this repo with `Contents` only, since the job runs Claude with unrestricted `Bash` over PR-branch code and checkout persists the credential to `.git/config`.
- **`ci-and-release` skill contradicted the code** — it still said "no PAT is needed"; a future reader following it would have deleted the secret and re-broken reviews. Updated, along with the `smoke.yml` row, plus new notes on the `GH_REPO` and off-the-hour-cron conventions.
- **Silent fallback** — added the warning step described above.
- **`GH_REPO` scope in ci-sentinel** — moved from job-level to step-level: it's only needed pre-checkout, and job-wide it would have broken the `gh pr create` that the Claude step depends on. Would have surfaced on the first red `main`.
- **Unexercised Claude steps** — `backlog-groomer` and `feedback-remediation` were the only Claude jobs in the repo running without a checkout, and nothing downstream of their first step has ever executed. Added a shallow checkout to both rather than shipping that unknown.
- **Rejected: "dedupe fails open silently."** GitHub's default `run:` shell is `bash -e {0}`, and `set -uo pipefail` does not clear `-e`, so a failing `gh` assignment aborts the step. Verified directly: `bash -e` on that exact snippet exits 1 without reaching the next line. The bug hid because ci-sentinel has never fired, not because it fails open.

Two `nit`s also applied: the `smoke.yml` comment suggested restoring `"0 6 * * 1"`, which is the on-the-hour slot this PR moves away from; and `Bash(date:*)` was removed from the dry-run allowlist, where the digest is unreachable anyway, keeping "hand Claude ONLY read tools" literally true.

## Test plan

- `make lint` — clean
- `make test` — 6403 passed, 46 skipped
- All 13 workflow files parse; `GH_REPO` placement, checkout tokens, and the dry-run allowlist asserted programmatically
- `bash -e` repro confirming the rejected finding

Workflow triggers can't be verified locally — `schedule` and `workflow_run` need the files on `main`. Post-merge:
- **Decisive check:** the next PR touching `src/yeaboi/` should produce a bump-commit CI run whose `actor` is no longer `github-actions[bot]`, followed within seconds by a Claude Review run.
- `gh workflow run feedback-remediation.yml -f dry_run=true` and `gh workflow run backlog-groomer.yml` — the collect step should report a count instead of the git error.
- `gh workflow run ci-sentinel.yml -f run_id=<a failed CI run id>` exercises the previously unreachable dedupe path.

## Note before merging

`backlog-groomer` has **no dry-run mode**, so its first-ever successful run will label, cross-link and comment across the entire open backlog unreviewed. Worth either dispatching it manually while watching, or adding a dry-run path first. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
