### PR TITLE
fix the auto-version guard that swallowed PR #111, and release 2.43.0

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -85,9 +85,9 @@ jobs:
       - name: Deterministic guards
         id: guard
         env:
-          GH_TOKEN: ${{ github.token }}
+          # No GH_TOKEN / PR number: this step is pure git + grep over the
+          # checkout now, and calls no API at all.
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR: ${{ github.event.pull_request.number }}
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           set -euo pipefail
@@ -125,7 +125,22 @@ jobs:
           # 3) Trivial PR? No shipping code changed -> skip (docs/chore/tests/CI only).
           #    The changelog data file is excluded: an entry-only edit (e.g. a
           #    wording fix) must not trigger a new release by itself.
-          if gh pr diff "$PR" --name-only | grep -E '^src/yeaboi/' | grep -vE '^src/yeaboi/changelog_data\.json$' | grep -q .; then
+          #
+          #    The file list comes from the local checkout, NOT `gh pr diff`. The
+          #    API refuses any diff over 20000 lines with `HTTP 406 ... diff
+          #    exceeded the maximum number of lines`, and because the call sat in
+          #    an `if` condition, `set -e` did not apply: the failure was
+          #    indistinguishable from "no files matched" and fell straight into
+          #    the skip branch. PR #111 (the React migration) rewrote most of
+          #    src/yeaboi/ and shipped with no bump and no release because of it —
+          #    the only trace was a `::notice::no src/yeaboi changes` on a PR that
+          #    changed hundreds of them. `fetch-depth: 0` plus the base fetch above
+          #    make the merge-base diff exact and unbounded, and assigning it to a
+          #    variable first means a git failure aborts the job under `set -e`
+          #    instead of silently reading as "nothing to release".
+          CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)
+          echo "changed files: $(printf '%s' "$CHANGED" | grep -c . || true)"
+          if printf '%s\n' "$CHANGED" | grep -E '^src/yeaboi/' | grep -vE '^src/yeaboi/changelog_data\.json$' | grep -q .; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.42.0"
+version = "2.43.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,47 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.43.0",
+      "date": "2026-07-31",
+      "summary": "Every page yeaboi opens in a browser — the retro board, planning poker, the join screen and the reporting slide deck — has been rebuilt on one shared design, so they now read as parts of the same app rather than three pages that had quietly drifted apart. Inviting people got easier: both live boards hand you a copyable invite link, and you can copy it from the terminal too instead of only holding up a QR code. The retro board gains a composer at the top of every column and sixteen reactions to vote with, and dragging a card on a phone finally works — touch dragging never fired at all before. Planning poker's reveal is a moment now rather than a flicker, and the timer ends on a bell instead of an alarm. Boards also stay current without the constant one-second refresh, which is gentler on a phone battery and on a shared tunnel. Every exported HTML report is drawn by the same pieces as the live boards, so an export matches what you saw. One fix worth naming: a ticket link in an export could previously carry a script that ran when you clicked it, and can't any more.",
+      "highlights": [
+        {
+          "text": "The retro board, planning poker, the join screen and the slide deck rebuilt on one shared design",
+          "areas": [
+            "retro",
+            "planning",
+            "reporting"
+          ]
+        },
+        {
+          "text": "Copy a board's invite link from the browser or from the terminal, instead of only scanning the QR code",
+          "areas": [
+            "retro",
+            "planning"
+          ]
+        },
+        {
+          "text": "A composer at the top of every retro column, and sixteen reactions to vote with",
+          "areas": [
+            "retro"
+          ]
+        },
+        {
+          "text": "Cards can be dragged on a phone — touch dragging did not work before",
+          "areas": [
+            "retro"
+          ]
+        },
+        {
+          "text": "A ticket link in an exported report can no longer run a script when clicked",
+          "areas": [
+            "reporting",
+            "standup"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.42.0",
       "date": "2026-07-31",
       "summary": "The welcome screen gains a duck companion who now does more than sit there: press f and a speech bubble opens from him that you write your feedback straight into, pick a type and area for, paste screenshots into, or dictate out loud. Settings gets a full rebuild around boxed sections you can drive entirely from the keyboard — arrow between boxes, Enter to focus one, then arrow between the values inside it — with storage settings moved under System and long status lines that wrap instead of getting cut off. Clicking now works across the whole app rather than just the main menu, and a handful of small annoyances are gone: the Back button leaves in one click, the controls drawer opens with c, and the wordmark intro no longer replays every time you open Changelog, Feedback, or All Tips.",

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.42.0"
+version = "2.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
PR #111 merged with no PyPI release. The publish pipeline **did** run — it no-op'd in 20s, correctly, because the version bump upstream of it never happened.

## What went wrong

`auto-version.yml`'s third deterministic guard asked the API for the changed files:

```bash
if gh pr diff "$PR" --name-only | grep -E '^src/yeaboi/' | ... | grep -q .; then
```

GitHub refuses any diff over 20000 lines:

```
could not find pull request diff: HTTP 406: Sorry, the diff exceeded the maximum number of lines (20000)
PullRequest.diff too_large
##[notice]no src/yeaboi changes; skipping version bump.
```

`set -euo pipefail` does not apply inside an `if` condition, so a failed `gh` was indistinguishable from "no files matched" and fell into the skip branch. A PR that rewrote 296 files, nearly all of `src/yeaboi/`, was classified as docs/CI-only. `pyproject.toml` stayed at `2.42.0`, `v2.42.0` was already tagged, and `publish.yml` concluded there was nothing to publish.

This is the second silent failure of this workflow this week — `d1ae297` fixed the haiku alias one. Same signature both times: a failure that reads as "no release needed".

## The fix

Compute the file list from the checkout instead:

```bash
CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)
```

`fetch-depth: 0` plus the base fetch already in the step make the merge-base diff exact, it has no size cap, and assigning it to a variable first means a git failure aborts the job under `set -e` rather than reading as "nothing to release". The step now calls no API at all, so `GH_TOKEN` and the PR number are dropped from its env.

Replayed over recent history:

| range | files | verdict |
|---|---|---|
| `5c3bc59...d70f399` (PR #111) | 296 | `skip=false` — bumps |
| `871f3e8...c7c1a49` (changelog only) | 1 | `skip=true` |
| `c7c1a49...5c3bc59` (CI only) | 0 | `skip=true` |

## The release

Second commit bumps to **2.43.0** with its changelog entry — the bump PR #111 should have carried. Minor rather than patch: the migration landed new user-facing capability (the invite on both live boards, per-column composers, sixteen reactions, working touch drag) alongside the rebuild.

Merging this publishes 2.43.0.

## Verification

`make lint` clean; `make test` green (6792 passed, 46 skipped).

Note: the `ci-and-release` skill still says "no PAT is needed" for auto-version, which went stale when `AUTO_VERSION_PAT` was introduced. Left alone here — flagging it rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)