### PR TITLE
mark performance mode as beta across every surface

### DIFF
--- a/.claude/skills/project-map/SKILL.md
+++ b/.claude/skills/project-map/SKILL.md
@@ -11,7 +11,8 @@ description: Full annotated module map of src/yeaboi/ (incl. the MCP server, roa
 src/yeaboi/
   __init__.py           — Version (__version__), LangSmith noise suppression
   cli.py                — CLI entry point (argparse, 20 flags, headless mode, session mgmt)
-  config.py             — Environment/config (API keys, LangSmith, proxy detection)
+  config.py             — Environment/config (API keys, LangSmith, proxy detection, beta-notice acks)
+  beta.py               — Canonical wording for features shipping in beta (BETA_LABEL/BETA_TAG/BETA_RGB + the per-mode notice). **Import-free by contract** — every surface pulls from it, incl. mcp/tools_performance.py at module scope, so an import here would drag langchain into MCP boot; test_beta.py AST-scans it
   persistence.py        — Session persistence layer (checkpoint system)
   sessions.py           — SessionStore (SQLite), state serialization, schema versioning
   setup_wizard.py       — First-time setup flow (provider selection, API key validation)
@@ -228,6 +229,9 @@ The `src/yeaboi/mcp/` package exposes yeaboi to AI coding agents (Claude Code, C
 - `YEABOI_NO_TUNNEL` — optional, `1`/`true`/`yes` stops the live boards opening a Cloudflare tunnel (`config.tunnels_disabled()`). The board still runs for the host on `127.0.0.1` but has nothing to share. Needed because the tunnel now auto-starts: without it `make run-dry` would download ~40 MB and publish a public URL
 - `CLOUDFLARED_PATH` — optional, path to an existing `cloudflared` binary for Retro remote tunnels (else the app auto-downloads one to `~/.yeaboi/bin/`)
 - `PERFORMANCE_FRAMEWORK_PATH` — optional, path to a custom competency framework / review template for Performance mode's 6-month review (else the bundled `performance/references/competency_framework.md` default is used). 1:1 summary emails reuse the standup `STANDUP_SMTP_*` / `STANDUP_EMAIL_RECIPIENTS` settings.
+- `BETA_NOTICES_ENABLED` — default on; `false` silences the one-line beta caveat the CLI prints to stderr before a beta subcommand runs (`yeaboi perf …`). Does **not** affect the TUI's one-time notice.
+- `BETA_NOTICES_ACK` — **state, not configuration.** Comma-separated `_MODE_CARDS` keys whose one-time TUI beta notice has been dismissed; written automatically to `~/.yeaboi/.env` on Continue. Not surfaced on the Settings page (it would invite hand-editing).
+- `YEABOI_FORCE_BETA_NOTICE` — re-show an already-acknowledged TUI beta notice. `1`/`true` for all modes, or a comma-separated list of mode keys. The only way to re-check a once-ever gate for demos, screenshots or review.
 - `SESSION_PRUNE_DAYS` — auto-prune sessions older than N days (default: 30, 0 = disabled)
 - `LOG_LEVEL` — file logger level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)
 - `LANGSMITH_TRACING`, `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT` — optional, enables LangSmith tracing

--- a/.claude/skills/tui-standards/SKILL.md
+++ b/.claude/skills/tui-standards/SKILL.md
@@ -19,7 +19,16 @@ All TUI screens MUST use the shared component system in `src/yeaboi/ui/shared/_c
 | Viewport | `calc_viewport(height, header_h=, action_h=)` | Viewport height calculation |
 | Titles | `planning_title()`, `analysis_title()`, `usage_title()`, `settings_title()` | ASCII art headers |
 | Popup | `build_popup(message, width=, border_style=)` | Confirmation dialogs |
+| Badge | `build_badge(label, rgb=BETA_RGB, dim=)` | Inverse-video status chip (BETA, COMING SOON). Takes an rgb **tuple**, not a colour string — `dim` does arithmetic on the channels, and `COLOR_RGB` only knows the mode accents. Never draw a chip with box glyphs: the mode-card click hit-testing finds title rows by scanning for `█▀▄` |
 | Padding | `PAD` constant | Left indent for visual balance |
+
+**Beta modes.** A mode whose output isn't verified yet keeps `"available": True`
+in `_MODE_CARDS` (that flag gates Enter, the click handler *and* the welcome
+screen's `g` jump key — flipping it removes the feature rather than labelling
+it) and adds `"badge": BETA_LABEL`. Three markers must move together, and
+`test_beta_surfaces.py::TestBetaMarkersAgree` enforces it: the card badge, a
+`_BETA_MODES` entry in `ui/shared/_beta_notice.py` (the one-time entry notice),
+and `FeatureTip(is_beta=True)`. Where both could render, **BETA beats NEW**.
 
 ## Page Structure (every `_build_*_screen` function MUST follow)
 

--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,21 @@ VOICE_MODEL=base
 # welcome screen (the choice is saved back here automatically).
 TIPS_ENABLED=true
 
+# Beta notices — two separate mechanisms, one per surface.
+#
+# CLI only: the one-line maturity caveat printed to stderr before a beta
+# subcommand runs (e.g. `yeaboi perf`). Default on; set false for cron/CI that
+# captures stderr. This does NOT affect the TUI's one-time notice.
+BETA_NOTICES_ENABLED=true
+#
+# TUI only: the one-time notice shown the first time a beta mode is opened.
+# It has no on/off switch — it shows once, then never again. BETA_NOTICES_ACK
+# records which modes have been acknowledged and is written automatically on
+# Continue; it's state, not configuration, so don't hand-edit it. To see the
+# notices again, clear it or set YEABOI_FORCE_BETA_NOTICE (1 for every mode, or
+# a comma-separated list of mode keys).
+# YEABOI_FORCE_BETA_NOTICE=1
+
 # Session management
 # Auto-prune sessions older than N days (default 30, set to 0 to disable)
 SESSION_PRUNE_DAYS=30

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ yeaboi --non-interactive --description @project-brief.txt --output html --team-s
 
 🖥️ **Full-screen TUI** — Animated splash, mode selection, pipeline progress, dark/light themes
 🧠 **Smart Intake** — Extracts answers from your project description, asks only what's missing — or feed it a whole quarterly roadmap with Roadmap Intake
-🔄 **Six modes, one command** — Planning, Daily Standup, Retro, Performance, Reporting, Team Analysis
+🔄 **Six modes, one command** — Planning, Daily Standup, Retro, Performance _(beta)_, Reporting, Team Analysis
 🔌 **35+ tools** — GitHub, Azure DevOps, Jira, Confluence, Notion, local codebase scanning, and more
 📤 **5 export formats** — Markdown, HTML, JSON, Jira sync, Azure DevOps Boards sync
 🤖 **5 LLM providers** — Claude (default), GPT, Gemini, AWS Bedrock, or fully local & keyless with Ollama

--- a/claude-plugin/yeaboi/skills/performance/SKILL.md
+++ b/claude-plugin/yeaboi/skills/performance/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: performance
-description: "Manage engineers with yeaboi: 1:1 prep from real delivery data, 1:1 completion summaries with tracked action items, periodic performance reviews, and quick notes. Use when the user wants to prepare for a 1:1, write up a held 1:1, draft a performance review, or record an observation about an engineer."
+description: "(beta) Manage engineers with yeaboi: 1:1 prep from real delivery data, 1:1 completion summaries with tracked action items, periodic performance reviews, and quick notes. Use when the user wants to prepare for a 1:1, write up a held 1:1, draft a performance review, or record an observation about an engineer."
 ---
 
 # Performance workflows with yeaboi
+
+> **Beta.** Performance mode is in beta — its output is not yet verified against real delivery data.
+> Treat every 1:1 prep, summary and review as a draft to edit, not a verdict, and
+> say so when you present it to the user.
 
 1. **Know the roster.** Call `perf_roster` to list the engineers derived from
    recent Jira/Azure DevOps assignees — these are the names every other tool
@@ -25,8 +29,9 @@ description: "Manage engineers with yeaboi: 1:1 prep from real delivery data, 1:
    - **Record an observation** → `perf_note_add` with the engineer and the
      note. Notes feed future preps and reviews.
 
-3. **Surface `warnings`** (tracker 401s, missing SMTP, LLM fallback) so the
-   user knows what informed — or didn't inform — the output.
+3. **Surface `warnings`** (the beta caveat, tracker 401s, missing SMTP, LLM
+   fallback) so the user knows what informed — or didn't inform — the output.
+   Every perf tool now returns the beta caveat as its first warning.
 
 4. **Sensitive data.** This is personnel material: keep it in the conversation,
    don't post it anywhere external unless explicitly asked. Exports auto-save

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -311,6 +311,18 @@ ul.nav-tree ul.nav-tree{margin:3px 0 6px 12px; border-left:1px solid var(--borde
 .badge::before{content:""; width:6px; height:6px; border-radius:50%; background:var(--success);
   box-shadow:0 0 8px var(--success)}
 
+/* Beta pill — a caution marker for a feature that ships but whose output isn't
+   verified yet. Deliberately NOT a .badge: that one injects a green "live" dot,
+   which says the opposite. The amber matches BETA_RGB in src/yeaboi/beta.py, so
+   the terminal chip and this pill are the same colour. */
+.beta-pill{
+  display:inline-block; vertical-align:middle; margin-left:10px;
+  font-family:var(--mono); font-size:.62rem; letter-spacing:.14em;
+  text-transform:uppercase; font-weight:600; line-height:1;
+  color:rgb(224,138,72); border:1px solid rgba(224,138,72,.45);
+  border-radius:999px; padding:4px 8px;
+}
+
 /* ---- terminal window chrome ---- */
 .term{
   background:#0a0b0c; border:1px solid var(--border-strong); border-radius:var(--radius-lg);

--- a/docs/docs/architecture.html
+++ b/docs/docs/architecture.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -301,6 +301,6 @@ for chunk, metadata in app.stream(
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -152,6 +152,6 @@ yeaboi --dry-run                                  # TUI with mock data</code></p
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/deployment.html
+++ b/docs/docs/deployment.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -274,6 +274,6 @@ grep LLM_PROVIDER ~/.yeaboi/.env</code></pre>
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/development.html
+++ b/docs/docs/development.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -212,6 +212,6 @@ make clean                # remove build artifacts and caches</code></pre>
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/getting-started.html
+++ b/docs/docs/getting-started.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -154,6 +154,6 @@ LANGSMITH_PROJECT=yeaboi</code></pre>
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -41,7 +41,7 @@
       <ul>
         <li><a href="/docs/getting-started.html">Getting Started</a> — install, setup, API keys, intake modes</li>
         <li><a href="/docs/cli-reference.html">CLI Reference</a> — every flag, headless mode, session flags</li>
-        <li><a href="/docs/modes/index.html">Modes</a> — Planning, Daily Standup, Retro, Performance, Reporting, Team Analysis</li>
+        <li><a href="/docs/modes/index.html">Modes</a> — Planning, Daily Standup, Retro, Performance (beta), Reporting, Team Analysis</li>
         <li><a href="/docs/integrations-exports.html">Integrations &amp; Exports</a> — Markdown, HTML, Notion, Confluence, Jira, Azure DevOps, JSON</li>
         <li><a href="/docs/session-management.html">Session Management</a> — sessions, Usage page, Settings page</li>
         <li><a href="/docs/tools.html">Tools</a> — all 35 tools and their risk levels</li>
@@ -55,6 +55,6 @@
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/integrations-exports.html
+++ b/docs/docs/integrations-exports.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -139,6 +139,6 @@ AZURE_DEVOPS_TEAM=MyProject Team    # optional — defaults to "{project} Team"<
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/modes/index.html
+++ b/docs/docs/modes/index.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -46,7 +46,8 @@
       <p>Open a board your whole team joins from any browser on the network. Cards, reactions, a shared timer — then AI action items. A small local HTTP server hosts the board with a share code and QR join, no install required for teammates.</p>
       <p><a href="/docs/modes/retro.html">Full Retro docs →</a></p>
 
-      <h2 id="performance">Performance</h2>
+      <h2 id="performance">Performance <span class="beta-pill">Beta</span></h2>
+      <p><strong>Beta:</strong> Performance mode's output is not yet verified against real delivery data — treat every prep, summary and review as a draft to edit, not a verdict.</p>
       <p>Prep and write up 1:1s, and synthesize six-month reviews from each engineer's real delivery history. The roster is derived from who actually did the work in Jira/Azure DevOps, and open action items from one 1:1 carry forward automatically into the prep for the next.</p>
       <p><a href="/docs/modes/performance.html">Full Performance docs →</a></p>
 
@@ -62,6 +63,6 @@
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/modes/performance.html
+++ b/docs/docs/modes/performance.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -31,8 +31,9 @@
   <aside class="docs-sidebar" id="docs-sidebar"></aside>
   <main class="docs-content">
     <article>
-      <h1>Performance</h1>
+      <h1>Performance <span class="beta-pill">Beta</span></h1>
       <p class="lede">Three connected workflows for managing each engineer — 1:1 prep, 1:1 completion, and six-month reviews.</p>
+      <p><strong>Beta.</strong> Performance mode is in beta — its output is not yet verified against real delivery data. Treat every 1:1 prep, summary and review as a draft to edit, not a verdict.</p>
 
       <h2 id="roster">Roster</h2>
       <p>Performance mode's roster of engineers isn't a headcount number typed in during setup — it's derived from who actually did work in Jira or Azure DevOps. That keeps the list of people you're managing through the mode in sync with who's genuinely shipping, rather than an org chart that can drift out of date.</p>
@@ -53,6 +54,6 @@
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/modes/planning.html
+++ b/docs/docs/modes/planning.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -90,6 +90,6 @@
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/modes/reporting.html
+++ b/docs/docs/modes/reporting.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -58,6 +58,6 @@
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/modes/retro.html
+++ b/docs/docs/modes/retro.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -56,6 +56,6 @@
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/modes/standup.html
+++ b/docs/docs/modes/standup.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -72,6 +72,6 @@ yeaboi --standup-run --standup-session latest --standup-output terminal</code></
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/modes/team-analysis.html
+++ b/docs/docs/modes/team-analysis.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -141,6 +141,6 @@
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/scrum-standards.html
+++ b/docs/docs/scrum-standards.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -476,6 +476,6 @@ And   no duplicate account should be created</code></pre>
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/session-management.html
+++ b/docs/docs/session-management.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -100,6 +100,6 @@ yeaboi --resume &lt;id&gt;       # specific session ID</code></pre>
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/docs/tools.html
+++ b/docs/docs/tools.html
@@ -13,9 +13,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body class="docs">
 <header class="navbar">
@@ -140,6 +140,6 @@
   <nav class="docs-toc" id="docs-toc"></nav>
 </div>
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,9 +17,9 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=JetBrains+Mono:wght@400..800&display=swap" />
-<link rel="stylesheet" href="/assets/site.css?v=132" />
-<link rel="stylesheet" href="/assets/landing.css?v=132" />
-<link rel="stylesheet" href="/docs/assets/docs.css?v=132" />
+<link rel="stylesheet" href="/assets/site.css?v=133" />
+<link rel="stylesheet" href="/assets/landing.css?v=133" />
+<link rel="stylesheet" href="/docs/assets/docs.css?v=133" />
 </head>
 <body>
 
@@ -104,7 +104,7 @@
 █▀▄ ██▄ ░█░ █▀▄ █▄█</pre>
                 <p class="tui-mode-desc" aria-hidden="true"></p>
               </button>
-              <button type="button" class="tui-mode" data-mode="4" style="--mc:220,110,90; --mcd:110,55,45" data-desc="Manage each engineer: 1:1 prep, 1:1 summaries, and 6-month reviews from real delivery data." aria-label="Performance — manage each engineer: 1:1 prep, 1:1 summaries, and 6-month reviews from real delivery data.">
+              <button type="button" class="tui-mode" data-mode="4" style="--mc:220,110,90; --mcd:110,55,45" data-desc="Manage each engineer: 1:1 prep, 1:1 summaries, and 6-month reviews from real delivery data.  BETA" aria-label="Performance (beta) — manage each engineer: 1:1 prep, 1:1 summaries, and 6-month reviews from real delivery data.">
 <pre class="tui-mode-title" aria-hidden="true">█▀█ █▀▀ █▀█ █▀▀ █▀█ █▀█ █▀▄▀█ ▄▀█ █▄░█ █▀▀ █▀▀
 █▀▀ ██▄ █▀▄ █▀░ █▄█ █▀▄ █░▀░█ █▀█ █░▀█ █▄▄ ██▄</pre>
                 <p class="tui-mode-desc" aria-hidden="true"></p>
@@ -238,8 +238,8 @@
         <span class="mode-tag">live board · secure tunnel</span>
       </div>
       <div class="mode-card" data-reveal style="--mh:var(--m-performance)">
-        <div class="mode-head"><span class="num">05</span><h3>Performance</h3></div>
-        <p>Prep and write up 1:1s, and synthesize six-month reviews from each engineer's real delivery history.</p>
+        <div class="mode-head"><span class="num">05</span><h3>Performance</h3><span class="beta-pill">Beta</span></div>
+        <p>Prep and write up 1:1s, and synthesize six-month reviews from each engineer's real delivery history. Beta — output is not yet verified against real delivery data.</p>
         <span class="mode-tag">1:1s · six-month reviews</span>
       </div>
       <div class="mode-card" data-reveal style="--mh:var(--m-reporting)">
@@ -326,6 +326,6 @@
 </main>
 
 <script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="/assets/site.js?v=132"></script>
+<script src="/assets/site.js?v=133"></script>
 </body>
 </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.44.0"
+version = "2.45.0"
 description = "yeaboi.ai — a team lead's best friend. A terminal AI agent that decomposes projects into epics, user stories, tasks, and sprint plans."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/beta.py
+++ b/src/yeaboi/beta.py
@@ -1,0 +1,55 @@
+"""Canonical wording for features that ship in beta.
+
+A feature is "beta" here when it works end to end but its *output* has not been
+validated against real-world data yet. That is a different claim from "coming
+soon" (not usable) and from "new" (usable and verified, just recent), and it
+deserves its own vocabulary so every surface says the same thing.
+
+This module is deliberately **import-free**. Every surface pulls from it —
+``cli.py``, ``mcp/tools_performance.py``, the TUI screens, the tip registry —
+and two of those are startup-latency sensitive:
+
+* The constants cannot live in ``performance/``. ``mcp/tools_performance.py``
+  reaches the engines through function-level imports precisely so the MCP
+  server boots without them; a module-scope ``from yeaboi.performance.beta
+  import …`` would execute ``performance/__init__.py``, which eagerly imports
+  ``context``/``roster``/``store`` and through them ``langchain_core`` — about
+  0.2s onto every server start. (Note ``performance/__init__.py``'s own
+  docstring still claims importing the package "never drags in langchain";
+  that is stale — ``import yeaboi.performance`` does pull ``langchain_core``
+  today. Its lazy ``__getattr__`` defers only the three engine entry points.)
+* ``ui/shared/`` is out too — ``mcp/`` importing a UI module inverts the layering.
+
+``tests/unit/test_beta.py`` AST-scans this file and fails if an import ever
+appears, because the cost would be silent.
+
+HTML, Markdown and the plugin ``SKILL.md`` cannot import Python, so their copies
+are hand-written; ``tests/unit/test_beta_surfaces.py`` pins them to these values.
+"""
+
+# The badge/pill/chip text. Short, uppercase, rendered as an inverse-video chip
+# in the TUI and a rounded pill on the docs site.
+BETA_LABEL = "BETA"
+
+# The inline qualifier for running prose and one-line help strings, matching the
+# lowercase-parenthetical house style of the other CLI subcommand help lines.
+BETA_TAG = "(beta)"
+
+# The load-bearing claim, kept short enough to survive HTML re-wrapping — this
+# is the token the cross-surface sync test greps for in the docs and SKILL.md.
+PERFORMANCE_BETA_PHRASE = "not yet verified against real delivery data"
+
+# The full caveat. One sentence of status, one of instruction. "a draft to edit,
+# not a verdict" is lifted from the performance plugin skill's existing voice so
+# the caveat reads as part of the product rather than bolted on.
+PERFORMANCE_BETA_NOTICE = (
+    "Performance mode is in beta — its output is not yet verified against real "
+    "delivery data. Treat every 1:1 prep, summary and review as a draft to edit, "
+    "not a verdict."
+)
+
+# Amber caution. Deliberately *not* the warm gold (226,186,96) used by the NEW
+# badge: beta is a warning, new is a freshness cue, and the two appear side by
+# side in the tips gallery where they must not read as the same thing. The docs
+# site's ``.beta-pill`` uses the same rgb() triple.
+BETA_RGB = (224, 138, 72)

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,38 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.45.0",
+      "date": "2026-07-31",
+      "summary": "Performance mode is now clearly marked as beta wherever you meet it. The mode works exactly as before and nothing has been taken away \u2014 but its 1:1 preps, completion summaries and six-month reviews have not yet been checked against a real team's delivery data, and until now nothing on screen said so. That matters more here than elsewhere, because these drafts are about named people. The Performance card on the welcome screen and the page header both carry a BETA tag, and the first time you open the mode you get a short one-time note explaining what is and isn't reliable: the drafts are a starting point rather than an assessment, a board with little on it produces thin and sometimes misleading signals, and nothing is emailed to anyone unless you ask for it. You will only see that note once. The same caveat now appears when you use Performance from the command line or through an AI assistant.",
+      "highlights": [
+        {
+          "text": "Performance is labelled BETA on the mode card and page header \u2014 the mode stays fully usable",
+          "areas": [
+            "performance"
+          ]
+        },
+        {
+          "text": "A one-time notice on first entry explains what the drafts can and can't tell you, and that nothing is sent automatically",
+          "areas": [
+            "performance"
+          ]
+        },
+        {
+          "text": "The same beta caveat now reaches the command line and AI-assistant integrations, not just the app",
+          "areas": [
+            "performance",
+            "general"
+          ]
+        },
+        {
+          "text": "Beta notices can be silenced for scripted runs, and replayed on demand for demos",
+          "areas": [
+            "settings"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.44.0",
       "date": "2026-07-31",
       "summary": "Inviting people to a live retro or planning poker board is now one link that works for everyone, wherever they are. Boards used to offer a link that only worked for teammates on the same Wi-Fi, with a separate \u201cShare Remotely\u201d button to add an internet-reachable one on top \u2014 and it was easy to send the wrong one to someone at home. Every board now sets up a single secure link by itself the moment it opens, and that is the link Copy Invite gives you. The board is also no longer reachable from your local network at all, so it is not exposed to everyone else on an office or caf\u00e9 connection, and your own host link travels encrypted. Two things to know: hosting a board now needs an internet connection, and the invite link takes a few seconds to appear while it is being prepared \u2014 the access code works straight away.",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -14,6 +14,7 @@ from rich.table import Table
 from rich.text import Text
 
 from yeaboi import __version__, fs_policy, paths
+from yeaboi.beta import BETA_TAG, PERFORMANCE_BETA_NOTICE
 from yeaboi.config import (
     detect_proxy,
     disable_langsmith_tracing,
@@ -604,16 +605,28 @@ def build_parser() -> argparse.ArgumentParser:
     standup_p.add_argument("--strict", action="store_true", help="Exit 3 on a degraded run (warnings present)")
     standup_p.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
 
-    perf_p = subparsers.add_parser("perf", help="Performance mode: 1:1 prep/completion, reviews, notes")
+    perf_p = subparsers.add_parser(
+        "perf",
+        help=f"Performance mode {BETA_TAG}: 1:1 prep/completion, reviews, notes",
+        description=PERFORMANCE_BETA_NOTICE,
+    )
     perf_sub = perf_p.add_subparsers(dest="perf_command", metavar="{roster,prep,complete,review,note}", required=True)
-    perf_sub.add_parser("roster", help="List the engineer roster from recent tracker assignees")
-    prep_p = perf_sub.add_parser("prep", help="Prepare a 1:1 for an engineer")
+    # Every child carries the same description: `yeaboi perf prep --help` is a
+    # perfectly normal place to arrive without ever seeing the parent's help.
+    perf_sub.add_parser(
+        "roster",
+        help="List the engineer roster from recent tracker assignees",
+        description=PERFORMANCE_BETA_NOTICE,
+    )
+    prep_p = perf_sub.add_parser("prep", help="Prepare a 1:1 for an engineer", description=PERFORMANCE_BETA_NOTICE)
     prep_p.add_argument("engineer", help="Engineer name (see `yeaboi perf roster`)")
     prep_p.add_argument("--session", default="", metavar="ID", help="Session for team context (default: most recent)")
     prep_p.add_argument("--jira-project", default="", metavar="KEY", help="Jira project key override")
     prep_p.add_argument("--azdo-project", default="", metavar="NAME", help="Azure DevOps project override")
     prep_p.add_argument("--strict", action="store_true", help="Exit 3 on a degraded run (warnings present)")
-    complete_p = perf_sub.add_parser("complete", help="Complete a held 1:1 from its transcript")
+    complete_p = perf_sub.add_parser(
+        "complete", help="Complete a held 1:1 from its transcript", description=PERFORMANCE_BETA_NOTICE
+    )
     complete_p.add_argument("engineer", help="Engineer name")
     complete_p.add_argument(
         "--transcript", required=True, metavar="TEXT", help="Transcript text; @file.txt reads from file"
@@ -627,14 +640,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--recipients", nargs="+", default=None, metavar="EMAIL", help="Email recipients override (with --deliver)"
     )
     complete_p.add_argument("--strict", action="store_true", help="Exit 3 on a degraded run (warnings present)")
-    review_p = perf_sub.add_parser("review", help="Draft a periodic performance review")
+    review_p = perf_sub.add_parser(
+        "review", help="Draft a periodic performance review", description=PERFORMANCE_BETA_NOTICE
+    )
     review_p.add_argument("engineer", help="Engineer name")
     review_p.add_argument("--months", type=int, default=6, help="Review period in months (default 6)")
     review_p.add_argument("--session", default="", metavar="ID", help="Session for team context")
     review_p.add_argument("--jira-project", default="", metavar="KEY", help="Jira project key override")
     review_p.add_argument("--azdo-project", default="", metavar="NAME", help="Azure DevOps project override")
     review_p.add_argument("--strict", action="store_true", help="Exit 3 on a degraded run (warnings present)")
-    note_p = perf_sub.add_parser("note", help="Record a note about an engineer")
+    note_p = perf_sub.add_parser("note", help="Record a note about an engineer", description=PERFORMANCE_BETA_NOTICE)
     note_p.add_argument("engineer", help="Engineer name")
     note_p.add_argument("--text", required=True, help="The note text")
 
@@ -1225,6 +1240,23 @@ def _strict_exit(strict: bool, warnings, empty: bool = False) -> int:
     return 0
 
 
+def _print_beta_notice(notice: str) -> None:
+    """Print a beta-maturity caveat before a beta subcommand runs.
+
+    stderr, not stdout: the artifact these commands print is routinely piped or
+    redirected, and a caveat inside the file would be worse than no caveat. It
+    also matches the ``⚠ {warning}`` lines the handlers already emit. Scripted
+    callers turn it off with ``BETA_NOTICES_ENABLED=false``.
+
+    Deliberately NOT routed through the engine's warnings tuple: ``--strict``
+    maps any warning to exit 3, which would make every strict run fail forever.
+    """
+    from yeaboi.config import is_beta_notice_enabled
+
+    if is_beta_notice_enabled():
+        print(f"⚠ {notice}", file=sys.stderr)
+
+
 def _cmd_report(args: argparse.Namespace, console: "Console") -> int:
     from yeaboi.reporting.engine import run_delivery_report
     from yeaboi.reporting.render import format_report_rich
@@ -1363,6 +1395,10 @@ def _cmd_standup_schedule(args: argparse.Namespace, console: "Console", session_
 
 
 def _cmd_perf(args: argparse.Namespace, console: "Console") -> int:
+    logging.getLogger(__name__).info("perf %s (beta)", args.perf_command)
+    # One call site ahead of the branch covers all five subcommands.
+    _print_beta_notice(PERFORMANCE_BETA_NOTICE)
+
     if args.perf_command == "roster":
         from yeaboi.performance.roster import fetch_roster
 

--- a/src/yeaboi/config.py
+++ b/src/yeaboi/config.py
@@ -144,6 +144,16 @@ def is_tips_enabled() -> bool:
     return os.getenv("TIPS_ENABLED", "true").strip().lower() != "false"
 
 
+def is_beta_notice_enabled() -> bool:
+    """Return True if CLI runs should print the beta-maturity caveat (default on).
+
+    Mirrors :func:`is_tips_enabled`: any value other than "false" keeps it on, so
+    an unset var means enabled — a maturity caveat has to be opt-out, never
+    opt-in. Scripted and cron callers that capture stderr can turn it off.
+    """
+    return os.getenv("BETA_NOTICES_ENABLED", "true").strip().lower() != "false"
+
+
 def set_tips_enabled(enabled: bool) -> None:
     """Persist the tips on/off preference to ~/.scrum-agent/.env and apply it now.
 
@@ -190,6 +200,60 @@ def set_music_channel(idx: int) -> None:
     config_file = set_config_value("MUSIC_CHANNEL", value)
     os.environ["MUSIC_CHANNEL"] = value
     logger.info("Music channel set to %s (persisted to %s)", value, config_file)
+
+
+# Modes that ship in beta show a one-time notice the first time they're opened.
+# The acknowledgement is a comma-separated list of _MODE_CARDS keys rather than a
+# boolean per mode, so the next beta mode costs one card key instead of a new env
+# var and a new pair of functions.
+BETA_ACK_KEY = "BETA_NOTICES_ACK"
+FORCE_BETA_NOTICE_ENV = "YEABOI_FORCE_BETA_NOTICE"
+
+
+def beta_notices_acked() -> set[str]:
+    """Return the set of mode keys whose beta notice has been acknowledged."""
+    raw = os.getenv(BETA_ACK_KEY, "")
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def is_beta_notice_seen(mode_key: str) -> bool:
+    """Return True if ``mode_key``'s one-time beta notice has already been shown.
+
+    ``YEABOI_FORCE_BETA_NOTICE`` overrides the acknowledgement — either truthy
+    (all modes) or a comma-separated list of specific keys. A once-ever gate is
+    otherwise impossible to re-check by hand after the first click, which makes
+    it impossible to demo, screenshot, or eyeball during review.
+    """
+    forced = os.getenv(FORCE_BETA_NOTICE_ENV, "").strip().lower()
+    if forced:
+        if forced in {"1", "true", "yes", "on"}:
+            return False
+        if mode_key in {part.strip() for part in forced.split(",") if part.strip()}:
+            return False
+    return mode_key in beta_notices_acked()
+
+
+def mark_beta_notice_seen(mode_key: str) -> None:
+    """Record that ``mode_key``'s beta notice has been acknowledged.
+
+    Deliberately not :func:`apply_config_value` (which does the same pair): that
+    helper writes to disk *first*, so a failed write would skip the ``os.environ``
+    update too. Here the order is inverted — ``os.environ`` is set even when the
+    disk write fails (read-only home, odd permissions), because a user who just
+    dismissed the notice must not see it again in the same session. Re-showing
+    it on the next restart is the lesser failure.
+    """
+    acked = beta_notices_acked()
+    if mode_key in acked:
+        return
+    value = ",".join(sorted(acked | {mode_key}))
+    os.environ[BETA_ACK_KEY] = value
+    try:
+        config_file = set_config_value(BETA_ACK_KEY, value)
+    except OSError as exc:
+        logger.warning("Could not persist beta notice acknowledgement for %s: %s", mode_key, exc)
+        return
+    logger.info("Beta notice acknowledged for %s (persisted to %s)", mode_key, config_file)
 
 
 # Proxy environment variables to check (both uppercase and lowercase conventions).

--- a/src/yeaboi/mcp/tools_performance.py
+++ b/src/yeaboi/mcp/tools_performance.py
@@ -8,6 +8,7 @@ import logging
 # stringified type hints (PEP 563) of tool functions against this namespace.
 from mcp.server.fastmcp import Context
 
+from yeaboi.beta import PERFORMANCE_BETA_NOTICE
 from yeaboi.mcp.runtime import run_engine, run_readonly
 
 logger = logging.getLogger(__name__)
@@ -91,14 +92,41 @@ def _six_month_review(engineer: str, period_months: int, session_id: str, jira_p
     )
 
 
+def _with_beta(payload: dict) -> dict:
+    """Prepend the beta caveat to a success envelope's warnings.
+
+    ``warnings`` is the only envelope field that both the server instructions and
+    the performance skill tell the client to surface *to the user*; a tool
+    description only ever reaches the model. For drafts about named people, that
+    difference is the whole point.
+
+    Applied here in the adapter and NEVER in the engine artifact's own warnings
+    tuple: ``cli._strict_exit`` maps any engine warning to exit 3, so pushing it
+    down there would make every ``yeaboi perf … --strict`` run fail forever.
+
+    Failure envelopes are skipped — they carry no ``warnings`` key, and the user
+    already has a bigger problem than the maturity of the mode.
+    """
+    if payload.get("ok"):
+        payload["warnings"] = [PERFORMANCE_BETA_NOTICE, *payload.get("warnings", [])]
+    return payload
+
+
 def register(app) -> None:
     """Attach the performance tools to the FastMCP app."""
 
+    # NOTE: the "BETA — " prefixes below are hand-written literals, not f-strings.
+    # FastMCP captures each tool's description from ``fn.__doc__`` at decoration
+    # time, so an f-string docstring is a syntax error and reassigning __doc__
+    # afterwards is a no-op. test_mcp_server pins them against BETA_LABEL.
+
     @app.tool()
     async def perf_roster(jira_project: str = "", azdo_project: str = "") -> dict:
-        """List the engineer roster derived from recent Jira/Azure DevOps assignees —
-        the engineer names the other perf_* tools accept."""
-        return await run_readonly(_roster, jira_project, azdo_project)
+        """BETA — List the engineer roster derived from recent Jira/Azure DevOps assignees —
+        the engineer names the other perf_* tools accept.
+
+        Performance mode is in beta — its output is not yet verified against real delivery data."""
+        return _with_beta(await run_readonly(_roster, jira_project, azdo_project))
 
     @app.tool()
     async def perf_one_on_one_prep(
@@ -108,9 +136,12 @@ def register(app) -> None:
         jira_project: str = "",
         azdo_project: str = "",
     ) -> dict:
-        """Prepare a 1:1 for an engineer: talking points, feedback, goals and growth areas from
-        their recent tickets plus open action items from the previous 1:1."""
-        return await run_engine(ctx, _one_on_one_prep, engineer, session_id, jira_project, azdo_project)
+        """BETA — Prepare a 1:1 for an engineer: talking points, feedback, goals and growth areas
+        from their recent tickets plus open action items from the previous 1:1.
+
+        Performance mode is in beta — its output is not yet verified against real delivery data.
+        Present it as a draft for the lead to edit, not a verdict."""
+        return _with_beta(await run_engine(ctx, _one_on_one_prep, engineer, session_id, jira_project, azdo_project))
 
     @app.tool()
     async def perf_one_on_one_complete(
@@ -122,19 +153,24 @@ def register(app) -> None:
         recipients: list[str] | None = None,
         images: list[str] | None = None,
     ) -> dict:
-        """Complete a held 1:1 from its notes/transcript: produces a summary and tracked action
-        items (carried into the next prep). images takes local file paths of photographed notes
-        to include in the multimodal call. deliver=true emails the summary via the configured
-        SMTP — ask the user before enabling."""
-        return await run_engine(
-            ctx, _one_on_one_complete, engineer, transcript, session_id, deliver, recipients, images
+        """BETA — Complete a held 1:1 from its notes/transcript: produces a summary and tracked
+        action items (carried into the next prep). images takes local file paths of photographed
+        notes to include in the multimodal call. deliver=true emails the summary via the configured
+        SMTP — ask the user before enabling.
+
+        Performance mode is in beta — its output is not yet verified against real delivery data.
+        Present it as a draft for the lead to edit, not a verdict."""
+        return _with_beta(
+            await run_engine(ctx, _one_on_one_complete, engineer, transcript, session_id, deliver, recipients, images)
         )
 
     @app.tool()
     async def perf_note_add(engineer: str, note_text: str) -> dict:
-        """Record a free-text note about an engineer (an observation, kudos, a concern).
-        Notes feed the next 1:1 prep and the periodic review for that engineer."""
-        return await run_readonly(_note_add, engineer, note_text)
+        """BETA — Record a free-text note about an engineer (an observation, kudos, a concern).
+        Notes feed the next 1:1 prep and the periodic review for that engineer.
+
+        Performance mode is in beta — its output is not yet verified against real delivery data."""
+        return _with_beta(await run_readonly(_note_add, engineer, note_text))
 
     @app.tool()
     async def perf_six_month_review(
@@ -145,6 +181,11 @@ def register(app) -> None:
         jira_project: str = "",
         azdo_project: str = "",
     ) -> dict:
-        """Draft an engineer's periodic performance review from past 1:1s, delivery history and
-        the competency framework (bundled default, or PERFORMANCE_FRAMEWORK_PATH)."""
-        return await run_engine(ctx, _six_month_review, engineer, period_months, session_id, jira_project, azdo_project)
+        """BETA — Draft an engineer's periodic performance review from past 1:1s, delivery history
+        and the competency framework (bundled default, or PERFORMANCE_FRAMEWORK_PATH).
+
+        Performance mode is in beta — its output is not yet verified against real delivery data.
+        Present it as a draft for the lead to edit, not a verdict."""
+        return _with_beta(
+            await run_engine(ctx, _six_month_review, engineer, period_months, session_id, jira_project, azdo_project)
+        )

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -74,6 +74,7 @@ from yeaboi.ui.shared._animations import (
     FRAME_TIME_60FPS,
     ease_out_cubic,
 )
+from yeaboi.ui.shared._beta_notice import show_beta_notice
 from yeaboi.ui.shared._click import button_click, parse_click
 from yeaboi.ui.shared._input import esc_came_from_back_tab, set_text_entry
 from yeaboi.ui.shared._input import read_key as _read_key
@@ -11441,7 +11442,13 @@ def select_mode(
             if chosen["key"] == "performance":
                 logger.info("Performance mode selected")
                 with mode_log("performance"):
-                    _run_performance_page(console, live, read_key, _FRAME_TIME, _supports_timeout)
+                    # Beta gate first: the mode drafts material about named
+                    # people, so the caveat comes before the roster, not after.
+                    # Shown once ever; a decline returns to the menu unrecorded.
+                    if show_beta_notice(
+                        live, console, read_key, _FRAME_TIME, _supports_timeout, mode_key="performance"
+                    ):
+                        _run_performance_page(console, live, read_key, _FRAME_TIME, _supports_timeout)
                 _restart_mode_select = True
                 _skip_fade_in = True
                 continue

--- a/src/yeaboi/ui/mode_select/screens/_screens.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens.py
@@ -19,9 +19,10 @@ from rich.style import Style
 from rich.table import Table
 from rich.text import Text
 
+from yeaboi.beta import BETA_LABEL, BETA_RGB
 from yeaboi.ui.shared._animations import BLACK_RGB, COLOR_RGB, lerp_color, shimmer_style
 from yeaboi.ui.shared._ascii_font import render_ascii_text
-from yeaboi.ui.shared._components import PAD, build_page_panel
+from yeaboi.ui.shared._components import PAD, build_badge, build_page_panel
 from yeaboi.ui.shared._mascot import render_head, render_head_shades
 from yeaboi.ui.shared._tips import TIP_ROTATE_SECONDS
 
@@ -74,7 +75,11 @@ _MODE_CARDS: list[dict[str, Any]] = [
         "key": "performance",
         "title": "Performance",
         "description": "Manage each engineer: 1:1 prep, 1:1 summaries, and 6-month reviews from real delivery data.",
+        # Beta, not unavailable: the mode runs, but its output hasn't been
+        # validated against a real team's tracker yet. "available" must stay True
+        # — it gates Enter, the click handler, and the tip jump key.
         "available": True,
+        "badge": BETA_LABEL,
         "color": "rgb(220,110,90)",
     },
     {
@@ -194,6 +199,10 @@ _COMPANION_COLS = 44  # right-hand lane width (bubble + duck); wide enough for t
 # a flatter left-to-right curtain. This is the inverse of the splash crumble.
 _SWEEP_ROW_WEIGHT = 4.0
 
+# Chip colour for an unavailable (COMING SOON) card — the same dead grey the
+# disabled title uses, so the whole row reads as one state.
+_DISABLED_BADGE_RGB = (90, 90, 100)
+
 
 def mode_title_widths() -> list[int]:
     """Block-font column width of every mode title, index-aligned to _MODE_CARDS.
@@ -202,6 +211,21 @@ def mode_title_widths() -> list[int]:
     in (see the reveal loop in :mod:`yeaboi.ui.mode_select`).
     """
     return [max(len(line) for line in render_ascii_text(mode["title"])) for mode in _MODE_CARDS]
+
+
+def _card_badge(mode: dict[str, Any]) -> str:
+    """Return the status chip text for a card, or "" when it has no status.
+
+    An explicit ``badge`` wins; otherwise an unavailable card is a COMING SOON.
+
+    ``badge`` is read with ``.get`` because ``_build_mode_row`` is also fed dicts
+    synthesised at runtime — the Performance roster builds one per engineer —
+    which set ``available`` but never ``badge``, and so must render no chip.
+    """
+    badge = mode.get("badge", "")
+    if badge:
+        return str(badge)
+    return "" if mode.get("available", True) else "COMING SOON"
 
 
 def _build_mode_row(
@@ -230,9 +254,12 @@ def _build_mode_row(
     """
     available = mode["available"]
     color = mode["color"]
-    lines = render_ascii_text(mode["title"])
+    full_lines = render_ascii_text(mode["title"])
+    lines = full_lines
     if sweep_front is not None:
-        lines = [line[: max(0, int(sweep_front - (row_base + r) * _SWEEP_ROW_WEIGHT))] for r, line in enumerate(lines)]
+        lines = [
+            line[: max(0, int(sweep_front - (row_base + r) * _SWEEP_ROW_WEIGHT))] for r, line in enumerate(full_lines)
+        ]
 
     rendered = Text(justify="left")
 
@@ -260,6 +287,32 @@ def _build_mode_row(
         rendered.append(_PAD + lines[0] + "\n", style=_unsel_style)
         rendered.append(_PAD + lines[1], style=_unsel_style)
 
+    # Status chip (BETA / COMING SOON), pinned to the end of the second block-font
+    # line. It goes on the title rather than the description because the
+    # description only renders on the selected card, and a status marker you have
+    # to arrow onto isn't labelling. Held back until the intro sweep has finished
+    # drawing this row, so no chip floats beside a half-drawn wordmark.
+    badge = _card_badge(mode)
+    if badge and (sweep_front is None or len(lines[1]) == len(full_lines[1])):
+        # An unavailable card's chip is grey in both selection states — the card
+        # is disabled, and a chip that changed hue as you arrowed onto it would
+        # read as a state change. A beta chip keeps its amber and only dims.
+        badge_rgb = BETA_RGB if available else _DISABLED_BADGE_RGB
+        rendered.append("  ")
+        if override_style:
+            # Menu fades restyle the whole row; the chip fades out with it rather
+            # than staying lit over a dissolving title.
+            rendered.append(f" {badge} ", style=override_style)
+        else:
+            rendered.append_text(build_badge(badge, rgb=badge_rgb, dim=not selected))
+
+    # The row is exactly two block-font lines tall and the whole menu's click
+    # hit-testing (mode_at_row / selected_title_offset) derives from that. Crop
+    # rather than wrap so a long title plus a chip can never add a third row —
+    # no_wrap alone is not enough, Rich still folds an over-long line.
+    rendered.no_wrap = True
+    rendered.overflow = "crop"
+
     items: list = [rendered]
 
     # Reserve description space on the selected item so switching never changes the
@@ -284,8 +337,6 @@ def _build_mode_row(
                     if available and 0 <= (solid_count - consumed) < len(wline) and frac > 0:
                         gray = int(255 * frac)  # sub-char fade on the cursor's line
                         lt.append(wline[shown], style=f"rgb({gray},{gray},{gray})")
-                    if not available and line_i == len(wrapped) - 1 and shown >= len(wline):
-                        lt.append("  (coming soon)", style="rgb(60,60,70)")
                     consumed += len(wline)
             else:
                 # Single line: clip with an ellipsis (a wrapped continuation would
@@ -298,8 +349,6 @@ def _build_mode_row(
                 if available and frac > 0 and solid_count < len(desc_full):
                     gray = int(255 * frac)
                     lt.append(desc_full[solid_count], style=f"rgb({gray},{gray},{gray})")
-                if not available and solid_count >= len(desc_full):
-                    lt.append("  (coming soon)", style="rgb(60,60,70)")
 
         items.append(Text(""))
         items.extend(desc_lines)
@@ -315,6 +364,9 @@ _TIP_BODY = (198, 198, 208)  # soft grey-white for the tip text
 _TIP_DOT_DIM = (70, 70, 82)  # inactive position dots (matches the app's hollow ○)
 _TIP_DOT_ON = (226, 186, 96)  # warm accent for the active dot
 _TIP_KEY = (210, 210, 220)  # the "t" keycap glyph
+# Amber caution for the BETA badge — shared with the mode-card chip and the docs
+# site's pill, and deliberately distinct from the gold NEW badge above.
+_TIP_BETA = BETA_RGB
 
 
 def _build_tip_rows(shimmer_tick: float, *, tip_offset: int = 0) -> list[Text]:
@@ -351,9 +403,14 @@ def _build_tip_rows(shimmer_tick: float, *, tip_offset: int = 0) -> list[Text]:
 
     body_style = lerp_color(b, _TIP_BG, _TIP_BODY)
 
-    # Row 1 — an optional NEW badge, then the tip, faded toward full body colour.
+    # Row 1 — an optional BETA/NEW badge, then the tip, faded toward full body colour.
+    # BETA wins over NEW: a maturity caveat outranks a freshness cue, and two
+    # badges would push the centred line out of the companion duck's lane.
     tip_line = Text(justify="center")
-    if tip.is_new:
+    if tip.is_beta:
+        tip_line.append(f" {BETA_LABEL} ", style=f"bold {lerp_color(b, _TIP_BG, _TIP_BETA)}")
+        tip_line.append("  ")
+    elif tip.is_new:
         tip_line.append(" NEW ", style=f"bold {lerp_color(b, _TIP_BG, _TIP_DOT_ON)}")
         tip_line.append("  ")
     tip_line.append(tip.text, style=body_style)

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -15,6 +15,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from yeaboi.beta import BETA_LABEL, BETA_RGB
 from yeaboi.ui.mode_select.screens._analysis_sections import (
     _TA_CARDS,
     _measure_render_height,
@@ -3152,6 +3153,7 @@ def _build_all_tips_screen(
     sub = build_reveal_subtitle("Everything yeaboi can do", sub_reveal, pad=_PAD + "  ")
     cards = {card["key"]: card for card in _MODE_CARDS}
     gold = f"rgb({_TIP_DOT_ON[0]},{_TIP_DOT_ON[1]},{_TIP_DOT_ON[2]})"
+    beta_c = f"rgb({BETA_RGB[0]},{BETA_RGB[1]},{BETA_RGB[2]})"
 
     body_lines: list = []
     if message:
@@ -3215,12 +3217,15 @@ def _build_all_tips_screen(
                 prefix = bullet_prefix if i == 0 else continuation_prefix
                 body_lines.append(Text(prefix + chunk, style=theme.value, justify="left"))
 
-            if tip.is_new or (tip.mode_key and tip.mode_key in cards):
+            if tip.is_beta or tip.is_new or (tip.mode_key and tip.mode_key in cards):
                 metadata = Text(continuation_prefix, justify="left")
-                if tip.is_new:
+                # Same precedence as the welcome tip row: BETA outranks NEW.
+                if tip.is_beta:
+                    metadata.append(BETA_LABEL, style=f"bold {beta_c}")
+                elif tip.is_new:
                     metadata.append("NEW", style=f"bold {gold}")
                 if tip.mode_key and tip.mode_key in cards:
-                    if tip.is_new:
+                    if tip.is_beta or tip.is_new:
                         metadata.append("  ·  ", style=theme.sep)
                     metadata.append("opens ", style=theme.muted)
                     card = cards[tip.mode_key]
@@ -3556,11 +3561,25 @@ def _build_performance_screen(
     # See docs: "Performance Mode" — TUI page
     """
     from yeaboi.ui.mode_select.screens._screens import _build_mode_row
-    from yeaboi.ui.shared._components import PERFORMANCE_THEME, build_reveal_subtitle, performance_title
+    from yeaboi.ui.shared._components import (
+        PERFORMANCE_THEME,
+        build_badge,
+        build_reveal_subtitle,
+        performance_title,
+    )
 
     theme = PERFORMANCE_THEME
     _accent = "rgb(220,110,90)"  # PERFORMANCE_THEME accent — the mode-row colour key
     title = performance_title(shimmer_tick, width=width)
+    # The BETA chip is the standing reminder once the one-time entry notice has
+    # been dismissed, so it sits on the header of both views. Appended here rather
+    # than inside performance_title(): that wordmark is shared with the export
+    # picker and the run hub, which we didn't decide to label. no_wrap keeps the
+    # header at TITLE_ROWS rows, which the viewport maths assumes.
+    title.append("  ")
+    title.append_text(build_badge(BETA_LABEL))
+    title.no_wrap = True
+    title.overflow = "crop"
     view = performance_data.get("view", "roster")
     session_name = performance_data.get("session_name", "")
 

--- a/src/yeaboi/ui/shared/_beta_notice.py
+++ b/src/yeaboi/ui/shared/_beta_notice.py
@@ -1,0 +1,180 @@
+"""One-time entry notice for modes that ship in beta.
+
+A mode card's BETA chip says *that* a mode is unverified; it has nowhere to say
+*how*. This is the screen that says how — shown once, the first time the mode is
+opened, then never again. The chip on the card and the page header carry the
+reminder from then on, which is what makes "once ever" honest rather than a
+disclaimer the user clicks past and never sees again.
+
+Modelled on :mod:`yeaboi.ui.shared._export_picker`: one modal run-loop that takes
+the caller's Live/console/read_key, so it composes with any frame-timed page
+loop. Returns True to enter the mode, False to go back to the menu.
+
+The acknowledgement lives in ``~/.yeaboi/.env`` (see ``config.mark_beta_notice_seen``)
+and is written only on Continue — backing out leaves the notice pending, so
+someone who bailed still gets told next time.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.text import Text
+
+from yeaboi.beta import BETA_LABEL
+from yeaboi.config import is_beta_notice_seen, mark_beta_notice_seen
+from yeaboi.ui.shared._click import button_click, parse_click
+from yeaboi.ui.shared._components import (
+    PAD,
+    PERFORMANCE_THEME,
+    Theme,
+    build_action_buttons,
+    build_badge,
+    build_page_panel,
+    build_reveal_subtitle,
+    performance_title,
+)
+
+logger = logging.getLogger(__name__)
+
+_ACTIONS = ["Continue", "Back"]
+
+
+@dataclass(frozen=True)
+class _BetaMode:
+    """Everything a beta notice needs to look like the mode it gates."""
+
+    title_fn: Callable[..., Text]
+    theme: Theme
+    subtitle: str
+    headline: str
+    body: tuple[str, ...]
+
+
+# Copy rule: name what can actually go wrong and what stays local. A generic
+# "this feature is experimental" tells the user nothing they can act on, and
+# reads as liability cover rather than information.
+_BETA_MODES: dict[str, _BetaMode] = {
+    "performance": _BetaMode(
+        title_fn=performance_title,
+        theme=PERFORMANCE_THEME,
+        subtitle="Beta — worth thirty seconds",
+        headline="Performance is in beta.",
+        body=(
+            "1:1 preps, completions and 6-month reviews are drafted from your tracker",
+            "data — read them as a starting point, not an assessment.",
+            "",
+            "Coverage depends on how much of the work is actually on the board; sparse",
+            "boards produce thin, sometimes misleading signals.",
+            "",
+            "Nothing is sent to anyone automatically. Exports stay on this machine",
+            "under ~/.yeaboi/exports/performance.",
+        ),
+    ),
+}
+
+
+def _build_beta_notice_screen(
+    *,
+    mode_key: str,
+    action_sel: int = 0,
+    shimmer_tick: float | None = None,
+    sub_reveal: float | None = None,
+    width: int = 80,
+    height: int = 24,
+) -> Panel:
+    """Render the beta notice as a standard full-screen page.
+
+    Follows the shared page structure (title → subtitle → content → buttons) and
+    wears the gated mode's own title and theme, so the notice reads as part of
+    entering that mode rather than as an interstitial bolted in front of it.
+    """
+    spec = _BETA_MODES[mode_key]
+    theme = spec.theme
+
+    # shimmer_tick=None (not 0.0) — 0.0 is the animated path frozen at tick 0,
+    # which leaves a stationary highlight sitting in the wordmark. The picker
+    # this screen is modelled on calls title_fn(width=...) for the same reason.
+    title = spec.title_fn(shimmer_tick, width=width)
+    title.append("  ")
+    title.append_text(build_badge(BETA_LABEL))
+    title.no_wrap = True
+    title.overflow = "crop"
+
+    lines: list = [Text(""), title, Text("")]
+    lines.append(build_reveal_subtitle(spec.subtitle, sub_reveal, pad=PAD + "  "))
+    lines.append(Text(""))
+    lines.append(Text(PAD + spec.headline, style="bold white", justify="left"))
+    lines.append(Text(""))
+    for line in spec.body:
+        lines.append(Text(PAD + line, style=theme.desc, justify="left") if line else Text(""))
+    lines.append(Text(""))
+    lines.append(Text(PAD + "You'll only see this once — the BETA tag stays on the page.", style=theme.muted))
+    lines.append(Text(""))
+
+    btn_top, btn_mid, btn_bot = build_action_buttons(_ACTIONS, action_sel)
+    lines += [btn_top, btn_mid, btn_bot]
+
+    return build_page_panel(Group(*lines), theme=theme, border_style=theme.sep, height=height)
+
+
+def show_beta_notice(
+    live,
+    console,
+    read_key,
+    frame_time,
+    supports_timeout,
+    *,
+    mode_key: str,
+) -> bool:
+    """Show the one-time beta notice; return True to enter the mode.
+
+    Returns True immediately (rendering nothing at all) when the notice has
+    already been acknowledged, so the gate is invisible after the first run.
+    Back/Esc return False and record nothing.
+    """
+    if mode_key not in _BETA_MODES or is_beta_notice_seen(mode_key):
+        return True
+
+    logger.info("Beta notice shown for %s", mode_key)
+    sel = 0
+    while True:
+        w, h = console.size
+        panel = _build_beta_notice_screen(mode_key=mode_key, action_sel=sel, width=w, height=h)
+        live.update(panel)
+        # Some phase loops pass a _key() that doesn't take the kwarg — same
+        # TypeError fallback the export picker and the phase loops use.
+        try:
+            k = read_key(timeout=frame_time) if supports_timeout else read_key()
+        except TypeError:
+            k = read_key()
+        # "" is a timeout tick (or a consumed mouse event), not a keypress.
+        if not k:
+            continue
+
+        clicked = parse_click(k)
+        if clicked is not None:
+            idx = button_click(console, panel, clicked[0], clicked[1], _ACTIONS)
+            if idx is None:
+                continue  # clicked off the button row
+            sel = idx
+            k = "enter"
+
+        if k == "left":
+            sel = max(0, sel - 1)
+        elif k == "right":
+            sel = min(len(_ACTIONS) - 1, sel + 1)
+        elif k in ("enter", " "):
+            if sel == 0:
+                logger.info("Beta notice acknowledged for %s — entering mode", mode_key)
+                mark_beta_notice_seen(mode_key)
+                return True
+            logger.info("Beta notice declined for %s — returning to menu", mode_key)
+            return False
+        elif k in ("esc", "q"):
+            logger.info("Beta notice dismissed for %s (esc) — returning to menu", mode_key)
+            return False

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -14,6 +14,7 @@ import rich.box
 from rich.panel import Panel
 from rich.text import Text
 
+from yeaboi.beta import BETA_RGB
 from yeaboi.ui.shared._animations import COLOR_RGB
 from yeaboi.ui.shared._ascii_font import render_ascii_text
 
@@ -359,6 +360,32 @@ def feedback_title(shimmer_tick: float | None = None, *, width: int | None = Non
 def tips_title(shimmer_tick: float | None = None, *, width: int | None = None) -> Text:
     """Return the Tips ASCII title (silver accent). Optionally shimmering."""
     return build_ascii_title("Tips", "rgb(160,160,180)", shimmer_tick=shimmer_tick, width=width)
+
+
+def build_badge(label: str, *, rgb: tuple[int, int, int] = BETA_RGB, dim: bool = False) -> Text:
+    """Build a small inverse-video status chip (BETA, COMING SOON).
+
+    Rendered as ``" LABEL "`` in bold black on the given colour — a solid block
+    reads as a status marker at a glance, where coloured text alone reads as
+    emphasis. Deliberately plain text plus a background: the mode-card click
+    hit-testing in ``mode_select`` locates rows by scanning for block-font glyphs
+    (``█▀▄``), so a chip drawn with box characters would be mistaken for a title.
+
+    Takes an rgb tuple rather than a Rich colour string because the ``dim``
+    variant has to do arithmetic on the channels, and the ``COLOR_RGB`` lookup
+    only knows the mode accents — a chip colour absent from it would silently
+    fall through to a default grey.
+
+    Args:
+        label: Chip text. Kept short — it sits beside a wordmark.
+        rgb: Chip background channels. Defaults to the beta amber.
+        dim: Halve the channels for unselected rows, matching the mode-row
+            treatment so a chip never out-shouts the title it annotates.
+    """
+    r, g, b = rgb
+    if dim:
+        r, g, b = max(40, r // 2), max(40, g // 2), max(40, b // 2)
+    return Text(f" {label} ", style=f"bold black on rgb({r},{g},{b})")
 
 
 def build_popup(

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import lru_cache
 
+from yeaboi.beta import BETA_LABEL
+
 # Seconds each tip stays on screen before the next one rotates in.
 TIP_ROTATE_SECONDS = 6.0
 
@@ -43,12 +45,16 @@ class FeatureTip:
     synthetic keys and are exempt from parity. ``mode_key`` is the ``_MODE_CARDS``
     key to jump to when the user presses the open key, or ``None`` when the feature
     isn't reachable as a home-screen mode. ``is_new`` renders a small NEW badge.
+    ``is_beta`` renders a BETA badge — the capability ships and works, but its
+    output isn't verified yet. The two are different claims and must not be
+    conflated; where both are set, BETA wins (see the render sites).
     """
 
     key: str
     text: str
     mode_key: str | None = None
     is_new: bool = False
+    is_beta: bool = False
 
 
 # Feature tips — one per user-facing capability. Each is short (one line) and
@@ -88,6 +94,11 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
         "performance",
         "\U0001f3af Tip: Performance preps 1:1s and 6-month reviews from real delivery data",
         mode_key="performance",
+        # Not is_new: the mode isn't recent, it's unverified. The text stays a
+        # plain capability description — the gallery strips the "Tip: " prefix,
+        # so a caveat written into the prose renders inconsistently across the
+        # two surfaces where a flag renders the same on both.
+        is_beta=True,
     ),
     FeatureTip(
         "reporting",
@@ -175,7 +186,8 @@ def build_tips_text() -> str:
     Powers the "Copy all" action on the All Tips page, mirroring
     ``build_changelog_text``. Pure — :func:`get_tips` already resolves
     voice/music availability. Carded tips note the mode they open (by its
-    friendly ``_MODE_CARDS`` title) and freshly-shipped ones are marked ``(NEW)``.
+    friendly ``_MODE_CARDS`` title), freshly-shipped ones are marked ``(NEW)``
+    and unverified ones ``(BETA)``.
     """
     # Lazy import to avoid a UI import cycle (screens import from this module).
     from yeaboi.ui.mode_select.screens._screens import _MODE_CARDS
@@ -184,7 +196,11 @@ def build_tips_text() -> str:
     lines = ["# yeaboi — Tips", ""]
     for tip in get_tips():
         line = f"- {tip.text}"
-        if tip.is_new:
+        # BETA outranks NEW: a maturity caveat matters more than a freshness cue,
+        # and a copied tip list that says both reads as neither.
+        if tip.is_beta:
+            line += f" ({BETA_LABEL})"
+        elif tip.is_new:
             line += " (NEW)"
         if tip.mode_key and tip.mode_key in titles:
             line += f" → opens {titles[tip.mode_key]}"

--- a/tests/unit/test_beta.py
+++ b/tests/unit/test_beta.py
@@ -1,0 +1,45 @@
+"""Tests for the canonical beta wording (src/yeaboi/beta.py)."""
+
+import ast
+from pathlib import Path
+
+from yeaboi import beta
+
+
+class TestConstants:
+    def test_all_constants_are_populated(self):
+        assert beta.BETA_LABEL == "BETA"
+        assert beta.BETA_TAG == "(beta)"
+        assert beta.PERFORMANCE_BETA_PHRASE
+        assert beta.PERFORMANCE_BETA_NOTICE
+
+    def test_notice_contains_the_greppable_phrase(self):
+        # The cross-surface sync test (test_beta_surfaces.py) greps docs and
+        # Markdown for the short phrase; if the notice ever stops containing it,
+        # the two checks would drift apart silently.
+        assert beta.PERFORMANCE_BETA_PHRASE in beta.PERFORMANCE_BETA_NOTICE
+
+    def test_notice_names_the_mode_and_gives_an_instruction(self):
+        assert "Performance" in beta.PERFORMANCE_BETA_NOTICE
+        assert "draft" in beta.PERFORMANCE_BETA_NOTICE
+
+    def test_beta_colour_differs_from_the_new_badge_gold(self):
+        # A caution and a freshness cue render side by side in the tips gallery;
+        # sharing a colour would make them indistinguishable.
+        assert beta.BETA_RGB != (226, 186, 96)
+        assert all(0 <= channel <= 255 for channel in beta.BETA_RGB)
+
+
+class TestModuleStaysImportFree:
+    def test_beta_module_has_no_imports(self):
+        """The whole design depends on this module being free to import.
+
+        ``mcp/tools_performance.py`` imports it at module scope. If someone adds
+        ``from yeaboi.performance import ...`` here, every MCP server boot starts
+        paying for langchain — a regression with no visible symptom other than
+        latency, which is exactly the kind that survives review.
+        """
+        source = Path(beta.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imports = [node for node in ast.walk(tree) if isinstance(node, ast.Import | ast.ImportFrom)]
+        assert imports == [], f"src/yeaboi/beta.py must import nothing, found: {ast.dump(imports[0])}"

--- a/tests/unit/test_beta_notice.py
+++ b/tests/unit/test_beta_notice.py
@@ -1,0 +1,176 @@
+"""Tests for the one-time beta entry notice (ui/shared/_beta_notice.py)."""
+
+from io import StringIO
+
+import pytest
+from rich.console import Console
+from rich.panel import Panel
+
+from yeaboi.beta import BETA_LABEL
+from yeaboi.config import BETA_ACK_KEY, FORCE_BETA_NOTICE_ENV, is_beta_notice_seen
+from yeaboi.ui.shared._beta_notice import _build_beta_notice_screen, show_beta_notice
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(monkeypatch, tmp_path):
+    """Keep the acknowledgement out of the developer's real ~/.yeaboi/.env."""
+    monkeypatch.setattr("yeaboi.config.get_config_file", lambda: tmp_path / ".env")
+    monkeypatch.delenv(BETA_ACK_KEY, raising=False)
+    monkeypatch.delenv(FORCE_BETA_NOTICE_ENV, raising=False)
+
+
+def _render(panel: Panel, width: int = 100) -> str:
+    buf = StringIO()
+    Console(file=buf, width=width, legacy_windows=False).print(panel)
+    return buf.getvalue()
+
+
+class TestBuildBetaNoticeScreen:
+    def test_returns_a_panel(self):
+        assert isinstance(_build_beta_notice_screen(mode_key="performance"), Panel)
+
+    def test_shows_the_badge_headline_and_buttons(self):
+        out = _render(_build_beta_notice_screen(mode_key="performance", width=100, height=32))
+        assert BETA_LABEL in out
+        assert "Performance is in beta." in out
+        assert "Continue" in out and "Back" in out
+
+    def test_says_what_can_go_wrong_and_what_stays_local(self):
+        # The point of the screen is the specifics; a generic disclaimer would
+        # pass a "renders without error" test just as well.
+        out = _render(_build_beta_notice_screen(mode_key="performance", width=100, height=32))
+        assert "not an assessment" in out
+        assert "Nothing is sent to anyone automatically" in out
+
+    def test_header_stays_two_rows_at_a_narrow_width(self):
+        out = _render(_build_beta_notice_screen(mode_key="performance", width=60, height=30), width=60)
+        glyph_rows = [line for line in out.splitlines() if any(ch in line for ch in "█▀▄")]
+        assert len(glyph_rows) == 2
+
+
+class _FakeConsole:
+    size = (100, 30)
+
+
+class _FakeLive:
+    def __init__(self):
+        self.frames = 0
+
+    def update(self, _panel):
+        self.frames += 1
+
+
+def _run(keys, *, mode_key="performance"):
+    it = iter(keys)
+
+    def _read_key(timeout=None):
+        return next(it)
+
+    live = _FakeLive()
+    result = show_beta_notice(live, _FakeConsole(), _read_key, 0.05, True, mode_key=mode_key)
+    return result, live
+
+
+class TestShowBetaNotice:
+    def test_continue_enters_the_mode_and_records_the_ack(self):
+        result, live = _run(["enter"])
+
+        assert result is True
+        assert live.frames >= 1
+        assert is_beta_notice_seen("performance") is True
+
+    def test_back_returns_to_the_menu_without_recording(self):
+        # Someone who backed out hasn't read it — they get told again next time.
+        result, _ = _run(["right", "enter"])
+
+        assert result is False
+        assert is_beta_notice_seen("performance") is False
+
+    def test_esc_returns_to_the_menu_without_recording(self):
+        result, _ = _run(["esc"])
+
+        assert result is False
+        assert is_beta_notice_seen("performance") is False
+
+    def test_idle_ticks_are_not_keypresses(self):
+        result, live = _run(["", "", "enter"])
+
+        assert result is True
+        assert live.frames == 3
+
+    def test_already_acked_renders_nothing(self, monkeypatch):
+        monkeypatch.setenv(BETA_ACK_KEY, "performance")
+
+        result, live = _run([])  # would StopIteration if it tried to read a key
+
+        assert result is True
+        assert live.frames == 0
+
+    def test_force_flag_regates_an_acked_mode(self, monkeypatch):
+        monkeypatch.setenv(BETA_ACK_KEY, "performance")
+        monkeypatch.setenv(FORCE_BETA_NOTICE_ENV, "1")
+
+        result, live = _run(["enter"])
+
+        assert result is True
+        assert live.frames >= 1
+
+    def test_mode_without_a_notice_passes_straight_through(self):
+        # Only registered beta modes are gated; everything else must not be
+        # blocked by a screen that has no copy written for it.
+        result, live = _run([], mode_key="reporting")
+
+        assert result is True
+        assert live.frames == 0
+
+    def test_read_key_without_a_timeout_kwarg_still_works(self):
+        """Some phase loops pass a `_key()` that doesn't accept `timeout=`.
+
+        The export picker carries the same TypeError fallback; without it the
+        notice would explode on exactly those callers.
+        """
+        keys = iter(["enter"])
+
+        def _read_key_no_timeout():  # no timeout parameter at all
+            return next(keys)
+
+        live = _FakeLive()
+        result = show_beta_notice(live, _FakeConsole(), _read_key_no_timeout, 0.05, True, mode_key="performance")
+
+        assert result is True
+        assert is_beta_notice_seen("performance") is True
+
+
+class TestShowBetaNoticeClicks:
+    """Clicking a button must behave exactly like arrowing to it and pressing Enter."""
+
+    def _click_key(self, console, label_index: int) -> str:
+        """Build a `click:x:y` key aimed at the centre of a rendered button."""
+        from yeaboi.ui.shared._click import _button_runs
+
+        panel = _build_beta_notice_screen(mode_key="performance", width=100, height=30)
+        lines = console.render_lines(panel, console.options, pad=True)
+        row = next(r for r, ln in enumerate(lines) if len(_button_runs("".join(s.text for s in ln))) == 2)
+        start, end = _button_runs("".join(s.text for s in lines[row]))[label_index]
+        return f"click:{(start + end) // 2}:{row + 2}"
+
+    def _run_clicks(self, keys):
+        console = Console(file=StringIO(), width=100, height=30, legacy_windows=False)
+        resolved = [self._click_key(console, k) if isinstance(k, int) else k for k in keys]
+        it = iter(resolved)
+        live = _FakeLive()
+        result = show_beta_notice(live, console, lambda timeout=None: next(it), 0.05, True, mode_key="performance")
+        return result
+
+    def test_clicking_continue_enters_and_acks(self):
+        assert self._run_clicks([0]) is True
+        assert is_beta_notice_seen("performance") is True
+
+    def test_clicking_back_returns_without_acking(self):
+        assert self._run_clicks([1]) is False
+        assert is_beta_notice_seen("performance") is False
+
+    def test_clicking_off_the_button_row_is_ignored(self):
+        # A stray click must not count as a dismissal of a one-time notice.
+        assert self._run_clicks(["click:50:3", 1]) is False
+        assert is_beta_notice_seen("performance") is False

--- a/tests/unit/test_beta_surfaces.py
+++ b/tests/unit/test_beta_surfaces.py
@@ -1,0 +1,160 @@
+"""The beta label reaches every surface, including the ones that can't import it.
+
+HTML, Markdown and the plugin SKILL.md carry hand-written copies of the wording
+in ``src/yeaboi.beta``. Nothing else checks them — the docs site has no test and
+no CI job — so this file is what stops the copies drifting from the constant, and
+what catches a half-finished rollout.
+
+Assertions deliberately use the SHORT phrase, never the full sentence: HTML
+re-wraps at whatever width the author's editor chose, so a whole-sentence match
+would fail for a purely cosmetic reformat.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from yeaboi.beta import BETA_LABEL, BETA_RGB, BETA_TAG, PERFORMANCE_BETA_PHRASE
+
+REPO = Path(__file__).resolve().parents[2]
+DOCS = REPO / "docs"
+PERFORMANCE_SKILL = REPO / "claude-plugin" / "yeaboi" / "skills" / "performance" / "SKILL.md"
+
+# Pages that describe Performance to a reader and must carry the caveat.
+BETA_DOC_PAGES = (
+    DOCS / "index.html",
+    DOCS / "docs" / "modes" / "index.html",
+    DOCS / "docs" / "modes" / "performance.html",
+)
+
+
+class TestHandWrittenCopies:
+    @pytest.mark.parametrize("page", BETA_DOC_PAGES, ids=lambda p: p.name)
+    def test_docs_page_carries_the_phrase(self, page):
+        assert PERFORMANCE_BETA_PHRASE in page.read_text(encoding="utf-8")
+
+    def test_plugin_skill_carries_the_phrase(self):
+        assert PERFORMANCE_BETA_PHRASE in PERFORMANCE_SKILL.read_text(encoding="utf-8")
+
+    def test_plugin_skill_frontmatter_is_tagged(self):
+        # Reaches Claude at skill-selection time, before any tool description does.
+        lines = PERFORMANCE_SKILL.read_text(encoding="utf-8").splitlines()
+        description = next(line for line in lines if line.startswith("description:"))
+        assert BETA_TAG in description
+
+    def test_plugin_skill_name_is_untouched(self):
+        # Load-bearing for test_claude_plugin and the surface-parity registry.
+        lines = PERFORMANCE_SKILL.read_text(encoding="utf-8").splitlines()
+        assert lines[1] == "name: performance"
+
+    def test_readme_marks_the_mode(self):
+        readme = (REPO / "README.md").read_text(encoding="utf-8")
+        modes_line = next(line for line in readme.splitlines() if "Six modes, one command" in line)
+        assert "beta" in modes_line.lower()
+
+
+class TestDocsPill:
+    def test_beta_pill_class_is_defined(self):
+        css = (DOCS / "assets" / "site.css").read_text(encoding="utf-8")
+        assert ".beta-pill{" in css
+
+    def test_pill_colour_matches_the_terminal_chip(self):
+        css = (DOCS / "assets" / "site.css").read_text(encoding="utf-8")
+        pill = css.split(".beta-pill{", 1)[1].split("}", 1)[0]
+        assert f"rgb({BETA_RGB[0]},{BETA_RGB[1]},{BETA_RGB[2]})" in pill
+
+    def test_pill_is_not_the_live_badge(self):
+        # `.badge::before` injects a green "live" dot, which says the opposite of
+        # what a beta marker means. The pill must stay its own class.
+        css = (DOCS / "assets" / "site.css").read_text(encoding="utf-8")
+        pill = css.split(".beta-pill{", 1)[1].split("}", 1)[0]
+        assert "var(--success)" not in pill
+
+    def test_every_page_using_the_pill_links_site_css(self):
+        for page in DOCS.rglob("*.html"):
+            text = page.read_text(encoding="utf-8")
+            if 'class="beta-pill"' in text:
+                assert "/assets/site.css" in text, page
+
+
+class TestCacheBust:
+    def test_all_docs_pages_share_one_cache_bust_version(self):
+        """A new CSS class behind a stale cached stylesheet is an invisible badge.
+
+        That failure mode is silent — the page renders, the pill just doesn't —
+        so a half-finished `?v=` sweep is exactly the kind of mistake that ships.
+        """
+        versions: dict[str, set[str]] = {}
+        for page in DOCS.rglob("*.html"):
+            found = set(re.findall(r"\?v=(\d+)", page.read_text(encoding="utf-8")))
+            if found:
+                versions[page.relative_to(DOCS).as_posix()] = found
+
+        assert versions, "no cache-busted asset links found — did the convention change?"
+        all_versions = set().union(*versions.values())
+        assert len(all_versions) == 1, f"mixed cache-bust versions: {versions}"
+
+
+class TestBetaMarkersAgree:
+    """The three in-app beta markers must move together.
+
+    A card badged BETA with no ``_BETA_MODES`` entry ships a chip and no notice —
+    ``show_beta_notice`` returns True for an unregistered key, so the gate simply
+    doesn't appear and nothing complains. Every *other* copy of the wording is
+    pinned by the tests above; this is the one link that isn't, so it gets the
+    two-way set equality the surface-parity registry uses.
+    """
+
+    def _badged_card_keys(self) -> set[str]:
+        from yeaboi.ui.mode_select.screens._screens import _MODE_CARDS
+
+        return {card["key"] for card in _MODE_CARDS if card.get("badge") == BETA_LABEL}
+
+    def test_every_badged_card_has_an_entry_notice(self):
+        from yeaboi.ui.shared._beta_notice import _BETA_MODES
+
+        assert self._badged_card_keys() == set(_BETA_MODES)
+
+    def test_every_badged_card_has_a_beta_tip(self):
+        from yeaboi.ui.shared._tips import _FEATURE_TIPS
+
+        beta_tip_modes = {tip.mode_key for tip in _FEATURE_TIPS if tip.is_beta}
+        assert self._badged_card_keys() == beta_tip_modes
+
+    def test_beta_is_not_also_flagged_new(self):
+        # Different claims: new is recent-and-verified, beta is unverified.
+        from yeaboi.ui.shared._tips import _FEATURE_TIPS
+
+        assert [tip.key for tip in _FEATURE_TIPS if tip.is_beta and tip.is_new] == []
+
+    def test_a_badged_card_stays_selectable(self):
+        # Beta labels a mode; it does not take it away. `available` gates Enter,
+        # the click handler and the welcome screen's `g` jump key.
+        from yeaboi.ui.mode_select.screens._screens import _MODE_CARDS
+
+        for card in _MODE_CARDS:
+            if card.get("badge") == BETA_LABEL:
+                assert card["available"] is True, card["key"]
+
+
+class TestConstantsAreUsedNotRetyped:
+    """Python surfaces import the constants; only the un-importable ones retype."""
+
+    @pytest.mark.parametrize(
+        "module",
+        ["cli.py", "ui/shared/_tips.py", "ui/shared/_beta_notice.py", "mcp/tools_performance.py"],
+    )
+    def test_python_surface_imports_from_beta(self, module):
+        source = (REPO / "src" / "yeaboi" / module).read_text(encoding="utf-8")
+        assert "from yeaboi.beta import" in source, module
+
+    def test_mcp_descriptions_are_the_one_allowed_python_retype(self):
+        # FastMCP captures fn.__doc__ at decoration time, so these can't be
+        # f-strings; this assertion is what keeps the five literals honest.
+        # Matched at the docstring opening so the explanatory comment above them
+        # doesn't count itself.
+        source = (REPO / "src" / "yeaboi" / "mcp" / "tools_performance.py").read_text(encoding="utf-8")
+        assert source.count(f'"""{BETA_LABEL} — ') == 5

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -10,6 +10,7 @@ import os
 import pytest
 
 from yeaboi.agent.state import DeliveryReport, OneOnOnePrep, OneOnOneRecord, SixMonthReview, StandupReport
+from yeaboi.beta import BETA_TAG, PERFORMANCE_BETA_NOTICE, PERFORMANCE_BETA_PHRASE
 from yeaboi.cli import _cmd_analyze, _cmd_perf, _cmd_report, _cmd_standup, _run_subcommand, build_parser
 
 
@@ -431,6 +432,81 @@ class TestPerfCommand:
 
         with PerformanceStore(db) as store:
             assert store.get_notes("Sam")[0]["note_text"] == "shipped the migration solo"
+
+
+class TestPerfBetaLabelling:
+    """`yeaboi perf` says it's beta in its help and before every run."""
+
+    def _perf_parser(self):
+        parser = build_parser()
+        subs = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+        return subs
+
+    def test_parent_help_carries_the_tag_and_description(self):
+        subs = self._perf_parser()
+        assert subs.choices["perf"].description == PERFORMANCE_BETA_NOTICE
+        help_text = next(a.help for a in subs._choices_actions if a.dest == "perf")
+        assert BETA_TAG in help_text
+
+    def test_every_child_help_carries_the_description(self):
+        # `yeaboi perf prep --help` is a normal place to land without ever
+        # seeing the parent's help.
+        perf = self._perf_parser().choices["perf"]
+        nested = next(a for a in perf._actions if isinstance(a, argparse._SubParsersAction))
+        for name, child in nested.choices.items():
+            assert child.description == PERFORMANCE_BETA_NOTICE, name
+
+    def _run_note(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        args = build_parser().parse_args(["perf", "note", "Sam", "--text", "x"])
+        return _cmd_perf(args, _console())
+
+    def test_notice_goes_to_stderr_not_stdout(self, monkeypatch, tmp_path, capsys):
+        # The artifact is routinely piped; a caveat inside the file is worse
+        # than no caveat at all.
+        monkeypatch.delenv("BETA_NOTICES_ENABLED", raising=False)
+        assert self._run_note(monkeypatch, tmp_path) == 0
+
+        captured = capsys.readouterr()
+        assert PERFORMANCE_BETA_PHRASE in captured.err
+        assert PERFORMANCE_BETA_PHRASE not in captured.out
+
+    def test_notice_suppressed_by_env(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("BETA_NOTICES_ENABLED", "false")
+        assert self._run_note(monkeypatch, tmp_path) == 0
+
+        assert PERFORMANCE_BETA_PHRASE not in capsys.readouterr().err
+
+    @pytest.mark.parametrize("subcommand", ["roster", "prep", "complete", "review", "note"])
+    def test_notice_prints_for_every_subcommand(self, monkeypatch, tmp_path, capsys, subcommand):
+        # Guards against the call being pushed down into one branch later.
+        monkeypatch.delenv("BETA_NOTICES_ENABLED", raising=False)
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        monkeypatch.setattr("yeaboi.cli._resolve_cli_session", lambda s: "sid")
+        monkeypatch.setattr("yeaboi.performance.roster.fetch_roster", lambda **kw: [])
+        monkeypatch.setattr(
+            "yeaboi.performance.engine.run_one_on_one_prep",
+            lambda engineer, **kw: OneOnOnePrep(engineer=engineer),
+        )
+        monkeypatch.setattr(
+            "yeaboi.performance.engine.complete_one_on_one",
+            lambda engineer, transcript, **kw: OneOnOneRecord(engineer=engineer),
+        )
+        monkeypatch.setattr(
+            "yeaboi.performance.engine.run_six_month_review",
+            lambda engineer, **kw: SixMonthReview(engineer=engineer),
+        )
+        argv = {
+            "roster": ["perf", "roster"],
+            "prep": ["perf", "prep", "Sam"],
+            "complete": ["perf", "complete", "Sam", "--transcript", "notes"],
+            "review": ["perf", "review", "Sam"],
+            "note": ["perf", "note", "Sam", "--text", "x"],
+        }[subcommand]
+
+        _cmd_perf(build_parser().parse_args(argv), _console())
+
+        assert PERFORMANCE_BETA_PHRASE in capsys.readouterr().err
 
 
 class TestRetroCommand:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,7 +5,10 @@ import os
 import pytest
 
 from yeaboi.config import (
+    BETA_ACK_KEY,
+    FORCE_BETA_NOTICE_ENV,
     VALID_LOG_LEVELS,
+    beta_notices_acked,
     detect_proxy,
     disable_langsmith_tracing,
     get_anthropic_api_key,
@@ -20,9 +23,12 @@ from yeaboi.config import (
     get_team_analysis_fast_model,
     get_team_analysis_llm_max_concurrency,
     get_team_analysis_llm_target_seconds,
+    is_beta_notice_enabled,
+    is_beta_notice_seen,
     is_langsmith_enabled,
     is_tips_enabled,
     load_user_config,
+    mark_beta_notice_seen,
     set_log_level,
     set_tips_enabled,
 )
@@ -179,6 +185,88 @@ def test_set_tips_enabled_round_trips(monkeypatch, tmp_path):
     set_tips_enabled(True)
     assert os.environ["TIPS_ENABLED"] == "true"
     assert is_tips_enabled() is True
+
+
+class TestBetaNotices:
+    """The one-time beta-notice acknowledgement (persisted to ~/.yeaboi/.env)."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_env(self, monkeypatch, tmp_path):
+        self.config_file = tmp_path / ".env"
+        monkeypatch.setattr("yeaboi.config.get_config_file", lambda: self.config_file)
+        monkeypatch.delenv(BETA_ACK_KEY, raising=False)
+        monkeypatch.delenv(FORCE_BETA_NOTICE_ENV, raising=False)
+
+    def test_unseen_by_default(self):
+        assert is_beta_notice_seen("performance") is False
+        assert beta_notices_acked() == set()
+
+    def test_mark_round_trips(self):
+        mark_beta_notice_seen("performance")
+
+        assert os.environ[BETA_ACK_KEY] == "performance"
+        assert BETA_ACK_KEY in self.config_file.read_text()
+        assert is_beta_notice_seen("performance") is True
+
+    def test_other_modes_stay_unseen(self):
+        mark_beta_notice_seen("performance")
+        assert is_beta_notice_seen("reporting") is False
+
+    def test_accumulates_without_duplicating(self):
+        mark_beta_notice_seen("performance")
+        mark_beta_notice_seen("reporting")
+        mark_beta_notice_seen("performance")
+
+        assert beta_notices_acked() == {"performance", "reporting"}
+        assert os.environ[BETA_ACK_KEY] == "performance,reporting"
+
+    @pytest.mark.parametrize("raw", ["", "   ", ",,", " , performance ,"])
+    def test_tolerates_hand_edited_values(self, monkeypatch, raw):
+        # The key lives in a file users open to edit their API keys.
+        monkeypatch.setenv(BETA_ACK_KEY, raw)
+        assert is_beta_notice_seen("reporting") is False
+        assert is_beta_notice_seen("performance") is ("performance" in raw)
+
+    @pytest.mark.parametrize("forced", ["1", "true", "TRUE", "yes", "on"])
+    def test_force_flag_regates_an_acked_mode(self, monkeypatch, forced):
+        mark_beta_notice_seen("performance")
+        monkeypatch.setenv(FORCE_BETA_NOTICE_ENV, forced)
+        assert is_beta_notice_seen("performance") is False
+
+    def test_force_flag_accepts_a_mode_list(self, monkeypatch):
+        mark_beta_notice_seen("performance")
+        mark_beta_notice_seen("reporting")
+        monkeypatch.setenv(FORCE_BETA_NOTICE_ENV, "performance")
+
+        assert is_beta_notice_seen("performance") is False
+        assert is_beta_notice_seen("reporting") is True
+
+    def test_unwritable_config_still_suppresses_for_this_session(self, monkeypatch):
+        def _boom(key, value):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr("yeaboi.config.set_config_value", _boom)
+
+        mark_beta_notice_seen("performance")  # must not raise
+
+        assert is_beta_notice_seen("performance") is True
+
+
+class TestIsBetaNoticeEnabled:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("BETA_NOTICES_ENABLED", raising=False)
+        assert is_beta_notice_enabled() is True
+
+    @pytest.mark.parametrize("value", ["false", "FALSE", "  false  "])
+    def test_disabled_when_false(self, monkeypatch, value):
+        monkeypatch.setenv("BETA_NOTICES_ENABLED", value)
+        assert is_beta_notice_enabled() is False
+
+    @pytest.mark.parametrize("value", ["0", "off", "nonsense"])
+    def test_only_false_disables_it(self, monkeypatch, value):
+        # Opt-out semantics: a typo must not silently hide the caveat.
+        monkeypatch.setenv("BETA_NOTICES_ENABLED", value)
+        assert is_beta_notice_enabled() is True
 
 
 class TestSetLogLevel:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -17,6 +17,7 @@ pytest.importorskip("mcp", reason="mcp extra not installed")
 
 from mcp.shared.memory import create_connected_server_and_client_session  # noqa: E402
 
+from yeaboi.beta import BETA_LABEL, PERFORMANCE_BETA_NOTICE, PERFORMANCE_BETA_PHRASE  # noqa: E402
 from yeaboi.mcp.runtime import LLM_HINT, envelope, error_envelope, to_jsonable  # noqa: E402
 from yeaboi.mcp.server import create_app  # noqa: E402
 
@@ -134,6 +135,32 @@ class TestToolInventory:
         # never print to it (stderr is fine).
         call_tool("sessions_list")
         assert capsys.readouterr().out == ""
+
+    def test_perf_tools_are_marked_beta(self):
+        # The prefixes are hand-written literals (FastMCP reads __doc__ at
+        # decoration time, so they can't be f-strings) — this is what keeps
+        # them in sync with the constant.
+        async def _run():
+            app = create_app()
+            async with create_connected_server_and_client_session(app._mcp_server) as client:
+                listed = await client.list_tools()
+                return {tool.name: tool.description or "" for tool in listed.tools}
+
+        descriptions = anyio.run(_run)
+        for name, description in descriptions.items():
+            if name.startswith("perf_"):
+                assert BETA_LABEL in description, name
+                assert PERFORMANCE_BETA_PHRASE in description, name
+
+    def test_non_perf_tools_are_not_marked_beta(self):
+        async def _run():
+            app = create_app()
+            async with create_connected_server_and_client_session(app._mcp_server) as client:
+                listed = await client.list_tools()
+                return {tool.name: tool.description or "" for tool in listed.tools}
+
+        descriptions = anyio.run(_run)
+        assert BETA_LABEL not in descriptions["report_delivery"]
 
 
 class TestSessionTools:
@@ -421,6 +448,37 @@ class TestEngineTools:
         payload = call_tool("perf_six_month_review", {"engineer": "Sam", "period_months": 12})
         assert payload["ok"] is True
         assert payload["data"]["months"] == 12
+
+    def test_perf_envelope_carries_the_beta_warning(self, tmp_db, monkeypatch):
+        # `warnings` is the only envelope field the server instructions tell the
+        # client to surface to the user; the description reaches only the model.
+        monkeypatch.setattr("yeaboi.performance.roster.fetch_roster", lambda **kw: [{"name": "Sam"}])
+        payload = call_tool("perf_roster")
+        assert payload["warnings"][0] == PERFORMANCE_BETA_NOTICE
+
+    def test_beta_warning_preserves_engine_warnings(self, tmp_db, provider_mode, monkeypatch):
+        monkeypatch.setattr(
+            "yeaboi.performance.engine.run_one_on_one_prep",
+            lambda engineer, **kw: {"engineer": engineer, "warnings": ["Jira returned 401"]},
+        )
+        payload = call_tool("perf_one_on_one_prep", {"engineer": "Sam"})
+        assert payload["warnings"][0] == PERFORMANCE_BETA_NOTICE
+        assert "Jira returned 401" in payload["warnings"]
+
+    def test_error_envelope_has_no_beta_warning(self, tmp_db, provider_mode):
+        payload = call_tool("perf_one_on_one_complete", {"engineer": "Sam", "transcript": " "})
+        assert payload["ok"] is False
+        assert "warnings" not in payload
+
+    def test_non_perf_envelope_is_unaffected(self, tmp_db, provider_mode, monkeypatch):
+        # Proves the wrapper stayed local to tools_performance and didn't leak
+        # into the shared runtime every other tool module uses.
+        monkeypatch.setattr(
+            "yeaboi.reporting.engine.run_delivery_report",
+            lambda *a, **kw: {"executive_summary": "shipped", "warnings": []},
+        )
+        payload = call_tool("report_delivery", {"period": "last_sprint"})
+        assert payload["warnings"] == []
 
     def test_standup_run_channels_passthrough(self, seeded_session, provider_mode, monkeypatch):
         captured: dict = {}

--- a/tests/unit/test_mode_cards.py
+++ b/tests/unit/test_mode_cards.py
@@ -1,0 +1,191 @@
+"""Tests for the mode-card status chip (_card_badge / _build_mode_row).
+
+The chip is drawn onto the two block-font title rows, which the welcome screen's
+click hit-testing measures. These tests pin both halves of that: what renders,
+and that the row height never moves.
+"""
+
+import io
+
+from rich.console import Console, Group
+from rich.panel import Panel
+
+from yeaboi.beta import BETA_LABEL, BETA_RGB
+from yeaboi.ui.mode_select.screens._screens import (
+    _INTAKE_CARDS,
+    _MODE_CARDS,
+    _OFFLINE_CARDS,
+    _build_mode_row,
+    _build_mode_screen,
+    _card_badge,
+)
+
+
+def _render(renderables, width: int = 120) -> str:
+    """Render mode rows the way the screen does — grouped inside a page panel.
+
+    Rich only honours a Text's ``no_wrap``/``overflow`` when it is rendered as a
+    child renderable; a bare ``console.print(text)`` re-derives them from the
+    print call and folds instead. Rendering through Panel(Group(...)) is both the
+    faithful path and the one where the crop guarantee actually applies.
+    """
+    console = Console(file=io.StringIO(), width=width)
+    console.print(Panel(Group(*renderables), width=width))
+    return console.file.getvalue()
+
+
+def _performance_card() -> dict:
+    return next(card for card in _MODE_CARDS if card["key"] == "performance")
+
+
+class TestCardBadge:
+    def test_explicit_badge_wins(self):
+        assert _card_badge({"badge": "BETA", "available": True}) == "BETA"
+
+    def test_unavailable_card_is_coming_soon(self):
+        assert _card_badge({"available": False}) == "COMING SOON"
+
+    def test_available_card_without_a_badge_has_no_chip(self):
+        assert _card_badge({"available": True}) == ""
+
+    def test_runtime_roster_card_has_no_chip(self):
+        # The Performance roster synthesises a card per engineer and feeds it to
+        # the same renderer. It sets `available` but never `badge`, so it must
+        # render no chip — an engineer is not a beta feature.
+        assert _card_badge({"title": "Ada Lovelace", "color": "rgb(220,110,90)", "available": True}) == ""
+
+
+class TestPerformanceCardRegistration:
+    def test_performance_is_flagged_beta(self):
+        assert _performance_card()["badge"] == BETA_LABEL
+
+    def test_performance_stays_available(self):
+        # Beta is not "coming soon". `available` gates Enter, the click handler
+        # and the welcome-screen jump key — flipping it would take the mode away,
+        # which is a different decision than labelling it.
+        assert _performance_card()["available"] is True
+
+    def test_no_other_card_carries_a_badge(self):
+        badged = [
+            card["key"]
+            for card in (*_MODE_CARDS, *_INTAKE_CARDS, *_OFFLINE_CARDS)
+            if card.get("badge") and card.get("key") != "performance"
+        ]
+        assert badged == []
+
+    def test_every_card_still_has_the_core_keys(self):
+        for card in (*_MODE_CARDS, *_INTAKE_CARDS, *_OFFLINE_CARDS):
+            assert {"title", "description", "available", "color"} <= set(card)
+
+
+class TestChipRendering:
+    def test_chip_shows_when_the_card_is_selected(self):
+        idx = _MODE_CARDS.index(_performance_card())
+        out = _render([_build_mode_screen(idx, width=120, height=40, desc_reveal=999)])
+        assert BETA_LABEL in out
+
+    def test_chip_shows_when_the_card_is_not_selected(self):
+        # A status marker you only see after arrowing onto the card isn't labelling.
+        idx = _MODE_CARDS.index(_performance_card())
+        other = 0 if idx != 0 else 1
+        out = _render([_build_mode_screen(other, width=120, height=40, desc_reveal=999)])
+        assert BETA_LABEL in out
+
+    def test_chip_is_hidden_until_the_intro_sweep_finishes_the_row(self):
+        card = _performance_card()
+        mid_sweep = _render(_build_mode_row(card, selected=False, sweep_front=6.0), width=120)
+        assert BETA_LABEL not in mid_sweep
+
+        finished = _render(_build_mode_row(card, selected=False, sweep_front=9_999.0), width=120)
+        assert BETA_LABEL in finished
+
+    def test_chip_uses_no_block_glyphs(self):
+        # mode_at_row locates title rows by scanning for block-font glyphs; a chip
+        # drawn with box characters would register as a title row of its own.
+        chip_only = _render(
+            _build_mode_row(
+                {"title": " ", "color": "rgb(220,110,90)", "available": True, "badge": "BETA"}, selected=False
+            )
+        )
+        assert not any(ch in chip_only for ch in "█▀▄")
+
+
+class TestComingSoonChip:
+    """The generalised unavailable path — no card uses it today, but it's the
+    branch this change replaced the old description suffix with."""
+
+    def _card(self) -> dict:
+        return {
+            "title": "Ghost",
+            "description": "Not built yet.",
+            "available": False,
+            "color": "rgb(160,160,180)",
+        }
+
+    def test_unavailable_card_renders_coming_soon(self):
+        out = _render(_build_mode_row(self._card(), selected=False))
+        assert "COMING SOON" in out
+
+    def _chip_line(self, selected: bool) -> str:
+        from rich.console import Console as RichConsole
+
+        console = RichConsole(file=io.StringIO(), width=120, force_terminal=True, color_system="truecolor")
+        console.print(Panel(Group(*_build_mode_row(self._card(), selected=selected)), width=120))
+        return next(line for line in console.file.getvalue().splitlines() if "COMING SOON" in line)
+
+    def test_chip_stays_grey_in_both_selection_states(self):
+        # It may dim when unselected (every row does), but it must never change
+        # hue — an amber chip on a disabled card would read as a beta marker.
+        amber = f"{BETA_RGB[0]};{BETA_RGB[1]};{BETA_RGB[2]}"
+        for selected in (False, True):
+            line = self._chip_line(selected)
+            assert amber not in line, f"selected={selected}"
+
+    def test_selected_chip_uses_the_disabled_grey(self):
+        assert "90;90;100" in self._chip_line(selected=True)
+
+    def test_beta_chip_is_not_the_disabled_grey(self):
+        from rich.console import Console as RichConsole
+
+        console = RichConsole(file=io.StringIO(), width=120, force_terminal=True, color_system="truecolor")
+        console.print(Panel(Group(*_build_mode_row(_performance_card(), selected=True)), width=120))
+        chip_line = next(line for line in console.file.getvalue().splitlines() if BETA_LABEL in line)
+        assert f"{BETA_RGB[0]};{BETA_RGB[1]};{BETA_RGB[2]}" in chip_line
+
+
+class TestRowHeightIsUnaffected:
+    def _row_count(self, card: dict, *, selected: bool, width: int) -> int:
+        out = _render(_build_mode_row(card, selected=selected, desc_max_lines=2), width=width)
+        # Rich prints each renderable on its own line; the title renderable is the
+        # first, and it must occupy exactly the two block-font rows.
+        return len([line for line in out.splitlines() if any(ch in line for ch in "█▀▄")])
+
+    def test_badged_card_is_two_title_rows(self):
+        assert self._row_count(_performance_card(), selected=False, width=120) == 2
+
+    def test_badged_card_is_two_title_rows_when_selected(self):
+        assert self._row_count(_performance_card(), selected=True, width=120) == 2
+
+    def test_badged_card_is_two_title_rows_at_the_narrow_layout(self):
+        # 108 columns is the narrowest layout that still shows the companion, and
+        # the Performance wordmark plus chip clears the column budget by one.
+        assert self._row_count(_performance_card(), selected=False, width=58) == 2
+
+    def test_long_roster_name_crops_rather_than_folding(self):
+        """The crop applies to every row, not just badged ones.
+
+        The Performance roster feeds engineer names through this same renderer.
+        A long name used to fold onto extra rows; it now crops. That's required
+        for the row-height invariant, and this pins the behaviour change.
+        """
+        card = {
+            "title": "Bartholomew Featherstonehaugh",
+            "description": "3 open 1:1 actions",
+            "available": True,
+            "color": "rgb(220,110,90)",
+        }
+        assert self._row_count(card, selected=False, width=60) == 2
+
+    def test_absurdly_long_title_with_a_chip_still_crops(self):
+        card = {"title": "A" * 60, "description": "x", "available": True, "badge": "BETA", "color": "rgb(220,110,90)"}
+        assert self._row_count(card, selected=False, width=60) == 2

--- a/tests/unit/test_performance_screen.py
+++ b/tests/unit/test_performance_screen.py
@@ -5,7 +5,10 @@ import io
 from rich.console import Console
 from rich.panel import Panel
 
+from yeaboi.beta import BETA_LABEL
+from yeaboi.ui.mode_select.screens._screens import _MIN_WIDTH
 from yeaboi.ui.mode_select.screens._screens_secondary import _build_performance_screen
+from yeaboi.ui.shared._components import TITLE_ROWS
 
 
 def _render(panel: Panel) -> str:
@@ -69,3 +72,39 @@ class TestBuildPerformanceScreen:
         data = {"view": "detail", "detail_title": "x", "detail_lines": lines, "actions": ["Export", "Back"]}
         panel = _build_performance_screen(data, width=100, height=20, scroll_offset=40)
         assert isinstance(panel, Panel)
+
+
+class TestBetaChip:
+    """The mode is usable but unverified — the header says so on every view."""
+
+    def test_roster_header_carries_the_beta_chip(self):
+        data = {"session_name": "Demo", "view": "roster", "roster": ["Ada Lovelace"], "selected_idx": 0}
+        out = _render(_build_performance_screen(data, width=100, height=30))
+        assert BETA_LABEL in out
+
+    def test_detail_header_carries_the_beta_chip(self):
+        data = {
+            "view": "detail",
+            "detail_title": "1:1 Prep — Ada",
+            "detail_lines": ["Talking points:", "  • one"],
+            "actions": ["Export", "Back"],
+        }
+        out = _render(_build_performance_screen(data, width=100, height=32))
+        assert BETA_LABEL in out
+
+    def test_header_stays_two_rows_and_keeps_the_chip_at_min_width(self):
+        # The chip is appended to the wordmark, so the narrowest supported
+        # terminal is where it would wrap and silently push every viewport row
+        # down by one. Asserted at _MIN_WIDTH rather than something arbitrarily
+        # narrow: below ~64 columns the chip is cropped off entirely, so a
+        # narrower assertion would still pass if the chip were never appended.
+        # An empty roster isolates the header — engineer names use block font too.
+        data = {"view": "roster", "roster": [], "selected_idx": 0}
+        panel = _build_performance_screen(data, width=_MIN_WIDTH, height=30)
+        console = Console(file=io.StringIO(), width=_MIN_WIDTH)
+        console.print(panel)
+        out = console.file.getvalue()
+
+        glyph_rows = [line for line in out.splitlines() if any(ch in line for ch in "█▀▄")]
+        assert len(glyph_rows) == TITLE_ROWS
+        assert BETA_LABEL in out

--- a/tests/unit/test_screen_backgrounds.py
+++ b/tests/unit/test_screen_backgrounds.py
@@ -154,6 +154,12 @@ class TestRepresentativeScreens:
         out = _render(build_screensaver(width=18, height=6, elapsed=0.0), width=18, height=6)
         assert _bg_escape(NEUTRAL_BG) in out
 
+    def test_beta_notice_uses_the_gated_modes_theme(self):
+        from yeaboi.ui.shared._beta_notice import _build_beta_notice_screen
+
+        out = _render(_build_beta_notice_screen(mode_key="performance", width=100, height=30))
+        assert _bg_escape(PERFORMANCE_THEME.bg) in out
+
 
 class TestNoRawFullScreenPanels:
     """AST guard: full-screen Panels must be built via build_page_panel.

--- a/tests/unit/test_tips.py
+++ b/tests/unit/test_tips.py
@@ -170,6 +170,35 @@ def test_at_least_one_new_feature_tip(monkeypatch):
     _clear_cache()
 
 
+def test_at_least_one_beta_feature_tip(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    # The BETA badge branch would otherwise go dead without anything noticing.
+    assert any(t.is_beta for t in _tips._FEATURE_TIPS)
+    _clear_cache()
+
+
+def test_performance_tip_is_beta_not_new(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    perf = next(t for t in _tips._FEATURE_TIPS if t.key == "performance")
+    # Unverified, not recent — the two badges make different promises.
+    assert perf.is_beta is True
+    assert perf.is_new is False
+    _clear_cache()
+
+
+def test_build_tips_text_marks_beta(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    lines = _tips.build_tips_text().splitlines()
+    perf_line = next(line for line in lines if "Performance preps 1:1s" in line)
+    planning_line = next(line for line in lines if "Planning breaks a project" in line)
+    assert "(BETA)" in perf_line
+    assert "(BETA)" not in planning_line
+    _clear_cache()
+
+
 def test_carded_tips_have_mode_keys(monkeypatch):
     _clear_cache()
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))

--- a/tests/unit/test_tips_ui.py
+++ b/tests/unit/test_tips_ui.py
@@ -155,6 +155,32 @@ def test_tip_rows_new_badge_when_flagged(monkeypatch):
     _tips.get_tips.cache_clear()
 
 
+def test_tip_rows_beta_badge_when_flagged(monkeypatch):
+    monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    _tips.get_tips.cache_clear()
+    tips = _tips.get_tips()
+    beta_idx = next(i for i, t in enumerate(tips) if t.is_beta)
+    plain_idx = next(i for i, t in enumerate(tips) if not t.is_beta and not t.is_new)
+    assert "BETA" in _tip_rows_text(shimmer_tick=0.0, tip_offset=beta_idx)
+    assert "BETA" not in _tip_rows_text(shimmer_tick=0.0, tip_offset=plain_idx)
+    _tips.get_tips.cache_clear()
+
+
+def test_tip_rows_beta_badge_wins_over_new(monkeypatch):
+    # A maturity caveat outranks a freshness cue, and two badges would push the
+    # centred row out of the companion duck's lane.
+    monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    both = _tips.FeatureTip("x", "🎯 Tip: both flags", mode_key=None, is_new=True, is_beta=True)
+    monkeypatch.setattr(_tips, "get_tips", lambda: (both,))
+
+    out = _tip_rows_text(shimmer_tick=0.0, tip_offset=0)
+
+    assert "BETA" in out
+    assert "NEW" not in out
+
+
 def test_tip_offset_shifts_the_shown_tip(monkeypatch):
     monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
@@ -196,6 +222,18 @@ def test_all_tips_screen_shows_a_tip_and_new_badge(monkeypatch):
     out = _all_tips_rendered(shimmer_tick=0.0, sub_reveal=99)
     assert "NEW" in out
     assert "opens" in out  # a carded tip's "→ opens <Mode>" note
+    _tips.get_tips.cache_clear()
+
+
+def test_all_tips_screen_shows_the_beta_badge(monkeypatch):
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr(
+        "yeaboi.ui.mode_select.screens._screens_secondary.build_scrollbar",
+        lambda *_args, **_kwargs: None,
+    )
+    _tips.get_tips.cache_clear()
+    out = _all_tips_rendered(height=200, shimmer_tick=0.0, sub_reveal=99)
+    assert "BETA" in out
     _tips.get_tips.cache_clear()
 
 


### PR DESCRIPTION
## Summary

Performance ships as a first-class mode — a welcome card, five MCP tools, a `yeaboi perf` subcommand, a plugin skill and its own docs pages — with nothing telling anyone its output has never been validated against a real team's tracker. For a mode that drafts material about **named people** (1:1 preps, six-month reviews), that silence is the problem.

This is **labelling only**, as scoped. The mode stays fully usable; no engine changes, no TUI-loop test backfill, no async work on the blocking LLM calls.

**What a user sees**
- **Welcome card** — an amber `BETA` chip on the Performance wordmark, visible whether or not the card is selected (a label you only see after arrowing onto it isn't a label).
- **First entry** — a one-time notice naming what's actually unverified: output is drafted from tracker data and is a starting point not an assessment; sparse boards give thin signals; nothing is emailed automatically. Continue/Back. **Backing out doesn't record the acknowledgement**, so someone who bailed gets told again. After Continue it never returns — the chips carry it.
- **Inside the mode** — the same chip on the roster and detail headers.
- **Everywhere else** — `BETA` on the feature tip, `(beta)` in `yeaboi perf --help` plus a stderr caveat per run, `BETA —` on all five MCP tool descriptions with the caveat as `warnings[0]`, a callout in the plugin skill, an amber pill on the docs pages, and the README modes line.

## Design decisions worth reviewing

- **The card keeps `available: True`.** The pre-existing `available: False` → `(coming soon)` path was *not* reused: that flag gates Enter, the click handler **and** the welcome-screen `g` jump key, so flipping it removes the feature rather than labelling it. Instead it's generalised into one `_card_badge()` helper plus a shared `build_badge()` primitive. That also deletes a latent bug — the old description-suffix append could overflow the column and silently add a row, which `mode_at_row` / click hit-testing cannot survive.
- **`src/yeaboi/beta.py` is import-free by contract.** `mcp/tools_performance.py` imports it at module scope; anything under `yeaboi.performance` would execute that package's `__init__` and pull `langchain_core` into every MCP server boot (~0.2s). An AST scan in `test_beta.py` enforces it. (Noted in passing: `performance/__init__.py`'s docstring claim that importing the package "never drags in langchain" is stale — it does today. Documented, not changed, as out of scope.)
- **The MCP caveat is injected in the adapter (`_with_beta`), never in engine `warnings`.** `cli._strict_exit` maps any warning to exit 3, so pushing it down would make every `yeaboi perf … --strict` run fail forever. The reason lives in the code.
- **BETA beats NEW** wherever both could render — different claims (unverified vs recent), and two badges overflow the centred tip lane.

## Behaviour changes beyond the label

- `no_wrap`/`overflow="crop"` now applies to **every** mode row, including the Performance roster's per-engineer rows. Long engineer names crop instead of folding. Required for the row-height invariant; pinned by a test.
- `tests/unit/test_beta_surfaces.py` adds a repo-wide invariant that all `docs/**/*.html` share one `?v=` cache-bust value. Deliberate — a new CSS class behind a stale cached stylesheet renders as an *invisible* badge, a silent failure. It will fail a future single-page docs edit that bumps only one file.
- Known cosmetic gap, not fixed: the menu→page slide transition (`_build_slide_frame`) re-renders the title from `render_ascii_text` and drops the chip for those 15 frames.

## Test plan

- `make test` — **6931 passed, 16 skipped**
- `make lint` — clean
- `tests/test_mode_select.py` passes **unedited** — that was the acceptance criterion for the card chip (it pins the `2 + (3 if selected else 0)` row geometry that click hit-testing derives from)
- New: `test_beta.py`, `test_beta_notice.py`, `test_beta_surfaces.py`, `test_mode_cards.py`; extended `test_config.py`, `test_cli_subcommands.py`, `test_mcp_server.py`, `test_tips*.py`, `test_performance_screen.py`, `test_screen_backgrounds.py`
- `tests/unit/test_surface_parity.py` needed **no edit** — deliberate: no capability, card key, tip `mode_key` or tool name changed
- Manual: chip renders correctly at 108 and 120 columns and at `_MIN_WIDTH`; full notice flow verified (Back doesn't ack → reopen shows again → Continue acks → reopen is invisible → force flag re-gates); `yeaboi perf note … > file` keeps stdout clean with the caveat on stderr; `BETA_NOTICES_ENABLED=false` silences it

An independent `code-reviewer` pass raised 4 should-fix findings — misattributed rationale in the `beta.py` docstring, missing skill-doc updates, no guard tying the three beta markers together, and two untested branches in the notice loop. All four are fixed in this branch, along with several nits (a test that would have passed against a broken implementation, a chip that changed hue on selection, a frozen shimmer tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)