### PR TITLE
DO NOT MERGE: diagnose hidden Claude CI error

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -152,6 +152,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # TEMPORARY (diag/claude-ci-error): surface the SDK error the action hides.
+          show_full_output: true
           # Semver classification is mechanical (labels always win; the bump is a
           # script; the changelog paragraph is short) — routed to Haiku for cost.
           # If wrong-level bumps appear, promote to claude-sonnet-5 (one line).

--- a/src/yeaboi/__init__.py
+++ b/src/yeaboi/__init__.py
@@ -72,3 +72,4 @@ try:
     __version__ = _pkg_version("yeaboi")
 except PackageNotFoundError:  # running from a raw source tree without an install
     __version__ = "0.0.0+dev"
+# diag: force auto-version guard to reach the Claude step (revert me)


### PR DESCRIPTION
Temporary. Enables `show_full_output: true` on the auto-version Claude step to surface the SDK error the action suppresses, plus a one-line `src/yeaboi/` touch so the skip guard does not bypass the step.

Claude in CI has failed on every real invocation since 2026-07-27 (last good run: 12 turns, $0.35). Closing and deleting this branch once the error is captured.