### PR TITLE
fix(ci): unbreak the auto-version bump, and make it report its own errors

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -152,6 +152,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Show the SDK's own output. Without this the action prints only
+          # `Running Claude Code via SDK (full output hidden for security)` and a
+          # bare `is_error: true` with no message — which is why the two model
+          # outages below each took a round of blind guessing to diagnose. The
+          # prompt and diff here are public repo content, so there is nothing to
+          # hide; keep this on so the next failure reports itself.
+          show_full_output: true
           # Semver classification is mechanical (labels always win; the bump is a
           # script; the changelog paragraph is short) — routed to Haiku for cost.
           # If wrong-level bumps appear, promote to claude-sonnet-5 (one line).

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -169,6 +169,17 @@ jobs:
           # outages below each took a round of blind guessing to diagnose. The
           # prompt and diff here are public repo content, so there is nothing to
           # hide; keep this on so the next failure reports itself.
+          #
+          # THIS FLAG CANNOT BE TESTED ON THE PR THAT ADDS IT. The action
+          # validates that the workflow file is byte-identical to the copy on the
+          # default branch, and *skips itself* when it isn't:
+          #   "Skipping action due to workflow validation: … must have identical
+          #    content to the version on the repository's default branch"
+          # The skip reports the step as SUCCESS, so a PR editing this file gets a
+          # green auto-version that never ran Claude at all. Two consequences:
+          #   1. any change here is only exercised after it lands on main;
+          #   2. a green check on a workflow-editing PR proves nothing — read the
+          #      log for the validation warning before believing it.
           show_full_output: true
           # Semver classification is mechanical (labels always win; the bump is a
           # script; the changelog paragraph is short) — routed to Haiku for cost.

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -93,9 +93,20 @@ jobs:
           set -euo pipefail
           ver() { sed -nE 's/^version = "([^"]+)".*/\1/p' | head -1; }
           git fetch --no-tags origin "$BASE_REF"
-          BASE_V=$(git show "FETCH_HEAD:pyproject.toml" | ver)
+          # Compare against the MERGE-BASE, not the base tip. This guard asks
+          # "did *this PR* change the version?", and only the merge-base answers
+          # that. Against the tip, any branch that simply hasn't been rebased
+          # since main's last release reads as HEAD_V != BASE_V and falls into
+          # the "already bumped" skip below — shipping with no bump and no
+          # changelog entry, silently. Because auto-version bumps main on every
+          # release-worthy merge, that is the common case, not an edge case:
+          # PR #120 hit it within hours (base 2.44.0 vs an un-rebased 2.43.0).
+          # Same silent-skip class as the diff-range bug fixed in #114, which
+          # moved the *file list* to a merge-base diff but left this on the tip.
+          MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+          BASE_V=$(git show "$MERGE_BASE:pyproject.toml" | ver)
           HEAD_V=$(ver < pyproject.toml)
-          echo "base=$BASE_V head=$HEAD_V labels=[$LABELS]"
+          echo "base=$BASE_V head=$HEAD_V merge_base=$MERGE_BASE labels=[$LABELS]"
 
           # 1) Already bumped in this PR (manual, or a prior auto run)?
           #    If the changelog already has an entry for the new version too ->


### PR DESCRIPTION
## Summary

`auto-version` has been failing for **every** PR that touches `src/yeaboi/` since ~11:24 today. It looked healthy because every green run since then had *skipped* the Claude step (docs/CI-only PRs); every run that actually invoked it failed.

| Run | Branch | Claude step | Result |
|---|---|---|---|
| 17:25 | remove-local-sharing | skipped | ✅ |
| 17:15 | diag/claude-ci-error | skipped | ✅ |
| 17:06 | feature/demo-recorder | skipped | ✅ |
| 16:21 | feature/readme-banner | skipped | ✅ |
| 15:36 | remove-local-sharing | **ran** | ❌ |
| 15:46 → 17:33 (×3) | performance-coming-soon (#116) | **ran** | ❌ |

Failure signature every time: turn 1, ~2s, `total_cost_usd: 0`, `is_error: true`, **no message**. That is the same signature the file's own comment records from the 2026-07-29 alias outage — except the dated pin that fixed it last time is already in place, so the pin is not the whole story.

Meanwhile `claude-review.yml` (Opus-tier, **same** `CLAUDE_CODE_OAUTH_TOKEN`) succeeded at 17:11 and 17:19 and failed at 16:26 and 17:29 — so the token is valid and the failure is not account-wide.

## This PR

Commit 1 turns on `show_full_output: true`, keeping Haiku, so the run reproduces the failure **and prints the real SDK error** instead of a bare `is_error`. A follow-up commit applies the actual fix once that error is readable.

Keeping the diagnostic on permanently is the point: the prompt and diff here are public repo content, so there is nothing to hide, and both outages so far cost a round of blind elimination that a single error line would have prevented.

## How this gets tested without touching src/

A workflow-only PR would normally skip the Claude step and prove nothing. The guard has an explicit escape for exactly this — step 2, "A `semver:*` / `release:skip` label forces the LLM step to run" — and the workflow already triggers on `labeled`. Adding `semver:none` to this PR exercises the step with no shipping-code change.

## Test plan

- Label this PR `semver:none` → `auto-version` runs the Claude step → read the now-visible SDK error
- Apply the fix, confirm the step passes
- Re-run `auto-version` on #116 (the first PR blocked by this) and confirm it bumps + writes its changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)