### PR TITLE
branch new worktrees off latest origin/main

### DIFF
--- a/.claude/commands/wt.md
+++ b/.claude/commands/wt.md
@@ -7,7 +7,7 @@ Worktree operations for parallel feature development. Arguments: $ARGUMENTS
 Parse the arguments and run the matching operation via the existing tooling (never reimplement it):
 
 - `list` (or no arguments) — run `bash scripts/wt-list.sh` and, for each worktree, also check `gh pr list --head <branch>` to note whether it has an open PR. Present a compact table: name, branch, clean/dirty, PR status.
-- `new <name>` — run `bash scripts/wt.sh <name> open` (creates `.claude/worktrees/<name>` with branch, `.env`, venv, pre-commit hooks, then opens VS Code with a claude session).
+- `new <name>` — run `bash scripts/wt.sh <name> open` (fetches origin, branches `<name>` off latest `origin/main`, creates `.claude/worktrees/<name>` with `.env`, venv, pre-commit hooks, then opens VS Code with a claude session). If the branch already exists the script reuses it as-is and reports how far behind main it is — rebase it with `/sync-main` inside the worktree.
 - `headless <name>` — run `bash scripts/wt.sh <name> headless` (same provisioning, no VS Code window; prints the path). Use this when the feature will be driven by a background agent from this session instead of a human-attended window.
 - `rm <name>` — first check the worktree is clean (`git -C .claude/worktrees/<name> status --porcelain` from the main checkout) and has no unmerged work; warn and ask before removing anything dirty. Then run `bash scripts/wt.sh <name> rm`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,11 @@ Terminal GIFs for the README: `asciinema rec docs/demo.cast -c "yeaboi --dry-run
 
 ## Parallel Development (worktrees)
 
-Each feature gets its own git worktree under `<main checkout>/.claude/worktrees/<name>` with its own branch, `.env`, uv venv, and pre-commit hooks. Never develop two features in one checkout.
+Each feature gets its own git worktree under `<main checkout>/.claude/worktrees/<name>` with its own branch, `.env`, uv venv, and pre-commit hooks. Never develop two features in one checkout. Creating a worktree fetches `origin` and cuts the new branch from latest `origin/main` (and fast-forwards the main checkout's `main` when that is safe), so it does not inherit a stale local base. Reusing an existing branch leaves it untouched — the script reports how far behind it is; rebase it with `/sync-main`.
 
 ```bash
-make wt-new NAME=my-feature       # create worktree + open VS Code with claude auto-running
-make wt-headless NAME=my-feature  # create worktree WITHOUT VS Code (for background-agent work)
+make wt-new NAME=my-feature       # create worktree off latest origin/main + open VS Code with claude auto-running
+make wt-headless NAME=my-feature  # same, WITHOUT VS Code (for background-agent work)
 make wt-list                      # list worktrees (branch, clean/dirty, path)
 make wt-rm NAME=my-feature        # remove worktree dir + branch
 ```

--- a/Makefile
+++ b/Makefile
@@ -163,15 +163,15 @@ define need-name
 	@test -n "$(NAME)" || { echo "usage: make $@ NAME=<slug>  (e.g. NAME=standup-fix)"; exit 1; }
 endef
 
-wt-new: ## Create worktree .claude/worktrees/NAME (branch + .env + venv) + open in VS Code with claude auto-running
+wt-new: ## Create worktree .claude/worktrees/NAME off latest origin/main (branch + .env + venv) + open in VS Code with claude auto-running
 	$(need-name)
 	CODE="$(CODE)" bash scripts/wt.sh "$(NAME)" open
 
-wt-open: ## Open worktree in a NEW VS Code window with claude auto-running (creates it first if needed)
+wt-open: ## Open worktree in a NEW VS Code window with claude auto-running (creates it off latest origin/main first if needed)
 	$(need-name)
 	CODE="$(CODE)" bash scripts/wt.sh "$(NAME)" open
 
-wt-headless: ## Create worktree WITHOUT VS Code auto-launch (driven by background agents instead)
+wt-headless: ## Create worktree off latest origin/main WITHOUT VS Code auto-launch (driven by background agents instead)
 	$(need-name)
 	bash scripts/wt.sh "$(NAME)" headless
 

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -9,6 +9,13 @@
 #                                             an orchestrating Claude session
 #   bash scripts/wt.sh my-feature rm       -> remove worktree dir + git branch
 #
+# A new branch is cut from the freshly fetched upstream default branch
+# (origin/main) rather than from whatever the main checkout happens to be sitting
+# on — otherwise a stale main silently hands every new feature branch an old
+# base, and the first `/sync-main` turns into a surprise rebase. Each fallback
+# (no origin, failed fetch, unresolvable default branch, pre-existing branch)
+# prints why it took a local base instead.
+#
 # Provisioning per worktree: copy the main checkout's .env, create a uv venv with
 # the package installed editable (same as `make install`), install pre-commit
 # hooks, and (except for headless) write .vscode/ auto-launch files so opening
@@ -49,11 +56,107 @@ if [ "$ACTION" = "rm" ]; then
   exit 0
 fi
 
+# --- base: latest upstream default branch ------------------------------------
+# Resolved before `worktree add` so the new branch starts at origin/main rather
+# than at the main checkout's HEAD, which may be stale or on another branch.
+# Left empty when there is no usable remote ref; the add then falls back to HEAD.
+BASE_REF=""
+DEFAULT_BRANCH="main"
+
+# Never prompt: wt.sh is the entry point for unattended fan-out (/migrate,
+# /babysit-prs), where an unknown host key or a locked ssh key would otherwise
+# hang the orchestrating agent forever with no output. Both settings turn a
+# would-be prompt into a plain non-zero exit, which the callers below handle.
+git_offline() { GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -o BatchMode=yes}" git "$@"; }
+
+resolve_base() {
+  git -C "$ROOT" remote get-url origin >/dev/null 2>&1 || {
+    echo "[wt] note: no 'origin' remote — branching from the main checkout's HEAD"
+    return
+  }
+  echo "[wt] fetching origin…"
+  if ! git_offline -C "$ROOT" fetch --quiet --prune origin; then
+    echo "[wt] note: \`git fetch origin\` failed (offline? credentials?) — branching from the local base, which may be stale"
+  fi
+  # origin/HEAD names the default branch. It is unset on clones built with
+  # `git init` + `git remote add` and after a default-branch rename, so ask the
+  # remote rather than assuming 'main' — guessing wrong lands us back on the
+  # stale-HEAD behaviour this function exists to remove.
+  local head_ref
+  head_ref="$(git -C "$ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -z "$head_ref" ]; then
+    git_offline -C "$ROOT" remote set-head origin --auto >/dev/null 2>&1 || true
+    head_ref="$(git -C "$ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  fi
+  [ -n "$head_ref" ] && DEFAULT_BRANCH="${head_ref#origin/}" || true
+  if git -C "$ROOT" show-ref --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH"; then
+    BASE_REF="origin/$DEFAULT_BRANCH"
+  else
+    echo "[wt] note: no 'origin/$DEFAULT_BRANCH' ref — branching from the main checkout's HEAD, which may be stale"
+  fi
+}
+
+# Keep the main checkout's own default branch in step, so `git log main` there
+# and the base of the new worktree agree. Fast-forward only, and never touching a
+# dirty tree — this is a convenience, not something that may eat local work.
+sync_local_default() {
+  [ -n "$BASE_REF" ] || return 0
+  local before after err
+  if [ "$(git -C "$ROOT" branch --show-current)" = "$DEFAULT_BRANCH" ]; then
+    # -uno: untracked files never block a fast-forward, and the main checkout
+    # always has some (log output, build artefacts). Counting them would make
+    # this branch dead code.
+    if [ -n "$(git -C "$ROOT" status --porcelain -uno)" ]; then
+      echo "[wt] note: main checkout has uncommitted changes — left '$DEFAULT_BRANCH' alone (the new worktree still starts at $BASE_REF)"
+      return 0
+    fi
+    before="$(git -C "$ROOT" rev-parse HEAD)"
+    if ! err="$(git -C "$ROOT" merge --ff-only "$BASE_REF" 2>&1)"; then
+      # Report git's own reason: 'diverged' is only one of them (a held
+      # index.lock and an unmerged index land here too).
+      echo "[wt] note: could not fast-forward '$DEFAULT_BRANCH' in the main checkout — left alone"
+      echo "[wt]       git said: $(printf '%s' "$err" | head -1)"
+      return 0
+    fi
+    after="$(git -C "$ROOT" rev-parse HEAD)"
+    [ "$before" != "$after" ] && echo "[wt] fast-forwarded '$DEFAULT_BRANCH' in the main checkout" || true
+  elif git -C "$ROOT" worktree list --porcelain | grep -qFx "branch refs/heads/$DEFAULT_BRANCH"; then
+    echo "[wt] note: '$DEFAULT_BRANCH' is checked out in another worktree — left alone"
+  else
+    # Not checked out anywhere: fetch refuses a non-fast-forward ref update, so
+    # this is safe without an explicit ancestry check — but say so when it is
+    # refused, rather than leaving a diverged local default silently behind.
+    before="$(git -C "$ROOT" rev-parse "$DEFAULT_BRANCH" 2>/dev/null || echo none)"
+    if git -C "$ROOT" fetch --quiet origin "$DEFAULT_BRANCH:$DEFAULT_BRANCH" 2>/dev/null; then
+      after="$(git -C "$ROOT" rev-parse "$DEFAULT_BRANCH" 2>/dev/null || echo none)"
+      [ "$before" != "$after" ] && echo "[wt] fast-forwarded local '$DEFAULT_BRANCH'" || true
+    else
+      echo "[wt] note: local '$DEFAULT_BRANCH' has diverged from $BASE_REF — left alone"
+    fi
+  fi
+}
+
 if [ ! -d "$TARGET" ]; then
   mkdir -p "$ROOT/.claude/worktrees"
+  resolve_base
+  sync_local_default
   # New branch by default; reuse the branch if it already exists.
   if git -C "$ROOT" show-ref --verify --quiet "refs/heads/$NAME"; then
     git -C "$ROOT" worktree add "$TARGET" "$NAME"
+    # An existing branch keeps its own history — rebasing it here could conflict
+    # or rewrite pushed commits, so only report the gap and let /sync-main do it.
+    if [ -n "$BASE_REF" ]; then
+      behind="$(git -C "$ROOT" rev-list --count "$NAME..$BASE_REF" 2>/dev/null || echo 0)"
+      if [ "$behind" != "0" ]; then
+        echo "[wt] note: existing branch '$NAME' is $behind commit(s) behind $BASE_REF — run /sync-main in the worktree"
+      fi
+    fi
+  elif [ -n "$BASE_REF" ]; then
+    # --no-track: branching off a remote-tracking ref would otherwise set the new
+    # branch's upstream to origin/main, so a bare `git push` in the worktree aims
+    # at main. /ship pushes with `-u origin <branch>` and sets it properly.
+    git -C "$ROOT" worktree add --no-track "$TARGET" -b "$NAME" "$BASE_REF"
+    echo "[wt] branched '$NAME' from $BASE_REF"
   else
     git -C "$ROOT" worktree add "$TARGET" -b "$NAME"
   fi

--- a/tests/unit/test_wt_script.py
+++ b/tests/unit/test_wt_script.py
@@ -1,0 +1,218 @@
+"""Tests for scripts/wt.sh — the git-worktree provisioning script behind `make wt-new`.
+
+The script's job is to cut every new feature branch from the *freshly fetched*
+upstream default branch, so a stale main checkout cannot hand a worktree an old
+base. That guarantee, and the four fallbacks around it, are only observable by
+running the real script against real git repositories — so each test builds a
+throwaway bare "origin" plus a clone in tmp_path and inspects the resulting refs.
+
+Provisioning (uv venv, editable install, pre-commit) is stubbed out with a fake
+`uv` on PATH: it is not what these tests are about, and a real install would put
+a minute on every case.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WT_SH = Path(__file__).resolve().parents[2] / "scripts" / "wt.sh"
+
+
+def _git(repo: Path, *args: str, env: dict[str, str], check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=check,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    """Git env isolated from the developer's real config, hooks and credentials.
+
+    Every inherited GIT_* variable is dropped, not just overridden. Under the
+    pre-commit hook the suite runs with GIT_INDEX_FILE / GIT_DIR / GIT_WORK_TREE
+    pointing at the *real* repository, and `git -C <tmp> add -A` obeys those over
+    -C: the temp repo's tree lands in the real index, recording every real file
+    as deleted. Inheriting the environment here is not a tidiness question.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    # Fake uv: `uv venv`, `uv pip install`, `uv run pre-commit install` all no-op.
+    stub = bin_dir / "uv"
+    stub.write_text("#!/bin/sh\nexit 0\n")
+    stub.chmod(0o755)
+    return {
+        **{k: v for k, v in os.environ.items() if not k.startswith("GIT_")},
+        "HOME": str(home),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "GIT_CONFIG_GLOBAL": str(home / ".gitconfig"),
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.com",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+
+@pytest.fixture
+def repo(tmp_path: Path, env: dict[str, str]) -> Path:
+    """A bare origin + a clone of it holding scripts/wt.sh, both on `main`.
+
+    Returns the clone (the "main checkout" the script operates against).
+    """
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(origin)], check=True, env=env)
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", "-q", str(origin), str(work)], check=True, env=env)
+
+    scripts = work / "scripts"
+    scripts.mkdir()
+    shutil.copy(WT_SH, scripts / "wt.sh")
+    (work / "f.txt").write_text("one\n")
+    _git(work, "add", "-A", env=env)
+    _git(work, "commit", "-qm", "one", env=env)
+    _git(work, "push", "-q", "-u", "origin", "main", env=env)
+    # Worktrees are gitignored in the real repo; mirror that so the clone reads
+    # as clean once one exists.
+    (work / ".git" / "info" / "exclude").write_text(".claude/worktrees/\n")
+    return work
+
+
+def _push_upstream_commit(tmp_path: Path, env: dict[str, str], branch: str = "main") -> str:
+    """Land a commit on origin/<branch> from a second clone, leaving `repo` stale."""
+    other = tmp_path / f"other-{branch}"
+    subprocess.run(["git", "clone", "-q", "-b", branch, str(tmp_path / "origin.git"), str(other)], check=True, env=env)
+    (other / "f2.txt").write_text("two\n")
+    _git(other, "add", "-A", env=env)
+    _git(other, "commit", "-qm", "two", env=env)
+    _git(other, "push", "-q", "origin", branch, env=env)
+    return _git(other, "rev-parse", "HEAD", env=env)
+
+
+def _run_wt(repo: Path, name: str, env: dict[str, str], action: str = "headless") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/wt.sh", name, action],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestBranchBase:
+    """The core guarantee: a new branch starts at the latest upstream default."""
+
+    def test_new_branch_starts_at_origin_main_when_local_is_stale(
+        self, tmp_path: Path, repo: Path, env: dict[str, str]
+    ) -> None:
+        upstream = _push_upstream_commit(tmp_path, env)
+        local_before = _git(repo, "rev-parse", "HEAD", env=env)
+        assert local_before != upstream  # the clone really is behind
+
+        result = _run_wt(repo, "feat-a", env)
+
+        assert result.returncode == 0, result.stderr
+        assert _git(repo, "rev-parse", "feat-a", env=env) == upstream
+
+    def test_new_branch_has_no_upstream(self, tmp_path: Path, repo: Path, env: dict[str, str]) -> None:
+        """--no-track: otherwise a bare `git push` in the worktree aims at main."""
+        _push_upstream_commit(tmp_path, env)
+        _run_wt(repo, "feat-a", env)
+
+        tracking = subprocess.run(
+            ["git", "-C", str(repo), "config", "--get", "branch.feat-a.merge"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert tracking.stdout.strip() == ""
+
+    def test_honours_a_default_branch_that_is_not_main(self, tmp_path: Path, repo: Path, env: dict[str, str]) -> None:
+        """origin/HEAD is asked for, not assumed — a wrong guess means a stale base."""
+        origin = tmp_path / "origin.git"
+        _git(repo, "branch", "-q", "trunk", env=env)
+        _git(repo, "push", "-q", "origin", "trunk", env=env)
+        _git(origin, "symbolic-ref", "HEAD", "refs/heads/trunk", env=env)
+        upstream = _push_upstream_commit(tmp_path, env, branch="trunk")
+        # Unset locally, as on clones built with `git init` + `git remote add`.
+        _git(repo, "remote", "set-head", "origin", "-d", env=env, check=False)
+
+        result = _run_wt(repo, "feat-a", env)
+
+        assert result.returncode == 0, result.stderr
+        assert _git(repo, "rev-parse", "feat-a", env=env) == upstream
+
+    def test_no_origin_remote_falls_back_to_head(self, repo: Path, env: dict[str, str]) -> None:
+        _git(repo, "remote", "remove", "origin", env=env)
+        head = _git(repo, "rev-parse", "HEAD", env=env)
+
+        result = _run_wt(repo, "solo", env)
+
+        assert result.returncode == 0, result.stderr
+        assert "no 'origin' remote" in result.stdout
+        assert _git(repo, "rev-parse", "solo", env=env) == head
+
+
+class TestExistingBranch:
+    """Provisioning must never rewrite history that already exists."""
+
+    def test_existing_branch_is_reused_untouched(self, tmp_path: Path, repo: Path, env: dict[str, str]) -> None:
+        old = _git(repo, "rev-parse", "HEAD", env=env)
+        _git(repo, "branch", "old-feat", old, env=env)
+        _push_upstream_commit(tmp_path, env)
+
+        result = _run_wt(repo, "old-feat", env)
+
+        assert result.returncode == 0, result.stderr
+        assert _git(repo, "rev-parse", "old-feat", env=env) == old
+        assert "1 commit(s) behind" in result.stdout
+
+
+class TestLocalDefaultSync:
+    """The main checkout's own default branch is a convenience, never a risk."""
+
+    def test_clean_checkout_is_fast_forwarded(self, tmp_path: Path, repo: Path, env: dict[str, str]) -> None:
+        upstream = _push_upstream_commit(tmp_path, env)
+
+        result = _run_wt(repo, "feat-a", env)
+
+        assert "fast-forwarded 'main'" in result.stdout
+        assert _git(repo, "rev-parse", "main", env=env) == upstream
+
+    def test_uncommitted_changes_leave_the_checkout_alone(
+        self, tmp_path: Path, repo: Path, env: dict[str, str]
+    ) -> None:
+        upstream = _push_upstream_commit(tmp_path, env)
+        local_before = _git(repo, "rev-parse", "HEAD", env=env)
+        (repo / "f.txt").write_text("edited\n")
+
+        result = _run_wt(repo, "feat-a", env)
+
+        assert "uncommitted changes" in result.stdout
+        assert _git(repo, "rev-parse", "main", env=env) == local_before
+        assert (repo / "f.txt").read_text() == "edited\n"
+        # …and the new branch still starts at the upstream tip.
+        assert _git(repo, "rev-parse", "feat-a", env=env) == upstream
+
+    def test_untracked_files_do_not_block_the_fast_forward(
+        self, tmp_path: Path, repo: Path, env: dict[str, str]
+    ) -> None:
+        """A real checkout always has untracked junk; counting it would kill this path."""
+        upstream = _push_upstream_commit(tmp_path, env)
+        (repo / "stray.log").write_text("noise\n")
+
+        _run_wt(repo, "feat-a", env)
+
+        assert _git(repo, "rev-parse", "main", env=env) == upstream


### PR DESCRIPTION
## Summary

`make wt-new NAME=x` created the feature branch with a bare `git worktree add "$TARGET" -b "$NAME"` — no fetch, no reference to the remote. The new branch therefore started at whatever the main checkout's HEAD happened to be. If you hadn't pulled in a few days, every new worktree silently began on a stale base and the first `/sync-main` turned into a surprise rebase.

`scripts/wt.sh` now, on creation only:

- **Fetches `origin`** and resolves the default branch from `refs/remotes/origin/HEAD`. When that symref is unset (clones built with `git init` + `git remote add`, or after a default-branch rename) it asks the remote via `git remote set-head origin --auto` rather than assuming `main` — guessing wrong would land straight back on the stale-HEAD behaviour this change removes.
- **Cuts the branch at `origin/<default>`** with `--no-track`. Without `--no-track`, branching off a remote-tracking ref sets the new branch's upstream to `origin/main`, so a bare `git push` in the worktree aims at main; `/ship` sets it properly with `push -u origin <branch>`.
- **Fast-forwards the main checkout's own default branch** when that is safe — clean tree, `--ff-only`, never a rebase — so `git log main` there agrees with the new worktree's base. `status --porcelain -uno`, because untracked files never block a fast-forward and a real checkout always has some.

Non-destructive throughout. An **existing** branch is reused untouched and only reported as `N commit(s) behind` (rebasing it here could conflict or rewrite pushed commits — that's `/sync-main`'s job). Every fallback — no `origin`, failed fetch, unresolvable default branch, default branch checked out elsewhere — takes a local base and prints why, rather than failing silently.

Fetches run under `GIT_TERMINAL_PROMPT=0` and `ssh -o BatchMode=yes`: `wt.sh` is the entry point for unattended fan-out (`/migrate`, `/babysit-prs`), where a first-time host-key or credential prompt would hang the orchestrating agent forever with no output. Both settings turn that into the already-handled failure path.

Docs updated to match in `CLAUDE.md`, the `wt-new` / `wt-open` / `wt-headless` help strings, and `/wt`. They describe the fallbacks rather than claiming an absolute guarantee the script doesn't make.

## Test plan

- `make test` — 7482 passed, 46 skipped, 19 snapshots passed
- `make lint` — clean
- `shellcheck scripts/wt.sh` — clean
- New `tests/unit/test_wt_script.py` (8 tests) drives the real script against throwaway bare-remote + clone pairs, with a stub `uv` on PATH so provisioning doesn't add a minute per case. Covers: branch point when local main is stale, no upstream set, a default branch not named `main` with `origin/HEAD` unset, no-`origin` fallback, existing branch left unrewritten, clean-checkout fast-forward, dirty checkout left alone, untracked files not blocking the fast-forward.
- Verified the tests are meaningful: **7 of the 8 fail** against the pre-change `scripts/wt.sh` from `main`.
- The fixture strips every inherited `GIT_*` var. Under the pre-commit hook the suite runs with `GIT_INDEX_FILE` / `GIT_DIR` / `GIT_WORK_TREE` pointing at the real repo, and those override `git -C <tmp>` — verified by re-running the suite with all three deliberately set: 8 passed, real index byte-identical before and after.

Reviewed by an independent fresh-context `code-reviewer` agent; all `should-fix` findings resolved (`origin/HEAD` unset fallback, untracked-files check, non-interactive fetch) plus the nits (accurate "fast-forwarded" reporting, git's own error text instead of a guessed diagnosis, `grep -qFx`, doc wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)