### PR TITLE
integrate GitLab: 3 read tools + 1 write tool, wired into the intake repo scan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,17 @@ LANGSMITH_PROJECT=yeaboi
 # No token: works for public repos at 60 req/hour (unauthenticated)
 GITHUB_TOKEN=your-github-personal-access-token
 
+# GitLab (optional — enables project context tools and issue creation)
+# Create at: GitLab → User Settings → Access Tokens
+# Scopes: read_api (read tools) or api (also create issues)
+# Unlike GitHub there is no unauthenticated fallback — without a token the
+# GitLab tools return "GitLab is not configured" rather than trying anonymously.
+# Real tokens are issued with a "glpat-" prefix; the placeholder below omits it
+# so secret scanners don't flag this example file.
+GITLAB_TOKEN=your-gitlab-personal-access-token
+# Optional: point at a self-hosted GitLab. Defaults to https://gitlab.com.
+GITLAB_URL=https://gitlab.com
+
 # Azure DevOps (optional — enables repo context tools and board sync; required for private projects)
 # PAT permissions needed: Code=Read, Work Items=Read+Write, Project=Read
 AZURE_DEVOPS_TOKEN=your-azure-devops-personal-access-token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.51.0"
+version = "2.52.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -46,6 +46,10 @@ dependencies = [
     # Notion doc tools (tools/notion.py) — official SDK, mirrors how Confluence
     # uses atlassian-python-api. Notion has its own integration token (NOTION_TOKEN).
     "notion-client",
+    # GitLab repo/issue tools (tools/gitlab.py) — the maintained official SDK,
+    # mirroring how GitHub uses PyGithub. Auth is a personal access token
+    # (GITLAB_TOKEN); GITLAB_URL points it at a self-hosted instance.
+    "python-gitlab",
     # SQLite-backed checkpoint store for Phase 8 session persistence.
     # SqliteSaver is used as a standalone store; the graph itself stays
     # stateless for now (Phase 8B wires it as a full LangGraph checkpointer).

--- a/src/yeaboi/agent/nodes.py
+++ b/src/yeaboi/agent/nodes.py
@@ -2437,10 +2437,10 @@ def _fetch_notion_context(
 def _scan_repo_context(questionnaire: QuestionnaireState) -> tuple[str | None, dict]:
     """Scan the repo referenced in Q17 and return a combined context string + status.
 
-    Calls GitHub or AzDO read tools directly as Python functions — no LLM
-    ReAct loop needed, they are plain functions that return strings.
+    Calls GitHub, GitLab, or AzDO read tools directly as Python functions — no
+    LLM ReAct loop needed, they are plain functions that return strings.
     Returns (None, status) if no URL was provided, the platform is unsupported
-    (GitLab, Bitbucket — tools not yet implemented), or all tool calls fail.
+    (Bitbucket — tools not yet implemented), or all tool calls fail.
     The caller proceeds gracefully with reduced context when None is returned.
 
     Returns:
@@ -2474,6 +2474,20 @@ def _scan_repo_context(questionnaire: QuestionnaireState) -> tuple[str | None, d
             if result and not result.startswith("Error:"):
                 sections.append(result)
 
+        elif platform == "GitLab":
+            # Same two-call shape as GitHub above (tree + README). GitLab needs a
+            # token even for public projects, so an unconfigured user falls
+            # through to the "returned no data" branch rather than erroring.
+            from yeaboi.tools.gitlab import gitlab_read_readme, gitlab_read_repo
+
+            for fn, kwargs in [
+                (gitlab_read_repo, {"project_url": url}),
+                (gitlab_read_readme, {"project_url": url}),
+            ]:
+                result = fn.invoke(kwargs)
+                if result and not result.startswith("Error:"):
+                    sections.append(result)
+
         elif not url.startswith(("http://", "https://")):
             # Treat as a local filesystem path (user selected "local only" in Q16
             # or typed an absolute/relative path instead of a remote URL).
@@ -2484,7 +2498,7 @@ def _scan_repo_context(questionnaire: QuestionnaireState) -> tuple[str | None, d
                 sections.append(result)
 
         else:
-            # GitLab and Bitbucket: no tools implemented yet
+            # Bitbucket: no tools implemented yet
             return None, {"name": "Repository", "status": "skipped", "detail": f"{platform} not yet supported"}
 
     except Exception as e:

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -4,7 +4,7 @@
     {
       "version": "2.52.0",
       "date": "2026-08-02",
-      "summary": "GitLab support is now complete. Intake now scans GitLab projects for repository metadata, readme files, and open issues — the same way it already does for GitHub and Azure DevOps. Read tools work anonymously for public projects and with a token for private ones; the write tool creates GitLab issues during planning, gated behind human review. Self-hosted GitLab instances are supported by setting GITLAB_URL. Fixes the broken contract where intake Q16 offered GitLab as a code-host option but then reported it wasn't supported yet.",
+      "summary": "GitLab support is now complete. Intake scans GitLab projects for repository metadata, readme files, and open issues — the same way it already does for GitHub and Azure DevOps. GitLab needs a token even for public projects: set GITLAB_TOKEN, or the tools report that GitLab is not configured. The write tool creates GitLab issues during planning, gated behind human review. Self-hosted GitLab instances are supported by setting GITLAB_URL. Fixes the broken contract where intake Q16 offered GitLab as a code-host option but then reported it wasn't supported yet.",
       "highlights": [
         {
           "text": "Intake now scans GitLab repositories for project metadata, directory trees, and open issues",
@@ -14,7 +14,7 @@
           ]
         },
         {
-          "text": "Create GitLab issues directly from planning poker, the same way GitHub and Jira do",
+          "text": "Create a GitLab issue from planning, after yeaboi asks you to confirm it",
           "areas": [
             "planning"
           ]
@@ -26,7 +26,7 @@
           ]
         },
         {
-          "text": "GitLab token authentication via GITLAB_TOKEN environment variable",
+          "text": "GitLab token authentication via GITLAB_TOKEN — required, with no anonymous fallback",
           "areas": [
             "settings"
           ]

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,38 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.52.0",
+      "date": "2026-08-02",
+      "summary": "GitLab support is now complete. Intake now scans GitLab projects for repository metadata, readme files, and open issues — the same way it already does for GitHub and Azure DevOps. Read tools work anonymously for public projects and with a token for private ones; the write tool creates GitLab issues during planning, gated behind human review. Self-hosted GitLab instances are supported by setting GITLAB_URL. Fixes the broken contract where intake Q16 offered GitLab as a code-host option but then reported it wasn't supported yet.",
+      "highlights": [
+        {
+          "text": "Intake now scans GitLab repositories for project metadata, directory trees, and open issues",
+          "areas": [
+            "planning",
+            "general"
+          ]
+        },
+        {
+          "text": "Create GitLab issues directly from planning poker, the same way GitHub and Jira do",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Support for both gitlab.com and self-hosted GitLab instances via GITLAB_URL",
+          "areas": [
+            "settings"
+          ]
+        },
+        {
+          "text": "GitLab token authentication via GITLAB_TOKEN environment variable",
+          "areas": [
+            "settings"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.51.0",
       "date": "2026-08-02",
       "summary": "Daily Standup now flags engineering practices that might cost your team later — work that lands with no ticket, a board left stale after a merge, too many changes open at once, or changes too big to review. Seven deterministic rules catch these patterns per team member, capped at three signals each. Every signal names the exact changes it observed — no LLM is involved in detection. Wrong calls are answered: teammates can thumbs-down to hide a signal and it remembers; thumbs-up confirms it. Answers appear in the TUI, over MCP, and in the shared HTML page where the teammate reading it usually spots the mistake first.",

--- a/src/yeaboi/config.py
+++ b/src/yeaboi/config.py
@@ -276,6 +276,33 @@ def get_github_token() -> str | None:
     return os.getenv("GITHUB_TOKEN") or None
 
 
+def get_gitlab_token() -> str | None:
+    """Return the GitLab personal access token, or None if not set.
+
+    Unlike GitHub (whose tools fall back to unauthenticated access for public
+    repos), the GitLab tools require this — see the module docstring of
+    tools/gitlab.py for why anonymous access is not worth supporting there.
+    """
+    return os.getenv("GITLAB_TOKEN") or None
+
+
+def get_gitlab_url() -> str:
+    """Return the GitLab instance URL, defaulting to https://gitlab.com.
+
+    Set GITLAB_URL to point the tools at a self-hosted instance. Normalised on
+    read: whitespace and trailing slashes stripped, and a missing scheme
+    defaulted to https:// — python-gitlab joins this with API paths directly, so
+    a bare "gitlab.example.com" would otherwise reach requests as a relative URL
+    and fail with a MissingSchema error on every GitLab call.
+    """
+    raw = (os.getenv("GITLAB_URL") or "").strip().rstrip("/")
+    if not raw:
+        return "https://gitlab.com"
+    if "://" not in raw:
+        return f"https://{raw}"
+    return raw
+
+
 def get_azure_devops_token() -> str | None:
     """Return the Azure DevOps PAT, or None if not set."""
     return os.getenv("AZURE_DEVOPS_TOKEN") or None

--- a/src/yeaboi/redaction.py
+++ b/src/yeaboi/redaction.py
@@ -50,6 +50,7 @@ SECRET_ENV_KEYS: tuple[str, ...] = (
     "GOOGLE_API_KEY",
     "LANGSMITH_API_KEY",
     "GITHUB_TOKEN",
+    "GITLAB_TOKEN",
     "JIRA_API_TOKEN",
     "AZURE_DEVOPS_TOKEN",
     "CONFLUENCE_API_TOKEN",
@@ -74,6 +75,9 @@ _TOKEN_PATTERNS: tuple[str, ...] = (
     r"sk-[A-Za-z0-9_-]{20,}",
     r"gh[pousr]_[A-Za-z0-9]{20,}",
     r"github_pat_[A-Za-z0-9_]{20,}",
+    # GitLab personal access tokens (glpat-) and their CI/runner siblings
+    # (glrt-, gldt-, glsoat-), all of which share the "gl<kind>-" prefix.
+    r"gl[a-z]{2,6}-[A-Za-z0-9_-]{20,}",
     r"xox[abprs]-[\w-]{10,}",
     r"AIza[\w-]{35}",
     r"AKIA[0-9A-Z]{16}",

--- a/src/yeaboi/tools/__init__.py
+++ b/src/yeaboi/tools/__init__.py
@@ -80,6 +80,12 @@ def get_tools() -> list[BaseTool]:
         github_read_readme,
         github_read_repo,
     )
+    from yeaboi.tools.gitlab import (
+        gitlab_create_issue,
+        gitlab_list_issues,
+        gitlab_read_readme,
+        gitlab_read_repo,
+    )
     from yeaboi.tools.jira import (
         jira_create_epic,
         jira_create_sprint,
@@ -103,6 +109,10 @@ def get_tools() -> list[BaseTool]:
         github_read_file,
         github_list_issues,
         github_read_readme,
+        gitlab_read_repo,
+        gitlab_read_readme,
+        gitlab_list_issues,
+        gitlab_create_issue,
         azdevops_read_repo,
         azdevops_read_file,
         azdevops_list_work_items,

--- a/src/yeaboi/tools/gitlab.py
+++ b/src/yeaboi/tools/gitlab.py
@@ -1,0 +1,462 @@
+"""GitLab tools — 3 read-only + 1 write (with user-confirmation guard in the docstring).
+
+# See docs: "Tools" — tool types, @tool decorator, risk levels
+#
+# This module mirrors tools/github.py: the same read surface (repo tree, README,
+# issues) so the intake repo-scan path can treat GitLab exactly like GitHub, plus
+# one write tool. Read tools are low-risk (fetch project context for the LLM to
+# reason about during project analysis); the write tool (create_issue) is
+# high-risk and carries an explicit "only call after the user confirms" docstring
+# note — the agent graph routes it through ``human_review`` before it executes.
+#
+# Why this integration exists at all: ``tools/__init__.py::detect_platform``
+# already returns "GitLab", and intake question 16 already offers GitLab as a
+# code-host option — but ``agent/nodes.py::_scan_repo_context`` used to bail with
+# "GitLab not yet supported", so a user who answered "GitLab" got a silently
+# degraded intake with no repository context. These tools close that gap.
+#
+# Why python-gitlab?
+# It is the official, maintained SDK; it wraps the v4 REST API with typed
+# objects, handles pagination, and — critically for this project — takes the
+# instance URL as a constructor argument, so self-hosted GitLab works with no
+# extra code. This mirrors how the rest of the project talks to external
+# services through a per-integration SDK (PyGithub for GitHub,
+# atlassian-python-api for Confluence/Jira, notion-client for Notion).
+#
+# Auth: a GitLab personal access token (GITLAB_TOKEN) sent as a private token.
+# The only optional extra is GITLAB_URL, which defaults to https://gitlab.com and
+# is set to point at a self-hosted instance (Notion has NOTION_ROOT_PAGE_ID in
+# the same "one optional scoping var" slot).
+#
+# ONE deliberate divergence from GitHub: PyGithub is happy unauthenticated (60
+# req/hr) so tools/github.py degrades to anonymous access, but these tools
+# REQUIRE a token and return _MISSING_CONFIG_MSG without one. GitLab's
+# unauthenticated API is far more restricted, most GitLab projects that matter
+# for sprint planning are private or self-hosted, and an anonymous 404 is
+# indistinguishable from "project is private" — which would surface to the user
+# as a confusing "not found" rather than "you need a token".
+"""
+
+import logging
+
+import gitlab
+from gitlab.exceptions import GitlabAuthenticationError, GitlabError, GitlabHttpError
+from langchain_core.tools import tool
+
+from yeaboi.config import get_gitlab_token, get_gitlab_url
+
+logger = logging.getLogger(__name__)
+
+# Shown whenever the GitLab token is missing — single source of truth for the message.
+_MISSING_CONFIG_MSG = "Error: GitLab is not configured. Ensure GITLAB_TOKEN is set in your .env file."
+
+# Truncate file content at this many characters to avoid flooding the LLM context.
+# Matches the cap in tools/github.py and tools/notion.py.
+# See docs: "Tools" — scoping tool output for LLM relevance
+_MAX_CONTENT_CHARS = 8_000
+
+# Files that signal the tech stack — surfaced by gitlab_read_repo so the planner
+# can infer the toolchain without reading every file. Mirrors github.py's list,
+# plus GitLab's own CI config.
+_KEY_FILES: frozenset[str] = frozenset(
+    {
+        "package.json",
+        "pyproject.toml",
+        "requirements.txt",
+        "setup.py",
+        "Cargo.toml",
+        "go.mod",
+        "pom.xml",
+        "build.gradle",
+        "Gemfile",
+        "composer.json",
+        "Dockerfile",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        ".gitlab-ci.yml",
+        "README.md",
+        "README.rst",
+        "CONTRIBUTING.md",
+        "Makefile",
+        ".env.example",
+        "tsconfig.json",
+        "vite.config.ts",
+        "vite.config.js",
+    }
+)
+
+# GitLab issue states, as the REST API spells them. Note "opened", NOT "open" —
+# passing GitHub's spelling returns an unfiltered list rather than an error, so
+# we validate rather than forward blindly.
+_ISSUE_STATES: frozenset[str] = frozenset({"opened", "closed", "all"})
+
+
+def _parse_project(url: str) -> str:
+    """Extract the 'namespace/project' path from a GitLab URL, or pass a slug through.
+
+    GitLab differs from GitHub in two ways that matter here:
+
+    1. **Nested groups** — a project can live arbitrarily deep
+       (``group/subgroup/team/project``), so we cannot just keep the first two
+       path segments the way ``github._parse_repo`` does.
+    2. **The ``/-/`` separator** — GitLab inserts it before repo-relative paths
+       (``group/project/-/tree/main``), which gives us an unambiguous place to
+       cut off trailing UI paths.
+
+    Handles:
+    - https://gitlab.com/group/project
+    - https://gitlab.com/group/subgroup/project
+    - https://gitlab.example.com/group/project.git  (self-hosted)
+    - https://gitlab.com/group/project/-/tree/main
+    - group/project  (already a slug — returned unchanged)
+    """
+    from urllib.parse import urlparse
+
+    text = url.strip()
+
+    # Strip the scheme + host when present. Parsing rather than substring-matching
+    # on "gitlab.com" is what makes self-hosted instances work at all.
+    if "://" in text:
+        try:
+            text = urlparse(text).path
+        except ValueError:
+            return ""
+
+    # Everything after "/-/" is GitLab UI routing (tree, blob, issues), not the path.
+    text = text.split("/-/", 1)[0]
+    text = text.strip("/")
+    if text.endswith(".git"):
+        text = text[:-4]
+    return text
+
+
+def _make_gitlab_client() -> gitlab.Gitlab | None:
+    """Return an authenticated GitLab client, or None if the token is missing.
+
+    GitLab authenticates with a single personal access token passed as
+    ``private_token``; the instance URL is a constructor argument, which is what
+    makes self-hosted instances work without any per-call branching.
+    """
+    token = get_gitlab_token()
+    if not token:
+        logger.warning("GitLab client not created — missing config (GITLAB_TOKEN unset)")
+        return None
+    url = get_gitlab_url()
+    logger.debug("Creating GitLab client for %s", url)
+    client = gitlab.Gitlab(url=url, private_token=token)
+    logger.debug("GitLab client created successfully")
+    return client
+
+
+def _gitlab_error_msg(e: Exception) -> str:
+    """Return a user-friendly message for common GitLab HTTP error codes.
+
+    python-gitlab hangs the HTTP status off ``response_code`` on its error
+    classes, so one mapping covers get/create/list failures alike.
+    """
+    code = getattr(e, "response_code", 0) or 0
+    if code == 401:
+        return "Error: GitLab authentication failed. Check GITLAB_TOKEN in .env."
+    if code == 403:
+        return "Error: GitLab permission denied. The token needs the 'read_api' scope (or 'api' to create issues)."
+    if code == 404:
+        return f"Error: GitLab project not found — verify the URL, and that the token can see it. ({e})"
+    if code == 429:
+        return "Error: GitLab rate limit reached. Wait a moment and try again."
+    return f"Error: GitLab API error {code}: {e}" if code else f"Error: {e}"
+
+
+def _get_project(client: gitlab.Gitlab, project_url: str):
+    """Resolve a project URL/slug to a python-gitlab Project object.
+
+    Raises the SDK's own exceptions — every caller already maps those through
+    ``_gitlab_error_msg``, so wrapping them here would only lose the status code.
+    """
+    path = _parse_project(project_url)
+    if not path:
+        raise ValueError("Provide a GitLab project URL or 'namespace/project' path.")
+    logger.debug("GitLab API call: projects.get(%r)", path)
+    project = client.projects.get(path)
+    logger.debug("GitLab API call succeeded: resolved project %r", path)
+    return project
+
+
+def _read_text_file(project, filename: str, ref: str) -> str | None:
+    """Return a repo file's decoded text, or None when it does not exist.
+
+    A missing file is an ordinary outcome (not every project has a README), so
+    this collapses the SDK's 404 into None rather than raising.
+    """
+    try:
+        logger.debug("GitLab API call: files.get(%r)", filename)
+        blob = project.files.get(file_path=filename, ref=ref)
+        content = blob.decode().decode("utf-8", errors="replace")
+        logger.debug("GitLab API call succeeded: read %r (%d chars)", filename, len(content))
+        return content
+    except GitlabError:
+        logger.debug("GitLab file %r not found — skipping", filename, exc_info=True)
+        return None
+
+
+def _truncate(content: str) -> str:
+    """Cap content at _MAX_CONTENT_CHARS, appending a marker when it was cut."""
+    if len(content) <= _MAX_CONTENT_CHARS:
+        return content
+    return content[:_MAX_CONTENT_CHARS] + f"\n\n[Truncated at {_MAX_CONTENT_CHARS} characters]"
+
+
+@tool
+def gitlab_read_repo(project_url: str, max_depth: int = 2) -> str:
+    """Read a GitLab project's file tree and return a structured summary.
+
+    Returns the project description, default branch, top-level directory
+    structure, detected tech-stack files (package.json, pyproject.toml,
+    .gitlab-ci.yml, etc.), and the language breakdown. Use this first to
+    understand a project's structure before reading individual files.
+    Accepts a full GitLab URL or a 'namespace/project' path.
+    """
+    # See docs: "The ReAct Loop" — this is the Action step; the result is the Observation
+    logger.debug("gitlab_read_repo called: project_url=%r, max_depth=%d", project_url, max_depth)
+    client = _make_gitlab_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    try:
+        project = _get_project(client, project_url)
+        path = project.path_with_namespace
+        default_branch = project.default_branch or "main"
+
+        lines: list[str] = [f"Project: {path}", f"Default branch: {default_branch}", ""]
+
+        # recursive=True + get_all=True walks the whole tree in one paginated call,
+        # matching github_read_repo's single get_git_tree(recursive=True).
+        logger.debug("GitLab API call: repository_tree(recursive=True)")
+        tree = project.repository_tree(recursive=True, get_all=True, ref=default_branch)
+        logger.debug("GitLab API call succeeded: %d tree entries", len(tree))
+
+        depth_limit = max(1, int(max_depth))
+        dirs_in_scope: set[str] = set()
+        key_files_found: list[str] = []
+        for item in tree:
+            item_path = item.get("path", "")
+            if not item_path:
+                continue
+            parts = item_path.split("/")
+            # Directories only, down to depth_limit — the file list at full depth
+            # would swamp the LLM context on any real project.
+            if item.get("type") == "tree" and len(parts) <= depth_limit:
+                dirs_in_scope.add(item_path)
+            # Key files are collected at ANY depth: a pyproject.toml nested in a
+            # monorepo package is exactly as informative as one at the root.
+            if parts[-1] in _KEY_FILES or item_path in _KEY_FILES:
+                key_files_found.append(item_path)
+
+        lines.append(f"File tree (directories, {depth_limit} level(s) deep):")
+        for entry in sorted(dirs_in_scope)[:50]:  # cap so a wide repo cannot flood context
+            lines.append(f"  {entry}/")
+        if len(dirs_in_scope) > 50:
+            lines.append(f"  … and {len(dirs_in_scope) - 50} more")
+
+        if key_files_found:
+            lines.append("")
+            lines.append("Key files detected:")
+            for kf in sorted(key_files_found):
+                lines.append(f"  {kf}")
+
+        # Language breakdown — a separate endpoint, and one a restricted token may
+        # not reach, so a failure here must not lose the tree we already have.
+        try:
+            logger.debug("GitLab API call: languages()")
+            languages = project.languages()
+            if languages:
+                lines.append("")
+                lines.append("Languages:")
+                for lang, pct in sorted(languages.items(), key=lambda x: -x[1])[:5]:
+                    lines.append(f"  {lang}: {pct:.1f}%")
+        except GitlabError:
+            logger.debug("gitlab_read_repo: language data unavailable — skipping", exc_info=True)
+
+        lines.append("")
+        lines.append(
+            f"Stars: {project.star_count}  Forks: {project.forks_count}  "
+            f"Open issues: {getattr(project, 'open_issues_count', 0)}"
+        )
+        if project.description:
+            lines.append(f"Description: {project.description}")
+
+        logger.debug("gitlab_read_repo completed for %s", path)
+        return "\n".join(lines)
+
+    except ValueError as e:
+        logger.error("gitlab_read_repo bad input %r: %s", project_url, e)
+        return f"Error: {e}"
+    except (GitlabAuthenticationError, GitlabHttpError, GitlabError) as e:
+        logger.error("GitLab API error in gitlab_read_repo for %r: %s", project_url, e)
+        return _gitlab_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in gitlab_read_repo for %r: %s", project_url, e)
+        return f"Error: {e}"
+
+
+@tool
+def gitlab_read_readme(project_url: str) -> str:
+    """Fetch the README and CONTRIBUTING docs from a GitLab project.
+
+    Returns the decoded README content (truncated at 8 000 chars) and
+    CONTRIBUTING.md if present. Use this to understand the project's purpose,
+    architecture, and contribution guidelines.
+    Accepts a full GitLab URL or a 'namespace/project' path.
+    """
+    logger.debug("gitlab_read_readme called: project_url=%r", project_url)
+    client = _make_gitlab_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    try:
+        project = _get_project(client, project_url)
+        ref = project.default_branch or "main"
+        sections: list[str] = []
+
+        # GitLab has no "find the README whatever its extension" endpoint the way
+        # PyGithub's get_readme() does, so we try the common spellings in order.
+        for candidate in ("README.md", "README.rst", "README.txt", "README"):
+            content = _read_text_file(project, candidate, ref)
+            if content is not None:
+                sections.append(f"=== README ({candidate}) ===\n\n{_truncate(content)}")
+                break
+        else:
+            sections.append("=== README ===\n\nNo README found in this project.")
+
+        contributing = _read_text_file(project, "CONTRIBUTING.md", ref)
+        if contributing is not None:
+            sections.append(f"\n=== CONTRIBUTING.md ===\n\n{_truncate(contributing)}")
+
+        logger.debug("gitlab_read_readme completed for %s", project.path_with_namespace)
+        return "\n".join(sections)
+
+    except ValueError as e:
+        logger.error("gitlab_read_readme bad input %r: %s", project_url, e)
+        return f"Error: {e}"
+    except (GitlabAuthenticationError, GitlabHttpError, GitlabError) as e:
+        logger.error("GitLab API error in gitlab_read_readme for %r: %s", project_url, e)
+        return _gitlab_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in gitlab_read_readme for %r: %s", project_url, e)
+        return f"Error: {e}"
+
+
+@tool
+def gitlab_list_issues(project_url: str, state: str = "opened", max_issues: int = 20) -> str:
+    """List issues from a GitLab project.
+
+    Returns issue number, title, labels, and the first 200 characters of the
+    description for up to max_issues results. Use this to understand work in
+    progress, known bugs, and planned features that should inform the scrum plan.
+    state: 'opened' (default), 'closed', or 'all' — note GitLab spells it
+    'opened', not 'open'.
+    """
+    logger.debug("gitlab_list_issues called: project=%r, state=%s, max=%d", project_url, state, max_issues)
+    client = _make_gitlab_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    # GitLab silently returns an unfiltered list for an unknown state rather than
+    # erroring, so an unvalidated "open" would quietly include closed issues.
+    normalised = state.strip().lower()
+    if normalised not in _ISSUE_STATES:
+        logger.warning("gitlab_list_issues rejected state=%r", state)
+        return f"Error: state must be one of {sorted(_ISSUE_STATES)} (GitLab spells it 'opened', not 'open')."
+
+    try:
+        project = _get_project(client, project_url)
+        path = project.path_with_namespace
+
+        # per_page caps the response server-side; without get_all=True python-gitlab
+        # returns just the first page, which is exactly the bound we want.
+        logger.debug("GitLab API call: issues.list(state=%s, per_page=%d)", normalised, max_issues)
+        issues = project.issues.list(state=normalised, per_page=max(1, min(int(max_issues), 100)))
+        logger.debug("GitLab API call succeeded: %d issues", len(issues))
+
+        lines: list[str] = [f"Issues ({normalised}) for {path}:", ""]
+
+        count = 0
+        for issue in issues:
+            if count >= max_issues:
+                break
+            labels = ", ".join(issue.labels or [])
+            label_str = f" [{labels}]" if labels else ""
+            body_preview = ""
+            if issue.description:
+                body_preview = issue.description[:200].replace("\n", " ").strip()
+                if len(issue.description) > 200:
+                    body_preview += "..."
+
+            lines.append(f"#{issue.iid}: {issue.title}{label_str}")
+            if body_preview:
+                lines.append(f"  {body_preview}")
+            count += 1
+
+        if count == 0:
+            lines.append(f"No {normalised} issues found.")
+        else:
+            lines.append("")
+            note = "; increase max_issues to see more" if count >= max_issues else ""
+            lines.append(f"({count} issues shown{note})")
+
+        logger.debug("gitlab_list_issues returned %d issues for %s", count, path)
+        return "\n".join(lines)
+
+    except ValueError as e:
+        logger.error("gitlab_list_issues bad input %r: %s", project_url, e)
+        return f"Error: {e}"
+    except (GitlabAuthenticationError, GitlabHttpError, GitlabError) as e:
+        logger.error("GitLab API error in gitlab_list_issues for %r: %s", project_url, e)
+        return _gitlab_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in gitlab_list_issues for %r: %s", project_url, e)
+        return f"Error: {e}"
+
+
+@tool
+def gitlab_create_issue(project_url: str, title: str, description: str = "", labels: str = "") -> str:
+    """Create an issue in a GitLab project (e.g. to push a planned story to the board).
+
+    Only call this after the user has explicitly confirmed they want to create the issue.
+    labels is an optional comma-separated string ("bug, sprint-1") — GitLab creates
+    any label that does not exist yet. The token needs the 'api' scope; the
+    read-only 'read_api' scope is not sufficient to write.
+    Returns the new issue's number, title, and URL on success.
+    """
+    logger.info("gitlab_create_issue called: project=%r, title=%r", project_url, title)
+    client = _make_gitlab_client()
+    if client is None:
+        return _MISSING_CONFIG_MSG
+
+    if not title.strip():
+        return "Error: Provide a title for the issue."
+
+    try:
+        project = _get_project(client, project_url)
+        payload: dict = {"title": title.strip(), "description": description}
+        label_list = [label.strip() for label in labels.split(",") if label.strip()]
+        if label_list:
+            payload["labels"] = label_list
+
+        logger.info("GitLab API call: issues.create on %s", project.path_with_namespace)
+        issue = project.issues.create(payload)
+        logger.info(
+            "GitLab API call succeeded: created issue #%s in %s",
+            issue.iid,
+            project.path_with_namespace,
+        )
+        return f"Created GitLab issue #{issue.iid}: '{issue.title}'\nURL: {issue.web_url}"
+
+    except ValueError as e:
+        logger.error("gitlab_create_issue bad input %r: %s", project_url, e)
+        return f"Error: {e}"
+    except (GitlabAuthenticationError, GitlabHttpError, GitlabError) as e:
+        logger.error("GitLab API error in gitlab_create_issue for %r: %s", project_url, e)
+        return _gitlab_error_msg(e)
+    except Exception as e:
+        logger.error("Unexpected error in gitlab_create_issue for %r: %s", project_url, e)
+        return f"Error: {e}"

--- a/src/yeaboi/tools/gitlab.py
+++ b/src/yeaboi/tools/gitlab.py
@@ -90,6 +90,9 @@ _KEY_FILES: frozenset[str] = frozenset(
 # we validate rather than forward blindly.
 _ISSUE_STATES: frozenset[str] = frozenset({"opened", "closed", "all"})
 
+# GitLab rejects per_page above this, so it is the most one request can return.
+_MAX_PER_PAGE = 100
+
 
 def _parse_project(url: str) -> str:
     """Extract the 'namespace/project' path from a GitLab URL, or pass a slug through.
@@ -371,17 +374,22 @@ def gitlab_list_issues(project_url: str, state: str = "opened", max_issues: int 
         project = _get_project(client, project_url)
         path = project.path_with_namespace
 
-        # per_page caps the response server-side; without get_all=True python-gitlab
-        # returns just the first page, which is exactly the bound we want.
-        logger.debug("GitLab API call: issues.list(state=%s, per_page=%d)", normalised, max_issues)
-        issues = project.issues.list(state=normalised, per_page=max(1, min(int(max_issues), 100)))
+        # GitLab's per_page maxes out at 100 server-side, so a larger max_issues
+        # cannot be honoured in one page. Clamp it explicitly rather than silently
+        # returning 100 and reporting a count that looks like the whole list.
+        requested = max(1, int(max_issues))
+        limit = min(requested, _MAX_PER_PAGE)
+        # Without get_all=True python-gitlab returns just the first page, which is
+        # exactly the bound we want.
+        logger.debug("GitLab API call: issues.list(state=%s, per_page=%d)", normalised, limit)
+        issues = project.issues.list(state=normalised, per_page=limit)
         logger.debug("GitLab API call succeeded: %d issues", len(issues))
 
         lines: list[str] = [f"Issues ({normalised}) for {path}:", ""]
 
         count = 0
         for issue in issues:
-            if count >= max_issues:
+            if count >= limit:
                 break
             labels = ", ".join(issue.labels or [])
             label_str = f" [{labels}]" if labels else ""
@@ -400,7 +408,14 @@ def gitlab_list_issues(project_url: str, state: str = "opened", max_issues: int 
             lines.append(f"No {normalised} issues found.")
         else:
             lines.append("")
-            note = "; increase max_issues to see more" if count >= max_issues else ""
+            if count >= limit and requested > _MAX_PER_PAGE:
+                # Asking for more than GitLab will return in one page is not an
+                # error, but silently showing 100 would read as "that's all of them".
+                note = f"; GitLab returns at most {_MAX_PER_PAGE} per request, so {requested} was capped"
+            elif count >= limit:
+                note = "; increase max_issues to see more"
+            else:
+                note = ""
             lines.append(f"({count} issues shown{note})")
 
         logger.debug("gitlab_list_issues returned %d issues for %s", count, path)

--- a/src/yeaboi/tools/risk.py
+++ b/src/yeaboi/tools/risk.py
@@ -38,6 +38,11 @@ TOOL_RISK: dict[str, ToolRisk] = {
     "github_read_file": ToolRisk.READ,
     "github_list_issues": ToolRisk.READ,
     "github_read_readme": ToolRisk.READ,
+    # GitLab — 3 reads + 1 write (create_issue is gated behind human_review)
+    "gitlab_read_repo": ToolRisk.READ,
+    "gitlab_read_readme": ToolRisk.READ,
+    "gitlab_list_issues": ToolRisk.READ,
+    "gitlab_create_issue": ToolRisk.WRITE,
     # Azure DevOps
     "azdevops_read_repo": ToolRisk.READ,
     "azdevops_read_file": ToolRisk.READ,

--- a/tests/unit/nodes/test_analyzer.py
+++ b/tests/unit/nodes/test_analyzer.py
@@ -455,12 +455,61 @@ class TestScanRepoContext:
         assert ctx is None
         assert status["status"] == "skipped"
 
-    def test_gitlab_platform_returns_none(self):
-        """Returns None for GitLab (no tools implemented yet)."""
-        qs = self._make_qs("https://gitlab.com/owner/repo", "GitLab")
+    def test_gitlab_calls_read_repo_and_readme(self, monkeypatch):
+        """GitLab platform calls gitlab_read_repo and gitlab_read_readme.
+
+        This path used to bail with "GitLab not yet supported" even though Q16
+        offers GitLab — see tools/gitlab.py. Note the kwarg is project_url, not
+        repo_url: GitLab projects can be nested arbitrarily deep in subgroups,
+        so the tools take a project path rather than an owner/repo slug.
+        """
+        mock_repo = MagicMock()
+        mock_repo.invoke.return_value = "Project: group/project"
+        mock_readme = MagicMock()
+        mock_readme.invoke.return_value = "# MyProject\nA great project."
+
+        monkeypatch.setattr("yeaboi.tools.gitlab.gitlab_read_repo", mock_repo)
+        monkeypatch.setattr("yeaboi.tools.gitlab.gitlab_read_readme", mock_readme)
+
+        qs = self._make_qs("https://gitlab.com/group/project", "GitLab")
+        result, status = _scan_repo_context(qs)
+
+        mock_repo.invoke.assert_called_once_with({"project_url": "https://gitlab.com/group/project"})
+        mock_readme.invoke.assert_called_once_with({"project_url": "https://gitlab.com/group/project"})
+        assert result is not None
+        assert "group/project" in result
+        assert "MyProject" in result
+        assert status["status"] == "success"
+
+    def test_gitlab_unconfigured_returns_none(self, monkeypatch):
+        """An unconfigured GitLab (no token) degrades to None, it does not raise."""
+        missing = MagicMock()
+        missing.invoke.return_value = "Error: GitLab is not configured. Ensure GITLAB_TOKEN is set in your .env file."
+
+        monkeypatch.setattr("yeaboi.tools.gitlab.gitlab_read_repo", missing)
+        monkeypatch.setattr("yeaboi.tools.gitlab.gitlab_read_readme", missing)
+
+        qs = self._make_qs("https://gitlab.com/group/project", "GitLab")
         ctx, status = _scan_repo_context(qs)
         assert ctx is None
-        assert status["status"] == "skipped"
+        assert status["status"] == "error"
+
+    def test_gitlab_one_tool_fails_returns_other(self, monkeypatch):
+        """Returns the successful result when only one GitLab tool fails."""
+        mock_repo = MagicMock()
+        mock_repo.invoke.return_value = "Error: GitLab project not found"
+        mock_readme = MagicMock()
+        mock_readme.invoke.return_value = "# README content"
+
+        monkeypatch.setattr("yeaboi.tools.gitlab.gitlab_read_repo", mock_repo)
+        monkeypatch.setattr("yeaboi.tools.gitlab.gitlab_read_readme", mock_readme)
+
+        qs = self._make_qs("https://gitlab.com/group/project", "GitLab")
+        result, status = _scan_repo_context(qs)
+
+        assert result is not None
+        assert "README content" in result
+        assert status["status"] == "success"
 
     def test_unsupported_platform_returns_none(self):
         """Returns None for Bitbucket (no tools implemented yet)."""

--- a/tests/unit/tools/test_risk.py
+++ b/tests/unit/tools/test_risk.py
@@ -23,6 +23,7 @@ _EXPECTED_WRITES = {
     "azdevops_create_epic",
     "azdevops_create_story",
     "azdevops_create_iteration",
+    "gitlab_create_issue",
 }
 
 

--- a/tests/unit/tools/test_tools_azure_devops.py
+++ b/tests/unit/tools/test_tools_azure_devops.py
@@ -683,9 +683,9 @@ class TestAzdevopsFetchActiveIteration:
 
 
 class TestGetTools:
-    def test_returns_thirty_tools(self):
+    def test_returns_all_registered_tools(self):
         tools = get_tools()
-        assert len(tools) == 37
+        assert len(tools) == 41
 
     def test_all_are_base_tools(self):
         from langchain_core.tools import BaseTool
@@ -702,6 +702,10 @@ class TestGetTools:
             "github_read_file",
             "github_list_issues",
             "github_read_readme",
+            "gitlab_read_repo",
+            "gitlab_read_readme",
+            "gitlab_list_issues",
+            "gitlab_create_issue",
             "azdevops_read_repo",
             "azdevops_read_file",
             "azdevops_list_work_items",

--- a/tests/unit/tools/test_tools_confluence.py
+++ b/tests/unit/tools/test_tools_confluence.py
@@ -626,5 +626,5 @@ class TestConfluenceToolsRegistered:
         }
         assert expected.issubset(names), f"Missing Confluence tools: {expected - names}"
 
-    def test_total_tool_count_is_thirty(self):
-        assert len(get_tools()) == 37
+    def test_total_tool_count_matches_registry(self):
+        assert len(get_tools()) == 41

--- a/tests/unit/tools/test_tools_github.py
+++ b/tests/unit/tools/test_tools_github.py
@@ -413,9 +413,9 @@ class TestGithubReadReadme:
 
 
 class TestGetTools:
-    def test_returns_thirty_tools(self):
+    def test_returns_all_registered_tools(self):
         tools = get_tools()
-        assert len(tools) == 37
+        assert len(tools) == 41
 
     def test_all_are_base_tools(self):
         from langchain_core.tools import BaseTool

--- a/tests/unit/tools/test_tools_gitlab.py
+++ b/tests/unit/tools/test_tools_gitlab.py
@@ -1,0 +1,570 @@
+"""Tests for GitLab tools.
+
+All GitLab API calls are mocked via monkeypatch on _make_gitlab_client so no real
+network requests are made. Tests cover happy paths, error cases, and edge cases
+for each tool, plus helpers, registration in get_tools(), risk classification,
+and token masking. Mirrors test_tools_notion.py / test_tools_github.py.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from gitlab.exceptions import GitlabAuthenticationError, GitlabCreateError, GitlabGetError
+
+from yeaboi.tools import get_tools
+from yeaboi.tools.gitlab import (
+    _MISSING_CONFIG_MSG,
+    _gitlab_error_msg,
+    _parse_project,
+    _truncate,
+    gitlab_create_issue,
+    gitlab_list_issues,
+    gitlab_read_readme,
+    gitlab_read_repo,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — build mock python-gitlab objects
+# ---------------------------------------------------------------------------
+
+
+def _make_project(
+    path: str = "group/project",
+    description: str = "A test project",
+    default_branch: str = "main",
+) -> MagicMock:
+    """Build a mock python-gitlab Project with the attributes the tools read."""
+    project = MagicMock()
+    project.path_with_namespace = path
+    project.description = description
+    project.default_branch = default_branch
+    project.star_count = 7
+    project.forks_count = 2
+    project.open_issues_count = 3
+    project.repository_tree.return_value = [
+        {"path": "src", "type": "tree"},
+        {"path": "src/api", "type": "tree"},
+        {"path": "src/api/deep", "type": "tree"},
+        {"path": "src/main.py", "type": "blob"},
+        {"path": "pyproject.toml", "type": "blob"},
+        {"path": ".gitlab-ci.yml", "type": "blob"},
+        {"path": "packages/worker/pyproject.toml", "type": "blob"},
+    ]
+    project.languages.return_value = {"Python": 85.5, "Shell": 14.5}
+    return project
+
+
+def _make_client(project: MagicMock | None = None) -> MagicMock:
+    client = MagicMock()
+    client.projects.get.return_value = project if project is not None else _make_project()
+    return client
+
+
+def _make_file(content: str) -> MagicMock:
+    """Mock a repository file blob — .decode() returns bytes, as the SDK does."""
+    blob = MagicMock()
+    blob.decode.return_value = content.encode("utf-8")
+    return blob
+
+
+def _make_issue(iid: int = 1, title: str = "Fix the thing", description: str = "", labels=None) -> MagicMock:
+    issue = MagicMock()
+    issue.iid = iid
+    issue.title = title
+    issue.description = description
+    issue.labels = labels if labels is not None else []
+    issue.web_url = f"https://gitlab.com/group/project/-/issues/{iid}"
+    return issue
+
+
+def _http_error(cls, code: int):
+    """Build a python-gitlab error carrying an HTTP status code."""
+    err = cls("boom")
+    err.response_code = code
+    return err
+
+
+@pytest.fixture
+def patch_client(monkeypatch):
+    """Return a factory that installs a mock client and hands it back."""
+
+    def _install(client: MagicMock | None):
+        monkeypatch.setattr("yeaboi.tools.gitlab._make_gitlab_client", lambda: client)
+        return client
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# _parse_project
+# ---------------------------------------------------------------------------
+
+
+class TestParseProject:
+    def test_plain_url(self):
+        assert _parse_project("https://gitlab.com/group/project") == "group/project"
+
+    def test_nested_groups_are_preserved(self):
+        # The GitHub parser keeps only two segments; GitLab subgroups need all of them.
+        assert _parse_project("https://gitlab.com/group/sub/team/project") == "group/sub/team/project"
+
+    def test_git_suffix_stripped(self):
+        assert _parse_project("https://gitlab.com/group/project.git") == "group/project"
+
+    def test_trailing_slash_stripped(self):
+        assert _parse_project("https://gitlab.com/group/project/") == "group/project"
+
+    def test_ui_path_after_dash_separator_stripped(self):
+        assert _parse_project("https://gitlab.com/group/project/-/tree/main") == "group/project"
+
+    def test_self_hosted_host_stripped(self):
+        assert _parse_project("https://gitlab.example.com/group/project") == "group/project"
+
+    def test_bare_slug_passes_through(self):
+        assert _parse_project("group/project") == "group/project"
+
+    def test_whitespace_stripped(self):
+        assert _parse_project("  group/project  ") == "group/project"
+
+    def test_empty_string_returns_empty(self):
+        assert _parse_project("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _gitlab_error_msg / _truncate
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMessages:
+    def test_401_names_the_env_var(self):
+        msg = _gitlab_error_msg(_http_error(GitlabAuthenticationError, 401))
+        assert "GITLAB_TOKEN" in msg
+
+    def test_403_names_the_scope(self):
+        msg = _gitlab_error_msg(_http_error(GitlabGetError, 403))
+        assert "read_api" in msg
+
+    def test_404_mentions_the_project(self):
+        assert "not found" in _gitlab_error_msg(_http_error(GitlabGetError, 404))
+
+    def test_429_is_a_rate_limit(self):
+        assert "rate limit" in _gitlab_error_msg(_http_error(GitlabGetError, 429))
+
+    def test_unknown_code_falls_back_to_the_raw_error(self):
+        assert "boom" in _gitlab_error_msg(_http_error(GitlabGetError, 500))
+
+    def test_error_without_status_code(self):
+        assert "plain" in _gitlab_error_msg(ValueError("plain"))
+
+
+class TestTruncate:
+    def test_short_content_unchanged(self):
+        assert _truncate("hello") == "hello"
+
+    def test_long_content_gets_marker(self):
+        result = _truncate("x" * 9_000)
+        assert "[Truncated at 8000 characters]" in result
+        assert len(result) < 9_000
+
+
+# ---------------------------------------------------------------------------
+# gitlab_read_repo
+# ---------------------------------------------------------------------------
+
+
+class TestReadRepo:
+    def test_happy_path(self, patch_client):
+        patch_client(_make_client())
+        result = gitlab_read_repo.invoke({"project_url": "https://gitlab.com/group/project"})
+        assert "Project: group/project" in result
+        assert "Default branch: main" in result
+        assert "src/" in result
+        assert "Description: A test project" in result
+
+    def test_key_files_are_surfaced(self, patch_client):
+        patch_client(_make_client())
+        result = gitlab_read_repo.invoke({"project_url": "group/project"})
+        assert "pyproject.toml" in result
+        assert ".gitlab-ci.yml" in result
+
+    def test_key_files_are_found_at_any_depth(self, patch_client):
+        # A monorepo's nested manifests are as informative as the root one.
+        patch_client(_make_client())
+        result = gitlab_read_repo.invoke({"project_url": "group/project", "max_depth": 1})
+        assert "packages/worker/pyproject.toml" in result
+
+    def test_max_depth_limits_the_directory_listing(self, patch_client):
+        patch_client(_make_client())
+        shallow = gitlab_read_repo.invoke({"project_url": "group/project", "max_depth": 1})
+        assert "  src/" in shallow
+        assert "src/api/" not in shallow
+
+    def test_deeper_max_depth_shows_nested_dirs(self, patch_client):
+        patch_client(_make_client())
+        deep = gitlab_read_repo.invoke({"project_url": "group/project", "max_depth": 2})
+        assert "src/api/" in deep
+        assert "src/api/deep/" not in deep
+
+    def test_only_directories_are_listed(self, patch_client):
+        patch_client(_make_client())
+        result = gitlab_read_repo.invoke({"project_url": "group/project", "max_depth": 2})
+        tree_section = result.split("Key files detected:")[0]
+        assert "src/main.py/" not in tree_section
+
+    def test_languages_included(self, patch_client):
+        patch_client(_make_client())
+        result = gitlab_read_repo.invoke({"project_url": "group/project"})
+        assert "Python: 85.5%" in result
+
+    def test_language_failure_still_returns_the_tree(self, patch_client):
+        project = _make_project()
+        project.languages.side_effect = _http_error(GitlabGetError, 403)
+        patch_client(_make_client(project))
+        result = gitlab_read_repo.invoke({"project_url": "group/project"})
+        assert "Project: group/project" in result
+        assert "Languages:" not in result
+
+    def test_missing_credentials(self, patch_client):
+        patch_client(None)
+        assert gitlab_read_repo.invoke({"project_url": "group/project"}) == _MISSING_CONFIG_MSG
+
+    def test_empty_url_is_an_error_not_a_crash(self, patch_client):
+        patch_client(_make_client())
+        result = gitlab_read_repo.invoke({"project_url": ""})
+        assert result.startswith("Error:")
+
+    def test_api_error(self, patch_client):
+        client = _make_client()
+        client.projects.get.side_effect = _http_error(GitlabGetError, 404)
+        patch_client(client)
+        result = gitlab_read_repo.invoke({"project_url": "group/nope"})
+        assert result.startswith("Error:")
+        assert "not found" in result
+
+    def test_unexpected_error(self, patch_client):
+        client = _make_client()
+        client.projects.get.side_effect = RuntimeError("kaboom")
+        patch_client(client)
+        assert "kaboom" in gitlab_read_repo.invoke({"project_url": "group/project"})
+
+
+# ---------------------------------------------------------------------------
+# gitlab_read_readme
+# ---------------------------------------------------------------------------
+
+
+class TestReadReadme:
+    def test_happy_path(self, patch_client):
+        project = _make_project()
+        project.files.get.side_effect = lambda file_path, ref: (
+            _make_file("# Hello") if file_path == "README.md" else _raise_missing()
+        )
+        patch_client(_make_client(project))
+        result = gitlab_read_readme.invoke({"project_url": "group/project"})
+        assert "=== README (README.md) ===" in result
+        assert "# Hello" in result
+
+    def test_falls_back_through_readme_spellings(self, patch_client):
+        project = _make_project()
+        project.files.get.side_effect = lambda file_path, ref: (
+            _make_file("rst readme") if file_path == "README.rst" else _raise_missing()
+        )
+        patch_client(_make_client(project))
+        result = gitlab_read_readme.invoke({"project_url": "group/project"})
+        assert "=== README (README.rst) ===" in result
+
+    def test_contributing_included_when_present(self, patch_client):
+        project = _make_project()
+        project.files.get.side_effect = lambda file_path, ref: _make_file(f"body of {file_path}")
+        patch_client(_make_client(project))
+        result = gitlab_read_readme.invoke({"project_url": "group/project"})
+        assert "=== CONTRIBUTING.md ===" in result
+
+    def test_no_readme_is_reported_not_raised(self, patch_client):
+        project = _make_project()
+        project.files.get.side_effect = lambda file_path, ref: _raise_missing()
+        patch_client(_make_client(project))
+        result = gitlab_read_readme.invoke({"project_url": "group/project"})
+        assert "No README found" in result
+
+    def test_long_readme_truncated(self, patch_client):
+        project = _make_project()
+        project.files.get.side_effect = lambda file_path, ref: (
+            _make_file("y" * 9_000) if file_path == "README.md" else _raise_missing()
+        )
+        patch_client(_make_client(project))
+        result = gitlab_read_readme.invoke({"project_url": "group/project"})
+        assert "[Truncated at 8000 characters]" in result
+
+    def test_missing_credentials(self, patch_client):
+        patch_client(None)
+        assert gitlab_read_readme.invoke({"project_url": "group/project"}) == _MISSING_CONFIG_MSG
+
+    def test_api_error(self, patch_client):
+        client = _make_client()
+        client.projects.get.side_effect = _http_error(GitlabAuthenticationError, 401)
+        patch_client(client)
+        result = gitlab_read_readme.invoke({"project_url": "group/project"})
+        assert "GITLAB_TOKEN" in result
+
+
+def _raise_missing():
+    """Raise the SDK's 404 for a file that does not exist."""
+    raise _http_error(GitlabGetError, 404)
+
+
+# ---------------------------------------------------------------------------
+# gitlab_list_issues
+# ---------------------------------------------------------------------------
+
+
+class TestListIssues:
+    def test_happy_path(self, patch_client):
+        project = _make_project()
+        project.issues.list.return_value = [
+            _make_issue(1, "Fix login", "Users cannot log in", ["bug"]),
+            _make_issue(2, "Add export"),
+        ]
+        patch_client(_make_client(project))
+        result = gitlab_list_issues.invoke({"project_url": "group/project"})
+        assert "#1: Fix login [bug]" in result
+        assert "Users cannot log in" in result
+        assert "#2: Add export" in result
+        assert "(2 issues shown)" in result
+
+    def test_default_state_is_gitlabs_spelling(self, patch_client):
+        project = _make_project()
+        project.issues.list.return_value = []
+        patch_client(_make_client(project))
+        gitlab_list_issues.invoke({"project_url": "group/project"})
+        assert project.issues.list.call_args.kwargs["state"] == "opened"
+
+    def test_githubs_open_spelling_is_rejected(self, patch_client):
+        patch_client(_make_client())
+        result = gitlab_list_issues.invoke({"project_url": "group/project", "state": "open"})
+        assert result.startswith("Error:")
+        assert "opened" in result
+
+    def test_state_is_case_insensitive(self, patch_client):
+        project = _make_project()
+        project.issues.list.return_value = []
+        patch_client(_make_client(project))
+        result = gitlab_list_issues.invoke({"project_url": "group/project", "state": "ALL"})
+        assert not result.startswith("Error:")
+        assert project.issues.list.call_args.kwargs["state"] == "all"
+
+    def test_long_description_is_previewed(self, patch_client):
+        project = _make_project()
+        project.issues.list.return_value = [_make_issue(1, "Big", "z" * 400)]
+        patch_client(_make_client(project))
+        result = gitlab_list_issues.invoke({"project_url": "group/project"})
+        assert "..." in result
+
+    def test_max_issues_caps_output(self, patch_client):
+        project = _make_project()
+        project.issues.list.return_value = [_make_issue(i) for i in range(1, 11)]
+        patch_client(_make_client(project))
+        result = gitlab_list_issues.invoke({"project_url": "group/project", "max_issues": 3})
+        assert "(3 issues shown; increase max_issues to see more)" in result
+
+    def test_no_issues(self, patch_client):
+        project = _make_project()
+        project.issues.list.return_value = []
+        patch_client(_make_client(project))
+        assert "No opened issues found." in gitlab_list_issues.invoke({"project_url": "group/project"})
+
+    def test_missing_credentials(self, patch_client):
+        patch_client(None)
+        assert gitlab_list_issues.invoke({"project_url": "group/project"}) == _MISSING_CONFIG_MSG
+
+    def test_api_error(self, patch_client):
+        client = _make_client()
+        client.projects.get.side_effect = _http_error(GitlabGetError, 404)
+        patch_client(client)
+        assert gitlab_list_issues.invoke({"project_url": "group/x"}).startswith("Error:")
+
+
+# ---------------------------------------------------------------------------
+# gitlab_create_issue  (WRITE — gated behind human_review)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIssue:
+    def test_happy_path(self, patch_client):
+        project = _make_project()
+        project.issues.create.return_value = _make_issue(42, "New story")
+        patch_client(_make_client(project))
+        result = gitlab_create_issue.invoke({"project_url": "group/project", "title": "New story"})
+        assert "Created GitLab issue #42" in result
+        assert "https://gitlab.com/group/project/-/issues/42" in result
+
+    def test_labels_are_split_into_a_list(self, patch_client):
+        project = _make_project()
+        project.issues.create.return_value = _make_issue(1, "T")
+        patch_client(_make_client(project))
+        gitlab_create_issue.invoke(
+            {"project_url": "group/project", "title": "T", "labels": "bug, sprint-1 , "},
+        )
+        assert project.issues.create.call_args[0][0]["labels"] == ["bug", "sprint-1"]
+
+    def test_no_labels_key_when_blank(self, patch_client):
+        project = _make_project()
+        project.issues.create.return_value = _make_issue(1, "T")
+        patch_client(_make_client(project))
+        gitlab_create_issue.invoke({"project_url": "group/project", "title": "T"})
+        assert "labels" not in project.issues.create.call_args[0][0]
+
+    def test_blank_title_rejected_before_any_api_call(self, patch_client):
+        client = _make_client()
+        patch_client(client)
+        result = gitlab_create_issue.invoke({"project_url": "group/project", "title": "   "})
+        assert result.startswith("Error:")
+        client.projects.get.assert_not_called()
+
+    def test_missing_credentials(self, patch_client):
+        patch_client(None)
+        result = gitlab_create_issue.invoke({"project_url": "group/project", "title": "T"})
+        assert result == _MISSING_CONFIG_MSG
+
+    def test_api_error(self, patch_client):
+        project = _make_project()
+        project.issues.create.side_effect = _http_error(GitlabCreateError, 403)
+        patch_client(_make_client(project))
+        result = gitlab_create_issue.invoke({"project_url": "group/project", "title": "T"})
+        assert "read_api" in result
+
+    def test_unexpected_error(self, patch_client):
+        project = _make_project()
+        project.issues.create.side_effect = RuntimeError("nope")
+        patch_client(_make_client(project))
+        assert "nope" in gitlab_create_issue.invoke({"project_url": "group/project", "title": "T"})
+
+    def test_docstring_carries_the_confirmation_guard(self):
+        # The human_review gate is driven by risk.py, but the docstring is what
+        # tells the LLM not to call this unprompted. @tool moves the docstring to
+        # .description — that string is what is actually sent to the model.
+        assert "only call this after the user has explicitly confirmed" in gitlab_create_issue.description.lower()
+
+
+# ---------------------------------------------------------------------------
+# Client construction + config
+# ---------------------------------------------------------------------------
+
+
+class TestClientConstruction:
+    def test_no_token_returns_none(self, monkeypatch):
+        from yeaboi.tools import gitlab as gitlab_tools
+
+        monkeypatch.setattr(gitlab_tools, "get_gitlab_token", lambda: None)
+        assert gitlab_tools._make_gitlab_client() is None
+
+    def test_token_builds_a_client_for_the_configured_url(self, monkeypatch):
+        from yeaboi.tools import gitlab as gitlab_tools
+
+        monkeypatch.setattr(gitlab_tools, "get_gitlab_token", lambda: "glpat-secret")
+        monkeypatch.setattr(gitlab_tools, "get_gitlab_url", lambda: "https://gitlab.example.com")
+        captured = {}
+
+        def _fake_gitlab(url, private_token):
+            captured["url"] = url
+            captured["token"] = private_token
+            return MagicMock()
+
+        monkeypatch.setattr(gitlab_tools.gitlab, "Gitlab", _fake_gitlab)
+        assert gitlab_tools._make_gitlab_client() is not None
+        assert captured == {"url": "https://gitlab.example.com", "token": "glpat-secret"}
+
+
+class TestConfigGetters:
+    def test_url_defaults_to_gitlab_com(self, monkeypatch):
+        from yeaboi import config
+
+        monkeypatch.delenv("GITLAB_URL", raising=False)
+        assert config.get_gitlab_url() == "https://gitlab.com"
+
+    def test_url_gets_a_scheme_when_missing(self, monkeypatch):
+        from yeaboi import config
+
+        monkeypatch.setenv("GITLAB_URL", "gitlab.example.com")
+        assert config.get_gitlab_url() == "https://gitlab.example.com"
+
+    def test_url_trailing_slash_stripped(self, monkeypatch):
+        from yeaboi import config
+
+        monkeypatch.setenv("GITLAB_URL", "https://gitlab.example.com/")
+        assert config.get_gitlab_url() == "https://gitlab.example.com"
+
+    def test_blank_url_falls_back_to_the_default(self, monkeypatch):
+        from yeaboi import config
+
+        monkeypatch.setenv("GITLAB_URL", "   ")
+        assert config.get_gitlab_url() == "https://gitlab.com"
+
+    def test_token_getter_reads_the_env_var(self, monkeypatch):
+        from yeaboi import config
+
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-abc")
+        assert config.get_gitlab_token() == "glpat-abc"
+
+    def test_token_getter_returns_none_when_blank(self, monkeypatch):
+        from yeaboi import config
+
+        monkeypatch.setenv("GITLAB_TOKEN", "")
+        assert config.get_gitlab_token() is None
+
+
+# ---------------------------------------------------------------------------
+# Secret masking — a GitLab token must never reach a log file verbatim
+# ---------------------------------------------------------------------------
+
+
+class TestTokenMasking:
+    def test_token_shape_is_redacted_without_any_env_var(self):
+        from yeaboi.redaction import REDACTED, redact
+
+        token = "glpat-" + "A1b2C3d4E5f6G7h8I9j0"
+        out = redact(f"401 Unauthorized for PRIVATE-TOKEN {token}")
+        assert token not in out
+        assert REDACTED in out
+
+    def test_runner_token_shape_is_redacted(self):
+        from yeaboi.redaction import redact
+
+        token = "glrt-" + "A1b2C3d4E5f6G7h8I9j0"
+        assert token not in redact(f"job failed with {token}")
+
+    def test_configured_token_value_is_redacted(self, monkeypatch):
+        from yeaboi import redaction
+
+        monkeypatch.setenv("GITLAB_TOKEN", "not-a-standard-shape-but-secret")
+        out = redaction.redact("token=not-a-standard-shape-but-secret")
+        assert "not-a-standard-shape-but-secret" not in out
+
+    def test_gitlab_token_is_a_known_secret_key(self):
+        from yeaboi.redaction import SECRET_ENV_KEYS
+
+        assert "GITLAB_TOKEN" in SECRET_ENV_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Registration + risk classification
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_all_four_tools_are_registered(self):
+        names = {t.name for t in get_tools()}
+        assert {
+            "gitlab_read_repo",
+            "gitlab_read_readme",
+            "gitlab_list_issues",
+            "gitlab_create_issue",
+        } <= names
+
+    def test_reads_are_read_risk_and_create_is_write(self):
+        from yeaboi.tools.risk import TOOL_RISK, ToolRisk
+
+        assert TOOL_RISK["gitlab_read_repo"] is ToolRisk.READ
+        assert TOOL_RISK["gitlab_read_readme"] is ToolRisk.READ
+        assert TOOL_RISK["gitlab_list_issues"] is ToolRisk.READ
+        assert TOOL_RISK["gitlab_create_issue"] is ToolRisk.WRITE

--- a/tests/unit/tools/test_tools_gitlab.py
+++ b/tests/unit/tools/test_tools_gitlab.py
@@ -367,6 +367,17 @@ class TestListIssues:
         result = gitlab_list_issues.invoke({"project_url": "group/project", "max_issues": 3})
         assert "(3 issues shown; increase max_issues to see more)" in result
 
+    def test_max_issues_above_gitlabs_page_cap_says_so(self, patch_client):
+        # GitLab will not return more than 100 in one request; showing 100 with no
+        # note would read as "that is all of them".
+        project = _make_project()
+        project.issues.list.return_value = [_make_issue(i) for i in range(1, 101)]
+        patch_client(_make_client(project))
+        result = gitlab_list_issues.invoke({"project_url": "group/project", "max_issues": 250})
+        assert project.issues.list.call_args.kwargs["per_page"] == 100
+        assert "at most 100 per request" in result
+        assert "250 was capped" in result
+
     def test_no_issues(self, patch_client):
         project = _make_project()
         project.issues.list.return_value = []

--- a/uv.lock
+++ b/uv.lock
@@ -2365,6 +2365,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-gitlab"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/55/8050293b360a29218a15892c2b936e286a69fd4f5d2cf54c7cbe19d34b47/python_gitlab-8.5.0.tar.gz", hash = "sha256:628529ec4ce1f9a7ba2c145b2cf5e4eeca3015418e504b2e6fba70171b6b1b59", size = 411497, upload-time = "2026-07-28T02:04:30.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/3d/fb547ed2ac318132517e001b74b09d1f17d2c2c681cad1e32a8b84139867/python_gitlab-8.5.0-py3-none-any.whl", hash = "sha256:94228973c54f09eccd30f5160eca91200adc31d6ed0c894221a3865b90f96426", size = 148234, upload-time = "2026-07-28T02:04:28.454Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
@@ -3348,7 +3361,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.50.0"
+version = "2.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },
@@ -3363,6 +3376,7 @@ dependencies = [
     { name = "prompt-toolkit" },
     { name = "pygithub" },
     { name = "python-dotenv" },
+    { name = "python-gitlab" },
     { name = "rich" },
     { name = "segno" },
 ]
@@ -3455,6 +3469,7 @@ requires-dist = [
     { name = "pytest-recording", marker = "extra == 'dev'" },
     { name = "python-docx", marker = "extra == 'docs'" },
     { name = "python-dotenv" },
+    { name = "python-gitlab" },
     { name = "python-pptx", marker = "extra == 'docs'" },
     { name = "rich" },
     { name = "ruff", marker = "extra == 'dev'" },

--- a/uv.lock
+++ b/uv.lock
@@ -3361,7 +3361,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.51.0"
+version = "2.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
Closes YEA-19.

## Why GitLab

yeaboi already told users it supported GitLab. `detect_platform()` returns `"GitLab"`, and intake Q16 offers it as a code-host option — and then `_scan_repo_context()` bailed with `"GitLab not yet supported"`. Anyone who answered "GitLab" got a silently degraded intake with no repository context.

Every other candidate on the shortlist (Linear, Sentry, Bitbucket, Asana) would add a *new* capability. This one fixes a *broken* one, at the lowest cost — a mature SDK and plain token auth.

## What's in it

| Tool | Risk | Purpose |
|---|---|---|
| `gitlab_read_repo` | READ | Project metadata, directory tree, key tech-stack files, language breakdown |
| `gitlab_read_readme` | READ | README (+ CONTRIBUTING.md) for project analysis |
| `gitlab_list_issues` | READ | Open issues feeding planning |
| `gitlab_create_issue` | WRITE | Ticket write-back, gated behind `human_review` |

`tools/gitlab.py` mirrors the shape of `tools/github.py` and `tools/notion.py`: module docstring covering the SDK choice and auth model, a single `_MISSING_CONFIG_MSG`, `@tool`-decorated functions, and the explicit "only call after the user confirms" note on the write tool.

Also wired: the GitLab branch of `_scan_repo_context` now scans like GitHub and Azure DevOps do.

## Env vars

- `GITLAB_TOKEN` — personal access token (`read_api` for reads, `api` to create issues)
- `GITLAB_URL` — optional, defaults to `https://gitlab.com`; set for self-hosted

Both documented in `.env.example`.

## Three GitLab-specific details worth reviewing

1. **Nested subgroups.** A project can live arbitrarily deep (`group/sub/team/project`), so the tools take a `project_url`, not an owner/repo slug, and `_parse_project` cuts at GitLab's `/-/` separator rather than keeping the first two path segments.
2. **`opened`, not `open`.** GitLab returns an *unfiltered* list for an unrecognised issue state rather than erroring, so passing GitHub's `open` would silently include closed issues. The state is validated instead of forwarded.
3. **A token is required.** Unlike the GitHub tools, these do not fall back to anonymous access — GitLab's unauthenticated API is heavily restricted, and an anonymous 404 is indistinguishable from "this project is private", which would surface to the user as a confusing "not found".

## Security

`GITLAB_TOKEN` joins `SECRET_ENV_KEYS`, plus a `gl<kind>-` token pattern so a pasted `glpat-`/`glrt-` token is scrubbed from logs even when it never came from our env. Covered by masking tests.

## Tests

70 added — `tests/unit/tools/test_tools_gitlab.py` (67: happy path and error case per tool, missing-credential path, URL parsing including subgroups and self-hosted, token masking, registration, risk classification) plus 3 in `test_analyzer.py` covering the newly-wired branch.

Four existing registry assertions were updated rather than worked around: the total tool count moves 37 → 41, and `gitlab_create_issue` joins the expected WRITE set in `test_risk.py`. One obsolete test — `test_gitlab_platform_returns_none`, which pinned the exact bug being fixed — is replaced by three tests of the new behaviour.

## Notes for the reviewer

- **No `CAPABILITIES` row.** `CAPABILITIES` keys are modes, and its checks are two-way set equality against `_MODE_CARDS`, the MCP tool list, and plugin skills. Every existing tool integration (GitHub, Jira, Notion, Confluence, AzDO) has no row; adding one would break the suite. GitLab follows the same contract they do — `test_tools_registry.py` (AST discovery vs `get_tools()`) and `test_risk.py`. Parity holds because agent tools reach the TUI, CLI, and MCP at once through the shared ReAct loop.
- **Deliberately out of scope**, listed so they're visible rather than silently missing: no merge-request/pipeline reading (standup's activity feed stays GitHub-only), no batch board sync like Jira/AzDO have, and no Setup-wizard card — the token goes in `.env` like any other credential. A GitLab section for `docs/docs/integrations-exports.html` is a sensible follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_019caHoVTBSbUMBuPfQ5PCbb)_