### PR TITLE
add render tests for provider-select and vc-select screens

### DIFF
--- a/tests/unit/test_provider_select_pickers.py
+++ b/tests/unit/test_provider_select_pickers.py
@@ -67,6 +67,11 @@ def _render_ansi(panel: Panel, *, width: int = 80, height: int = _TALL) -> str:
         color_system="truecolor",
         legacy_windows=False,
         highlight=False,
+        # Rich reads NO_COLOR from the environment even with force_terminal +
+        # color_system set, and strips every SGR when it is present. Pinning it
+        # keeps the escape-matching assertions below from failing on the machine
+        # of anyone who sets NO_COLOR=1 while CI stays green.
+        no_color=False,
     )
     console.print(panel)
     return console.file.getvalue()
@@ -82,6 +87,22 @@ def _vc(selected: int = 0, **kwargs) -> Panel:
     """Build the version-control picker at a frame height that fits every row."""
     kwargs.setdefault("height", _TALL)
     return _build_vc_select_screen(selected, **kwargs)
+
+
+def _card(provider_val: str) -> dict:
+    """The provider card for *provider_val* — by identity, never by list index."""
+    return next(card for card in _PROVIDER_CARDS if card["provider_val"] == provider_val)
+
+
+def _tagline(card: dict) -> str:
+    """A card's tagline, read the way the screen reads it.
+
+    ``_screens.py`` uses ``.get("tagline", "")`` and falls through to the plain
+    separator when there is none, so the tests must tolerate a card without one
+    instead of raising ``KeyError`` and taking the suite down with an error
+    rather than a failure.
+    """
+    return card.get("tagline", "")
 
 
 def _art_top(name: str) -> str:
@@ -106,16 +127,23 @@ def _active_chip(out: str) -> str | None:
     return match.group(1) if match else None
 
 
-def _has_subtitle(out: str, text: str) -> bool:
-    """True when *text* appears on the frame's subtitle row, not just anywhere.
+def _text_rows(out: str) -> set[str]:
+    """The frame's content rows, stripped of the page panel's border and padding.
 
-    The VC picker's subtitle is "Version Control" and its active progress chip is
-    labelled "Version Control" too (``_STEPS[3]``), so a plain ``in`` check passes
-    with the subtitle row deleted — it only re-proves the chip. The chip row is
-    the one drawn with the ▟/▛ parallelogram caps, so excluding those lines
-    isolates the subtitle.
+    Whole rows rather than a substring scan over the whole capture, because both
+    kinds of substring collision are live here:
+
+    - across rows: the VC picker's subtitle is "Version Control" and so is its
+      active progress chip (``_STEPS[3]``), so ``"Version Control" in out`` holds
+      with the subtitle row deleted — it only re-proves the chip;
+    - within a row: Anthropic's tagline ("Recommended cloud · API key required")
+      ends with OpenAI's ("Cloud · API key required") bar the capital, so the day
+      someone normalises that copy a substring check starts claiming OpenAI's
+      tagline is on screen when it is not.
+
+    An exact row match is immune to both.
     """
-    return any(text in line and "▟" not in line and "▛" not in line for line in out.splitlines())
+    return {line.strip().strip("│").strip() for line in out.splitlines()}
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +156,7 @@ class TestSelectScreen:
         assert isinstance(_select(0), Panel)
 
     def test_subtitle_renders(self):
-        assert _has_subtitle(_render(_select(0)), "Select your LLM provider")
+        assert "Select your LLM provider" in _text_rows(_render(_select(0)))
 
     def test_every_provider_row_renders(self):
         # Provider names are drawn as two-line block art, not plain text, so the
@@ -141,16 +169,20 @@ class TestSelectScreen:
         # The selected card's separator row doubles as its tagline — the "what am
         # I signing up for" line. Ollama's is the one that makes the free option
         # visible before any card is entered.
-        ollama = next(i for i, c in enumerate(_PROVIDER_CARDS) if c["provider_val"] == "ollama")
-        out = _render(_select(ollama))
-        assert _PROVIDER_CARDS[ollama]["tagline"] in out
+        ollama = _PROVIDER_CARDS.index(_card("ollama"))
+        tagline = _tagline(_PROVIDER_CARDS[ollama])
+        assert tagline, "the free/local option must carry a tagline"
+        assert tagline in _text_rows(_render(_select(ollama)))
 
     def test_unselected_rows_hide_their_taglines(self):
         # Only one tagline is ever on screen; the rest are plain separators.
-        out = _render(_select(0))
-        assert _PROVIDER_CARDS[0]["tagline"] in out
+        rows = _text_rows(_render(_select(0)))
+        assert _tagline(_PROVIDER_CARDS[0]) in rows
         for card in _PROVIDER_CARDS[1:]:
-            assert card["tagline"] not in out
+            # A card with no tagline has no row to look for — the blank separator
+            # it draws instead is not evidence of anything.
+            if _tagline(card):
+                assert _tagline(card) not in rows
 
     def test_visible_restricts_the_rows_drawn(self):
         # The intro/outro transitions reveal and retract rows one at a time.
@@ -162,14 +194,15 @@ class TestSelectScreen:
     def test_selection_outside_visible_draws_no_tagline(self):
         # Mid-transition the selection can sit on a row that is not on screen yet;
         # every drawn row then falls through to the plain separator branch.
-        out = _render(_select(4, visible=[0, 1]))
+        rows = _text_rows(_render(_select(4, visible=[0, 1])))
         for card in _PROVIDER_CARDS:
-            assert card["tagline"] not in out
+            if _tagline(card):
+                assert _tagline(card) not in rows
 
     def test_empty_visible_still_renders_the_frame(self):
         # The first transition frame has nothing revealed yet — the subtitle and
         # the progress bar must still draw.
-        assert _has_subtitle(_render(_select(0, visible=[])), "Select your LLM provider")
+        assert "Select your LLM provider" in _text_rows(_render(_select(0, visible=[])))
         assert _active_chip(_render_ansi(_select(0, visible=[]))) == "LLM Provider"
 
     def test_selected_style_overrides_the_selected_row(self):
@@ -197,23 +230,40 @@ class TestSelectScreen:
         assert _active_chip(_render_ansi(_select(0))) == "LLM Provider"
         assert _active_chip(_render_ansi(_select(0, step=2))) == "Docs"
 
+    # Both xfails below pin the same defect, #153 (YEA-37), from its two ends.
+    # `_build_screen_frame` gives the middle a fixed budget — at height 24,
+    # `middle_h` clamps to 9 rows against a five-card body that needs 14 — and
+    # neither scrolls nor windows the overflow, so Rich crops from the bottom:
+    # first the last provider rows, then the footer. 24 rows is the classic
+    # terminal size and the height the picker is really built at (`h` comes from
+    # `console.size` — see ui/provider_select/__init__.py:207), so this is a
+    # default-terminal experience, not a contrived one.
+    #
+    # Asserting a line count instead — the obvious "it must not overflow" test —
+    # would be vacuous: build_page_panel passes an explicit `height` to Rich,
+    # which pads or crops to it whatever the body contains.
+
     @pytest.mark.xfail(
         strict=True,
-        reason="five provider rows overflow a 24-row frame and crop the progress bar away "
-        "— see the cowork proposal for the provider-select height crop",
+        reason="#153: five provider rows overflow a 24-row frame and crop the progress bar away",
     )
     def test_progress_bar_survives_a_short_terminal(self):
-        # The frame is fixed-height and does not scroll, so overflowing body rows
-        # push the footer off the bottom. 24 rows is the classic terminal size and
-        # the height the picker is actually built at (`h` comes from
-        # `console.size` — see ui/provider_select/__init__.py), so a user on a
-        # short terminal loses the whole "where am I in setup" progress bar.
-        #
-        # Asserting the line count instead would be vacuous: build_page_panel
-        # passes an explicit `height` to Rich, which pads or crops to it whatever
-        # the body contains.
+        # Losing the footer costs the user the whole "where am I in setup" bar.
         out = _render_ansi(_select(0, width=80, height=_SHORT), height=_SHORT)
         assert _active_chip(out) == "LLM Provider"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#153: the last provider rows are cropped at a 24-row frame, "
+        "so Ollama — the free, no-API-key option — is never seen",
+    )
+    def test_last_provider_row_survives_a_short_terminal(self):
+        # The crop takes the bottom rows before it reaches the footer, and Ollama
+        # is last. That is the expensive half: a user on a 24-row terminal is
+        # never shown the option that needs no API key and no spend, and nothing
+        # on screen hints that the list continues.
+        out = _render(_select(0, width=80, height=_SHORT), height=_SHORT)
+        assert _art_top(_card("ollama")["name"]) in out
 
 
 # ---------------------------------------------------------------------------
@@ -227,8 +277,8 @@ class TestVcSelectScreen:
 
     def test_subtitle_renders(self):
         # "Version Control" is also the active chip's label here, so this asserts
-        # on the subtitle row specifically — see _has_subtitle.
-        assert _has_subtitle(_render(_vc(0)), "Version Control")
+        # on the subtitle row specifically — see _text_rows.
+        assert "Version Control" in _text_rows(_render(_vc(0)))
 
     def test_every_option_row_renders(self):
         # GitHub and Skip — "Skip" is an option, not a key binding, so it has to
@@ -247,7 +297,7 @@ class TestVcSelectScreen:
         assert _art_top(_VC_OPTIONS[1]["name"]) not in out
 
     def test_empty_visible_still_renders_the_frame(self):
-        assert _has_subtitle(_render(_vc(0, visible=[])), "Version Control")
+        assert "Version Control" in _text_rows(_render(_vc(0, visible=[])))
         assert _active_chip(_render_ansi(_vc(0, visible=[]))) == "Version Control"
 
     def test_selected_style_overrides_the_selected_row(self):

--- a/tests/unit/test_provider_select_pickers.py
+++ b/tests/unit/test_provider_select_pickers.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import io
 import re
 
+import pytest
 from rich.console import Console
 from rich.panel import Panel
 
@@ -39,6 +40,9 @@ _PROBE_FG = "38;2;1;2;3"
 # content build at a height that fits the whole picker; the crop behaviour gets
 # its own test rather than silently swallowing every other assertion.
 _TALL = 40
+# The classic terminal height, and the builders' own default — a real user's
+# frame, not a contrived one.
+_SHORT = 24
 
 
 def _render(panel: Panel, *, width: int = 80, height: int = _TALL) -> str:
@@ -102,6 +106,18 @@ def _active_chip(out: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _has_subtitle(out: str, text: str) -> bool:
+    """True when *text* appears on the frame's subtitle row, not just anywhere.
+
+    The VC picker's subtitle is "Version Control" and its active progress chip is
+    labelled "Version Control" too (``_STEPS[3]``), so a plain ``in`` check passes
+    with the subtitle row deleted — it only re-proves the chip. The chip row is
+    the one drawn with the ▟/▛ parallelogram caps, so excluding those lines
+    isolates the subtitle.
+    """
+    return any(text in line and "▟" not in line and "▛" not in line for line in out.splitlines())
+
+
 # ---------------------------------------------------------------------------
 # _build_select_screen — the LLM provider picker (wizard step 0)
 # ---------------------------------------------------------------------------
@@ -112,7 +128,7 @@ class TestSelectScreen:
         assert isinstance(_select(0), Panel)
 
     def test_subtitle_renders(self):
-        assert "Select your LLM provider" in _render(_select(0))
+        assert _has_subtitle(_render(_select(0)), "Select your LLM provider")
 
     def test_every_provider_row_renders(self):
         # Provider names are drawn as two-line block art, not plain text, so the
@@ -151,11 +167,10 @@ class TestSelectScreen:
             assert card["tagline"] not in out
 
     def test_empty_visible_still_renders_the_frame(self):
-        # The first transition frame has nothing revealed yet — the title,
-        # subtitle and progress bar must still draw.
-        out = _render(_select(0, visible=[]))
-        assert "Select your LLM provider" in out
-        assert "LLM Provider" in out
+        # The first transition frame has nothing revealed yet — the subtitle and
+        # the progress bar must still draw.
+        assert _has_subtitle(_render(_select(0, visible=[])), "Select your LLM provider")
+        assert _active_chip(_render_ansi(_select(0, visible=[]))) == "LLM Provider"
 
     def test_selected_style_overrides_the_selected_row(self):
         out = _render_ansi(_select(0, selected_style=_PROBE))
@@ -182,11 +197,23 @@ class TestSelectScreen:
         assert _active_chip(_render_ansi(_select(0))) == "LLM Provider"
         assert _active_chip(_render_ansi(_select(0, step=2))) == "Docs"
 
-    def test_render_never_exceeds_the_frame_height(self):
-        # More providers than fit a short terminal: the frame is fixed-height and
-        # does not scroll, so it must crop rather than push the progress bar off.
-        out = _render(_select(0, width=80, height=24), height=24)
-        assert out.count("\n") <= 24
+    @pytest.mark.xfail(
+        strict=True,
+        reason="five provider rows overflow a 24-row frame and crop the progress bar away "
+        "— see the cowork proposal for the provider-select height crop",
+    )
+    def test_progress_bar_survives_a_short_terminal(self):
+        # The frame is fixed-height and does not scroll, so overflowing body rows
+        # push the footer off the bottom. 24 rows is the classic terminal size and
+        # the height the picker is actually built at (`h` comes from
+        # `console.size` — see ui/provider_select/__init__.py), so a user on a
+        # short terminal loses the whole "where am I in setup" progress bar.
+        #
+        # Asserting the line count instead would be vacuous: build_page_panel
+        # passes an explicit `height` to Rich, which pads or crops to it whatever
+        # the body contains.
+        out = _render_ansi(_select(0, width=80, height=_SHORT), height=_SHORT)
+        assert _active_chip(out) == "LLM Provider"
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +226,9 @@ class TestVcSelectScreen:
         assert isinstance(_vc(0), Panel)
 
     def test_subtitle_renders(self):
-        assert "Version Control" in _render(_vc(0))
+        # "Version Control" is also the active chip's label here, so this asserts
+        # on the subtitle row specifically — see _has_subtitle.
+        assert _has_subtitle(_render(_vc(0)), "Version Control")
 
     def test_every_option_row_renders(self):
         # GitHub and Skip — "Skip" is an option, not a key binding, so it has to
@@ -218,8 +247,8 @@ class TestVcSelectScreen:
         assert _art_top(_VC_OPTIONS[1]["name"]) not in out
 
     def test_empty_visible_still_renders_the_frame(self):
-        out = _render(_vc(0, visible=[]))
-        assert "Version Control" in out
+        assert _has_subtitle(_render(_vc(0, visible=[])), "Version Control")
+        assert _active_chip(_render_ansi(_vc(0, visible=[]))) == "Version Control"
 
     def test_selected_style_overrides_the_selected_row(self):
         out = _render_ansi(_vc(0, selected_style=_PROBE))
@@ -241,6 +270,9 @@ class TestVcSelectScreen:
         # is which name is lit.
         assert _render_ansi(_vc(0)) != _render_ansi(_vc(1))
 
-    def test_render_never_exceeds_the_frame_height(self):
-        out = _render(_vc(0, width=80, height=24), height=24)
-        assert out.count("\n") <= 24
+    def test_progress_bar_survives_a_short_terminal(self):
+        # Two options rather than five, so this picker's body still fits a 24-row
+        # frame and keeps its footer. Pinning that here is what makes the LLM
+        # picker's xfail a statement about row count rather than about the frame.
+        out = _render_ansi(_vc(0, width=80, height=_SHORT), height=_SHORT)
+        assert _active_chip(out) == "Version Control"

--- a/tests/unit/test_provider_select_pickers.py
+++ b/tests/unit/test_provider_select_pickers.py
@@ -1,0 +1,246 @@
+"""Render tests for the setup wizard's two picker screens.
+
+``_build_select_screen`` (pick an LLM provider) and ``_build_vc_select_screen``
+(pick a version-control provider) are the first and last pickers of the
+first-run wizard. Both are pure builders returning the page ``Panel`` that
+``select_provider``'s ``live.update()`` loop draws, and both carry animation
+arguments (``visible``, ``fade_style``/``fade_indices``, ``selected_style``,
+``shimmer_tick``) that only the transition code passes — so a regression in any
+of those branches is invisible until someone runs setup by hand.
+
+Rendering goes through the returned page ``Panel`` exactly as the Live loop does
+it (see ``ui/provider_select/_transitions.py``). That is already the "render
+inside a Panel context" path the TUI standards require: the rows are child
+renderables of the panel, so Rich honours their justification rather than
+re-deriving it from a bare ``console.print(text)``.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+
+from rich.console import Console
+from rich.panel import Panel
+
+from yeaboi.ui.provider_select._constants import _PROVIDER_CARDS, _VC_OPTIONS
+from yeaboi.ui.provider_select.screens._screens import _ACCENT, _build_select_screen
+from yeaboi.ui.provider_select.screens._screens_vc import _build_vc_select_screen
+from yeaboi.ui.shared._ascii_font import render_ascii_text
+
+# A style the wizard never uses, so finding its SGR escape in a capture proves
+# the argument under test reached the row it was meant to paint.
+_PROBE = "rgb(1,2,3)"
+_PROBE_FG = "38;2;1;2;3"
+
+
+# The frame is fixed-height and does not scroll, so a short terminal genuinely
+# crops the lowest rows (and the progress bar with them). Tests that assert on
+# content build at a height that fits the whole picker; the crop behaviour gets
+# its own test rather than silently swallowing every other assertion.
+_TALL = 40
+
+
+def _render(panel: Panel, *, width: int = 80, height: int = _TALL) -> str:
+    """Render a page panel to plain text (no escapes), the way the Live loop draws it.
+
+    Both dimensions are pinned: the pickers size their vertical centring from the
+    ``height`` argument, and a non-tty console's ambient height would otherwise
+    make the capture order-dependent.
+    """
+    console = Console(file=io.StringIO(), width=width, height=height, highlight=False)
+    console.print(panel)
+    return console.file.getvalue()
+
+
+def _render_ansi(panel: Panel, *, width: int = 80, height: int = _TALL) -> str:
+    """Render with truecolor escapes retained, so per-row styles are assertable."""
+    console = Console(
+        file=io.StringIO(),
+        width=width,
+        height=height,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    console.print(panel)
+    return console.file.getvalue()
+
+
+def _select(selected: int = 0, **kwargs) -> Panel:
+    """Build the LLM picker at a frame height that fits every row."""
+    kwargs.setdefault("height", _TALL)
+    return _build_select_screen(selected, **kwargs)
+
+
+def _vc(selected: int = 0, **kwargs) -> Panel:
+    """Build the version-control picker at a frame height that fits every row."""
+    kwargs.setdefault("height", _TALL)
+    return _build_vc_select_screen(selected, **kwargs)
+
+
+def _art_top(name: str) -> str:
+    """The top row of a name's two-line block-font art, as the picker draws it."""
+    return render_ascii_text(name)[0]
+
+
+def _accent_bg() -> str:
+    """Truecolor background SGR fragment for the wizard accent (the active chip)."""
+    r, g, b = re.fullmatch(r"rgb\((\d+),(\d+),(\d+)\)", _ACCENT).groups()
+    return f"48;2;{r};{g};{b}"
+
+
+def _active_chip(out: str) -> str | None:
+    """Label of the progress chip painted with the accent background in *out*.
+
+    ``_build_progress`` gives the active step ``bold white on <accent>``; done
+    steps get a green background and future steps a dim grey one, so the accent
+    background uniquely identifies the active chip in a truecolor capture.
+    """
+    match = re.search(rf"{_accent_bg()}m ([A-Za-z ]+?) \x1b", out)
+    return match.group(1) if match else None
+
+
+# ---------------------------------------------------------------------------
+# _build_select_screen — the LLM provider picker (wizard step 0)
+# ---------------------------------------------------------------------------
+
+
+class TestSelectScreen:
+    def test_returns_page_panel(self):
+        assert isinstance(_select(0), Panel)
+
+    def test_subtitle_renders(self):
+        assert "Select your LLM provider" in _render(_select(0))
+
+    def test_every_provider_row_renders(self):
+        # Provider names are drawn as two-line block art, not plain text, so the
+        # assertion goes through the same font helper the picker uses.
+        out = _render(_select(0))
+        for card in _PROVIDER_CARDS:
+            assert _art_top(card["name"]) in out, f"{card['name']} row missing"
+
+    def test_selected_row_shows_its_tagline(self):
+        # The selected card's separator row doubles as its tagline — the "what am
+        # I signing up for" line. Ollama's is the one that makes the free option
+        # visible before any card is entered.
+        ollama = next(i for i, c in enumerate(_PROVIDER_CARDS) if c["provider_val"] == "ollama")
+        out = _render(_select(ollama))
+        assert _PROVIDER_CARDS[ollama]["tagline"] in out
+
+    def test_unselected_rows_hide_their_taglines(self):
+        # Only one tagline is ever on screen; the rest are plain separators.
+        out = _render(_select(0))
+        assert _PROVIDER_CARDS[0]["tagline"] in out
+        for card in _PROVIDER_CARDS[1:]:
+            assert card["tagline"] not in out
+
+    def test_visible_restricts_the_rows_drawn(self):
+        # The intro/outro transitions reveal and retract rows one at a time.
+        out = _render(_select(0, visible=[0]))
+        assert _art_top(_PROVIDER_CARDS[0]["name"]) in out
+        for card in _PROVIDER_CARDS[1:]:
+            assert _art_top(card["name"]) not in out
+
+    def test_selection_outside_visible_draws_no_tagline(self):
+        # Mid-transition the selection can sit on a row that is not on screen yet;
+        # every drawn row then falls through to the plain separator branch.
+        out = _render(_select(4, visible=[0, 1]))
+        for card in _PROVIDER_CARDS:
+            assert card["tagline"] not in out
+
+    def test_empty_visible_still_renders_the_frame(self):
+        # The first transition frame has nothing revealed yet — the title,
+        # subtitle and progress bar must still draw.
+        out = _render(_select(0, visible=[]))
+        assert "Select your LLM provider" in out
+        assert "LLM Provider" in out
+
+    def test_selected_style_overrides_the_selected_row(self):
+        out = _render_ansi(_select(0, selected_style=_PROBE))
+        assert _PROBE_FG in out
+
+    def test_fade_style_applies_to_fade_indices(self):
+        out = _render_ansi(_select(0, fade_indices=[2], fade_style=_PROBE))
+        assert _PROBE_FG in out
+
+    def test_fade_style_without_indices_is_inert(self):
+        # fade_style alone must not repaint anything — the fading rows are named
+        # by fade_indices, and an empty list is the steady state.
+        out = _render_ansi(_select(0, fade_indices=[], fade_style=_PROBE))
+        assert _PROBE_FG not in out
+
+    def test_shimmer_tick_animates_the_selected_row(self):
+        # The selected row shimmers per character; two ticks must not be identical
+        # or the picker would look frozen.
+        assert _render_ansi(_select(0, shimmer_tick=0.0)) != _render_ansi(_select(0, shimmer_tick=0.5))
+
+    def test_step_argument_drives_the_active_chip(self):
+        # The picker is reachable as a re-entry from a later section, so the chip
+        # it highlights is caller-driven rather than pinned to step 0.
+        assert _active_chip(_render_ansi(_select(0))) == "LLM Provider"
+        assert _active_chip(_render_ansi(_select(0, step=2))) == "Docs"
+
+    def test_render_never_exceeds_the_frame_height(self):
+        # More providers than fit a short terminal: the frame is fixed-height and
+        # does not scroll, so it must crop rather than push the progress bar off.
+        out = _render(_select(0, width=80, height=24), height=24)
+        assert out.count("\n") <= 24
+
+
+# ---------------------------------------------------------------------------
+# _build_vc_select_screen — the version-control picker (wizard step 3)
+# ---------------------------------------------------------------------------
+
+
+class TestVcSelectScreen:
+    def test_returns_page_panel(self):
+        assert isinstance(_vc(0), Panel)
+
+    def test_subtitle_renders(self):
+        assert "Version Control" in _render(_vc(0))
+
+    def test_every_option_row_renders(self):
+        # GitHub and Skip — "Skip" is an option, not a key binding, so it has to
+        # be visibly on the list.
+        out = _render(_vc(0))
+        for option in _VC_OPTIONS:
+            assert _art_top(option["name"]) in out, f"{option['name']} row missing"
+
+    def test_active_chip_is_version_control(self):
+        # This picker hardcodes step 3 — it is the wizard's last section.
+        assert _active_chip(_render_ansi(_vc(0))) == "Version Control"
+
+    def test_visible_restricts_the_rows_drawn(self):
+        out = _render(_vc(0, visible=[0]))
+        assert _art_top(_VC_OPTIONS[0]["name"]) in out
+        assert _art_top(_VC_OPTIONS[1]["name"]) not in out
+
+    def test_empty_visible_still_renders_the_frame(self):
+        out = _render(_vc(0, visible=[]))
+        assert "Version Control" in out
+
+    def test_selected_style_overrides_the_selected_row(self):
+        out = _render_ansi(_vc(0, selected_style=_PROBE))
+        assert _PROBE_FG in out
+
+    def test_fade_style_applies_to_fade_indices(self):
+        out = _render_ansi(_vc(0, fade_indices=[1], fade_style=_PROBE))
+        assert _PROBE_FG in out
+
+    def test_fade_style_without_indices_is_inert(self):
+        out = _render_ansi(_vc(0, fade_indices=[], fade_style=_PROBE))
+        assert _PROBE_FG not in out
+
+    def test_shimmer_tick_animates_the_selected_row(self):
+        assert _render_ansi(_vc(0, shimmer_tick=0.0)) != _render_ansi(_vc(0, shimmer_tick=0.5))
+
+    def test_selecting_the_second_option_moves_the_highlight(self):
+        # The two rows must not render identically — the picker's only feedback
+        # is which name is lit.
+        assert _render_ansi(_vc(0)) != _render_ansi(_vc(1))
+
+    def test_render_never_exceeds_the_frame_height(self):
+        out = _render(_vc(0, width=80, height=24), height=24)
+        assert out.count("\n") <= 24

--- a/tests/unit/test_provider_select_pickers.py
+++ b/tests/unit/test_provider_select_pickers.py
@@ -245,7 +245,10 @@ class TestSelectScreen:
         assert _probe_row_count(out) == 2  # one card, two art rows
 
     def test_fade_style_applies_to_fade_indices(self):
-        faded = 2
+        # Phase 1 of the confirm transition: the unselected rows grey out while
+        # the selection is held on `selected_style` (_transitions.py:74).
+        faded = len(_PROVIDER_CARDS) - 1
+        assert faded != 0, "the faded row must not be the selected one"
         out = _render_ansi(_select(0, fade_indices=[faded], fade_style=_PROBE))
         assert _PROBE_FG in _art_row(out, _PROVIDER_CARDS[faded]["name"])
         for i, card in enumerate(_PROVIDER_CARDS):
@@ -253,6 +256,20 @@ class TestSelectScreen:
             # contiguous art to anchor on. The row count below covers it.
             if i not in (0, faded):
                 assert _PROBE_FG not in _art_row(out, card["name"])
+        assert _probe_row_count(out) == 2
+
+    def test_fade_style_applies_to_the_selected_row(self):
+        # A faded row and the selected row are the same row here, which no other
+        # test in this file arranges — and it is what the confirm pulse actually
+        # does: it puts the *selected* index in fade_indices and leaves
+        # selected_style empty (_transitions.py:37, and the pulse loop at :59).
+        #
+        # So the guard worth having is that the fade is not conditioned on the
+        # row being unselected. Add `and i != selected` to the fading arm in
+        # _screens.py — a plausible "the selection shimmers, let it be" tidy-up —
+        # and the pulse freezes with every other test here still green.
+        out = _render_ansi(_select(0, fade_indices=[0], fade_style=_PROBE))
+        assert _PROBE_FG in _art_row(out, _PROVIDER_CARDS[0]["name"])
         assert _probe_row_count(out) == 2
 
     def test_fade_style_without_indices_is_inert(self):
@@ -284,6 +301,12 @@ class TestSelectScreen:
     # Asserting a line count instead — the obvious "it must not overflow" test —
     # would be vacuous: build_page_panel passes an explicit `height` to Rich,
     # which pads or crops to it whatever the body contains.
+    #
+    # Both are strict, so they hard-fail the build the moment they pass. What
+    # makes them pass is "the body stopped overflowing 9 rows", which a shorter
+    # card list would also achieve — hence the guards below. The body needs
+    # 3n-1 rows for n cards, so the footer goes at n>=4 and the last card's own
+    # row at n>=5; measured, not derived on paper.
 
     @pytest.mark.xfail(
         strict=True,
@@ -291,6 +314,10 @@ class TestSelectScreen:
     )
     def test_progress_bar_survives_a_short_terminal(self):
         # Losing the footer costs the user the whole "where am I in setup" bar.
+        assert len(_PROVIDER_CARDS) >= 4, (
+            "at 3 cards or fewer the body fits a 24-row frame and keeps its footer — "
+            "this xfail would now pass for a reason unrelated to #153; recheck #153 before deleting it"
+        )
         out = _render_ansi(_select(0, width=80, height=_SHORT), height=_SHORT)
         assert _active_chip(out) == "LLM Provider"
 
@@ -304,8 +331,36 @@ class TestSelectScreen:
         # is last. That is the expensive half: a user on a 24-row terminal is
         # never shown the option that needs no API key and no spend, and nothing
         # on screen hints that the list continues.
+        assert len(_PROVIDER_CARDS) >= 5, (
+            "at 4 cards or fewer the last row still fits a 24-row frame (only the footer is lost) — "
+            "this xfail would now pass for a reason unrelated to #153; recheck #153 before deleting it"
+        )
         out = _render(_select(0, width=80, height=_SHORT), height=_SHORT)
         assert _art_top(_card("ollama")["name"]) in out
+
+
+def test_the_height_xfails_still_describe_a_layout_bug():
+    """The two #153 xfails assume list lengths; say so where it can be heard.
+
+    Each xfail carries the same guard inline, which stops a shorter card list
+    from turning it into a confusing XPASS. But an assertion that fails inside
+    an ``xfail`` is just another expected failure — the message never reaches
+    the run output. This test is the half that does: it fails loudly, by name,
+    the moment the assumption those xfails rest on stops holding.
+
+    Thresholds are measured, not derived: the body needs 3n-1 rows against a
+    9-row budget at height 24, so the footer goes at n>=4 and the last card's
+    own row at n>=5.
+    """
+    assert len(_PROVIDER_CARDS) >= 5, (
+        "the provider list shrank, so a 24-row frame may now fit it — the #153 xfails in "
+        "TestSelectScreen will silently stop testing the crop. Recheck #153 and delete them if it is gone."
+    )
+    assert len(_VC_OPTIONS) <= 3, (
+        "the version-control list grew, so a 24-row frame may no longer fit it — "
+        "TestVcSelectScreen.test_progress_bar_survives_a_short_terminal is about to fail with #153, "
+        "not a regression of its own."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -351,9 +406,23 @@ class TestVcSelectScreen:
         assert _probe_row_count(out) == 2
 
     def test_fade_style_applies_to_fade_indices(self):
+        # The fade-out that ends the step (__init__.py:912) greys the unselected
+        # rows while the selection is held on selected_style.
         faded = len(_VC_OPTIONS) - 1
+        assert faded != 0, "the faded row must not be the selected one"
         out = _render_ansi(_vc(0, fade_indices=[faded], fade_style=_PROBE))
         assert _PROBE_FG in _art_row(out, _VC_OPTIONS[faded]["name"])
+        assert _probe_row_count(out) == 2
+
+    def test_fade_style_applies_to_the_selected_row(self):
+        # Both of this picker's own fades put the selected index in fade_indices
+        # with selected_style empty: the entry fade-in passes every index
+        # (__init__.py:825) and the confirm pulse passes just the selected one
+        # (:898). Condition the fading arm in _screens_vc.py on the row being
+        # unselected and the entry fade-in stops animating entirely — the whole
+        # step would just appear, with nothing here to say so.
+        out = _render_ansi(_vc(0, fade_indices=[0], fade_style=_PROBE))
+        assert _PROBE_FG in _art_row(out, _VC_OPTIONS[0]["name"])
         assert _probe_row_count(out) == 2
 
     def test_fade_style_without_indices_is_inert(self):
@@ -372,5 +441,9 @@ class TestVcSelectScreen:
         # Two options rather than five, so this picker's body still fits a 24-row
         # frame and keeps its footer. Pinning that here is what makes the LLM
         # picker's xfail a statement about row count rather than about the frame.
+        assert len(_VC_OPTIONS) <= 3, (
+            "a 4th option would overflow a 24-row frame and lose this footer too — "
+            "that is #153, not a regression here; xfail this and say so"
+        )
         out = _render_ansi(_vc(0, width=80, height=_SHORT), height=_SHORT)
         assert _active_chip(out) == "Version Control"

--- a/tests/unit/test_provider_select_pickers.py
+++ b/tests/unit/test_provider_select_pickers.py
@@ -146,6 +146,31 @@ def _text_rows(out: str) -> set[str]:
     return {line.strip().strip("│").strip() for line in out.splitlines()}
 
 
+def _art_row(out: str, name: str) -> str:
+    """The one captured line carrying *name*'s art-top row, escapes and all.
+
+    Only meaningful for a row drawn in a single style — a uniformly styled row
+    emits its art as one contiguous span, whereas the shimmering selection is
+    styled per character and has no contiguous art to find. That asymmetry is
+    what ``_probe_row_count`` covers.
+    """
+    art = _art_top(name)
+    matches = [line for line in out.splitlines() if art in line]
+    assert len(matches) == 1, f"expected exactly one {name!r} art row in the capture, found {len(matches)}"
+    return matches[0]
+
+
+def _probe_row_count(out: str) -> int:
+    """How many captured lines carry the probe style.
+
+    A style override paints one card, which is two art rows. Counting them is
+    the half of the assertion ``_art_row`` cannot make: it catches an override
+    that leaked onto the shimmering selection, whose art is per-character styled
+    and so cannot be located by substring at all.
+    """
+    return sum(_PROBE_FG in line for line in out.splitlines())
+
+
 # ---------------------------------------------------------------------------
 # _build_select_screen — the LLM provider picker (wizard step 0)
 # ---------------------------------------------------------------------------
@@ -193,8 +218,12 @@ class TestSelectScreen:
 
     def test_selection_outside_visible_draws_no_tagline(self):
         # Mid-transition the selection can sit on a row that is not on screen yet;
-        # every drawn row then falls through to the plain separator branch.
-        rows = _text_rows(_render(_select(4, visible=[0, 1])))
+        # every drawn row then falls through to the plain separator branch. The
+        # selection is derived from the list length rather than hardcoded: a
+        # shrunken list would put a literal 4 out of range, matching no card, and
+        # the test would keep passing while asserting nothing.
+        offscreen = len(_PROVIDER_CARDS) - 1
+        rows = _text_rows(_render(_select(offscreen, visible=[0, 1])))
         for card in _PROVIDER_CARDS:
             if _tagline(card):
                 assert _tagline(card) not in rows
@@ -206,12 +235,25 @@ class TestSelectScreen:
         assert _active_chip(_render_ansi(_select(0, visible=[]))) == "LLM Provider"
 
     def test_selected_style_overrides_the_selected_row(self):
+        # Anchored to the selected card's own row: a bare "probe appears
+        # somewhere" scan would pass just as happily if the override landed on
+        # the wrong card, or on all of them.
         out = _render_ansi(_select(0, selected_style=_PROBE))
-        assert _PROBE_FG in out
+        assert _PROBE_FG in _art_row(out, _PROVIDER_CARDS[0]["name"])
+        for card in _PROVIDER_CARDS[1:]:
+            assert _PROBE_FG not in _art_row(out, card["name"])
+        assert _probe_row_count(out) == 2  # one card, two art rows
 
     def test_fade_style_applies_to_fade_indices(self):
-        out = _render_ansi(_select(0, fade_indices=[2], fade_style=_PROBE))
-        assert _PROBE_FG in out
+        faded = 2
+        out = _render_ansi(_select(0, fade_indices=[faded], fade_style=_PROBE))
+        assert _PROBE_FG in _art_row(out, _PROVIDER_CARDS[faded]["name"])
+        for i, card in enumerate(_PROVIDER_CARDS):
+            # Row 0 is the shimmering selection — per-character styles, so no
+            # contiguous art to anchor on. The row count below covers it.
+            if i not in (0, faded):
+                assert _PROBE_FG not in _art_row(out, card["name"])
+        assert _probe_row_count(out) == 2
 
     def test_fade_style_without_indices_is_inert(self):
         # fade_style alone must not repaint anything — the fading rows are named
@@ -294,7 +336,8 @@ class TestVcSelectScreen:
     def test_visible_restricts_the_rows_drawn(self):
         out = _render(_vc(0, visible=[0]))
         assert _art_top(_VC_OPTIONS[0]["name"]) in out
-        assert _art_top(_VC_OPTIONS[1]["name"]) not in out
+        for option in _VC_OPTIONS[1:]:
+            assert _art_top(option["name"]) not in out
 
     def test_empty_visible_still_renders_the_frame(self):
         assert "Version Control" in _text_rows(_render(_vc(0, visible=[])))
@@ -302,11 +345,16 @@ class TestVcSelectScreen:
 
     def test_selected_style_overrides_the_selected_row(self):
         out = _render_ansi(_vc(0, selected_style=_PROBE))
-        assert _PROBE_FG in out
+        assert _PROBE_FG in _art_row(out, _VC_OPTIONS[0]["name"])
+        for option in _VC_OPTIONS[1:]:
+            assert _PROBE_FG not in _art_row(out, option["name"])
+        assert _probe_row_count(out) == 2
 
     def test_fade_style_applies_to_fade_indices(self):
-        out = _render_ansi(_vc(0, fade_indices=[1], fade_style=_PROBE))
-        assert _PROBE_FG in out
+        faded = len(_VC_OPTIONS) - 1
+        out = _render_ansi(_vc(0, fade_indices=[faded], fade_style=_PROBE))
+        assert _PROBE_FG in _art_row(out, _VC_OPTIONS[faded]["name"])
+        assert _probe_row_count(out) == 2
 
     def test_fade_style_without_indices_is_inert(self):
         out = _render_ansi(_vc(0, fade_indices=[], fade_style=_PROBE))
@@ -315,10 +363,10 @@ class TestVcSelectScreen:
     def test_shimmer_tick_animates_the_selected_row(self):
         assert _render_ansi(_vc(0, shimmer_tick=0.0)) != _render_ansi(_vc(0, shimmer_tick=0.5))
 
-    def test_selecting_the_second_option_moves_the_highlight(self):
-        # The two rows must not render identically — the picker's only feedback
+    def test_selecting_another_option_moves_the_highlight(self):
+        # Two selections must not render identically — the picker's only feedback
         # is which name is lit.
-        assert _render_ansi(_vc(0)) != _render_ansi(_vc(1))
+        assert _render_ansi(_vc(0)) != _render_ansi(_vc(len(_VC_OPTIONS) - 1))
 
     def test_progress_bar_survives_a_short_terminal(self):
         # Two options rather than five, so this picker's body still fits a 24-row


### PR DESCRIPTION
## Summary

This week's `tui-ux` cowork sweep auto-lane pick (Linear [YEA-32](https://linear.app/yeaboi/issue/YEA-32/add-render-tests-for-provider-select-and-vc-select-screens)).

`_build_select_screen` (`src/yeaboi/ui/provider_select/screens/_screens.py:227`) and `_build_vc_select_screen` (`src/yeaboi/ui/provider_select/screens/_screens_vc.py:54`) are the LLM-provider-pick and version-control-provider-pick screens — the very first screens a new user sees during setup — and had zero render tests anywhere in `tests/unit`. This PR is a pure test addition; no production code changes.

- Adds `tests/unit/test_provider_select_pickers.py` (two classes, one per screen): returned `Panel`, subtitle row (exact-row matched, isolated from the progress chip and from other cards' taglines), every option row renders, selected-card tagline shown/hidden correctly, the `visible` reveal/retract transition window (including the empty-visible and selection-off-screen frames), `selected_style`/`fade_style`/`fade_indices` overrides on both the unselected and selected fade paths (the latter is the shape every real caller — the confirm pulse, the VC fade-in — actually uses), `shimmer_tick` animation, the `step` argument driving the active chip, and the real short-terminal invariant (progress chip and last provider row surviving a 24-row frame).
- Two tests (`TestSelectScreen::test_progress_bar_survives_a_short_terminal` and `test_last_provider_row_survives_a_short_terminal`) are `xfail(strict=True)`: independent code review of this PR found the LLM picker's progress footer *and* its last provider row are genuinely cropped off at short terminal heights (`_build_screen_frame` centres a fixed body height with no windowing). That's a real UX defect, filed separately as tui-ux proposal [#153](https://github.com/dinho149/yeaboi.ai/issues/153) / [YEA-37](https://linear.app/yeaboi/issue/YEA-37/stop-llm-provider-picker-from-cropping-ollama-row-and-progress-footer) rather than fixed here, since layout changes always propose per house-rules. Both xfails are pinned with a guard against unrelated changes (list-length drift) making them a confusing XPASS instead of a meaningful one, and will flip to hard failures the moment #153 is actually fixed.

## Test plan

- `make lint` — clean.
- `make test` — 9182 passed, 47 skipped, 2 xfailed (the two `#153` pins), 3 failed. All three failures are pre-existing and unrelated to this change (verified identical with this PR's file stashed): two `test_cowork_setup.py::TestGhWrites` tests skip/fail without `gh` on `PATH`, and `test_standup_transcripts.py::TestScanBounds::test_unreadable_directory_is_skipped_not_fatal` fails because the sandbox runs as root (a `chmod 000` directory is still readable).
- Diff went through three rounds of independent review (`code-reviewer` plus automated `claude-review.yml` passes); all should-fix and real coverage-gap findings are resolved, including anchoring style-override assertions to the specific row they claim to prove, deriving test indices from list length instead of hardcoding, pinning `no_color=False` so the SGR assertions aren't environment-dependent, and adding coverage for the fade-on-selected-row branch that production code actually exercises (confirmed via mutation testing that this — not an arm-order swap a reviewer also flagged, which is provably a no-op at every real call site — is the regression the test needed to catch).

## DoD exemptions

- Item 5 (surface parity) — no new capability, no `CAPABILITIES`/`FeatureTip` change needed.
- Item 7 (web bundles) — nothing under `frontend/`.
- Item 6 (observability) — `_build_*_screen` builders run every frame, so per tui-standards they carry no logging; this change adds only tests.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_012uB3gvLHc1H9ajVxzDSt5N)_