### PR TITLE
offer github as an analysis code source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,8 @@ JIRA_PROJECT_KEY=MYPROJ
 #TEAM_ANALYSIS_AZDO_REPO_ALLOWLIST=my-repo,other-repo
 # Exhaustive Analysis-mode estate boundaries (comma-separated).
 # Every repository/page within these configured containers is discovered.
+# Owners are also settable in Settings → GitHub → Analysis Owners, and pickable
+# per run in the Analysis setup wizard.
 #TEAM_ANALYSIS_GITHUB_OWNERS=my-org,another-owner
 #TEAM_ANALYSIS_AZDO_PROJECTS=MyProject,SharedPlatform
 #TEAM_ANALYSIS_CONFLUENCE_SPACES=ENG,OPS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.51.0"
+version = "2.52.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/analysis/ai_usage.py
+++ b/src/yeaboi/analysis/ai_usage.py
@@ -546,7 +546,7 @@ def collect_ai_activity(
             ",".join(github_owners) or "unconfigured",
             "repository estate",
             "inaccessible",
-            "TEAM_ANALYSIS_GITHUB_OWNERS / GITHUB_TOKEN not set",
+            "no GitHub token or owners — set Settings → GitHub, pass --github-owner, or pick owners in Analysis setup",
         )
 
     azdo_projects = scope.get("azdo") or list(get_team_analysis_azdo_projects())

--- a/src/yeaboi/analysis/engine.py
+++ b/src/yeaboi/analysis/engine.py
@@ -210,6 +210,33 @@ def _available_code_sources() -> list[str]:
     return out
 
 
+def _offerable_code_sources() -> list[str]:
+    """Which code hosts the setup wizard may OFFER, as opposed to scan unattended.
+
+    Deliberately distinct from :func:`_available_code_sources`, which answers
+    "scannable with zero further input" and drives the headless component default
+    (``_default_components``). GitHub needs only a token here because the wizard
+    discovers the owners itself (``_run_code_scope_select``) — whereas a headless
+    run has nobody to ask, so it still requires configured owners. Azure is the
+    same in both: its project list falls back to ``AZURE_DEVOPS_PROJECT``."""
+    out: list[str] = []
+    try:
+        from yeaboi.config import get_github_token
+
+        if get_github_token():
+            out.append("github")
+    except Exception:
+        pass
+    try:
+        from yeaboi.config import get_azure_devops_token, get_team_analysis_azdo_projects
+
+        if get_team_analysis_azdo_projects() and get_azure_devops_token():
+            out.append("azdo")
+    except Exception:
+        pass
+    return out
+
+
 def _available_doc_sources() -> list[str]:
     """Which doc platforms are configured (Confluence, Notion). Used to build the
     picker's Docs row."""

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,38 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.52.0",
+      "date": "2026-08-05",
+      "summary": "Analysis mode now discovers and offers GitHub as a code source in the setup wizard — owners, organizations, and repositories are discovered automatically, and the choice is saved to Settings for future runs. GitHub was technically supported all along but gated behind a configuration key that had no UI surface; now it reaches parity with Azure DevOps, which was always offered once connected.",
+      "highlights": [
+        {
+          "text": "GitHub is now discoverable and selectable in the Analysis setup wizard, on equal footing with Azure DevOps",
+          "areas": [
+            "analysis"
+          ]
+        },
+        {
+          "text": "GitHub owners and organizations are discovered automatically from the configured token, no manual entry needed",
+          "areas": [
+            "analysis"
+          ]
+        },
+        {
+          "text": "Chosen GitHub owners persist in Settings → GitHub → Analysis Owners for future runs and CLI commands",
+          "areas": [
+            "analysis",
+            "settings"
+          ]
+        },
+        {
+          "text": "Fine-grained GitHub PATs now work with Analysis — even if they cannot list organizations, the picker will find them via visible repositories",
+          "areas": [
+            "analysis"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.51.0",
       "date": "2026-08-02",
       "summary": "Daily Standup now flags engineering practices that might cost your team later — work that lands with no ticket, a board left stale after a merge, too many changes open at once, or changes too big to review. Seven deterministic rules catch these patterns per team member, capped at three signals each. Every signal names the exact changes it observed — no LLM is involved in detection. Wrong calls are answered: teammates can thumbs-down to hide a signal and it remembers; thumbs-up confirms it. Answers appear in the TUI, over MCP, and in the shared HTML page where the teammate reading it usually spots the mistake first.",

--- a/src/yeaboi/tools/github.py
+++ b/src/yeaboi/tools/github.py
@@ -169,6 +169,50 @@ def github_analysis_inventory(
     return out
 
 
+def github_list_owners(limit: int = 100) -> list[str]:
+    """List the GitHub owners/orgs visible to the configured token.
+
+    Feeds the Analysis setup picker, whose selection becomes the ``owners``
+    argument of :func:`github_analysis_inventory`. Three sources are unioned
+    because no single one is sufficient: the authenticated login (always
+    available), the user's organisations (classic PATs with ``read:org``), and
+    the owner of every visible repository — a *fine-grained* PAT commonly cannot
+    list orgs at all yet can still see that org's repos, which would otherwise
+    leave the picker empty for the most common modern token.
+
+    A failure in either optional lookup is logged and skipped rather than raised,
+    so a narrow token still yields the login. A client/auth failure propagates —
+    the caller owns the fallback (mirrors ``azdevops_list_projects``).
+    """
+    client = _get_github_client()
+    user = client.get_user()
+    owners: set[str] = set()
+    login = str(getattr(user, "login", "") or "").strip()
+    if login:
+        owners.add(login)
+    try:
+        for org in user.get_orgs()[:limit]:
+            name = str(getattr(org, "login", "") or "").strip()
+            if name:
+                owners.add(name)
+    except Exception as exc:
+        logger.warning("github_list_owners: organisation listing failed: %s", exc)
+    try:
+        # Most-recently-pushed first, NOT alphabetical: the slice is a bound on a
+        # potentially huge repo list, and sorting by name would drop everything
+        # past the cut — silently hiding a "z…" org from the picker, which is the
+        # very failure this lookup exists to prevent. Recency also matches what
+        # the scan itself considers (repos active within the window).
+        for repo in user.get_repos(sort="pushed", direction="desc")[:limit]:
+            name = str(getattr(getattr(repo, "owner", None), "login", "") or "").strip()
+            if name:
+                owners.add(name)
+    except Exception as exc:
+        logger.warning("github_list_owners: repository listing failed: %s", exc)
+    logger.info("github_list_owners: %d owner(s) discovered", len(owners))
+    return sorted(owners, key=str.lower)
+
+
 @tool
 def github_read_repo(repo_url: str, max_depth: int = 2) -> str:
     """Read the repository file tree and return a structured summary.

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -1377,6 +1377,9 @@ def _collect_settings_data() -> dict:
         "AZURE_DEVOPS_TOKEN",
         "AZURE_DEVOPS_TEAM",
         "GITHUB_TOKEN",
+        # Analysis' GitHub repository estate (comma-separated owners/orgs) — the
+        # default that lets CLI/MCP/headless runs scan GitHub without --github-owner.
+        "TEAM_ANALYSIS_GITHUB_OWNERS",
         "VOICE_MODEL",
         "AWS_REGION",
         "AWS_PROFILE",
@@ -6830,25 +6833,86 @@ def _run_member_select(
             return "cancel"
 
 
-def _run_code_project_select(
+# Everything that differs between the two code hosts' scope pickers. The screen,
+# the discovery thread and the key loop are identical, so they live once in
+# _run_code_scope_select and read their wording from here; a second copy of that
+# 70-line body would drift the moment either host gains a state.
+_CODE_SCOPE_PROVIDERS: dict[str, dict] = {
+    "github": {
+        "heading": "GitHub owners",
+        "unit": "owners",
+        "spinner": "Discovering GitHub owners and organisations…",
+        "thread": "analysis-github-owners",
+        # Owner granularity is what the engine takes (github_analysis_inventory
+        # walks an owner's repos), so the cost of one checkbox needs stating.
+        "hint": "Every non-archived repo with activity in the window is scanned.",
+        "empty": "No GitHub owners were visible to the configured token",
+        "require": "Select at least one GitHub owner.",
+        # Nothing pre-checked when config names no owners: discovery here is
+        # UNBOUNDED (personal login + every org, each fanning out to a whole repo
+        # estate), so an all-checked default would scan everything visible after
+        # three Enters. The user says which owners are theirs.
+        "select_all_default": False,
+    },
+    "azdo": {
+        "heading": "Azure projects",
+        "unit": "projects",
+        "spinner": "Discovering accessible Azure projects…",
+        "thread": "analysis-azdo-projects",
+        "hint": "",
+        "empty": "No Azure projects were accessible with the configured PAT",
+        "require": "Select at least one Azure project.",
+        # Azure is only ever offered when a project is already configured, so the
+        # config default always matches; all-checked is its pre-existing fallback.
+        "select_all_default": True,
+    },
+}
+
+
+def _code_scope_discovery(provider: str):
+    """(discover, configured_default) callables for one code host.
+
+    Imported lazily and separately from the driver so tests can monkeypatch the
+    underlying tool functions, and so a missing provider SDK never costs the
+    other host its picker."""
+    if provider == "github":
+        from yeaboi.config import get_team_analysis_github_owners
+        from yeaboi.tools.github import github_list_owners
+
+        return github_list_owners, get_team_analysis_github_owners
+    if provider == "azdo":
+        from yeaboi.config import get_team_analysis_azdo_projects
+        from yeaboi.tools.azure_devops import azdevops_list_projects
+
+        return azdevops_list_projects, get_team_analysis_azdo_projects
+    # Fail loudly: silently falling through to Azure would discover the wrong
+    # host's scope under a third host's heading.
+    raise ValueError(f"unknown code-scope provider: {provider}")
+
+
+def _run_code_scope_select(
     live,
     console: Console,
     read_key,
     frame_time: float,
     supports_timeout: bool,
-    initial_projects: list[str] | None = None,
+    *,
+    provider: str,
+    initial: list[str] | None = None,
 ) -> list[str] | str:
-    """Discover accessible Azure projects and choose the code scope for this run.
+    """Discover a code host's scope (GitHub owners, Azure projects) and pick it.
 
-    ``initial_projects`` restores a previous selection on wizard re-entry (discovery
-    itself re-runs; only the checked state carries over)."""
+    ``initial`` restores a previous selection on wizard re-entry (discovery itself
+    re-runs; only the checked state carries over). Discovery failure is a warning
+    on the screen, not an exit — the configured default still lets the run go
+    ahead."""
     import threading
 
-    from yeaboi.config import get_team_analysis_azdo_projects
-    from yeaboi.tools.azure_devops import azdevops_list_projects
+    cfg = _CODE_SCOPE_PROVIDERS[provider]
+    discover, configured_default = _code_scope_discovery(provider)
     from yeaboi.ui.mode_select.screens._screens_secondary import (
         _build_analysis_progress_screen,
-        _build_code_project_select_screen,
+        _build_code_scope_select_screen,
     )
 
     result: list = [None]
@@ -6857,54 +6921,67 @@ def _run_code_project_select(
 
     def _discover() -> None:
         try:
-            result[0] = azdevops_list_projects()
+            result[0] = discover()
         except Exception as exc:
+            # The screen shows this, but a run that quietly fell back to config
+            # would otherwise leave no trace of WHY its scope was narrow.
+            logger.warning("Analysis %s scope discovery failed: %s", provider, exc)
             error[0] = str(exc)
-            result[0] = list(get_team_analysis_azdo_projects())
+            result[0] = list(configured_default())
         finally:
             done.set()
 
+    logger.info("Analysis %s scope: discovering", provider)
     started = time.monotonic()
-    threading.Thread(target=_discover, name="analysis-azdo-projects", daemon=True).start()
+    threading.Thread(target=_discover, name=cfg["thread"], daemon=True).start()
     tick = 0.0
     while not done.is_set():
         tick += frame_time
         w, h = console.size
         live.update(
             _build_analysis_progress_screen(
-                ["Discovering accessible Azure projects…"],
+                [cfg["spinner"]],
                 width=w,
                 height=h,
                 elapsed=time.monotonic() - started,
                 anim_tick=tick,
-                source="azdo",
+                source=provider,
                 mode="analysis",
             )
         )
         time.sleep(frame_time)
 
-    projects = sorted(dict.fromkeys(result[0] or ()), key=str.lower)
-    if not projects:
-        return "cancel"
-    if initial_projects is not None:
-        wanted = {name.lower() for name in initial_projects}
-        checked = {idx for idx, name in enumerate(projects) if name.lower() in wanted}
+    items = sorted(dict.fromkeys(result[0] or ()), key=str.lower)
+    if initial is not None:
+        wanted = {name.lower() for name in initial}
+        checked = {idx for idx, name in enumerate(items) if name.lower() in wanted}
     else:
         checked = set()
     if not checked:
-        defaults = {name.lower() for name in get_team_analysis_azdo_projects()}
-        checked = {idx for idx, name in enumerate(projects) if name.lower() in defaults}
-    if not checked:
-        checked = set(range(len(projects)))
+        defaults = {name.lower() for name in configured_default()}
+        checked = {idx for idx, name in enumerate(items) if name.lower() in defaults}
+    if not checked and cfg["select_all_default"]:
+        checked = set(range(len(items)))
     cursor = 0
-    message = f"Discovery warning: {error[0]}" if error[0] else ""
+    # An empty estate is a real outcome, not a crash: stay on the screen and say
+    # why, so Esc back to the sources step is an informed choice.
+    if error[0]:
+        message = f"Discovery warning: {error[0]}"
+    elif not items:
+        message = cfg["empty"] + " — press Esc to go back."
+    else:
+        message = ""
     while True:
         w, h = console.size
         live.update(
-            _build_code_project_select_screen(
-                projects,
+            _build_code_scope_select_screen(
+                items,
                 checked,
                 cursor,
+                heading=cfg["heading"],
+                unit=cfg["unit"],
+                empty_label=cfg["empty"],
+                hint=cfg["hint"],
                 width=w,
                 height=h,
                 message=message,
@@ -6912,18 +6989,27 @@ def _run_code_project_select(
         )
         key = read_key(timeout=frame_time) if supports_timeout else read_key()
         if key in ("up", "down", "left", "right", "scroll_up", "scroll_down"):
-            cursor = _move_analysis_list_cursor(cursor, key, len(projects))
-        elif key == " ":
+            cursor = _move_analysis_list_cursor(cursor, key, len(items))
+        elif key == " " and items:
             checked.symmetric_difference_update({cursor})
             message = ""
-        elif key in ("a", "A"):
-            checked = set() if len(checked) == len(projects) else set(range(len(projects)))
+        elif key in ("a", "A") and items:
+            checked = set() if len(checked) == len(items) else set(range(len(items)))
             message = ""
         elif key == "enter":
             if not checked:
-                message = "Select at least one Azure project."
+                # "Select at least one…" is impossible advice with nothing to
+                # select, so an empty estate names the way out instead.
+                message = cfg["require"] if items else cfg["empty"] + " — press Esc to go back."
                 continue
-            return [projects[idx] for idx in sorted(checked)]
+            selected = [items[idx] for idx in sorted(checked)]
+            logger.info(
+                "Analysis %s scope: %d discovered, %d selected",
+                provider,
+                len(items),
+                len(selected),
+            )
+            return selected
         elif key in ("esc", "q"):
             return "cancel"
 
@@ -7177,7 +7263,20 @@ def _run_analysis_roster_lookup(
 # loops (and exited the app). Esc/"cancel" moves the index backward; steps whose
 # predicate no longer holds are transparent in BOTH directions, so backing over
 # e.g. the model offer after switching to Quick depth skips it cleanly.
-_WIZARD_STEPS = ("features", "sources", "code_projects", "depth", "model", "window", "members", "review")
+# One entry per SCREEN — the walker below expresses "back" only as index -= 1, so
+# a step that ran two pickers could not offer Esc between them. Hence one scope
+# step per code host, ordered github-then-azdo to match the Code row's order.
+_WIZARD_STEPS = (
+    "features",
+    "sources",
+    "github_owners",
+    "azdo_projects",
+    "depth",
+    "model",
+    "window",
+    "members",
+    "review",
+)
 
 
 def _run_analysis_setup_wizard(
@@ -7206,6 +7305,7 @@ def _run_analysis_setup_wizard(
     state: dict = {
         "features": None,
         "components": None,
+        "github_owners": None,
         "azdo_projects": None,
         "depth": "deep",
         "model": None,
@@ -7245,8 +7345,9 @@ def _run_analysis_setup_wizard(
         comps = state["components"] or {}
         if step in ("features", "sources", "review"):
             return True
-        if step == "code_projects":
-            return bool(fs & {"ai_footprint", "code_health"}) and "azdo" in (comps.get("code") or [])
+        if step in ("github_owners", "azdo_projects"):
+            host = "github" if step == "github_owners" else "azdo"
+            return bool(fs & {"ai_footprint", "code_health"}) and host in (comps.get("code") or [])
         if step == "depth":
             return _depth_applicable()
         if step == "model":
@@ -7261,12 +7362,17 @@ def _run_analysis_setup_wizard(
         comps = state["components"] or {}
         members = state["members"] if _applicable("members") else None
         trackers = comps.get("delivery") or roster_fallback
+        # Each host's scope is gated on its OWN applicability, so de-selecting a
+        # code host at the sources step coerces its stale picks out of the payload
+        # (the same discipline that keeps a stale Deep depth out of a docs-only run).
+        scope: dict[str, list[str]] = {}
+        for _step, _host in (("github_owners", "github"), ("azdo_projects", "azdo")):
+            if _applicable(_step) and state[_step]:
+                scope[_host] = state[_step]
         return {
             "features": state["features"],
             "components": comps,
-            "analysis_scope": (
-                {"azdo": state["azdo_projects"]} if _applicable("code_projects") and state["azdo_projects"] else {}
-            ),
+            "analysis_scope": scope,
             "depth": _effective_depth(),
             "model": state["model"] if _applicable("model") else None,
             "window_days": state["window_days"] if _applicable("window") else 120,
@@ -7346,18 +7452,19 @@ def _run_analysis_setup_wizard(
                 return "back"
             state["components"] = chosen
             return "next"
-        if step == "code_projects":
-            chosen = _run_code_project_select(
+        if step in ("github_owners", "azdo_projects"):
+            chosen = _run_code_scope_select(
                 live,
                 console,
                 read_key,
                 frame_time,
                 supports_timeout,
-                initial_projects=state["azdo_projects"],
+                provider="github" if step == "github_owners" else "azdo",
+                initial=state[step],
             )
             if chosen == "cancel":
                 return "back"
-            state["azdo_projects"] = chosen
+            state[step] = chosen
             return "next"
         if step == "depth":
             chosen = _run_analysis_depth_select(
@@ -12113,15 +12220,18 @@ def select_mode(
                         from yeaboi.analysis import run_team_analysis
                         from yeaboi.analysis.engine import (
                             AnalysisCancelledError,
-                            _available_code_sources,
                             _available_doc_sources,
                             _available_sources,
+                            _offerable_code_sources,
                         )
 
                         # Unified component grid: each component picks its OWN configured
                         # sub-sources (delivery \u2190 jira/azdevops, code \u2190 github/azdo, docs
-                        # \u2190 confluence/notion). The wizard owns Esc-back navigation;
-                        # backing out of its first step returns to the analysis screen.
+                        # \u2190 confluence/notion). The Code row lists hosts the wizard can
+                        # SCOPE, not only ones already scoped in config \u2014 GitHub owners are
+                        # discovered in-wizard, so a bare token is enough to offer it. The
+                        # wizard owns Esc-back navigation; backing out of its first step
+                        # returns to the analysis screen.
                         _ta_setup = _run_analysis_setup_wizard(
                             live,
                             console,
@@ -12130,7 +12240,7 @@ def select_mode(
                             _supports_timeout,
                             grid={
                                 "delivery": _available_sources(),
-                                "code": _available_code_sources(),
+                                "code": _offerable_code_sources(),
                                 "docs": _available_doc_sources(),
                             },
                             roster_fallback=_available_sources(),
@@ -13689,8 +13799,8 @@ def select_mode(
 
                     from yeaboi.analysis.engine import (
                         AnalysisCancelledError,
-                        _available_code_sources,
                         _available_doc_sources,
+                        _offerable_code_sources,
                     )
 
                     # The wizard owns the whole setup sequence (Esc steps back one
@@ -13704,7 +13814,8 @@ def select_mode(
                         _supports_timeout,
                         grid={
                             "delivery": _delivery_grid,
-                            "code": _available_code_sources(),
+                            # Offerable, not merely configured — see the sibling call site.
+                            "code": _offerable_code_sources(),
                             "docs": _available_doc_sources(),
                         },
                         roster_fallback=_delivery_grid,

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -998,41 +998,59 @@ def _build_member_select_screen(
     return build_page_panel(content, theme=ANALYSIS_THEME, height=height)
 
 
-def _build_code_project_select_screen(
-    projects: list[str],
+def _build_code_scope_select_screen(
+    items: list[str],
     checked: set[int],
     cursor: int,
     *,
+    heading: str = "Azure projects",
+    unit: str = "projects",
+    empty_label: str = "No projects found",
+    hint: str = "",
     width: int = 80,
     height: int = 24,
     message: str = "",
 ) -> Panel:
-    """Azure code-project multi-select for one Analysis run."""
+    """Code-scope multi-select for one Analysis run (Azure projects, GitHub owners).
+
+    One screen for both hosts: they differ only in wording, and a second copy
+    would drift the moment either gains a state. ``hint`` states what selecting an
+    entry costs — GitHub owners expand to every active repo underneath them, which
+    the user has no other way to see before pressing Enter."""
     theme = ANALYSIS_THEME
     rows: list[Text] = []
-    for idx, project in enumerate(projects):
+    for idx, item in enumerate(items):
         rows.append(
             _analysis_toggle_row(
-                project,
+                item,
                 "",
                 focused=idx == cursor,
                 selected=idx in checked,
             )
         )
     header = _analysis_setup_header(
-        "Azure projects",
+        heading,
         "Arrows move · Space selects · A selects all · Enter continues",
         message=message,
     )
+    # Empty discovery is a real outcome (a token with no visible orgs, a PAT
+    # scoped to nothing) — say so in the list rather than render a blank viewport.
+    if not items:
+        viewport_renderable = _analysis_toggle_row(empty_label, "", focused=False, enabled=False)
+    else:
+        viewport_renderable = _analysis_toggle_viewport(rows, cursor, height=height, header_h=12)
+    scope_lines = [Text(_PAD + f"{len(checked)} of {len(items)} {unit} selected", style=theme.accent_bright)]
+    if hint:
+        scope_lines.append(Text(_PAD + hint, style=theme.muted))
     return build_page_panel(
         Group(
             Text(""),
             _analysis_setup_title(width, height),
             Text(""),
             *header,
-            Text(_PAD + f"{len(checked)} of {len(projects)} projects selected", style=theme.accent_bright),
+            *scope_lines,
             Text(""),
-            _analysis_toggle_viewport(rows, cursor, height=height, header_h=12),
+            viewport_renderable,
         ),
         theme=ANALYSIS_THEME,
         height=height,
@@ -1079,10 +1097,13 @@ def _build_analysis_setup_review_screen(
         for component in ("delivery", "code", "docs")
         for source in components.get(component, [])
     ]
-    projects = analysis_scope.get("azdo") or []
     source_value = _summarize(source_names)
-    if projects:
-        source_value += f"\nAzure projects: {_summarize(projects)}"
+    # Both code hosts can carry a scope; the compact branch below folds the extra
+    # lines onto one with " · ", so adding a host costs no layout work.
+    for _scope_key, _scope_label in (("github", "GitHub owners"), ("azdo", "Azure projects")):
+        _scope_values = analysis_scope.get(_scope_key) or []
+        if _scope_values:
+            source_value += f"\n{_scope_label}: {_summarize(_scope_values)}"
     people_value = _summarize(members) if members else "All available team members"
     settings = f"{depth.title()} · {window_days} days"
     if model:
@@ -6158,6 +6179,25 @@ def _build_settings_screen(
         _heading("GitHub", wide=True)
         _row("Token", config_data.get("GITHUB_TOKEN", ""), masked=True, env="GITHUB_TOKEN")
         _token_help("GITHUB_TOKEN")
+        # The repository estate Analysis scans (comma-separated owners/orgs). The
+        # TUI wizard discovers and picks these per run, so this row is the default
+        # that lets CLI/MCP/headless runs reach GitHub without --github-owner.
+        _gh_owners = config_data.get("TEAM_ANALYSIS_GITHUB_OWNERS", "")
+        # Unset does not mean "nothing will be scanned": the getter falls back to
+        # the owner of STANDUP_GITHUB_REPO, so name that owner rather than imply
+        # headless runs have no estate at all.
+        _gh_legacy = (config_data.get("STANDUP_GITHUB_REPO", "") or "").split("/", 1)[0]
+        _gh_placeholder = (
+            f"{_gh_legacy} (from Standup repo) — chosen per run in Analysis setup"
+            if _gh_legacy
+            else "not set — chosen per run in Analysis setup"
+        )
+        _row(
+            "Analysis Owners",
+            _gh_owners or _gh_placeholder,
+            value_style="" if _gh_owners else theme.dim,
+            env="TEAM_ANALYSIS_GITHUB_OWNERS",
+        )
 
     def _sec_notion() -> None:
         # Independent doc tool (its own integration token, unlike Confluence).

--- a/tests/unit/test_ai_usage.py
+++ b/tests/unit/test_ai_usage.py
@@ -406,6 +406,52 @@ class TestCollectAiActivity:
         assert items and items[0]["source"] == "github"
         assert repos == ["GitHub (remote): o/r"]
 
+    def test_scope_owners_bypass_the_legacy_single_repo_shim(self, monkeypatch):
+        # The wizard now supplies owners, which must win over STANDUP_GITHUB_REPO:
+        # scanning one repo when the user picked an org IS the bug being fixed.
+        monkeypatch.setattr("yeaboi.config.get_standup_github_repo", lambda: "o/r")
+        monkeypatch.setattr("yeaboi.config.get_github_token", lambda: "tok")
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_github_owners", lambda: ())
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_project", lambda: "")
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_token", lambda: None)
+        seen: list = []
+
+        def _inventory(owners, days=120, include_trees=True):
+            seen.append(tuple(owners))
+            return [{"provider": "github", "container": "acme", "name": "acme/api", "active": True, "paths": []}]
+
+        monkeypatch.setattr("yeaboi.tools.github.github_analysis_inventory", _inventory)
+        monkeypatch.setattr(
+            "yeaboi.tools.github.github_recent_commits",
+            lambda repo, days=1, **k: [{"kind": "commit", "author": "A", "title": "x", "body": ""}],
+        )
+        monkeypatch.setattr("yeaboi.tools.github.github_recent_prs", lambda repo, days=1, **k: [])
+        _items, sources, _coverage, repos = collect_ai_activity("jira", "PROJ", analysis_scope={"github": ["acme"]})
+        assert seen == [("acme",)]
+        assert sources == ["github"]
+        assert repos == ["GitHub (remote): acme/api"]
+
+    def test_legacy_single_repo_shim_still_fires_without_a_scope(self, monkeypatch):
+        # Headless runs with only STANDUP_GITHUB_REPO keep their 1-repo behaviour —
+        # the picker must not have widened anyone's scan by side effect.
+        monkeypatch.setattr("yeaboi.config.get_standup_github_repo", lambda: "o/r")
+        monkeypatch.setattr("yeaboi.config.get_github_token", lambda: "tok")
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_project", lambda: "")
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_token", lambda: None)
+        monkeypatch.delenv("TEAM_ANALYSIS_GITHUB_OWNERS", raising=False)
+
+        def _boom(*a, **k):
+            raise AssertionError("estate discovery must not run without configured owners")
+
+        monkeypatch.setattr("yeaboi.tools.github.github_analysis_inventory", _boom)
+        monkeypatch.setattr(
+            "yeaboi.tools.github.github_recent_commits",
+            lambda repo, days=1, **k: [{"kind": "commit", "author": "A", "title": "x", "body": ""}],
+        )
+        monkeypatch.setattr("yeaboi.tools.github.github_recent_prs", lambda repo, days=1, **k: [])
+        _items, sources, _coverage, repos = collect_ai_activity("jira", "PROJ")
+        assert sources == ["github"] and repos == ["GitHub (remote): o/r"]
+
     def test_sub_sources_restricts_to_azdo_only(self, monkeypatch):
         # GitHub is configured but not requested → skipped; only Azure Repos scanned.
         monkeypatch.setattr("yeaboi.config.get_standup_github_repo", lambda: "o/r")

--- a/tests/unit/test_analysis_engine.py
+++ b/tests/unit/test_analysis_engine.py
@@ -714,3 +714,45 @@ class TestCliRunLearn:
         buf = io.StringIO()
         _run_learn(Console(file=buf, width=100))
         assert "No tracker configured" in buf.getvalue()
+
+
+class TestOfferableCodeSources:
+    """The Code row's gate, which is deliberately looser than the headless one.
+
+    ``_offerable_code_sources`` answers "what can the wizard set up during this
+    run"; ``_available_code_sources`` answers "what is scannable with zero further
+    input" and drives the headless component default. Collapsing the two would
+    either hide GitHub from the picker (the bug) or make headless runs emit an
+    empty code section for a user who never configured owners.
+    """
+
+    @staticmethod
+    def _gates(monkeypatch, *, gh_token="", gh_owners=(), azdo_token="", azdo_projects=()):
+        from yeaboi.analysis.engine import _available_code_sources, _offerable_code_sources
+
+        monkeypatch.setattr("yeaboi.config.get_github_token", lambda: gh_token)
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_github_owners", lambda: tuple(gh_owners))
+        monkeypatch.setattr("yeaboi.config.get_azure_devops_token", lambda: azdo_token)
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_azdo_projects", lambda: tuple(azdo_projects))
+        return _offerable_code_sources(), _available_code_sources()
+
+    def test_bare_token_is_offerable_but_not_yet_scannable(self, monkeypatch):
+        offerable, available = self._gates(monkeypatch, gh_token="ghp_x")
+        assert offerable == ["github"]
+        assert available == []
+
+    def test_configured_owners_satisfy_both_gates(self, monkeypatch):
+        offerable, available = self._gates(monkeypatch, gh_token="ghp_x", gh_owners=("acme",))
+        assert offerable == ["github"] and available == ["github"]
+
+    def test_no_token_offers_nothing(self, monkeypatch):
+        # Owners without a token are unusable — the picker must not offer a host
+        # whose discovery call would fail on the next screen.
+        offerable, available = self._gates(monkeypatch, gh_owners=("acme",))
+        assert offerable == [] and available == []
+
+    def test_azure_gate_is_unchanged_by_the_split(self, monkeypatch):
+        offerable, available = self._gates(monkeypatch, azdo_token="pat", azdo_projects=("Infra",))
+        assert offerable == ["azdo"] and available == ["azdo"]
+        offerable, available = self._gates(monkeypatch, azdo_token="pat")
+        assert offerable == [] and available == []

--- a/tests/unit/test_analysis_screens.py
+++ b/tests/unit/test_analysis_screens.py
@@ -31,7 +31,7 @@ from yeaboi.ui.mode_select.screens._screens_secondary import (
     _build_analysis_review_screen,
     _build_analysis_setup_review_screen,
     _build_analysis_window_screen,
-    _build_code_project_select_screen,
+    _build_code_scope_select_screen,
     _build_component_select_screen,
     _build_generate_confirm_screen,
     _build_instructions_review_screen,
@@ -76,7 +76,7 @@ def _make_body_lines(n: int = 10, prefix: str = "Line") -> list:
 
 def test_code_project_picker_shows_selected_scope():
     rendered = _render(
-        _build_code_project_select_screen(
+        _build_code_scope_select_screen(
             ["Infrastructure", "Product"],
             {1},
             1,
@@ -87,6 +87,46 @@ def test_code_project_picker_shows_selected_scope():
     assert "ANALYSIS SETUP" in rendered and "AZURE PROJECTS" in rendered
     assert "1 of 2 projects selected" in rendered
     assert "Product" in rendered
+
+
+def test_code_scope_picker_rebrands_for_github():
+    rendered = _render(
+        _build_code_scope_select_screen(
+            ["acme-corp", "dinho"],
+            {0},
+            0,
+            heading="GitHub owners",
+            unit="owners",
+            hint="Every non-archived repo with activity in the window is scanned.",
+            width=90,
+            height=24,
+        )
+    )
+    assert "GITHUB OWNERS" in rendered
+    assert "1 of 2 owners selected" in rendered
+    assert "acme-corp" in rendered
+    # The cost of one checkbox (an owner fans out to every active repo) has to be
+    # visible BEFORE Enter — there is no other screen that states it.
+    assert "non-archived repo" in rendered
+
+
+def test_code_scope_picker_explains_an_empty_estate():
+    # A token with no visible orgs is a real outcome; a blank viewport reads as a
+    # rendering bug and leaves the user with nothing to act on.
+    rendered = _render(
+        _build_code_scope_select_screen(
+            [],
+            set(),
+            0,
+            heading="GitHub owners",
+            unit="owners",
+            empty_label="No GitHub owners were visible to the configured token",
+            width=90,
+            height=24,
+        )
+    )
+    assert "No GitHub owners were visible" in rendered
+    assert "0 of 0 owners selected" in rendered
 
 
 # ---------------------------------------------------------------------------
@@ -1731,6 +1771,45 @@ class TestAnalysisSetupReviewScreen:
         assert "Alice, Bob" in out
         assert "Deep · 120 days" in out and "qwen3:4b" in out
 
+    def test_both_code_hosts_show_their_own_scope(self):
+        # The review screen is the last chance to notice the wrong owner was
+        # picked, so neither host may be summarised away.
+        out = _render(
+            _build_analysis_setup_review_screen(
+                features=["ai_footprint"],
+                components={"code": ["github", "azdo"]},
+                members=None,
+                analysis_scope={"github": ["acme-corp"], "azdo": ["Infrastructure"]},
+                depth="deep",
+                window_days=120,
+                width=100,
+                height=34,
+            ),
+            width=100,
+        )
+        assert "GitHub owners: acme-corp" in out
+        assert "Azure projects: Infrastructure" in out
+
+    def test_compact_review_folds_both_scopes_onto_one_line(self):
+        # The compact branch renders one Text per label, so the newline-separated
+        # scope lines have to be folded with " · " to survive it at all.
+        out = _render(
+            _build_analysis_setup_review_screen(
+                features=["ai_footprint"],
+                components={"code": ["github", "azdo"]},
+                members=None,
+                analysis_scope={"github": ["acme-corp"], "azdo": ["Infrastructure"]},
+                depth="deep",
+                window_days=120,
+                width=86,
+                height=24,
+            ),
+            width=86,
+        )
+        sources_line = next(line for line in out.splitlines() if "Sources" in line)
+        assert "GitHub owners: acme-corp" in sources_line
+        assert "Azure projects:" in sources_line
+
     def test_review_loop_can_go_back_or_run(self):
         from yeaboi.ui.mode_select import _run_analysis_setup_review
 
@@ -2072,19 +2151,115 @@ class TestComponentAndMemberLoops:
         assert result == {"delivery": ["azdevops"], "code": ["github", "azdo"], "docs": ["confluence"]}
 
     def test_code_project_initial_selection_is_restored(self, monkeypatch):
-        from yeaboi.ui.mode_select import _run_code_project_select
+        from yeaboi.ui.mode_select import _run_code_scope_select
 
         monkeypatch.setattr("yeaboi.tools.azure_devops.azdevops_list_projects", lambda: ["Alpha", "Beta", "Gamma"])
         monkeypatch.setattr("yeaboi.config.get_team_analysis_azdo_projects", lambda: [])
-        result = _run_code_project_select(
+        result = _run_code_scope_select(
             self._FakeLive(),
             self._console(),
             self._reader(["enter"]),
             0.01,
             True,
-            initial_projects=["beta"],
+            provider="azdo",
+            initial=["beta"],
         )
         assert result == ["Beta"]
+
+    def _github_scope(self, keys, monkeypatch, *, owners=None, initial=None, discover=None):
+        from yeaboi.ui.mode_select import _run_code_scope_select
+
+        monkeypatch.setattr(
+            "yeaboi.tools.github.github_list_owners",
+            discover or (lambda: list(owners if owners is not None else ["acme-corp", "dinho"])),
+        )
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_github_owners", lambda: ())
+        return _run_code_scope_select(
+            self._FakeLive(),
+            self._console(),
+            self._reader(keys),
+            0.01,
+            True,
+            provider="github",
+            initial=initial,
+        )
+
+    def test_github_owner_picker_pre_checks_nothing_without_configured_owners(self, monkeypatch):
+        # Discovery here is unbounded — personal login plus every org, each one a
+        # whole repo estate. Pre-checking all of it would make three Enters scan
+        # everything the token can see, so Enter must refuse until the user picks.
+        assert self._github_scope([" ", "enter"], monkeypatch) == ["acme-corp"]
+
+    def test_github_owner_picker_refuses_an_empty_pick(self, monkeypatch):
+        assert self._github_scope(["enter", "down", " ", "enter"], monkeypatch) == ["dinho"]
+
+    def test_github_owner_picker_pre_checks_configured_owners(self, monkeypatch):
+        # A saved Settings default IS an explicit choice, so it arrives checked.
+        from yeaboi.ui.mode_select import _run_code_scope_select
+
+        monkeypatch.setattr("yeaboi.tools.github.github_list_owners", lambda: ["acme-corp", "dinho"])
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_github_owners", lambda: ("acme-corp",))
+        result = _run_code_scope_select(
+            self._FakeLive(),
+            self._console(),
+            self._reader(["enter"]),
+            0.01,
+            True,
+            provider="github",
+        )
+        assert result == ["acme-corp"]
+
+    def test_github_owner_initial_selection_is_restored(self, monkeypatch):
+        assert self._github_scope(["enter"], monkeypatch, initial=["DINHO"]) == ["dinho"]
+
+    def test_github_owner_empty_estate_names_the_way_out(self, monkeypatch):
+        # "Select at least one GitHub owner." is impossible advice with an empty
+        # list — Enter has to point at the only key that works.
+        from yeaboi.ui.mode_select import _run_code_scope_select
+
+        monkeypatch.setattr("yeaboi.tools.github.github_list_owners", lambda: [])
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_github_owners", lambda: ())
+        captured: list = []
+        live = self._FakeLive()
+        live.update = captured.append
+        _run_code_scope_select(
+            live,
+            self._console(),
+            self._reader(["enter", "esc"]),
+            0.01,
+            True,
+            provider="github",
+        )
+        assert "press Esc to go back" in _render(captured[-1])
+
+    def test_github_owner_discovery_failure_falls_back_to_config(self, monkeypatch):
+        # Discovery failing must not strand the wizard: the configured default
+        # still lets the run proceed, with the reason on screen.
+        from yeaboi.ui.mode_select import _run_code_scope_select
+
+        def _boom():
+            raise RuntimeError("bad credentials")
+
+        monkeypatch.setattr("yeaboi.tools.github.github_list_owners", _boom)
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_github_owners", lambda: ("fallback-org",))
+        captured: list = []
+        live = self._FakeLive()
+        live.update = captured.append
+        result = _run_code_scope_select(
+            live,
+            self._console(),
+            self._reader(["enter"]),
+            0.01,
+            True,
+            provider="github",
+        )
+        assert result == ["fallback-org"]
+        assert "bad credentials" in _render(captured[-1])
+
+    def test_github_owner_empty_estate_stays_on_screen(self, monkeypatch):
+        # Enter with nothing to select must not return an empty scope — Esc is the
+        # only way out, so the user goes back and de-selects GitHub deliberately.
+        assert self._github_scope(["enter", "esc"], monkeypatch, owners=[]) == "cancel"
 
     def test_member_selection_can_be_restored_after_review_back(self):
         from yeaboi.ui.mode_select import _run_member_select
@@ -2194,6 +2369,8 @@ class TestAnalysisSetupWizard:
 
     _DOCS_ONLY = {"delivery": [], "code": [], "docs": ["confluence"]}
     _DELIVERY_ONLY = {"delivery": ["jira"], "code": [], "docs": []}
+    _GITHUB_ONLY = {"delivery": [], "code": ["github"], "docs": []}
+    _BOTH_HOSTS = {"delivery": [], "code": ["github", "azdo"], "docs": []}
 
     def _wizard(self, monkeypatch, keys, grid, *, roster=("Alice",), preflight=None, lookup_fails=False):
         from types import SimpleNamespace
@@ -2204,6 +2381,12 @@ class TestAnalysisSetupWizard:
             "yeaboi.analysis.llm_runtime.get_ollama_analysis_preflight",
             lambda db_path: preflight or {"offer": False},
         )
+        # Code-scope discovery is a network call per host; stub both regardless of
+        # the grid so a step that becomes applicable mid-test can never reach out.
+        monkeypatch.setattr("yeaboi.tools.github.github_list_owners", lambda: ["acme-corp", "dinho"])
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_github_owners", lambda: ())
+        monkeypatch.setattr("yeaboi.tools.azure_devops.azdevops_list_projects", lambda: ["Infra", "Product"])
+        monkeypatch.setattr("yeaboi.config.get_team_analysis_azdo_projects", lambda: ())
         lookup_result = (
             None if lookup_fails else SimpleNamespace(members=[SimpleNamespace(name=name) for name in roster])
         )
@@ -2274,6 +2457,45 @@ class TestAnalysisSetupWizard:
         # instead of exiting the app.
         keys = ["enter", "enter", "enter", "esc", "esc", "esc"]
         assert self._wizard(monkeypatch, keys, self._DELIVERY_ONLY, lookup_fails=True) is None
+
+    def test_github_owners_reach_the_run_config(self, monkeypatch):
+        # The whole point of the fix: a GitHub-only code estate produces a scope
+        # the engine can act on, without any AzDO involvement.
+        # features → sources → owners ("a" selects all, since nothing is
+        # pre-checked without configured owners) → depth → window → members → review
+        keys = ["enter", "enter", "a", "enter", "enter", "enter", "enter", "enter"]
+        config = self._wizard(monkeypatch, keys, self._GITHUB_ONLY)
+        assert config["components"] == {"code": ["github"]}
+        assert config["analysis_scope"] == {"github": ["acme-corp", "dinho"]}
+
+    def test_esc_from_azure_picker_lands_on_github_picker_with_its_pick_intact(self, monkeypatch):
+        # Two scope screens, so Esc must step between them — the reason each host
+        # gets its own wizard step rather than one combined screen.
+        keys = [
+            *["enter", "enter"],  # features → sources
+            *[" ", "enter"],  # owners: check the first owner only
+            *["esc"],  # azdo projects → back to owners
+            *["enter"],  # owners again, selection restored
+            *["enter", "enter", "enter", "enter", "enter"],  # azdo → depth → window → members → review
+        ]
+        config = self._wizard(monkeypatch, keys, self._BOTH_HOSTS)
+        assert config["analysis_scope"]["github"] == ["acme-corp"]
+        assert config["analysis_scope"]["azdo"] == ["Infra", "Product"]
+
+    def test_deselecting_github_coerces_its_scope_out(self, monkeypatch):
+        # Same discipline as the stale-depth case: a host dropped at the sources
+        # step must not leak its owners into the payload.
+        keys = [
+            *["enter", "enter", "a", "enter"],  # features → sources → owners (all)
+            *["enter", "enter", "enter", "enter"],  # azdo → depth → window → members
+            *["esc"] * 6,  # review→members→window→depth→azdo→owners→sources
+            *["down", " ", "enter"],  # sources: deselect github, leaving azdo
+            *["enter", "enter", "enter", "enter", "enter"],  # azdo → depth → window → members → review
+        ]
+        config = self._wizard(monkeypatch, keys, self._BOTH_HOSTS)
+        assert config["components"]["code"] == ["azdo"]
+        assert "github" not in config["analysis_scope"]
+        assert config["analysis_scope"]["azdo"] == ["Infra", "Product"]
 
     def test_empty_roster_is_transparent_in_both_directions(self, monkeypatch):
         # Forward: members auto-advances to review. Backward: Esc from review

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -772,6 +772,34 @@ class TestAllowedPaths:
         assert get_allowed_paths() == ("/existing", "/new")
 
 
+class TestTeamAnalysisGithubOwners:
+    """The GitHub estate Analysis scans (TEAM_ANALYSIS_GITHUB_OWNERS).
+
+    Now settable from Settings and pickable per run, so the parse and the legacy
+    fallback are what the TUI's pre-checked defaults are built from.
+    """
+
+    def test_csv_parsed_and_deduped(self, monkeypatch):
+        from yeaboi.config import get_team_analysis_github_owners
+
+        monkeypatch.setenv("TEAM_ANALYSIS_GITHUB_OWNERS", "acme, zeta ,acme,,  ")
+        assert get_team_analysis_github_owners() == ("acme", "zeta")
+
+    def test_falls_back_to_the_standup_repo_owner(self, monkeypatch):
+        from yeaboi.config import get_team_analysis_github_owners
+
+        monkeypatch.delenv("TEAM_ANALYSIS_GITHUB_OWNERS", raising=False)
+        monkeypatch.setenv("STANDUP_GITHUB_REPO", "acme/widget")
+        assert get_team_analysis_github_owners() == ("acme",)
+
+    def test_empty_when_nothing_is_configured(self, monkeypatch):
+        from yeaboi.config import get_team_analysis_github_owners
+
+        monkeypatch.delenv("TEAM_ANALYSIS_GITHUB_OWNERS", raising=False)
+        monkeypatch.delenv("STANDUP_GITHUB_REPO", raising=False)
+        assert get_team_analysis_github_owners() == ()
+
+
 class TestStorageAndExportConfig:
     """Data-dir override + setup-owned publish destinations (with natural fallbacks)."""
 

--- a/tests/unit/test_shared_components.py
+++ b/tests/unit/test_shared_components.py
@@ -855,6 +855,35 @@ class TestSettingsScreen:
         assert "github.com/settings/tokens" in out  # GitHub creation link
         assert "Work Items" in out  # Azure scope text
 
+    def test_analysis_owners_row_rendered(self):
+        # The GitHub estate Analysis scans. Without an editable row here the key
+        # was only reachable by hand-editing .env, which is why GitHub never
+        # appeared as a code source. Rendered wide so the value is not ellipsized.
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_settings_screen
+
+        panel = _build_settings_screen(
+            {"GITHUB_TOKEN": "ghp_x", "TEAM_ANALYSIS_GITHUB_OWNERS": "acme-corp,zeta-labs"},
+            width=160,
+            height=80,
+            active_tab=0,
+        )
+        output = self._text(panel, width=160, height=80)
+        assert "Analysis Owners" in output
+        assert "acme-corp,zeta-labs" in output
+
+    def test_analysis_owners_empty_points_at_the_wizard(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_settings_screen
+
+        panel = _build_settings_screen({"GITHUB_TOKEN": "ghp_x"}, width=160, height=80, active_tab=0)
+        assert "chosen per run in Analysis setup" in self._text(panel, width=160, height=80)
+
+    def test_analysis_owners_is_an_editable_row(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_settings_screen
+
+        panel = _build_settings_screen({"GITHUB_TOKEN": "ghp_x"}, width=160, height=80, active_tab=0)
+        envs = [f[0] for box in panel._box_fields for f in box]
+        assert "TEAM_ANALYSIS_GITHUB_OWNERS" in envs  # reachable by keyboard and click
+
     def test_token_help_url_is_clickable(self):
         # The creation URL is an OSC-8 hyperlink in the read-only dashboard too.
         from io import StringIO
@@ -901,6 +930,15 @@ class TestCollectSettingsData:
         monkeypatch.setenv("YEABOI_ALLOWED_PATHS", "/a,/b")
         data = _collect_settings_data()
         assert data["YEABOI_ALLOWED_PATHS"] == "/a,/b"
+
+    def test_includes_analysis_github_owners(self, monkeypatch):
+        # An unregistered key renders blank however it is set, so the row would
+        # silently never show a saved value.
+        from yeaboi.ui.mode_select import _collect_settings_data
+
+        monkeypatch.setenv("TEAM_ANALYSIS_GITHUB_OWNERS", "acme,beta")
+        data = _collect_settings_data()
+        assert data["TEAM_ANALYSIS_GITHUB_OWNERS"] == "acme,beta"
 
 
 class TestSettingsSaveAllowedPaths:

--- a/tests/unit/tools/test_tools_github.py
+++ b/tests/unit/tools/test_tools_github.py
@@ -776,3 +776,99 @@ class TestGithubRecentReviews:
         assert _author_type(self._user("acme-scan[bot]")) == "bot"
         assert _author_type(self._user("alice")) == ""
         assert _author_type(None) == ""
+
+
+class TestGithubListOwners:
+    """Owner discovery for the Analysis setup picker.
+
+    Three independent lookups are unioned because no single one covers every
+    token shape — the tests pin that a token which can do only one of them still
+    produces a usable list rather than an empty picker.
+    """
+
+    @staticmethod
+    def _user(login: str, *, orgs=(), repos=(), orgs_fail=False, repos_fail=False):
+        def _get_orgs():
+            if orgs_fail:
+                raise RuntimeError("read:org scope missing")
+            return list(orgs)
+
+        def _get_repos(**_kwargs):
+            if repos_fail:
+                raise RuntimeError("repo listing forbidden")
+            return list(repos)
+
+        user = MagicMock()
+        user.login = login
+        user.get_orgs.side_effect = _get_orgs
+        user.get_repos.side_effect = _get_repos
+        return user
+
+    @staticmethod
+    def _named(login: str):
+        return MagicMock(login=login)
+
+    @staticmethod
+    def _repo(owner_login: str):
+        return MagicMock(owner=MagicMock(login=owner_login))
+
+    @patch("yeaboi.tools.github._get_github_client")
+    def test_unions_login_orgs_and_repo_owners(self, mock_client):
+        from yeaboi.tools.github import github_list_owners
+
+        mock_client.return_value.get_user.return_value = self._user(
+            "dinho",
+            orgs=[self._named("Acme-Corp")],
+            # Acme-Corp repeats via a repo, and a repo can reveal an org the
+            # orgs endpoint never returned — both must collapse to one entry.
+            repos=[self._repo("Acme-Corp"), self._repo("zeta-labs"), self._repo("dinho")],
+        )
+
+        assert github_list_owners() == ["Acme-Corp", "dinho", "zeta-labs"]
+
+    @patch("yeaboi.tools.github._get_github_client")
+    def test_org_listing_failure_still_returns_the_login(self, mock_client):
+        # A fine-grained PAT commonly cannot list orgs at all; losing the login
+        # too would leave the picker empty for the most common modern token.
+        from yeaboi.tools.github import github_list_owners
+
+        mock_client.return_value.get_user.return_value = self._user("dinho", orgs_fail=True, repos_fail=True)
+
+        assert github_list_owners() == ["dinho"]
+
+    @patch("yeaboi.tools.github._get_github_client")
+    def test_repo_listing_recovers_orgs_the_token_cannot_enumerate(self, mock_client):
+        from yeaboi.tools.github import github_list_owners
+
+        mock_client.return_value.get_user.return_value = self._user(
+            "dinho", orgs_fail=True, repos=[self._repo("acme-corp")]
+        )
+
+        assert github_list_owners() == ["acme-corp", "dinho"]
+
+    @patch("yeaboi.tools.github._get_github_client")
+    def test_auth_failure_propagates_to_the_caller(self, mock_client):
+        # The picker owns the fallback (configured owners + an on-screen warning),
+        # so a dead client must not be flattened into "no owners exist".
+        import pytest
+
+        from yeaboi.tools.github import github_list_owners
+
+        mock_client.return_value.get_user.side_effect = RuntimeError("bad credentials")
+
+        with pytest.raises(RuntimeError, match="bad credentials"):
+            github_list_owners()
+
+    @patch("yeaboi.tools.github._get_github_client")
+    def test_repo_listing_is_ordered_by_recent_push_not_name(self, mock_client):
+        # The slice is a bound on a possibly huge list; sorting by name would drop
+        # everything past the cut, hiding a "z…" org from the picker — exactly the
+        # invisible-GitHub failure this lookup exists to prevent.
+        from yeaboi.tools.github import github_list_owners
+
+        user = self._user("dinho", orgs_fail=True, repos=[self._repo("zeta-labs")])
+        mock_client.return_value.get_user.return_value = user
+
+        github_list_owners()
+
+        assert user.get_repos.call_args.kwargs == {"sort": "pushed", "direction": "desc"}


### PR DESCRIPTION
## Summary

With GitHub connected, Analysis mode never offered it as a code source — only Azure Repos — even when both were configured in Settings.

`_available_code_sources()` gated GitHub on `TEAM_ANALYSIS_GITHUB_OWNERS`, and **no UI surface anywhere wrote that key**: not Settings, not the first-run wizard, not the analysis setup wizard. Azure escaped this because `get_team_analysis_azdo_projects()` falls back to `AZURE_DEVOPS_PROJECT`, which Settings does set. GitHub was reachable only by hand-editing `.env`. The engine has supported GitHub scanning all along (`analysis/ai_usage.py`, `tools/github.py:github_analysis_inventory`) — only the gate and the missing config surface were broken.

**What changed**

- **`_offerable_code_sources()`** (`analysis/engine.py`) — the picker needs only a token, because the wizard discovers owners itself. `_available_code_sources()` deliberately stays strict: it also drives `_default_components()` for headless CLI/MCP runs, where nobody can be asked for owners, and relaxing it would have changed headless output shape (a code section instead of `null`) for users who never configured anything.
- **`github_list_owners()`** (`tools/github.py`) — unions the authenticated login, the user's orgs, and the owner of every visible repo. That third lookup is load-bearing: a fine-grained PAT typically cannot list orgs but can still see their repos, so without it the picker would be empty for the most common modern token. Repos are walked most-recently-pushed-first, not alphabetically — the bound is a slice, and sorting by name would silently hide a `z…` org, reproducing the very bug being fixed.
- **Wizard** — the AzDO-only `code_projects` step became per-host `github_owners` / `azdo_projects` steps over one provider-parameterised picker (`_run_code_scope_select`, `_build_code_scope_select_screen`, `_CODE_SCOPE_PROVIDERS`) rather than a duplicated 70-line body. Two steps rather than one combined screen because the wizard walker expresses "back" only as `index -= 1`.
- **Settings → GitHub → Analysis Owners** writes `TEAM_ANALYSIS_GITHUB_OWNERS`, so CLI/MCP/headless runs pick GitHub up too. No new CSV machinery — it rides the same `apply_config_value` / `_csv_config` path as Allowed Paths.

**Scope semantics worth knowing.** An owner fans out to that owner's whole active repo estate, because that is what `github_analysis_inventory(owners, …)` takes; the picker states this above the list. GitHub therefore pre-checks **nothing** when config names no owners — its discovery is unbounded (personal login plus every org), so an all-checked default would scan everything the token can see after three Enters. Azure keeps its all-checked fallback, which was already unreachable in practice since it is only offered once a project is configured. The legacy single-repo `STANDUP_GITHUB_REPO` shim is untouched and still fires for headless runs with no scope, pinned by a regression test.

## Test plan

- `make test` — 9191 passed, 47 skipped (run after rebasing onto `9abfb6b`)
- `make lint` — clean
- `make security` — ruff SAST clean, `pip-audit` reports no known vulnerabilities
- New/updated tests: `github_list_owners` (union, org-listing failure, repo-recovered orgs, auth propagation, push-ordered slice); `_offerable_code_sources` vs `_available_code_sources` divergence; picker render (both hosts, empty estate, hint line); picker driver (defaults, restore, discovery failure fallback, empty-estate dead end); wizard (owners reach the payload, Esc between the two pickers preserves picks, de-selecting a host coerces its scope out); `ai_usage` scope-vs-legacy-shim; Settings row + key registration; `get_team_analysis_github_owners` parse and fallback.
- Manual: with `GITHUB_TOKEN` set and `TEAM_ANALYSIS_GITHUB_OWNERS` unset, the Code row now offers GitHub, the picker discovers owners, and the review screen shows the chosen scope.

An independent fresh-context review ran against the diff before commit; all four `should-fix` findings are resolved in the committed code (empty-estate dead end, the over-wide default select-all, unlogged discovery failure, alphabetical repo truncation).

## Definition of Done

- Linear: [YEA-38](https://linear.app/yeaboi/issue/YEA-38/analysis-setup-never-offers-github-as-a-code-source)
- Item 5 (surface parity) — **no registry change needed**: `team_analyze` already exposes `analysis_scope` and the CLI already has `--github-owner`, already recorded in `CLI_HIDDEN["analyze"]`. `github_list_owners` is a tools-layer helper like `azdevops_list_projects`, which is exposed on no surface. Confirmed independently by the reviewer against `tests/unit/test_surface_parity.py`.
- Item 7 (web bundles) — **not applicable**: no `frontend/` changes.
- Items 8–9 (Notion, Slack) fire on merge via `pr-merged-close-loop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)