### PR TITLE
fix standup generate failing with "no such column: origin"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.55.1"
+version = "2.55.2"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,31 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.55.2",
+      "date": "2026-08-06",
+      "summary": "Fixed standup mode's Generate command failing with \"no such column: origin\" error. The issue was caused by a schema version collision in the session database — a migration that added edit-provenance tracking (`origin` column) was skipped due to version numbering conflicts, but code continued to query for those columns. The fix re-applies the missing migration idempotently, hardens the schema version tracking to prevent duplicates, and adds self-healing to all standalone mode stores so they can repair their own tables on opening.",
+      "highlights": [
+        {
+          "text": "Fixed standup Generate command crashing with \"no such column: origin\" error",
+          "areas": [
+            "standup"
+          ]
+        },
+        {
+          "text": "Database schema repairs are now idempotent and self-healing across all mode stores",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Session database schema version tracking deduplicated and race-guarded to prevent future collisions",
+          "areas": [
+            "general"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.55.1",
       "date": "2026-08-06",
       "summary": "Fixed planning mode's live chat asking about project size twice. The greeting's small-vs-large answer now properly flows through the chat, with mode-aware lead-ins for follow-up questions that acknowledge the earlier choice. Smart mode chat also hides the redundant sprint-count row that only appears for large projects.",

--- a/src/yeaboi/performance/store.py
+++ b/src/yeaboi/performance/store.py
@@ -159,6 +159,19 @@ class PerformanceStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.isolation_level = None  # autocommit
         self._conn.executescript(_PERFORMANCE_SCHEMA)
+        # Idempotent migration: edit-provenance columns (sessions.py v21/v26).
+        # A v21 version-number collision could leave a shared DB stamped past
+        # 21 without them, and the CLI and MCP tools open this store without
+        # ever constructing a SessionStore, so heal here too.
+        for table in ("performance_one_on_ones", "performance_reviews"):
+            for statement in (
+                f"ALTER TABLE {table} ADD COLUMN origin TEXT NOT NULL DEFAULT 'generated'",
+                f"ALTER TABLE {table} ADD COLUMN edited_from_id INTEGER NOT NULL DEFAULT 0",
+            ):
+                try:
+                    self._conn.execute(statement)
+                except sqlite3.OperationalError:
+                    pass  # column already exists
 
     # ── Lifecycle ─────────────────────────────────────────────────────────
 

--- a/src/yeaboi/reporting/store.py
+++ b/src/yeaboi/reporting/store.py
@@ -126,6 +126,19 @@ class ReportingStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.isolation_level = None  # autocommit
         self._conn.executescript(_REPORTING_SCHEMA)
+        # Idempotent migration: edit-provenance columns (sessions.py v21/v26).
+        # A v21 version-number collision could leave a shared DB stamped past
+        # 21 without them, and the CLI and MCP tools open this store without
+        # ever constructing a SessionStore; record_run and get_base_run read
+        # `origin`, so heal here too.
+        for statement in (
+            "ALTER TABLE reporting_history ADD COLUMN origin TEXT NOT NULL DEFAULT 'generated'",
+            "ALTER TABLE reporting_history ADD COLUMN edited_from_id INTEGER NOT NULL DEFAULT 0",
+        ):
+            try:
+                self._conn.execute(statement)
+            except sqlite3.OperationalError:
+                pass  # column already exists
 
     # ── Lifecycle ─────────────────────────────────────────────────────────
 

--- a/src/yeaboi/retro/store.py
+++ b/src/yeaboi/retro/store.py
@@ -112,6 +112,19 @@ class RetroStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.isolation_level = None  # autocommit
         self._conn.executescript(_RETRO_SCHEMA)
+        # Idempotent migration: edit-provenance columns (sessions.py v21/v26).
+        # A v21 version-number collision could leave a shared DB stamped past
+        # 21 without them, and the CLI and MCP tools open this store without
+        # ever constructing a SessionStore; record_run and get_base_run read
+        # `origin`, so heal here too.
+        for statement in (
+            "ALTER TABLE retro_history ADD COLUMN origin TEXT NOT NULL DEFAULT 'generated'",
+            "ALTER TABLE retro_history ADD COLUMN edited_from_id INTEGER NOT NULL DEFAULT 0",
+        ):
+            try:
+                self._conn.execute(statement)
+            except sqlite3.OperationalError:
+                pass  # column already exists
 
     # ── Lifecycle ─────────────────────────────────────────────────────────
 

--- a/src/yeaboi/roadmap/store.py
+++ b/src/yeaboi/roadmap/store.py
@@ -169,6 +169,18 @@ class RoadmapStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.isolation_level = None  # autocommit
         self._conn.executescript(_ROADMAP_SCHEMA)
+        # Idempotent migration: edit-provenance columns (sessions.py v21/v26).
+        # A v21 version-number collision could leave a shared DB stamped past
+        # 21 without them, and the CLI and MCP tools open this store without
+        # ever constructing a SessionStore, so heal here too.
+        for statement in (
+            "ALTER TABLE roadmap_history ADD COLUMN origin TEXT NOT NULL DEFAULT 'generated'",
+            "ALTER TABLE roadmap_history ADD COLUMN edited_from_id INTEGER NOT NULL DEFAULT 0",
+        ):
+            try:
+                self._conn.execute(statement)
+            except sqlite3.OperationalError:
+                pass  # column already exists
 
     # ── Lifecycle ─────────────────────────────────────────────────────────
 

--- a/src/yeaboi/sessions.py
+++ b/src/yeaboi/sessions.py
@@ -128,7 +128,7 @@ CREATE TABLE IF NOT EXISTS sessions_meta (
 #   stored < current → run migrations, UPDATE to current
 #   stored == current → schema_mismatch=False
 # See docs: "Memory & State" — session persistence
-CURRENT_SCHEMA_VERSION = 25  # v1=8A, v2=8B, v3=team_profiles, v4=session_mode, v5=token_usage, v6=standup, v7=retro, v8=performance, v9=reporting, v10=roadmap, v11=roadmap list, v12=token usage perf, v13=analysis ticket cache, v14=standup roster, v15=standup code scope, v16=standup documentation scope, v17=standup Azure project scope, v18=poker, v19=analysis enrichment cache, v20=analysis feature selection, v21=artifact edits, v22=standup transcript review, v23=standup practices, v24=standup practice AI matching, v25=standup practice feedback  # noqa: E501
+CURRENT_SCHEMA_VERSION = 26  # v1=8A, v2=8B, v3=team_profiles, v4=session_mode, v5=token_usage, v6=standup, v7=retro, v8=performance, v9=reporting, v10=roadmap, v11=roadmap list, v12=token usage perf, v13=analysis ticket cache, v14=standup roster, v15=standup code scope, v16=standup documentation scope, v17=standup Azure project scope, v18=poker, v19=analysis enrichment cache, v20=analysis feature selection, v21=artifact edits, v22=standup transcript review, v23=standup practices, v24=standup practice AI matching, v25=standup practice feedback, v26=edit-provenance collision repair  # noqa: E501
 
 _SCHEMA_INFO = """\
 CREATE TABLE IF NOT EXISTS schema_info (
@@ -463,14 +463,40 @@ class SessionStore:
         # so callers can warn the user (newer DB opened by older code).
         # See docs: "Memory & State" — session persistence
         self._conn.execute(_SCHEMA_INFO)
+        # Concurrent first-opens race the stamp INSERT below (nothing enforces
+        # the single-row assumption), leaving duplicate rows and making the
+        # fetchone() below read an arbitrary one. Keep exactly one row — the
+        # highest version, so a newer build's stamp (and schema_mismatch
+        # detection) survives the dedupe. Count first so the steady-state open
+        # stays read-only (a DELETE takes a write lock even when it matches
+        # nothing, and this DB is shared by the TUI, the MCP server and the
+        # scheduler); the repair itself is one atomic DELETE — the connection
+        # is autocommit, so a delete-all-then-reinsert would open a zero-row
+        # window for another process.
+        (info_rows,) = self._conn.execute("SELECT COUNT(*) FROM schema_info").fetchone()
+        if info_rows > 1:
+            cursor = self._conn.execute(
+                "DELETE FROM schema_info WHERE rowid NOT IN "
+                "(SELECT rowid FROM schema_info ORDER BY schema_version DESC, rowid DESC LIMIT 1)"
+            )
+            logger.warning("schema_info held %d duplicate rows; deduped to the highest version", cursor.rowcount)
         row = self._conn.execute("SELECT schema_version FROM schema_info").fetchone()
         if row is None:
-            # Pre-8C DB or brand-new DB — stamp with current version
-            self._conn.execute("INSERT INTO schema_info (schema_version) VALUES (?)", (CURRENT_SCHEMA_VERSION,))
+            # Pre-8C DB or brand-new DB — stamp with current version. Guarded
+            # so two processes racing this branch leave one row, not two.
+            self._conn.execute(
+                "INSERT INTO schema_info (schema_version) SELECT ? WHERE NOT EXISTS (SELECT 1 FROM schema_info)",
+                (CURRENT_SCHEMA_VERSION,),
+            )
             self._run_migrations(0)
             self.schema_mismatch = False
         elif row[0] > CURRENT_SCHEMA_VERSION:
-            # DB was written by a newer version of the code — warn but don't crash
+            # DB was written by a newer version of the code — warn but don't crash.
+            # Still self-heal the v21 collision: a future lineage stamping past
+            # 26 would otherwise skip the repair forever, which is exactly the
+            # failure v26 exists to fix. The body is idempotent and purely
+            # additive, so it is safe on a newer schema.
+            self._apply_edit_provenance()
             self.schema_mismatch = True
         else:
             # row[0] <= CURRENT_SCHEMA_VERSION — up to date (or migrated above)
@@ -707,25 +733,7 @@ class SessionStore:
             # v21: browser-editable shared artifacts. The append-only edit log
             # gets its own table; each history table learns where a row came
             # from, so a corrected report can be told from a generated one.
-            from yeaboi.artifacts.store import _ARTIFACT_EDITS_SCHEMA
-
-            self._conn.executescript(_ARTIFACT_EDITS_SCHEMA)
-            # `origin` and not a new `status` value: get_previous_report filters
-            # status IN ('success','partial'), so a third status would silently
-            # drop every corrected standup out of the next day's comparison.
-            for table in (
-                "standup_history",
-                "retro_history",
-                "reporting_history",
-                "roadmap_history",
-                "performance_one_on_ones",
-                "performance_reviews",
-            ):
-                for column, kind, default in (("origin", "TEXT", "'generated'"), ("edited_from_id", "INTEGER", "0")):
-                    try:
-                        self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {kind} NOT NULL DEFAULT {default}")
-                    except sqlite3.OperationalError:
-                        pass  # column already exists — the block stays idempotent
+            self._apply_edit_provenance()
             logger.info("Migration v21: created artifact_edits and edit-provenance columns")
 
         if from_version < 22:
@@ -781,6 +789,45 @@ class SessionStore:
 
             self._conn.execute(_STANDUP_PRACTICE_FEEDBACK_SCHEMA)
             logger.info("Migration v25: created standup practice feedback ledger")
+
+        if 21 <= from_version < 26:
+            # v26: repair the v21 number collision. A pre-rebase lineage stamped
+            # shared databases at 21 for standup transcript review, so main's
+            # v21 (edit-provenance columns + artifact_edits) was skipped while
+            # the DB went on to v25 — every origin-reading query then fails
+            # with "no such column: origin". The body is idempotent, so
+            # re-running it on a healthy DB is a no-op; the lower bound only
+            # skips the double-run when the v21 branch above just did the same
+            # work. Same idiom as the v19/v20 renumbering above.
+            self._apply_edit_provenance()
+            logger.info("Migration v26: re-applied edit-provenance columns (v21 number collision)")
+
+    def _apply_edit_provenance(self) -> None:
+        """The v21 migration body — idempotent, so v26 re-runs it verbatim.
+
+        A pre-rebase lineage stamped shared databases at 21 with a different
+        meaning (standup transcript review), so a DB could reach v25 with the
+        provenance columns missing. See migration v26.
+        """
+        from yeaboi.artifacts.store import _ARTIFACT_EDITS_SCHEMA
+
+        self._conn.executescript(_ARTIFACT_EDITS_SCHEMA)
+        # `origin` and not a new `status` value: get_previous_report filters
+        # status IN ('success','partial'), so a third status would silently
+        # drop every corrected standup out of the next day's comparison.
+        for table in (
+            "standup_history",
+            "retro_history",
+            "reporting_history",
+            "roadmap_history",
+            "performance_one_on_ones",
+            "performance_reviews",
+        ):
+            for column, kind, default in (("origin", "TEXT", "'generated'"), ("edited_from_id", "INTEGER", "0")):
+                try:
+                    self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {kind} NOT NULL DEFAULT {default}")
+                except sqlite3.OperationalError:
+                    pass  # column already exists — the block stays idempotent
 
     # ── Token usage persistence ──────────────────────────────────────────
 

--- a/src/yeaboi/standup/store.py
+++ b/src/yeaboi/standup/store.py
@@ -485,6 +485,16 @@ class StandupStore:
                ADD COLUMN habit_rules TEXT NOT NULL DEFAULT ''""",
             """ALTER TABLE standup_config
                ADD COLUMN habit_ai_match TEXT NOT NULL DEFAULT 'on'""",
+            # Edit-provenance columns (sessions.py v21/v26): a v21 version-number
+            # collision could leave a DB stamped past 21 without them, and
+            # several entry points (--standup-run, the MCP tools) open this
+            # store without ever constructing a SessionStore. record_run,
+            # get_previous_run and get_base_run all read `origin`, so heal here
+            # too.
+            """ALTER TABLE standup_history
+               ADD COLUMN origin TEXT NOT NULL DEFAULT 'generated'""",
+            """ALTER TABLE standup_history
+               ADD COLUMN edited_from_id INTEGER NOT NULL DEFAULT 0""",
         ):
             try:
                 self._conn.execute(statement)

--- a/tests/unit/test_analysis_sessions.py
+++ b/tests/unit/test_analysis_sessions.py
@@ -52,8 +52,10 @@ class TestSchemaVersion:
         # transcript columns; v23 adds the Standup practice-detection config
         # (habit_detection / habit_rules); v24 adds its LLM relatedness switch
         # (habit_ai_match); v25 adds the practice feedback ledger
-        # (standup_practice_feedback).
-        assert CURRENT_SCHEMA_VERSION == 25
+        # (standup_practice_feedback); v26 re-applies v21 — a pre-rebase
+        # lineage stamped shared DBs at 21 with a different meaning, so the
+        # provenance columns could be missing from a DB already at v25.
+        assert CURRENT_SCHEMA_VERSION == 26
 
     def test_new_db_has_session_mode_column(self, store: SessionStore):
         """A freshly created DB should have the session_mode column."""

--- a/tests/unit/test_artifacts_store.py
+++ b/tests/unit/test_artifacts_store.py
@@ -148,6 +148,27 @@ class TestRecording:
         assert not any(name.startswith("delete") for name in dir(store))
 
 
+def _strip_provenance(conn, table):
+    """Remove the v21 columns by rebuilding the table.
+
+    Not ``ALTER TABLE … DROP COLUMN``: that rewrites the stored CREATE TABLE
+    text and chokes on the inline comments some schemas carry ("incomplete
+    input"), so a swallowed error would leave the column in place and make the
+    migration test vacuous. The result is asserted so setup cannot silently
+    no-op.
+    """
+    keep = ", ".join(
+        row[1] for row in conn.execute(f"PRAGMA table_info({table})") if row[1] not in ("origin", "edited_from_id")
+    )
+    conn.executescript(
+        f"CREATE TABLE {table}_pre AS SELECT {keep} FROM {table};"
+        f"DROP TABLE {table};"
+        f"ALTER TABLE {table}_pre RENAME TO {table};"
+    )
+    remaining = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    assert not {"origin", "edited_from_id"} & remaining, table
+
+
 class TestMigration:
     """A v20 database must reach v21 cleanly, and twice must be the same as once."""
 
@@ -160,11 +181,7 @@ class TestMigration:
         conn.execute("UPDATE schema_info SET schema_version = 20")
         conn.execute("DROP TABLE IF EXISTS artifact_edits")
         for table in ("standup_history", "retro_history", "reporting_history"):
-            for column in ("origin", "edited_from_id"):
-                try:
-                    conn.execute(f"ALTER TABLE {table} DROP COLUMN {column}")
-                except sqlite3.OperationalError:
-                    pass
+            _strip_provenance(conn, table)
         conn.commit()
         conn.close()
         return path
@@ -222,6 +239,125 @@ class TestMigration:
         SessionStore(migrated).close()
         for table in ("standup_history", "retro_history", "reporting_history", "artifact_edits"):
             assert self._columns(fresh, table) == self._columns(migrated, table), table
+
+
+class TestVersionCollisionRepair:
+    """A DB stamped past 21 by the colliding lineage must still gain the columns.
+
+    A pre-rebase branch used version 21 for a different migration and stamped
+    shared databases with it, so main's v21 (edit provenance) was skipped while
+    the DB migrated on to v25. Migration v26 re-runs the idempotent body.
+    """
+
+    _TABLES = (
+        "standup_history",
+        "retro_history",
+        "reporting_history",
+        "roadmap_history",
+        "performance_one_on_ones",
+        "performance_reviews",
+    )
+
+    def _collided_db(self, tmp_path):
+        from yeaboi.sessions import SessionStore
+
+        path = tmp_path / "sessions.db"
+        SessionStore(path).close()  # creates at CURRENT_SCHEMA_VERSION
+        conn = sqlite3.connect(str(path))
+        conn.execute("UPDATE schema_info SET schema_version = 25")
+        conn.execute("DROP TABLE IF EXISTS artifact_edits")
+        for table in self._TABLES:
+            _strip_provenance(conn, table)
+        conn.commit()
+        conn.close()
+        return path
+
+    def _columns(self, path, table):
+        conn = sqlite3.connect(str(path))
+        try:
+            return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        finally:
+            conn.close()
+
+    def test_collided_db_upgrades_to_current(self, tmp_path):
+        from yeaboi.sessions import CURRENT_SCHEMA_VERSION, SessionStore
+
+        path = self._collided_db(tmp_path)
+        store = SessionStore(path)
+        try:
+            assert not store.schema_mismatch
+        finally:
+            store.close()
+        conn = sqlite3.connect(str(path))
+        try:
+            assert conn.execute("SELECT schema_version FROM schema_info").fetchone()[0] == CURRENT_SCHEMA_VERSION
+            assert conn.execute("SELECT COUNT(*) FROM artifact_edits").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+    @pytest.mark.parametrize(
+        "table",
+        [
+            "standup_history",
+            "retro_history",
+            "reporting_history",
+            "roadmap_history",
+            "performance_one_on_ones",
+            "performance_reviews",
+        ],
+    )
+    def test_provenance_columns_repaired(self, tmp_path, table):
+        from yeaboi.sessions import SessionStore
+
+        path = self._collided_db(tmp_path)
+        SessionStore(path).close()
+        assert {"origin", "edited_from_id"} <= self._columns(path, table)
+
+    def test_existing_rows_backfill_generated(self, tmp_path):
+        path = self._collided_db(tmp_path)
+        conn = sqlite3.connect(str(path))
+        conn.execute(
+            "INSERT INTO standup_history (session_id, run_at, standup_date) VALUES ('s1', 'now', '2026-08-01')"
+        )
+        conn.commit()
+        conn.close()
+
+        from yeaboi.sessions import SessionStore
+
+        SessionStore(path).close()
+        conn = sqlite3.connect(str(path))
+        try:
+            row = conn.execute("SELECT origin, edited_from_id FROM standup_history").fetchone()
+            assert row == ("generated", 0)
+        finally:
+            conn.close()
+
+    def test_repair_twice_is_harmless(self, tmp_path):
+        from yeaboi.sessions import SessionStore
+
+        path = self._collided_db(tmp_path)
+        SessionStore(path).close()
+        SessionStore(path).close()  # already repaired — must not raise
+
+    def test_newer_stamp_still_heals(self, tmp_path):
+        # A future lineage stamping past 26 must not re-create the trap: the
+        # schema_mismatch branch runs no migrations, so it applies the
+        # idempotent repair directly.
+        from yeaboi.sessions import CURRENT_SCHEMA_VERSION, SessionStore
+
+        path = self._collided_db(tmp_path)
+        conn = sqlite3.connect(str(path))
+        conn.execute("UPDATE schema_info SET schema_version = ?", (CURRENT_SCHEMA_VERSION + 5,))
+        conn.commit()
+        conn.close()
+
+        store = SessionStore(path)
+        try:
+            assert store.schema_mismatch  # the warning still fires
+        finally:
+            store.close()
+        for table in self._TABLES:
+            assert {"origin", "edited_from_id"} <= self._columns(path, table)
 
 
 class TestEditedRunsSupersede:

--- a/tests/unit/test_performance_store.py
+++ b/tests/unit/test_performance_store.py
@@ -146,3 +146,31 @@ class TestTeamWide:
             store.record_review(SixMonthReview(engineer="Bob", overall="y"))
             reviews = store.get_recent_reviews()
         assert {r.engineer for r in reviews} == {"Ada", "Bob"}
+
+
+class TestProvenanceSelfHeal:
+    """Performance tables missing the v21 provenance columns heal on store open.
+
+    The v21 schema-version collision could leave a shared DB stamped past 21
+    without origin/edited_from_id, and the CLI and MCP tools open this store
+    without ever constructing a SessionStore (whose v26 migration is the other
+    repair path).
+    """
+
+    def test_pre_v21_tables_heal_on_open(self, db_path):
+        import sqlite3
+
+        PerformanceStore(db_path).close()
+        conn = sqlite3.connect(str(db_path))
+        for table in ("performance_one_on_ones", "performance_reviews"):
+            keep = ", ".join(
+                r[1] for r in conn.execute(f"PRAGMA table_info({table})") if r[1] not in ("origin", "edited_from_id")
+            )
+            conn.executescript(
+                f"CREATE TABLE pre AS SELECT {keep} FROM {table};DROP TABLE {table};ALTER TABLE pre RENAME TO {table};"
+            )
+        conn.close()
+        with PerformanceStore(db_path) as store:
+            for table in ("performance_one_on_ones", "performance_reviews"):
+                cols = {r[1] for r in store._conn.execute(f"PRAGMA table_info({table})")}
+                assert {"origin", "edited_from_id"} <= cols, table

--- a/tests/unit/test_reporting_store.py
+++ b/tests/unit/test_reporting_store.py
@@ -146,3 +146,33 @@ class TestSupportingSignalsRoundTrip:
         )
         assert restored.supporting_signals[0].count == 0
         assert restored.supporting_signals[0].samples == ("a",)
+
+
+class TestProvenanceSelfHeal:
+    """A reporting_history missing the v21 provenance columns heals on store open.
+
+    The v21 schema-version collision could leave a shared DB stamped past 21
+    without origin/edited_from_id, and the CLI and MCP tools open this store
+    without ever constructing a SessionStore (whose v26 migration is the other
+    repair path).
+    """
+
+    def test_pre_v21_table_heals_on_open(self, db_path):
+        import sqlite3
+
+        ReportingStore(db_path).close()
+        conn = sqlite3.connect(str(db_path))
+        keep = ", ".join(
+            r[1]
+            for r in conn.execute("PRAGMA table_info(reporting_history)")
+            if r[1] not in ("origin", "edited_from_id")
+        )
+        conn.executescript(
+            f"CREATE TABLE pre AS SELECT {keep} FROM reporting_history;"
+            "DROP TABLE reporting_history;"
+            "ALTER TABLE pre RENAME TO reporting_history;"
+        )
+        conn.close()
+        with ReportingStore(db_path) as store:
+            cols = {r[1] for r in store._conn.execute("PRAGMA table_info(reporting_history)")}
+        assert {"origin", "edited_from_id"} <= cols

--- a/tests/unit/test_retro_store.py
+++ b/tests/unit/test_retro_store.py
@@ -135,3 +135,33 @@ class TestSavedRunsHub:
             assert store.delete_run(drop) is True
             assert store.delete_run(drop) is False
             assert {r["id"] for r in store.get_all_history()} == {keep}
+
+
+class TestProvenanceSelfHeal:
+    """A retro_history missing the v21 provenance columns heals on store open.
+
+    The v21 schema-version collision could leave a shared DB stamped past 21
+    without origin/edited_from_id, and the CLI and MCP tools open this store
+    without ever constructing a SessionStore (whose v26 migration is the other
+    repair path).
+    """
+
+    def test_pre_v21_table_heals_on_open(self, tmp_path):
+        import sqlite3
+
+        path = tmp_path / "sessions.db"
+        RetroStore(path).close()
+        conn = sqlite3.connect(str(path))
+        keep = ", ".join(
+            r[1] for r in conn.execute("PRAGMA table_info(retro_history)") if r[1] not in ("origin", "edited_from_id")
+        )
+        conn.executescript(
+            f"CREATE TABLE pre AS SELECT {keep} FROM retro_history;"
+            "DROP TABLE retro_history;"
+            "ALTER TABLE pre RENAME TO retro_history;"
+        )
+        conn.close()
+        with RetroStore(path) as store:
+            cols = {r[1] for r in store._conn.execute("PRAGMA table_info(retro_history)")}
+            assert {"origin", "edited_from_id"} <= cols
+            assert store.record_run(_report()) > 0  # the INSERT that names origin

--- a/tests/unit/test_roadmap_store.py
+++ b/tests/unit/test_roadmap_store.py
@@ -319,3 +319,31 @@ class TestFriendlyLabel:
             assert store.list_roadmaps()[0]["label"] == "Q3 2026 Roadmap"
             row = store.get_roadmap(rid)
             assert row is not None and row["label"] == "Q3 2026 Roadmap"
+
+
+class TestProvenanceSelfHeal:
+    """A roadmap_history missing the v21 provenance columns heals on store open.
+
+    The v21 schema-version collision could leave a shared DB stamped past 21
+    without origin/edited_from_id, and the CLI and MCP tools open this store
+    without ever constructing a SessionStore (whose v26 migration is the other
+    repair path).
+    """
+
+    def test_pre_v21_table_heals_on_open(self, db_path):
+        import sqlite3
+
+        RoadmapStore(db_path).close()
+        conn = sqlite3.connect(str(db_path))
+        keep = ", ".join(
+            r[1] for r in conn.execute("PRAGMA table_info(roadmap_history)") if r[1] not in ("origin", "edited_from_id")
+        )
+        conn.executescript(
+            f"CREATE TABLE pre AS SELECT {keep} FROM roadmap_history;"
+            "DROP TABLE roadmap_history;"
+            "ALTER TABLE pre RENAME TO roadmap_history;"
+        )
+        conn.close()
+        with RoadmapStore(db_path) as store:
+            cols = {r[1] for r in store._conn.execute("PRAGMA table_info(roadmap_history)")}
+        assert {"origin", "edited_from_id"} <= cols

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -1,15 +1,16 @@
-"""Tests for sessions.py — SessionStore file hardening.
+"""Tests for sessions.py — SessionStore file hardening and schema bookkeeping.
 
 (The store's behaviour is covered indirectly across the mode suites; this file
 holds the direct SessionStore unit tests, starting with the security bits.)
 """
 
 import os
+import sqlite3
 import stat
 
 import pytest
 
-from yeaboi.sessions import SessionStore
+from yeaboi.sessions import CURRENT_SCHEMA_VERSION, SessionStore
 
 
 class TestSessionStoreFilePermissions:
@@ -32,3 +33,59 @@ class TestSessionStoreFilePermissions:
             assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
         finally:
             store._conn.close()
+
+
+class TestSchemaInfoSingleRow:
+    """schema_info is a single-row table only by convention — opens must enforce it.
+
+    Concurrent first-opens (TUI + MCP server + scheduler on the shared DB) race
+    the stamp INSERT, leaving duplicate rows and making the version read
+    arbitrary — one observed DB held 37 rows. Every open now dedupes to the
+    single highest-version row.
+    """
+
+    def _rows(self, db_path):
+        conn = sqlite3.connect(str(db_path))
+        try:
+            return [r[0] for r in conn.execute("SELECT schema_version FROM schema_info")]
+        finally:
+            conn.close()
+
+    def _insert_rows(self, db_path, versions):
+        conn = sqlite3.connect(str(db_path))
+        for v in versions:
+            conn.execute("INSERT INTO schema_info (schema_version) VALUES (?)", (v,))
+        conn.commit()
+        conn.close()
+
+    def test_duplicate_rows_are_deduped_on_open(self, tmp_path):
+        db_path = tmp_path / "sessions.db"
+        SessionStore(db_path).close()
+        self._insert_rows(db_path, [CURRENT_SCHEMA_VERSION] * 30 + [1, 20, 25])
+
+        store = SessionStore(db_path)
+        try:
+            assert not store.schema_mismatch
+        finally:
+            store.close()
+        assert self._rows(db_path) == [CURRENT_SCHEMA_VERSION]
+
+    def test_dedupe_keeps_the_newest_stamp(self, tmp_path):
+        # A row stamped by a newer build must survive the dedupe, so the
+        # newer-DB-older-code warning still fires and nothing downgrades it.
+        db_path = tmp_path / "sessions.db"
+        SessionStore(db_path).close()
+        self._insert_rows(db_path, [CURRENT_SCHEMA_VERSION + 1, 3])
+
+        store = SessionStore(db_path)
+        try:
+            assert store.schema_mismatch
+        finally:
+            store.close()
+        assert self._rows(db_path) == [CURRENT_SCHEMA_VERSION + 1]
+
+    def test_single_row_open_is_untouched(self, tmp_path):
+        db_path = tmp_path / "sessions.db"
+        SessionStore(db_path).close()
+        SessionStore(db_path).close()
+        assert self._rows(db_path) == [CURRENT_SCHEMA_VERSION]

--- a/tests/unit/test_standup_store.py
+++ b/tests/unit/test_standup_store.py
@@ -287,6 +287,56 @@ class TestRunHistory:
             assert store.get_latest_report("s1") is None
 
 
+class TestProvenanceSelfHeal:
+    """A standup_history table missing the v21 provenance columns heals on open.
+
+    The v21 schema-version collision could leave a shared DB stamped past 21
+    without `origin`/`edited_from_id`, and several entry points (--standup-run,
+    the MCP tools) open this store without ever constructing a SessionStore —
+    whose v26 migration is the other repair path.
+    """
+
+    def test_pre_v21_history_table_heals_on_open(self, db_path):
+        import sqlite3
+
+        from yeaboi.standup.store import _standup_report_to_json
+
+        legacy = _make_report(date="2026-07-09")
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(
+            """CREATE TABLE standup_history (
+                   id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                   session_id      TEXT NOT NULL,
+                   run_at          TEXT NOT NULL,
+                   standup_date    TEXT NOT NULL DEFAULT '',
+                   sprint_day      INTEGER NOT NULL DEFAULT 0,
+                   confidence_pct  INTEGER NOT NULL DEFAULT 0,
+                   report_json     TEXT NOT NULL DEFAULT '',
+                   delivery_status TEXT NOT NULL DEFAULT '{}',
+                   status          TEXT NOT NULL DEFAULT 'success',
+                   error           TEXT NOT NULL DEFAULT ''
+               );"""
+        )
+        conn.execute(
+            "INSERT INTO standup_history (session_id, run_at, standup_date, report_json) VALUES (?, ?, ?, ?)",
+            ("s1", "2026-07-09T10:00:00", "2026-07-09", _standup_report_to_json(legacy)),
+        )
+        conn.commit()
+        conn.close()
+
+        with StandupStore(db_path) as store:
+            # The exact origin-reading queries Generate runs, in run order.
+            previous = store.get_previous_run("s1", "2026-07-10")
+            assert previous is not None
+            row_id, origin, edited_from_id, report = previous
+            assert origin == "generated"
+            assert edited_from_id == 0
+            assert report.date == "2026-07-09"
+            assert store.record_run(_make_report()) > row_id
+            base = store.get_base_run(session_id="s1")
+            assert base is not None
+
+
 class TestSavedRunsHub:
     """get_all_history / get_run_by_id / delete_run — power the TUI saved-runs hub."""
 


### PR DESCRIPTION
## Summary

Standup mode's Generate failed with `no such column: origin`. Root cause: a schema-version-number collision on the shared `~/.yeaboi/data/sessions.db` — a pre-rebase lineage stamped it at version 21 for standup transcript review, so main's v21 migration (edit-provenance `origin`/`edited_from_id` columns on six history tables + `artifact_edits`) was silently skipped while the DB migrated on to v25. Every origin-reading query in the standup store then raised.

Following the repo's v19/v20 renumbering idiom:

- **Migration v26** re-applies the idempotent v21 body (extracted into `SessionStore._apply_edit_provenance()`); `CURRENT_SCHEMA_VERSION` 25→26. The repair also runs on the `schema_mismatch` branch (DB stamped newer than the code), so a future lineage stamping past 26 can't recreate the trap.
- **Per-store self-heal**: `StandupStore`, `RetroStore`, `ReportingStore`, `RoadmapStore`, and `PerformanceStore` add the two columns idempotently in `__init__` — the CLI subcommands and MCP tools open these stores without ever constructing a `SessionStore`.
- **`schema_info` hardening**: opens dedupe the table to the single highest-version row (37 duplicate rows observed in the wild from concurrent first-opens), the read stays read-only in the steady state, and the first-stamp INSERT is now race-guarded.

Note for sibling worktrees: builds still at v25 will log a harmless `schema_mismatch` warning after this stamps 26; they cannot downgrade the stamp.

## Test plan

- New tests: `TestVersionCollisionRepair` (collided DB stamped 25 → repaired across all six tables, backfill defaults, twice-is-harmless, newer-stamp still heals), `TestProvenanceSelfHeal` in each of the five store test suites (store-only open heals a pre-v21 table), `TestSchemaInfoSingleRow` (dedupe keeps the newest stamp, mismatch still fires). The migration-test helper now rebuilds tables instead of `DROP COLUMN` (which silently failed on schemas with inline comments) and asserts the strip, so setup can't be vacuous.
- `make test` (9588 passed), `make lint`, `make security` all green.
- Verified end-to-end against a copy of the affected live DB: version 26, single `schema_info` row, all six tables repaired, rows backfilled `origin='generated'`.

## Linear

Closes YEA-45 — https://linear.app/yeaboi/issue/YEA-45/fix-standup-generate-failing-with-no-such-column-origin

DoD notes: no `frontend/` changes (web bundles n/a); no new capability (surface parity/FeatureTip n/a); Notion + Slack fire on merge via `pr-merged-close-loop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)