### PR TITLE
stop the planning chat asking project size twice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.55.0"
+version = "2.55.1"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,25 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.55.1",
+      "date": "2026-08-06",
+      "summary": "Fixed planning mode's live chat asking about project size twice. The greeting's small-vs-large answer now properly flows through the chat, with mode-aware lead-ins for follow-up questions that acknowledge the earlier choice. Smart mode chat also hides the redundant sprint-count row that only appears for large projects.",
+      "highlights": [
+        {
+          "text": "Fixed chat asking project size twice: mode-aware lead-ins now acknowledge the greeting answer",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Redundant option filtering: smart mode hides the 1–2 sprints row that only applies to large projects",
+          "areas": [
+            "planning"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.55.0",
       "date": "2026-08-05",
       "summary": "The idle screensaver expanded from a single duck to a yard of them — ten-odd heads adrift in zero gravity, spinning and ricocheting off each other and an anchored duck in the middle. The screensaver activates with Ctrl+Y as before, and still reads as a single resting duck on terminals smaller than 60x24, so the existing single-duck graphics cover those smaller screens.",

--- a/src/yeaboi/prompts/intake.py
+++ b/src/yeaboi/prompts/intake.py
@@ -650,7 +650,28 @@ CHAT_QUESTION_PREAMBLES: dict[int, str] = {
 }
 
 
-def decorate_question_for_chat(q_num: int, text: str) -> str:
+# Mode-aware overrides: the chat preamble already settled small-vs-large
+# before the graph ran, so Q8/Q10 must read as follow-ups to that answer,
+# not as asking "how big is this?" a second time. Keyed (q_num, intake_mode);
+# falls back to CHAT_QUESTION_PREAMBLES. Wording is mode-anchored, never
+# memory-anchored ("Since we're going Large", not "You mentioned") — the mode
+# can arrive via CLI preset or /large where the size question was never asked.
+CHAT_QUESTION_PREAMBLES_BY_MODE: dict[tuple[int, str], str] = {
+    (10, "smart"): "Since we're going Large here — delivery-wise:",
+    (8, "small_project"): "Since this is a quick one —",
+}
+
+# Chat-only: choice rows hidden from the inline list per intake mode.
+# "1–2 sprints" re-litigates small-vs-large after the user already chose
+# Large. Canonical QUESTION_METADATA options must NOT change — they are
+# served to the MCP intake_questions tool and the REPL/form, and typed-digit
+# resolution against the displayed rows is handled at the chat call sites.
+CHAT_MODE_HIDDEN_CHOICES: dict[tuple[int, str], frozenset[str]] = {
+    (10, "smart"): frozenset({"1–2 sprints"}),
+}
+
+
+def decorate_question_for_chat(q_num: int, text: str, intake_mode: str | None = None) -> str:
     """Prepend a conversational lead-in to a question for the chat surface.
 
     Presentation-only: the question text (including any numbered [1]/[2]
@@ -658,7 +679,11 @@ def decorate_question_for_chat(q_num: int, text: str) -> str:
     is never altered — unknown question numbers return the text unchanged.
     Only the TUI chat calls this; REPL and headless render the raw text.
     """
-    preamble = CHAT_QUESTION_PREAMBLES.get(q_num)
+    preamble = None
+    if intake_mode:
+        preamble = CHAT_QUESTION_PREAMBLES_BY_MODE.get((q_num, intake_mode))
+    if preamble is None:
+        preamble = CHAT_QUESTION_PREAMBLES.get(q_num)
     if not preamble:
         return text
     return f"{preamble}\n\n{text}"

--- a/src/yeaboi/repl/_questionnaire.py
+++ b/src/yeaboi/repl/_questionnaire.py
@@ -136,7 +136,7 @@ def _render_choice_options(console: Console, q_num: int, *, option_labels: tuple
     console.print("\n".join(parts))
 
 
-def _resolve_choice_input(user_input: str, q_num: int) -> str:
+def _resolve_choice_input(user_input: str, q_num: int, *, option_labels: tuple[str, ...] | None = None) -> str:
     """Resolve numeric input to the corresponding option text for choice questions.
 
     If the input is a valid number for a choice question, returns the option text.
@@ -145,6 +145,14 @@ def _resolve_choice_input(user_input: str, q_num: int) -> str:
     Args:
         user_input: The raw user input (stripped).
         q_num: The current question number.
+        option_labels: Optional override — the labels actually displayed. When
+            a surface hides rows (chat mode-aware filtering), typed digits must
+            resolve against what the user saw, not the canonical meta.options.
+            Every label must still BE a canonical option — this is the opposite
+            contract from _render_choice_options's option_labels, which takes
+            decorated display strings and resolves against meta.options.
+            Non-canonical labels are ignored (canonical resolution applies), so
+            a decorated label can never be stored as an answer.
 
     Returns:
         The resolved option text, or the original input if not a choice number.
@@ -159,9 +167,18 @@ def _resolve_choice_input(user_input: str, q_num: int) -> str:
         logger.debug("_resolve_choice_input: free-text for Q%d", q_num)
         return user_input
 
-    if 1 <= idx <= len(meta.options):
-        resolved = meta.options[idx - 1]
-        logger.debug("_resolve_choice_input: Q%d idx=%d -> %s", q_num, idx, resolved)
+    labels = meta.options
+    if option_labels is not None and set(option_labels) <= set(meta.options):
+        labels = option_labels
+    if 1 <= idx <= len(labels):
+        resolved = labels[idx - 1]
+        logger.debug(
+            "_resolve_choice_input: Q%d idx=%d -> %s%s",
+            q_num,
+            idx,
+            resolved,
+            " (displayed labels)" if labels is not meta.options else "",
+        )
         return resolved
     return user_input
 

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -603,7 +603,8 @@ class _ChatDriver:
             return
 
         if qs is not None and not qs.completed:
-            reply = decorate_question_for_chat(qs.current_question, reply)
+            mode = qs.intake_mode or self.state.get("_intake_mode") or None
+            reply = decorate_question_for_chat(qs.current_question, reply, intake_mode=mode)
         self._say(reply)
 
     def _drain_consents(self) -> None:
@@ -1553,4 +1554,10 @@ class _ChatDriver:
     def _resolve_choice(self, answer: str, q_num: int) -> str:
         from yeaboi.repl._questionnaire import _resolve_choice_input
 
-        return _resolve_choice_input(answer, q_num)
+        # Typed digits must map to the rows the user saw — the chat may hide
+        # mode-redundant rows (CHAT_MODE_HIDDEN_CHOICES), so canonical
+        # meta.options and the display can disagree.
+        labels = None
+        if self.choices is not None and not self.choices.multi and self.choices.options:
+            labels = tuple(label for label, _sel in self.choices.options)
+        return _resolve_choice_input(answer, q_num, option_labels=labels)

--- a/src/yeaboi/ui/session/chat/_question_view.py
+++ b/src/yeaboi/ui/session/chat/_question_view.py
@@ -7,18 +7,28 @@ design: these branches encode the private QuestionnaireState machinery (PTO
 sub-loop, tracker choice, Q27 sprint selection, probed questions), and any
 drift here changes which answer string reaches the node — i.e. planning
 results. Keep changes mirrored with the recorded-state tests.
+
+One sanctioned exception: CHAT_MODE_HIDDEN_CHOICES hides rows the pre-graph
+size answer made redundant (Q10's "1–2 sprints" after the user chose Large),
+so the chat can show fewer rows than the REPL/form for the same question.
+Typed digits stay consistent because _resolve_choice passes the displayed
+labels to _resolve_choice_input — the answer string itself is always one of
+the canonical meta.options.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 
 from langchain_core.messages import AIMessage
 
 from yeaboi.agent.state import TOTAL_QUESTIONS, QuestionnaireState
-from yeaboi.prompts.intake import PHASE_LABELS, QUESTION_METADATA, is_choice_question
+from yeaboi.prompts.intake import CHAT_MODE_HIDDEN_CHOICES, PHASE_LABELS, QUESTION_METADATA, is_choice_question
 from yeaboi.repl._io import _get_active_suggestion
 from yeaboi.repl._questionnaire import _split_intake_preamble
+
+logger = logging.getLogger(__name__)
 
 # Q27 (sprint selection) is single-select among the dynamic follow-up menus;
 # Q6 member selection is multi-select. Same table as the phase loop used.
@@ -96,6 +106,20 @@ def derive_question_view(graph_state: dict) -> QuestionView:
             # The pre-selected option IS the suggestion — drop the text form.
             if view.suggestion and pre_select_idx is not None:
                 view.suggestion = None
+
+    # Chat-only: hide rows made redundant by the pre-graph size answer
+    # (e.g. "1–2 sprints" after the user already chose Large). A pre-selected
+    # row survives — hiding it would silently drop an extracted suggestion.
+    hidden = CHAT_MODE_HIDDEN_CHOICES.get((cur_q, qs.intake_mode or ""))
+    if hidden and view.choices:
+        before = len(view.choices)
+        view.choices = [(opt, sel) for opt, sel in view.choices if opt not in hidden or sel]
+        if len(view.choices) != before:
+            # Once per question turn, never per frame — the caller derives the
+            # view when the intake advances, not while rendering.
+            logger.debug(
+                "chat: hid %d choice row(s) for Q%d in %s mode", before - len(view.choices), cur_q, qs.intake_mode
+            )
 
     # Dynamic choices — follow-up probes or node-generated menus (tracker
     # choice, Q27 sprint pick, Q6 member select). They override static ones.

--- a/tests/unit/prompts/test_intake_chat.py
+++ b/tests/unit/prompts/test_intake_chat.py
@@ -1,7 +1,9 @@
 """Tests for the chat presentation layer in prompts/intake.py."""
 
 from yeaboi.prompts.intake import (
+    CHAT_MODE_HIDDEN_CHOICES,
     CHAT_QUESTION_PREAMBLES,
+    CHAT_QUESTION_PREAMBLES_BY_MODE,
     INTAKE_QUESTIONS,
     QUESTION_METADATA,
     decorate_question_for_chat,
@@ -39,3 +41,64 @@ class TestDecorateQuestionForChat:
         texts = list(CHAT_QUESTION_PREAMBLES.values())
         assert len(set(texts)) == len(texts)  # 30 identical "Now…"s is a form again
         assert all(len(t) <= 60 for t in texts)
+
+
+class TestModeAwarePreambles:
+    def test_q10_smart_mode_acknowledges_size(self):
+        text = INTAKE_QUESTIONS[10]
+        decorated = decorate_question_for_chat(10, text, intake_mode="smart")
+        assert decorated.startswith(CHAT_QUESTION_PREAMBLES_BY_MODE[(10, "smart")])
+        assert decorated.endswith(text)
+
+    def test_q8_small_mode_acknowledges_size(self):
+        text = INTAKE_QUESTIONS[8]
+        decorated = decorate_question_for_chat(8, text, intake_mode="small_project")
+        assert decorated.startswith(CHAT_QUESTION_PREAMBLES_BY_MODE[(8, "small_project")])
+        assert decorated.endswith(text)
+
+    def test_wrong_mode_falls_back_to_base_preamble(self):
+        # Q10 has no small_project override, Q8 no smart override — base wins.
+        assert decorate_question_for_chat(10, INTAKE_QUESTIONS[10], intake_mode="small_project").startswith(
+            CHAT_QUESTION_PREAMBLES[10]
+        )
+        assert decorate_question_for_chat(8, INTAKE_QUESTIONS[8], intake_mode="smart").startswith(
+            CHAT_QUESTION_PREAMBLES[8]
+        )
+
+    def test_no_mode_is_unchanged(self):
+        text = INTAKE_QUESTIONS[10]
+        assert decorate_question_for_chat(10, text) == decorate_question_for_chat(10, text, intake_mode=None)
+
+    def test_mode_preambles_are_distinct_and_short(self):
+        texts = list(CHAT_QUESTION_PREAMBLES_BY_MODE.values())
+        assert len(set(texts)) == len(texts)
+        assert all(len(t) <= 60 for t in texts)
+        # Must differ from the base preamble they replace — otherwise the
+        # override is dead weight.
+        for (q_num, _mode), text in CHAT_QUESTION_PREAMBLES_BY_MODE.items():
+            assert text != CHAT_QUESTION_PREAMBLES[q_num]
+
+    def test_mode_keys_use_the_real_vocabulary(self):
+        # A typo'd mode ("large", "small") would produce an entry that
+        # silently never fires; and an override for a question outside the
+        # mode's essential set can never be reached in that mode.
+        from yeaboi.prompts.intake import QUICK_ESSENTIALS, SMALL_PROJECT_ESSENTIALS, SMART_ESSENTIALS
+
+        essentials = {
+            "smart": SMART_ESSENTIALS,
+            "quick": QUICK_ESSENTIALS,
+            "small_project": SMALL_PROJECT_ESSENTIALS,
+        }
+        for q_num, mode in list(CHAT_QUESTION_PREAMBLES_BY_MODE) + list(CHAT_MODE_HIDDEN_CHOICES):
+            assert mode in essentials, f"unknown intake mode {mode!r}"
+            assert q_num in essentials[mode], f"Q{q_num} is not essential in {mode!r} — the override never fires"
+
+    def test_hidden_choices_reference_real_canonical_options(self):
+        # A hidden label that drifts from meta.options would silently hide
+        # nothing — pin every entry to the canonical tuple.
+        for (q_num, _mode), labels in CHAT_MODE_HIDDEN_CHOICES.items():
+            meta = QUESTION_METADATA[q_num]
+            for label in labels:
+                assert label in meta.options
+            # Hiding must never empty the menu.
+            assert len(labels) < len(meta.options)

--- a/tests/unit/test_chat_driver.py
+++ b/tests/unit/test_chat_driver.py
@@ -147,6 +147,84 @@ class TestSizeSwitch:
         assert any("Already" in m.text for m in driver.transcript.messages)
 
 
+class TestModeAwareIntakePresentation:
+    """Q10/Q8 must read as follow-ups to the greeting's size answer, not a re-ask."""
+
+    def _intake_state(self, q_num: int, mode: str) -> dict:
+        from yeaboi.prompts.intake import INTAKE_QUESTIONS
+
+        qs = QuestionnaireState()
+        qs.current_question = q_num
+        qs.intake_mode = mode
+        return {
+            "messages": [AIMessage(content=INTAKE_QUESTIONS[q_num])],
+            "questionnaire": qs,
+            "_chat_greeting_done": True,
+            "_intake_mode": mode,
+        }
+
+    def test_q10_smart_reply_acknowledges_size(self):
+        from yeaboi.prompts.intake import CHAT_QUESTION_PREAMBLES, CHAT_QUESTION_PREAMBLES_BY_MODE
+
+        driver = _driver(FakeGraph([]), _keys([]), self._intake_state(10, "smart"))
+        driver._append_reply(streamed="")
+        bubble = next(m for m in reversed(driver.transcript.messages) if m.role == "assistant")
+        assert bubble.text.startswith(CHAT_QUESTION_PREAMBLES_BY_MODE[(10, "smart")])
+        assert not bubble.text.startswith(CHAT_QUESTION_PREAMBLES[10])
+
+    def test_q8_small_reply_acknowledges_size(self):
+        from yeaboi.prompts.intake import CHAT_QUESTION_PREAMBLES_BY_MODE
+
+        driver = _driver(FakeGraph([]), _keys([]), self._intake_state(8, "small_project"))
+        driver._append_reply(streamed="")
+        bubble = next(m for m in reversed(driver.transcript.messages) if m.role == "assistant")
+        assert bubble.text.startswith(CHAT_QUESTION_PREAMBLES_BY_MODE[(8, "small_project")])
+
+    def test_typed_digit_resolves_against_displayed_rows(self):
+        # Smart mode hides "1–2 sprints", so a typed "1" must select the
+        # first row the user actually saw, not canonical meta.options[0].
+        from yeaboi.ui.session.chat._screen import ChoiceRows
+
+        driver = _driver(FakeGraph([]), _keys([]), self._intake_state(10, "smart"))
+        driver.choices = ChoiceRows(
+            options=[("3–5 sprints", False), ("6–10 sprints", False), ("10+ sprints", False)],
+            multi=False,
+        )
+        assert driver._resolve_choice("1", 10) == "3–5 sprints"
+
+    def test_out_of_range_digit_falls_through_as_free_text(self):
+        # Canonical Q10 has 5 options but smart-mode chat shows 4. A typed
+        # "5" must NOT reach through to the hidden canonical fifth option —
+        # it falls through as free text, which Q10's parser reads as a sprint
+        # count (typing 5 at "how many sprints?" plausibly means 5 sprints).
+        from yeaboi.prompts.intake import QUESTION_METADATA
+        from yeaboi.ui.session.chat._screen import ChoiceRows
+
+        rows = [opt for opt in QUESTION_METADATA[10].options if opt != "1–2 sprints"]
+        driver = _driver(FakeGraph([]), _keys([]), self._intake_state(10, "smart"))
+        driver.choices = ChoiceRows(options=[(o, False) for o in rows], multi=False)
+        assert driver._resolve_choice("4", 10) == rows[3]
+        assert driver._resolve_choice("5", 10) == "5"
+
+    def test_decorated_labels_never_resolve(self):
+        # option_labels must be canonical options — decorated display strings
+        # (the REPL's "(~2 weeks)" hints) are ignored so they can never be
+        # stored as an answer. Resolution falls back to meta.options.
+        from yeaboi.prompts.intake import QUESTION_METADATA
+        from yeaboi.ui.session.chat._screen import ChoiceRows
+
+        driver = _driver(FakeGraph([]), _keys([]), self._intake_state(10, "smart"))
+        driver.choices = ChoiceRows(options=[("3–5 sprints (~1 quarter)", False)], multi=False)
+        assert driver._resolve_choice("1", 10) == QUESTION_METADATA[10].options[0]
+
+    def test_typed_digit_falls_back_to_canonical_without_rows(self):
+        from yeaboi.prompts.intake import QUESTION_METADATA
+
+        driver = _driver(FakeGraph([]), _keys([]), self._intake_state(10, "smart"))
+        driver.choices = None
+        assert driver._resolve_choice("1", 10) == QUESTION_METADATA[10].options[0]
+
+
 class TestPipelineProgress:
     def _mid_build_state(self) -> dict:
         qs = QuestionnaireState(completed=True)

--- a/tests/unit/test_chat_question_view.py
+++ b/tests/unit/test_chat_question_view.py
@@ -61,6 +61,55 @@ class TestStaticChoices:
         view = derive_question_view(_state(qs))
         assert view.choices is None
 
+    def test_mode_hidden_row_dropped_in_smart_mode(self):
+        # Q10's "1–2 sprints" re-litigates the size answer — hidden in chat
+        # when the user already chose Large (intake_mode="smart").
+        qs = QuestionnaireState()
+        qs.current_question = 10
+        qs.intake_mode = "smart"
+        view = derive_question_view(_state(qs))
+        labels = [label for label, _ in view.choices]
+        assert "1–2 sprints" not in labels
+        assert labels == [opt for opt in QUESTION_METADATA[10].options if opt != "1–2 sprints"]
+
+    def test_mode_hidden_row_keeps_default_preselection(self):
+        qs = QuestionnaireState()
+        qs.current_question = 10
+        qs.intake_mode = "smart"
+        view = derive_question_view(_state(qs))
+        meta = QUESTION_METADATA[10]
+        # Precondition, not a guard — a silent pass if Q10 loses its default
+        # would make this test vacuous.
+        assert meta.default_index is not None
+        selected = [label for label, sel in view.choices if sel]
+        assert selected == [meta.options[meta.default_index]]
+
+    def test_mode_hidden_row_shown_outside_smart_mode(self):
+        for mode in ("small_project", ""):
+            qs = QuestionnaireState()
+            qs.current_question = 10
+            qs.intake_mode = mode
+            view = derive_question_view(_state(qs))
+            assert [label for label, _ in view.choices] == list(QUESTION_METADATA[10].options)
+
+    def test_mode_hidden_row_survives_when_suggested(self):
+        # If the extractor pulled "1–2 sprints" out of the description, the
+        # pre-selected row must stay visible — hiding it would drop the
+        # suggestion silently.
+        qs = QuestionnaireState()
+        qs.current_question = 10
+        qs.intake_mode = "smart"
+        qs.suggested_answers = {10: "1–2 sprints"}
+        view = derive_question_view(_state(qs))
+        assert ("1–2 sprints", True) in view.choices
+
+    def test_mode_filter_leaves_other_questions_alone(self):
+        qs = QuestionnaireState()
+        qs.current_question = 2
+        qs.intake_mode = "smart"
+        view = derive_question_view(_state(qs))
+        assert [label for label, _ in view.choices] == list(QUESTION_METADATA[2].options)
+
     def test_multi_choice_preselects_from_comma_suggestion(self):
         multi_q = next(q for q, m in QUESTION_METADATA.items() if m.question_type == "multi_choice")
         meta = QUESTION_METADATA[multi_q]

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.54.0"
+version = "2.55.1"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

In planning mode's live chat, the opening greeting asks "how big is this — Small or Large?", but the answer is stored only as the intake mode and never reaches the questionnaire answers. One or two questions later the essential-gap scan asks Q10 "How many sprints are you targeting?" (large mode, complete with a "1–2 sprints" option) or Q8 "How long are your sprints?" (small mode) — which reads as the same question being asked twice.

Fix is acknowledge-and-reframe, confined entirely to the chat presentation layer:

- **Mode-aware chat lead-ins** (`CHAT_QUESTION_PREAMBLES_BY_MODE`): Q10 opens with "Since we're going Large here — delivery-wise:" and Q8 with "Since this is a quick one —", so they read as follow-ups to the greeting answer. Wording is mode-anchored, not "you mentioned…", because the mode can also arrive via CLI preset or `/large` without the greeting question.
- **Hidden redundant row** (`CHAT_MODE_HIDDEN_CHOICES`): smart-mode chat drops Q10's "1–2 sprints" row, which re-litigated small-vs-large. A row pre-selected by description extraction survives the filter.
- **Typed digits resolve against displayed rows**: `_resolve_choice_input` gains an `option_labels` override (canonical labels only — decorated display strings are ignored so they can never be stored as answers); out-of-range digits fall through as free text.

Canonical `INTAKE_QUESTIONS`/`QUESTION_METADATA` and the essential sets are untouched, so node output stays byte-identical across REPL, headless, and MCP. The `_question_view.py` module contract records this one sanctioned display divergence.

Independent code review ran pre-PR; all four should-fix findings addressed (resolver contract guard + docstring, module-contract note, out-of-range-digit and mode-vocabulary tests).

## Test plan

- `make test` — 9588 passed, 47 skipped (includes 18 new unit tests across `test_intake_chat.py`, `test_chat_question_view.py`, `test_chat_driver.py`)
- `make lint` — clean
- `make security` — SAST + pip-audit clean

## DoD notes

- Linear: https://linear.app/yeaboi/issue/YEA-46/planning-chat-asks-the-project-size-question-twice
- Web bundles (item 7): not applicable — no `frontend/` changes
- Surface parity (item 5): not applicable — no new capability; chat-only presentation of an existing mode, other surfaces intentionally unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)