### PR TITLE
give linear tickets a full pr lifecycle closed by the github integration

### DIFF
--- a/.claude/agents/cowork-builder.md
+++ b/.claude/agents/cowork-builder.md
@@ -27,8 +27,10 @@ Procedure:
    change touches `frontend/`, run `make web` and commit `src/yeaboi/web/static/` in the same commit.
    If it adds a capability, add its `CAPABILITIES` row and its `FeatureTip`.
 6. Commit with a lowercase imperative message and the `Co-Authored-By` trailer from `CLAUDE.md`.
-   Push, then `gh pr create` against `main` with a Summary, a Test plan, the Linear link, and a line
-   for any DoD item that genuinely does not apply.
+   Push, then `gh pr create` against `main` with a Summary, a Test plan, a `Closes YEA-NN` line
+   using the ticket identifier from your inputs (the magic word is what makes the Linear GitHub
+   integration attach the PR and move the ticket to Done on merge — a bare Linear URL does
+   neither), and a line for any DoD item that genuinely does not apply.
 7. Label the PR `cowork` and `workstream:<name>`.
 
 Rules:

--- a/.claude/agents/cowork-scribe.md
+++ b/.claude/agents/cowork-scribe.md
@@ -32,8 +32,16 @@ Targets (from `cowork/definition-of-done.md`): Linear team `Yeaboi`
 
 **Linear ticket** — title is imperative and specific ("stop practice signals firing on service-hook
 comments", not "standup improvements"). Body: what, why it matters, the paths involved, and the
-acceptance condition. Label `workstream:<name>`. Attach the PR with `create_attachment` when one
-exists.
+acceptance condition. Label `workstream:<name>`. Attach the PR when one exists by passing
+`links: [{url, title}]` to `save_issue` — the connector's `create_attachment` takes file uploads
+only, not URLs, so it cannot attach a PR.
+
+State tracks reality, always: open in **In Progress** — never leave a just-opened work ticket in
+Backlog, and move a found ticket out of Backlog/Todo when work on it starts. Move to **In Review**
+when attaching a PR. **Done is not yours to set** in the normal path — the `Closes YEA-NN` line in
+the PR body closes the ticket on merge via the Linear GitHub integration; you set Done only when
+repairing (the merge routine finds a ticket the magic word missed) or back-filling a human ship
+that never had one.
 
 Open one only for work that is **approved and starting** — an auto-lane item, or an issue that has
 just received `claude-implement`. Never for a proposal. Linear carries work; GitHub issues carry

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -10,7 +10,7 @@ The contract this branch must satisfy is `cowork/definition-of-done.md` — the 
 
 1. **Sanity check** — run `git branch --show-current`. If on `main`, stop: create a feature branch first.
 
-   **Linear (DoD item 1)** — spawn `cowork-scribe` to find the ticket for this branch on team `Yeaboi`, or create one if none exists. Never write to Linear inline; the scribe owns every outbound format.
+   **Linear (DoD item 1)** — spawn `cowork-scribe` to find the ticket for this branch on team `Yeaboi`, or create one if none exists — labelled `workstream:<name>` and in state **In Progress** (a found ticket sitting in Backlog/Todo is moved to In Progress: work on it is starting now). Keep the identifier (`YEA-NN`) for the PR body. Never write to Linear inline; the scribe owns every outbound format.
 
 2. **Independent verification (fresh context, no author bias)** — spawn the `code-reviewer` subagent (defined in `.claude/agents/code-reviewer.md`) at the `deep` tier (`cowork/models.md`). Give it ONLY: (a) the output of `git diff main...HEAD`, (b) a one-paragraph description of what this branch was supposed to do — NOT this conversation's history. Its checklist (spec fit, skill-based conventions, correctness) lives in the agent definition. Resolve every finding it reports at `blocker` or `should-fix` severity before proceeding (fix it, or explain in the PR body why it's intentionally not addressed).
 
@@ -20,11 +20,11 @@ The contract this branch must satisfy is `cowork/definition-of-done.md` — the 
 
 5. **Push + PR** — `git push -u origin <branch>`, then `gh pr create` against `main` with:
    - Title: same style as the commit message.
-   - Body: a Summary section (what and why), a Test plan section (what was run), the Linear link, a line for any DoD item that genuinely does not apply, and the standard "🤖 Generated with Claude Code" footer.
-   - Then have `cowork-scribe` attach the PR to the Linear ticket.
+   - Body: a Summary section (what and why), a Test plan section (what was run), the line `Closes YEA-NN` (the magic word is load-bearing: it is what makes the Linear GitHub integration attach the PR and move the ticket to Done on merge — a bare Linear URL does neither), a line for any DoD item that genuinely does not apply, and the standard "🤖 Generated with Claude Code" footer.
+   - Then have `cowork-scribe` attach the PR to the Linear ticket and move it to **In Review**.
 
-6. **Auto-merge (only if `auto-merge` was passed)** — confirm the change is genuinely low-risk (docs, chore, small fix; no `src/yeaboi/agent/`, schema, or workflow changes), then run `gh pr merge --auto --squash`. If it is not low-risk, say so and skip this step.
+6. **Auto-merge (only if `auto-merge` was passed)** — confirm the change is genuinely low-risk (docs, chore, small fix; no `src/yeaboi/agent/`, schema, or workflow changes), then run `gh pr merge --auto --squash`. If it is not low-risk, say so and skip this step. The `Closes YEA-NN` line from step 5 carries the ticket to Done when the merge lands — no extra Linear step here.
 
 7. **Report** — output the PR URL and a one-line status.
 
-DoD items 8 (Notion) and 9 (Slack) are **not** done here — the `pr-merged-close-loop` cowork routine fires them on merge, so a branch that never merges never announces itself.
+DoD items 8 (Notion) and 9 (Slack) are **not** done here — the `pr-merged-close-loop` cowork routine fires them on merge, so a branch that never merges never announces itself. The Linear → Done transition on merge rides the `Closes YEA-NN` line via the GitHub integration; the routine only verifies and repairs it.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -97,9 +97,10 @@ jobs:
                If the issue carries a `workstream:<name>` label, also Read
                `cowork/workstreams/<name>.md` and stay inside the paths it declares.
             3. DoD item 1, before any code: spawn the `cowork-scribe` agent to open the Linear ticket
-               on team `Yeaboi`, labelled with the issue's `workstream:<name>`, and to cross-link it
-               with this issue both ways. Approval is when the ticket is created — proposals do not
-               get one, because most of them are answered no. Keep the identifier for the PR body.
+               on team `Yeaboi` in state In Progress, labelled with the issue's `workstream:<name>`,
+               and to cross-link it with this issue both ways. Approval is when the ticket is
+               created — proposals do not get one, because most of them are answered no. Keep the
+               identifier for the PR body.
 
                Linear is an account-scoped connector and this job supplies no `mcp_config`, so the
                tool will often not exist in the runner. If the scribe reports it cannot reach Linear,
@@ -124,16 +125,19 @@ jobs:
                and the work here is larger than anything the auto lane is allowed to touch.
             8. Commit (lowercase imperative message + the Co-Authored-By trailer from CLAUDE.md),
                push the branch, and open a PR against main whose body summarizes the change,
-               lists what was verified, links the Linear ticket from step 3 (or records that item 1
-               is deferred to merge), notes any DoD item that genuinely does not apply, and closes
-               the issue (`Closes #${{ github.event.issue.number }}`).
+               lists what was verified, carries a `Closes YEA-NN` line for the ticket from step 3
+               (the magic word is what makes the Linear GitHub integration attach the PR and move
+               the ticket to Done on merge — a bare Linear URL does neither), notes any DoD item
+               that genuinely does not apply, and closes the issue
+               (`Closes #${{ github.event.issue.number }}`). If step 3 could not create a ticket,
+               write the item-1-deferred-to-merge line instead of the `Closes YEA-NN` line.
             9. Pass the labels to `gh pr create` itself — `--label cowork` plus the issue's
                `workstream:<name>` and `type:<kind>` labels if it had them (the merge ship note
                reads the type off the PR). Labelling in a second step means a run truncated
                between the two leaves an unlabelled bot PR, which `claude-review.yml` then skips
                silently; that is the failure the `cowork` carve-out exists to prevent.
-            10. If step 3 produced a ticket, have `cowork-scribe` attach the PR to it. Then comment
-                on the issue with a link to the PR.
+            10. If step 3 produced a ticket, have `cowork-scribe` attach the PR to it and move it
+                to In Review. Then comment on the issue with a link to the PR.
 
             Step 3 and step 10 are the ONLY Linear writes here, and they are the scribe's. Do not
             post to Slack or Notion at all — the `pr-merged-close-loop` cowork routine owns DoD

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -114,9 +114,9 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 
 | Routine | Trigger | Workstream | Tier | URL |
 |---|---|---|---|---|
-| `cron/marketing-weekly.md` | `0 8 * * 6` Sat | marketing | `deep` | https://claude.ai/code/routines/trig_0111WtcVcpYDKaL6Jw9ZaPjD |
+| `cron/marketing-weekly.md` | `0 8 * * 6` Sat | marketing | `deep` | https://claude.ai/code/routines/trig_011f1J2fUGPhDQKSmjEMEiGs |
 | `cron/digest.md` | `15 8 * * *` | — | `standard` | https://claude.ai/code/routines/trig_01VY1hbAZKeGuKA1GLyVhbow |
-| `cron/slack-relay.md` | `0 7-23 * * *` hourly | — | `fast` | |
+| `cron/slack-relay.md` | `0 7-23 * * *` hourly | — | `fast` | https://claude.ai/code/routines/trig_01X18LBBBZ1FWEtx2Cmffyow |
 | `events/pr-opened-dod-audit.md` | PR opened / synchronized | — | `standard` | |
 | `events/pr-merged-close-loop.md` | PR closed (merged) | — | `fast` | |
 | `events/release-published-announce.md` | Release published | — | `standard` | |

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -26,7 +26,8 @@ scout routine (per workstream, own cron)
         Linear ticket → build → code-reviewer → PR ───▶
                                                        │
                     pr-merged-close-loop ──────────────┘
-                    scribe: Linear → Done, Slack ship note, Notion page
+                    merge closes Linear via `Closes YEA-NN`;
+                    scribe: verify Done, Slack ship note, Notion page
 ```
 
 A proposal is a question, so it costs one GitHub issue and nothing else. The Linear ticket opens when
@@ -151,8 +152,12 @@ account-scoped and has no CLI behind it.
 
 **What neither can do**, and both report: connecting Linear/Slack/Notion at
 [claude.ai/customize/connectors](https://claude.ai/customize/connectors), installing the Claude GitHub
-App, setting the `AUTO_VERSION_PAT` secret, and the three **event** routines — the routines API takes
-a cron expression only, so those are added by hand.
+App, setting the `AUTO_VERSION_PAT` secret, the three **event** routines — the routines API takes
+a cron expression only, so those are added by hand — and the **Linear GitHub integration** on this
+repo (with issue-status automation on), which is what turns a PR body's `Closes YEA-NN` into the
+attach and the Done-on-merge transition. If that integration is off, every ticket silently stalls at
+In Review, and the only thing that would notice is `pr-merged-close-loop` — one of the hand-added
+event routines above.
 
 ## Running it afterwards
 

--- a/cowork/definition-of-done.md
+++ b/cowork/definition-of-done.md
@@ -5,7 +5,7 @@ Nothing is "done" because the code works — it is done when the loop is closed.
 
 | # | Item | How it is checked |
 |---|---|---|
-| 1 | **Linear ticket** exists on team `Yeaboi`, labelled `workstream:<name>`, with the PR attached | scribe: `save_issue` + `create_attachment` |
+| 1 | **Linear ticket** exists on team `Yeaboi`, labelled `workstream:<name>`, with the PR attached, `Closes YEA-NN` in the PR body, and a state that tracks reality — In Progress while building, In Review from PR open, Done on merge | scribe: `save_issue` (state + `links`); attach + merge close via the Linear GitHub integration reading `Closes YEA-NN` |
 | 2 | **Tests** — a unit test per new function (happy + error), render tests for every `_build_*_screen`, mock tests for LLM-dependent code (success / error fallback / code fences), round-trip tests for new state fields | `make test` |
 | 3 | **Lint** | `make lint` |
 | 4 | **Security** — ruff SAST + `pip-audit` clean, CodeQL not regressed | `make security` |
@@ -27,6 +27,11 @@ Nothing is "done" because the code works — it is done when the loop is closed.
   ticket behind each of the ~70% that age out unapproved. GitHub issues are the queue — Linear
   carries work, not candidates.
 - **Items 8 and 9 happen on merge**, not on PR open — driven by the `pr-merged-close-loop` routine.
+- **The ticket's state is part of item 1**, not an optional courtesy: the scribe opens it In
+  Progress and moves it to In Review when the PR is attached; the merge → Done transition belongs
+  to the Linear GitHub integration, fired by the `Closes YEA-NN` line every PR body must carry.
+  `pr-merged-close-loop` verifies that transition and repairs it when the magic word missed — a
+  ticket lingering in In Review after its PR merged is a bug in the loop, not a cosmetic detail.
 - Items 2–7 are the *gate*: they block the PR. A PR that cannot pass them is not opened; the finding
   is filed as a proposal instead.
 - **Exemptions are recorded, not assumed.** If an item genuinely does not apply (e.g. item 7 on a

--- a/cowork/models.md
+++ b/cowork/models.md
@@ -53,7 +53,7 @@ The rest do model-worthy work in their own session and carry a `**Model**` line.
 | `cron/digest.md` | `standard` | Ranks ~20 issue titles and writes one message |
 | `cron/slack-relay.md` | `fast` | Grammar-first matching against an allowlist, 17 times a day; it also answers free text, but its rule for anything unsure is ask-in-thread, never act — the judgement being relayed was the human's. Raise the tier if parses misfire |
 | `events/pr-opened-dod-audit.md` | `standard` | A nine-item checklist against a diff |
-| `events/pr-merged-close-loop.md` | `fast` | Linear → Done, one Slack line, a Notion page from a merged PR |
+| `events/pr-merged-close-loop.md` | `fast` | verify Linear reached Done, one Slack line, a Notion page from a merged PR |
 | `events/release-published-announce.md` | `standard` | Writes notes from commits, which needs judgement about what mattered |
 
 ### Agents

--- a/cowork/routines/events/pr-merged-close-loop.md
+++ b/cowork/routines/events/pr-merged-close-loop.md
@@ -4,16 +4,19 @@
 **Filters** — `is_merged` true only. A closed-unmerged PR does nothing here.
 **Model** — `fast` ([models.md](../../models.md)) — every step reads a field and writes a field
 
-This is where DoD items 1 (final state), 8, and 9 are satisfied. Everything below runs through
-`cowork-scribe`.
+This is where DoD items 8 and 9 are satisfied, and item 1's final state is verified (and repaired
+when the `Closes YEA-NN` magic word missed). Everything below runs through `cowork-scribe`.
 
 ## Run
 
 1. `gh pr view <n> --json title,body,labels,mergedAt,author,files` and `gh pr diff <n>`.
 
-2. **Linear** — find the ticket from the PR body link, or by searching team `Yeaboi` for the branch
-   name. Move it to Done and comment with the merge commit. If no ticket exists (a human shipped
-   without one), create it in Done rather than skipping — the record matters more than the order.
+2. **Linear** — verify and repair, not blind-write. Find the ticket from the `Closes YEA-NN` line
+   in the PR body, the PR attachment, or by searching team `Yeaboi` for the branch name. The magic
+   word normally already moved it: the GitHub integration closes a `Closes`-linked ticket on merge.
+   If it is already Done, just comment with the merge commit. If it is not (the line was missing or
+   typo'd), move it to Done and comment. If no ticket exists (a human shipped without one), create
+   it in Done rather than skipping — the record matters more than the order.
 
 3. **Notion** — only for user-facing change. Decide from the diff: does anything change what a user
    sees, types, or receives? If yes, create or update the page under 🤙 yeaboi

--- a/cowork/routines/events/pr-opened-dod-audit.md
+++ b/cowork/routines/events/pr-opened-dod-audit.md
@@ -20,7 +20,10 @@ exactly the PRs nobody watched being written. `claude-review.yml` carries the sa
 1. `gh pr view <n> --json title,body,files,labels,author` and `gh pr diff <n>`.
 2. Walk the DoD. For each item, decide **met / unmet / not applicable**, using evidence from the diff
    and not from the PR description's claims:
-   - **1 Linear** — a Linear link in the body or an attachment on the ticket
+   - **1 Linear** — a `Closes YEA-NN` line in the body: the magic word is what makes the Linear
+     GitHub integration attach the PR and close the ticket on merge; a bare Linear URL does neither.
+     Judge from the body only — the ticket's own state is not checked here (the scribe moves it to
+     In Review just after the PR opens, so reading it on the `opened` event would race the writer)
    - **2 Tests** — new/changed functions in the diff that have no corresponding test change
    - **3–4 Lint + security** — the CI `lint` and `security` job conclusions
    - **5 Surface parity** — a new capability with no `CAPABILITIES` row, or a card/tool/flag added

--- a/cowork/sweep-procedure.md
+++ b/cowork/sweep-procedure.md
@@ -35,6 +35,9 @@ workstream and any per-run focus; everything else is here.
    - resolve every `blocker` and `should-fix` finding, then have the builder open the PR labelled
      `cowork` + `workstream:<name>` + the find's `type:<type>` — the merge ship note reads the type
      off the PR, so a PR without one ships untagged
+   - once the PR exists, spawn `cowork-scribe` (`standard`) again to attach it to the Linear ticket
+     and move the ticket to **In Review** — the `Closes YEA-NN` line in the PR body then carries it
+     to Done on merge
 
 6. **Propose lane** — hand every remaining `propose` find to `cowork-scribe` (`standard`), which
    files one GitHub issue each (`cowork:proposal` + `workstream:<name>` + `type:<type>`). **No


### PR DESCRIPTION
## Summary

Linear tickets were created at ship time and never updated afterwards — the only close mechanism (`pr-merged-close-loop`) is an unregistered event routine, so tickets lingered in Backlog/In Progress after their PRs merged. This change gives every ticket a real lifecycle:

- **In Progress** at creation (`/ship` step 1, `claude.yml` step 3, scribe format)
- **In Review** when the scribe attaches the PR (`/ship` step 5, `claude.yml` step 10, and — per independent review — the cowork auto lane in `sweep-procedure.md`/`cowork-builder.md`, which previously never moved tickets at all)
- **Done on merge**, driven by a mandatory `Closes YEA-NN` line in every PR body: the Linear GitHub integration reads the magic word, attaches the PR, and closes the ticket — deterministically, with no dependency on the unregistered routine, covering auto-merge too. A bare Linear URL does neither, which was the root cause.

`pr-merged-close-loop` becomes verify-and-repair; DoD item 1 now includes state + the magic word; the PR-opened audit checks the body only (reading ticket state on `opened` would race the scribe's move). PR attachment is documented as `save_issue` `links` — the connector's `create_attachment` takes file uploads only. `cowork/README.md` records the Linear GitHub integration as a manual prerequisite alongside connectors and the event routines.

A one-time reconciliation of the existing board was done alongside this change: 7 tickets with merged PRs → Done, 5 with open PRs → In Review, each with the PR attached and an evidence comment.

The first commit is unrelated pre-existing routine-URL bookkeeping from a `/cowork deploy`, committed separately for blame hygiene.

## Test plan

- `make test` — 9580 passed, 47 skipped
- `make lint`, `make security` — clean
- `make cowork-check` + `tests/unit/test_cowork_models.py` / `test_cowork_setup.py` re-run after review fixes — clean
- Independent `code-reviewer` pass: 1 blocker (auto lane missed the lifecycle) + 5 should-fixes, all resolved in this diff

Closes YEA-47

DoD items 2/5/6/7 (tests, surface parity, observability, web bundles) do not apply — prose/prompt-only change, no Python or frontend code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)