### PR TITLE
a yard of ducks for the idle screensaver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.54.0"
+version = "2.55.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/demo_duck_mayhem.py
+++ b/scripts/demo_duck_mayhem.py
@@ -52,7 +52,6 @@ from yeaboi.ui.shared._mascot import (  # noqa: E402
     DUCK_HEAD_FACE,
     DUCK_HEAD_GLASSES,
     DUCK_HEAD_QUACK,
-    SHADES_LIFT_SEQUENCE,
     _compose,
     _pack_cells,
     _shift,
@@ -69,13 +68,19 @@ Grid = tuple[str, ...]
 # opposite of mayhem.
 DRIFT_SPEED = (26.0, 48.0)  # initial speed, px/s
 SPIN_SPEED = (-150.0, 150.0)  # deg/s; sign is direction
+# Half-angle of the cone each duck sets off in, aimed at the middle.
+CROSSING_SPREAD = math.radians(65)
 
 # Elastic. Any energy loss at all and a gravity-free yard visibly winds down
 # over eight seconds, with nothing to put the energy back.
 BOUNCE = 1.0
 
 QUACK_SECONDS = 0.22  # beak stays open this long after a hit
-ROT_STEPS = 24  # baked angles, i.e. 15 degrees apart
+# Rendered angles. At 24 (15 degrees apart) a duck spinning at 150 deg/s
+# changes pose six frames at a time and visibly clunks round; 48 halves the
+# step to 7.5 degrees and it reads as turning. Costs nothing but cache
+# entries, since these are built on demand rather than all up front.
+ROT_STEPS = 48
 
 # Squash and stretch on impact, recovering over SQUISH_SECONDS. Each entry is a
 # height multiplier; width takes the inverse, capped, so he reads as compressing
@@ -111,8 +116,18 @@ DUCK_SCALE = 2
 # The anchored duck in the middle — twice the crowd again, immovable, and the
 # fixed point the whole scene is arranged around.
 HERO_SCALE = DUCK_SCALE * 2
-HERO_SHADES_EVERY = 3.0
-HERO_SHADES_FPS = 8
+# Every 1.6s, not the saver's 3. The clip is four seconds long before it
+# ping-pongs, so a three-second cycle can land almost entirely outside the
+# window — the gag was rendering correctly and still looked frozen, because at
+# most one lift fell inside the take and a dozen ducks were flying over it.
+HERO_SHADES_EVERY = 1.6
+# Its own sequence rather than the app's SHADES_LIFT_SEQUENCE, and stepped more
+# than twice as fast. The app's is a slow reveal with a long hold at the top,
+# which suits a calm idle screen and is far too languid next to a dozen ducks
+# ricocheting around — it read as the glasses being stuck rather than lifting.
+# This pops up, holds a beat, drops: eight steps at 20/s, so 0.4s end to end.
+HERO_SHADES_FPS = 20
+HERO_LIFT_SEQUENCE = (2, 4, 5, 5, 5, 3, 1, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -214,23 +229,6 @@ def squashed(angle_idx: int, level: int, normal_idx: int, quack: bool) -> Grid:
     return rotate(squash(upright, SQUISH_CURVE[level - 1]), normal, SPRITE_SIZE)
 
 
-def bake(grid: Grid) -> tuple[tuple[Grid, ...], ...]:
-    """Every squash level at every angle, once, at import.
-
-    Five levels by twenty-four angles is 120 small grids per sprite — built once
-    in a few milliseconds, then indexed for the rest of the run. Doing either
-    transform live would be the same arithmetic a thousand times a second for
-    results that never change.
-    """
-    levels = (1.0, *SQUISH_CURVE)
-    return tuple(
-        tuple(rotate(squash(grid, level), i * 360.0 / ROT_STEPS, SPRITE_SIZE) for i in range(ROT_STEPS))
-        for level in levels
-    )
-
-
-ROTATED = bake(SOURCE)
-ROTATED_QUACK = bake(SOURCE_QUACK)
 # Collision radius from the *unrotated* sprite, not from the diagonal canvas it
 # is baked onto — the corners of that canvas are empty, and using them would
 # have ducks bouncing off each other's whitespace.
@@ -261,31 +259,28 @@ def hero_lift(elapsed: float) -> int:
     """How far the shades are currently raised, in source pixels. 0 at rest."""
     period = int(HERO_SHADES_EVERY * HERO_SHADES_FPS)
     step_i = int(elapsed * HERO_SHADES_FPS) % period
-    start = period - len(SHADES_LIFT_SEQUENCE)
-    return SHADES_LIFT_SEQUENCE[step_i - start] if step_i >= start else 0
+    start = period - len(HERO_LIFT_SEQUENCE)
+    return HERO_LIFT_SEQUENCE[step_i - start] if step_i >= start else 0
 
 
-def hero_quack_grid() -> Grid:
-    """The hero mid-quack, at the same height as every other hero frame.
+def hero_grid(elapsed: float, quacking: bool = False) -> Grid:
+    """The anchored duck: shades gag on a timer, open beak when hit, both at once.
 
-    Same reason hero_grid always pads: compose() centres a sprite on the duck,
-    so a grid that is shorter puts his head lower. He is hit constantly, and
-    without this he bobs up and down on every impact.
-    """
-    pad = ("." * len(DUCK_HEAD_QUACK[0]),) * HERO_PAD
-    return scale(pad + DUCK_HEAD_QUACK, HERO_SCALE)
+    The beak used to be a separate sprite that replaced this one, and the result
+    was that the gag never played at all — he is hit several times a second, so
+    the quack frame was up almost permanently and the sunglasses looked frozen.
+    Composing instead of choosing fixes it: the quack head is just a different
+    base to lay the glasses over.
 
-
-def hero_grid(elapsed: float) -> Grid:
-    """The anchored duck, running the shades gag on a timer.
-
-    Mirrors render_head_shades' composition rather than calling it: that returns
-    a packed renderable, and everything here stays an unpacked pixel grid until
-    the final blit.
+    Mirrors render_head_shades' composition rather than calling it, because that
+    returns a packed renderable and everything here stays an unpacked pixel grid
+    until the final blit. Always padded, at rest as well as mid-gag: compose()
+    centres a sprite on its duck, so a grid that changed height would bob.
     """
     pad = ("." * len(DUCK_HEAD_FACE[0]),) * HERO_PAD
-    face, glasses = pad + DUCK_HEAD_FACE, pad + DUCK_HEAD_GLASSES
-    return scale(_compose(face, glasses, _shift(glasses, hero_lift(elapsed))), HERO_SCALE)
+    base = pad + (DUCK_HEAD_QUACK if quacking else DUCK_HEAD_FACE)
+    glasses = pad + DUCK_HEAD_GLASSES
+    return scale(_compose(base, glasses, _shift(glasses, hero_lift(elapsed))), HERO_SCALE)
 
 
 def blit(canvas: list[list[str]], sprite: Grid, left: int, top: int) -> None:
@@ -338,7 +333,7 @@ class Duck:
         if self.is_hero:
             # Quacking beats the shades gag: he cannot be mid-cool-reveal and
             # mid-yelp at once, and the yelp is the one a duck to the face causes.
-            return hero_quack_grid() if now < self.quack_until else hero_grid(now)
+            return hero_grid(now, quacking=now < self.quack_until)
         level = 0
         if now < self.squish_until:
             # Flattest at the moment of impact, easing back out as the timer runs.
@@ -397,7 +392,13 @@ def make_ducks(count: int, width: int, height: int, rng: random.Random) -> list[
             if math.hypot(cx - hero.x, cy - hero.y) > hero.radius + DUCK_RADIUS + 2:
                 x, y = cx, cy
                 break
-        heading = rng.uniform(0, 2 * math.pi)
+        # Head broadly for the middle rather than in any direction at all. Left
+        # to chance, a duck starting in a corner spends the whole clip rattling
+        # around in it and never comes near anything — which is what left the
+        # left-hand ducks looking stranded. The spread is wide enough that they
+        # do not all converge on the hero like a target.
+        toward = math.atan2(hero.y - y, hero.x - x)
+        heading = toward + rng.uniform(-CROSSING_SPREAD, CROSSING_SPREAD)
         speed = rng.uniform(*DRIFT_SPEED)
         ducks.append(
             Duck(

--- a/scripts/demo_duck_mayhem.py
+++ b/scripts/demo_duck_mayhem.py
@@ -67,7 +67,7 @@ Grid = tuple[str, ...]
 # No gravity. Ducks drift; nothing falls and nothing piles up. With gravity they
 # spent the clip settling into a twitching heap along the floor, which is the
 # opposite of mayhem.
-DRIFT_SPEED = (9.0, 20.0)  # initial speed, px/s
+DRIFT_SPEED = (26.0, 48.0)  # initial speed, px/s
 SPIN_SPEED = (-150.0, 150.0)  # deg/s; sign is direction
 
 # Elastic. Any energy loss at all and a gravity-free yard visibly winds down
@@ -265,6 +265,17 @@ def hero_lift(elapsed: float) -> int:
     return SHADES_LIFT_SEQUENCE[step_i - start] if step_i >= start else 0
 
 
+def hero_quack_grid() -> Grid:
+    """The hero mid-quack, at the same height as every other hero frame.
+
+    Same reason hero_grid always pads: compose() centres a sprite on the duck,
+    so a grid that is shorter puts his head lower. He is hit constantly, and
+    without this he bobs up and down on every impact.
+    """
+    pad = ("." * len(DUCK_HEAD_QUACK[0]),) * HERO_PAD
+    return scale(pad + DUCK_HEAD_QUACK, HERO_SCALE)
+
+
 def hero_grid(elapsed: float) -> Grid:
     """The anchored duck, running the shades gag on a timer.
 
@@ -327,7 +338,7 @@ class Duck:
         if self.is_hero:
             # Quacking beats the shades gag: he cannot be mid-cool-reveal and
             # mid-yelp at once, and the yelp is the one a duck to the face causes.
-            return scale(DUCK_HEAD_QUACK, HERO_SCALE) if now < self.quack_until else hero_grid(now)
+            return hero_quack_grid() if now < self.quack_until else hero_grid(now)
         level = 0
         if now < self.squish_until:
             # Flattest at the moment of impact, easing back out as the timer runs.
@@ -364,14 +375,27 @@ def make_ducks(count: int, width: int, height: int, rng: random.Random) -> list[
 
     ducks: list[Duck] = []
     margin = SPRITE_SIZE / 2
-    for _ in range(count):
-        # Rejection-sample a start clear of the hero, so nothing begins the clip
-        # already inside him and gets flung out on frame one.
-        x = y = 0.0
-        for _attempt in range(200):
-            x = rng.uniform(margin, width - margin)
-            y = rng.uniform(margin, height - margin)
-            if math.hypot(x - hero.x, y - hero.y) > hero.radius + DUCK_RADIUS + 2:
+
+    # Stratified, not uniform: one duck per cell of a coarse grid, jittered
+    # inside it. Twelve uniform samples clump — the first take left the whole
+    # left third empty, which is what uniform random looks like at this count,
+    # and the eye reads it as a mistake rather than as chance.
+    across = math.ceil(math.sqrt(count))
+    down = math.ceil(count / across)
+    cell_w = (width - 2 * margin) / across
+    cell_h = (height - 2 * margin) / down
+
+    for i in range(count):
+        col, row = i % across, i // across
+        # Rejection-sample within the cell so nothing starts inside the hero and
+        # gets flung out on frame one. Falls back to the cell centre.
+        x = margin + (col + 0.5) * cell_w
+        y = margin + (row + 0.5) * cell_h
+        for _attempt in range(60):
+            cx = margin + (col + rng.uniform(0.15, 0.85)) * cell_w
+            cy = margin + (row + rng.uniform(0.15, 0.85)) * cell_h
+            if math.hypot(cx - hero.x, cy - hero.y) > hero.radius + DUCK_RADIUS + 2:
+                x, y = cx, cy
                 break
         heading = rng.uniform(0, 2 * math.pi)
         speed = rng.uniform(*DRIFT_SPEED)

--- a/scripts/demo_duck_mayhem.py
+++ b/scripts/demo_duck_mayhem.py
@@ -1,600 +1,56 @@
 #!/usr/bin/env python3
-"""A yard full of ducks, for recording. Not part of the app.
+"""Drive the screensaver's duck yard on demand, for recording.
 
-The idle screensaver is one calm head. This is the opposite: a dozen of them
-adrift in zero gravity, spinning, ricocheting off each other and off the big one
-anchored in the middle, quacking on every impact. It exists to be captured by
-tui-recorder and posted somewhere; nothing in yeaboi imports it.
+The simulation lives in ``yeaboi.ui.shared._mayhem`` — this is a window onto it.
+Two reasons to have it rather than just idling the app for five minutes: the
+sprite scale can be raised past what a real terminal would use, which is what
+makes a rotated duck survive being filmed, and it can be told to stop after a
+fixed number of seconds so a take is reproducible.
 
-Three things shape the implementation.
-
-**It composites at pixel level, not cell level.** The sprites in _mascot are
-half-block packed — two pixel rows per terminal row — and the packing happens
-last there. Doing the same here buys positions at half-cell precision, and it is
-also the only level at which a sprite can be rotated at all. Everything below
-works on grids of letter codes ('.' being transparent), exactly the form _mascot
-keeps its sprites in, and the whole canvas is packed once at the end.
-
-**Rotation is real, and pre-baked.** Each duck is nearest-neighbour rotated into
-ROT_STEPS fixed angles once at import, then indexed per frame. Rotating on the
-fly would be the same arithmetic a thousand times a second for results that
-never change. Nearest-neighbour rather than any smoothing: the edges are drawn
-deliberately at this size, and interpolating them just makes mud.
-
-**The simulation is deterministic.** Fixed timestep, RNG seeded once at setup and
-never touched while stepping. Re-recording a seed gives the same clip, which is
-the difference between a demo you can regenerate and one you got lucky with.
-
-    uv run python scripts/demo_duck_mayhem.py                 # size to terminal
-    uv run python scripts/demo_duck_mayhem.py --seconds 8     # then exit
-    uv run python scripts/demo_duck_mayhem.py --seed 7        # a different yard
+    uv run python scripts/demo_duck_mayhem.py                # as the app draws it
+    uv run python scripts/demo_duck_mayhem.py --scale 2      # for a 2x recording
+    uv run python scripts/demo_duck_mayhem.py --seconds 8    # then exit
 """
 
 from __future__ import annotations
 
 import argparse
-import math
-import random
 import sys
 import time
-from dataclasses import dataclass
-from functools import cache
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from rich.console import Console, Group  # noqa: E402
+from rich.console import Console  # noqa: E402
 from rich.live import Live  # noqa: E402
-from rich.text import Text  # noqa: E402
 
-from yeaboi.ui.shared._mascot import (  # noqa: E402
-    DUCK_HEAD,
-    DUCK_HEAD_FACE,
-    DUCK_HEAD_GLASSES,
-    DUCK_HEAD_QUACK,
-    _compose,
-    _pack_cells,
-    _shift,
-)
-
-Grid = tuple[str, ...]
-
-# ---------------------------------------------------------------------------
-# Tuning. Distances are sprite pixels, angles degrees, time seconds.
-# ---------------------------------------------------------------------------
-
-# No gravity. Ducks drift; nothing falls and nothing piles up. With gravity they
-# spent the clip settling into a twitching heap along the floor, which is the
-# opposite of mayhem.
-DRIFT_SPEED = (26.0, 48.0)  # initial speed, px/s
-SPIN_SPEED = (-150.0, 150.0)  # deg/s; sign is direction
-# Half-angle of the cone each duck sets off in, aimed at the middle.
-CROSSING_SPREAD = math.radians(65)
-
-# Elastic. Any energy loss at all and a gravity-free yard visibly winds down
-# over eight seconds, with nothing to put the energy back.
-BOUNCE = 1.0
-
-QUACK_SECONDS = 0.22  # beak stays open this long after a hit
-# Rendered angles. At 24 (15 degrees apart) a duck spinning at 150 deg/s
-# changes pose six frames at a time and visibly clunks round; 48 halves the
-# step to 7.5 degrees and it reads as turning. Costs nothing but cache
-# entries, since these are built on demand rather than all up front.
-ROT_STEPS = 48
-
-# Squash and stretch on impact, recovering over SQUISH_SECONDS. Each entry is a
-# height multiplier; width takes the inverse, capped, so he reads as compressing
-# rather than shrinking.
-#
-# Deliberately gentle. The first version squashed to 58% and looked broken: at
-# that depth the sunglasses and beak are folded into each other, and stacked on
-# top of a rotation there is no reading of the frame in which it is a duck. The
-# eye registers a squash from very little — a fifth of the height is plenty, and
-# the point is the impact reading as an impact, not the pose being legible.
-SQUISH_SECONDS = 0.16
-SQUISH_CURVE = (0.80, 0.87, 0.93, 0.97)
-MAX_STRETCH = 1.10
-# Quantised impact directions. The squash flattens along the contact normal —
-# the face that hit the wall is the face that goes flat, like a ball — so it has
-# to be applied in world space, after the duck's own rotation. Sixteen
-# directions is 22.5 degrees apart, finer than anyone can pick out mid-bounce.
-NORMAL_STEPS = 16
-
-# Crowd sprites are upscaled before they are rotated, and this is the single
-# thing that decides whether a rotated duck still looks like a duck.
-#
-# The sunglasses are one pixel thick in the source art. Rotate 16x14 by anything
-# that is not a multiple of 90 and that pixel lands between two others and is
-# lost, which turns the face to mush. At 2x it is two pixels thick and survives.
-#
-# It costs nothing on screen: a duck's size in the frame is its cell footprint
-# times the cell size, so doubling the sprite and halving the font leaves him
-# exactly as big while doubling the detail he is drawn with. Pair this with a
-# smaller terminal font, not with a bigger duck.
-DUCK_SCALE = 2
-
-# The anchored duck in the middle — twice the crowd again, immovable, and the
-# fixed point the whole scene is arranged around.
-HERO_SCALE = DUCK_SCALE * 2
-# Every 1.6s, not the saver's 3. The clip is four seconds long before it
-# ping-pongs, so a three-second cycle can land almost entirely outside the
-# window — the gag was rendering correctly and still looked frozen, because at
-# most one lift fell inside the take and a dozen ducks were flying over it.
-HERO_SHADES_EVERY = 1.6
-# Its own sequence rather than the app's SHADES_LIFT_SEQUENCE, and stepped more
-# than twice as fast. The app's is a slow reveal with a long hold at the top,
-# which suits a calm idle screen and is far too languid next to a dozen ducks
-# ricocheting around — it read as the glasses being stuck rather than lifting.
-# This pops up, holds a beat, drops: eight steps at 20/s, so 0.4s end to end.
-HERO_SHADES_FPS = 20
-HERO_LIFT_SEQUENCE = (2, 4, 5, 5, 5, 3, 1, 0)
-
-
-# ---------------------------------------------------------------------------
-# Grid helpers — a grid is a tuple of equal-length rows of letter codes
-# ---------------------------------------------------------------------------
-
-
-def scale(grid: Grid, factor: int) -> Grid:
-    """Nearest-neighbour upscale, the only honest way to enlarge pixel art."""
-    if factor == 1:
-        return grid
-    out: list[str] = []
-    for row in grid:
-        wide = "".join(ch * factor for ch in row)
-        out.extend([wide] * factor)
-    return tuple(out)
-
-
-def squash(grid: Grid, factor: float) -> Grid:
-    """Compress vertically by ``factor`` and widen by its inverse.
-
-    Applied *before* rotation, so the squash is along the duck's own body axis
-    and turns with him. Doing it after would need a general affine baked for
-    every (angle, impact-direction) pair, for a difference nobody watching a
-    dozen ducks at once could pick out.
-    """
-    if factor >= 1.0:
-        return grid
-    h, w = len(grid), len(grid[0])
-    new_h = max(1, round(h * factor))
-    new_w = max(1, round(w * min(1.0 / factor, MAX_STRETCH)))
-    return tuple(
-        "".join(grid[min(h - 1, y * h // new_h)][min(w - 1, x * w // new_w)] for x in range(new_w))
-        for y in range(new_h)
-    )
-
-
-def rotate(grid: Grid, degrees: float, size: int | None = None) -> Grid:
-    """Rotate about the centre onto a square canvas big enough for any angle.
-
-    Square and diagonal-sized so every baked angle comes out the same shape — a
-    sprite that changed size as it turned would need its geometry recomputed
-    every frame and would visibly breathe.
-
-    Inverse mapping (walk the destination, sample the source) rather than
-    forward: rotating source pixels *into* the destination leaves unpainted
-    holes wherever the mapping is not onto.
-    """
-    h, w = len(grid), len(grid[0])
-    # Callers pass an explicit size so every squash level bakes to the same
-    # canvas — a sprite whose footprint changed with its squash would need its
-    # geometry recomputed per frame.
-    size = size or math.ceil(math.hypot(w, h))
-    src_cx, src_cy = (w - 1) / 2, (h - 1) / 2
-    dst_c = (size - 1) / 2
-    rad = math.radians(degrees)
-    cos, sin = math.cos(rad), math.sin(rad)
-
-    out: list[str] = []
-    for dy in range(size):
-        row: list[str] = []
-        for dx in range(size):
-            ox, oy = dx - dst_c, dy - dst_c
-            sx = round(cos * ox + sin * oy + src_cx)
-            sy = round(-sin * ox + cos * oy + src_cy)
-            row.append(grid[sy][sx] if 0 <= sy < h and 0 <= sx < w else ".")
-        out.append("".join(row))
-    return tuple(out)
-
-
-SOURCE = scale(DUCK_HEAD, DUCK_SCALE)
-SOURCE_QUACK = scale(DUCK_HEAD_QUACK, DUCK_SCALE)
-
-# One canvas for every (squash, angle) pair: the widest the sprite ever gets, on
-# its diagonal.
-SPRITE_SIZE = math.ceil(math.hypot(len(SOURCE[0]) * MAX_STRETCH, len(SOURCE)))
-
-
-@cache
-def squashed(angle_idx: int, level: int, normal_idx: int, quack: bool) -> Grid:
-    """A duck at ``angle_idx``, flattened along world direction ``normal_idx``.
-
-    Squashing along an arbitrary world axis is three steps: turn that axis
-    vertical, squash vertically, turn back. Written out, the whole transform is
-    R(normal) . S_v(f) . R(angle - normal) applied to the source.
-
-    Cached rather than pre-baked. The full table is 5 levels x 24 angles x 16
-    normals x 2 beaks — 3,840 grids, several seconds of import for a set of
-    which a given clip touches a few hundred. lru_cache pays only for what is
-    actually asked for, and every combination repeats constantly once the yard
-    is moving.
-    """
-    source = SOURCE_QUACK if quack else SOURCE
-    if level == 0:
-        return rotate(source, angle_idx * 360.0 / ROT_STEPS, SPRITE_SIZE)
-    normal = normal_idx * 360.0 / NORMAL_STEPS
-    angle = angle_idx * 360.0 / ROT_STEPS
-    upright = rotate(source, angle - normal, SPRITE_SIZE)
-    return rotate(squash(upright, SQUISH_CURVE[level - 1]), normal, SPRITE_SIZE)
-
-
-# Collision radius from the *unrotated* sprite, not from the diagonal canvas it
-# is baked onto — the corners of that canvas are empty, and using them would
-# have ducks bouncing off each other's whitespace.
-DUCK_RADIUS = max(len(SOURCE[0]), len(SOURCE)) / 2.0
-
-# Where the sunglasses sit inside the source art, so the collider can be put on
-# them. Derived rather than typed in, or it silently drifts if the art changes.
-_GLASSES_PX = [(x, y) for y, row in enumerate(DUCK_HEAD_GLASSES) for x, ch in enumerate(row) if ch != "."]
-GLASSES_X0, GLASSES_X1 = min(x for x, _ in _GLASSES_PX), max(x for x, _ in _GLASSES_PX)
-GLASSES_Y0, GLASSES_Y1 = min(y for _, y in _GLASSES_PX), max(y for _, y in _GLASSES_PX)
-# A circle is a poor fit for something 12 wide and 3 tall, so this splits the
-# difference — big enough to feel solid, small enough not to bounce ducks off
-# thin air either side of him.
-GLASSES_RADIUS = (GLASSES_X1 - GLASSES_X0 + 1) / 3.0 * HERO_SCALE
-
-HERO_W = len(DUCK_HEAD[0]) * HERO_SCALE
-HERO_H = len(DUCK_HEAD) * HERO_SCALE
-HERO_RADIUS = max(HERO_W, HERO_H) / 2.0
-
-
-# Blank rows above the crown for the raised pair to float into. Always present,
-# even at rest: a grid that grew when the gag started would shift the head half a
-# dozen pixels every three seconds, because compose() centres on the duck.
-HERO_PAD = 4
-
-
-def hero_lift(elapsed: float) -> int:
-    """How far the shades are currently raised, in source pixels. 0 at rest."""
-    period = int(HERO_SHADES_EVERY * HERO_SHADES_FPS)
-    step_i = int(elapsed * HERO_SHADES_FPS) % period
-    start = period - len(HERO_LIFT_SEQUENCE)
-    return HERO_LIFT_SEQUENCE[step_i - start] if step_i >= start else 0
-
-
-def hero_grid(elapsed: float, quacking: bool = False) -> Grid:
-    """The anchored duck: shades gag on a timer, open beak when hit, both at once.
-
-    The beak used to be a separate sprite that replaced this one, and the result
-    was that the gag never played at all — he is hit several times a second, so
-    the quack frame was up almost permanently and the sunglasses looked frozen.
-    Composing instead of choosing fixes it: the quack head is just a different
-    base to lay the glasses over.
-
-    Mirrors render_head_shades' composition rather than calling it, because that
-    returns a packed renderable and everything here stays an unpacked pixel grid
-    until the final blit. Always padded, at rest as well as mid-gag: compose()
-    centres a sprite on its duck, so a grid that changed height would bob.
-    """
-    pad = ("." * len(DUCK_HEAD_FACE[0]),) * HERO_PAD
-    base = pad + (DUCK_HEAD_QUACK if quacking else DUCK_HEAD_FACE)
-    glasses = pad + DUCK_HEAD_GLASSES
-    return scale(_compose(base, glasses, _shift(glasses, hero_lift(elapsed))), HERO_SCALE)
-
-
-def blit(canvas: list[list[str]], sprite: Grid, left: int, top: int) -> None:
-    """Paint a sprite, skipping its transparent pixels."""
-    height, width = len(canvas), len(canvas[0])
-    for dy, row in enumerate(sprite):
-        cy = top + dy
-        if not 0 <= cy < height:
-            continue
-        for dx, ch in enumerate(row):
-            cx = left + dx
-            if ch != "." and 0 <= cx < width:
-                canvas[cy][cx] = ch
-
-
-# ---------------------------------------------------------------------------
-# Simulation. Positions are sprite centres — the only origin that still makes
-# sense once things rotate.
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class Duck:
-    x: float
-    y: float
-    vx: float
-    vy: float
-    angle: float = 0.0
-    spin: float = 0.0
-    quack_until: float = -1.0
-    squish_until: float = -1.0
-    # Direction the last hit came from, quantised. The squash flattens along it.
-    squish_normal: int = 0
-    radius: float = DUCK_RADIUS
-    anchored: bool = False
-    is_hero: bool = False
-    # The hero's raised sunglasses: a collider with no sprite of its own, live
-    # only while they are actually off his head. Ducks bounce off them.
-    is_shades: bool = False
-    enabled: bool = True
-    base_y: float = 0.0
-
-    @property
-    def mass(self) -> float:
-        """Area, so a 2x duck weighs four of the little ones. The hero is
-        anchored so it never comes up for him — but a second big one would work."""
-        return self.radius * self.radius
-
-    def sprite(self, now: float) -> Grid:
-        if self.is_hero:
-            # Quacking beats the shades gag: he cannot be mid-cool-reveal and
-            # mid-yelp at once, and the yelp is the one a duck to the face causes.
-            return hero_grid(now, quacking=now < self.quack_until)
-        level = 0
-        if now < self.squish_until:
-            # Flattest at the moment of impact, easing back out as the timer runs.
-            remaining = (self.squish_until - now) / SQUISH_SECONDS
-            level = 1 + min(len(SQUISH_CURVE) - 1, int((1.0 - remaining) * len(SQUISH_CURVE)))
-        angle_idx = int(self.angle / (360.0 / ROT_STEPS)) % ROT_STEPS
-        return squashed(angle_idx, level, self.squish_normal, now < self.quack_until)
-
-
-def _hit(duck: Duck, now: float, nx: float, ny: float) -> None:
-    """Record an impact: open the beak, and flatten along the contact normal."""
-    duck.quack_until = now + QUACK_SECONDS
-    if duck.is_hero or duck.is_shades:
-        return  # immovable things do not visibly give
-    duck.squish_until = now + SQUISH_SECONDS
-    duck.squish_normal = round(math.degrees(math.atan2(ny, nx)) / (360.0 / NORMAL_STEPS)) % NORMAL_STEPS
-
-
-def make_ducks(count: int, width: int, height: int, rng: random.Random) -> list[Duck]:
-    """Scatter drifting ducks, then anchor the hero dead centre in both axes.
-
-    RNG is used here and nowhere else, so a whole run is a pure function of the
-    seed.
-    """
-    hero = Duck(
-        x=width / 2,
-        y=height / 2,
-        vx=0.0,
-        vy=0.0,
-        radius=HERO_RADIUS,
-        anchored=True,
-        is_hero=True,
-    )
-
-    ducks: list[Duck] = []
-    margin = SPRITE_SIZE / 2
-
-    # Stratified, not uniform: one duck per cell of a coarse grid, jittered
-    # inside it. Twelve uniform samples clump — the first take left the whole
-    # left third empty, which is what uniform random looks like at this count,
-    # and the eye reads it as a mistake rather than as chance.
-    across = math.ceil(math.sqrt(count))
-    down = math.ceil(count / across)
-    cell_w = (width - 2 * margin) / across
-    cell_h = (height - 2 * margin) / down
-
-    for i in range(count):
-        col, row = i % across, i // across
-        # Rejection-sample within the cell so nothing starts inside the hero and
-        # gets flung out on frame one. Falls back to the cell centre.
-        x = margin + (col + 0.5) * cell_w
-        y = margin + (row + 0.5) * cell_h
-        for _attempt in range(60):
-            cx = margin + (col + rng.uniform(0.15, 0.85)) * cell_w
-            cy = margin + (row + rng.uniform(0.15, 0.85)) * cell_h
-            if math.hypot(cx - hero.x, cy - hero.y) > hero.radius + DUCK_RADIUS + 2:
-                x, y = cx, cy
-                break
-        # Head broadly for the middle rather than in any direction at all. Left
-        # to chance, a duck starting in a corner spends the whole clip rattling
-        # around in it and never comes near anything — which is what left the
-        # left-hand ducks looking stranded. The spread is wide enough that they
-        # do not all converge on the hero like a target.
-        toward = math.atan2(hero.y - y, hero.x - x)
-        heading = toward + rng.uniform(-CROSSING_SPREAD, CROSSING_SPREAD)
-        speed = rng.uniform(*DRIFT_SPEED)
-        ducks.append(
-            Duck(
-                x=x,
-                y=y,
-                vx=math.cos(heading) * speed,
-                vy=math.sin(heading) * speed,
-                angle=rng.uniform(0, 360),
-                spin=rng.uniform(*SPIN_SPEED),
-            )
-        )
-    # The raised sunglasses, as a collider with no sprite. Its resting centre is
-    # the glasses' own centre inside the hero grid; step() lifts it from there.
-    gx = (GLASSES_X0 + GLASSES_X1) / 2 - (len(DUCK_HEAD[0]) - 1) / 2
-    gy = HERO_PAD + (GLASSES_Y0 + GLASSES_Y1) / 2 - (HERO_PAD + len(DUCK_HEAD) - 1) / 2
-    ducks.append(
-        Duck(
-            x=hero.x + gx * HERO_SCALE,
-            y=hero.y + gy * HERO_SCALE,
-            vx=0.0,
-            vy=0.0,
-            radius=GLASSES_RADIUS,
-            anchored=True,
-            is_shades=True,
-            enabled=False,
-            base_y=hero.y + gy * HERO_SCALE,
-        )
-    )
-    ducks.append(hero)
-    return ducks
-
-
-def step(ducks: list[Duck], dt: float, now: float, width: int, height: int) -> None:
-    """Advance one fixed timestep. Mutates in place."""
-    margin = SPRITE_SIZE / 2
-
-    # The sunglasses are only solid while they are actually off his head.
-    lift = hero_lift(now)
-    for duck in ducks:
-        if duck.is_shades:
-            duck.enabled = lift > 0
-            duck.y = duck.base_y - lift * HERO_SCALE
-
-    for duck in ducks:
-        if duck.anchored:
-            continue
-        duck.x += duck.vx * dt
-        duck.y += duck.vy * dt
-        duck.angle = (duck.angle + duck.spin * dt) % 360.0
-
-        # Walls, clamped on the *drawn* half-size rather than the collision
-        # radius, so a rotated duck never has a corner cut off by the frame edge.
-        if duck.x <= margin:
-            duck.x, duck.vx = margin, abs(duck.vx) * BOUNCE
-            _hit(duck, now, -1.0, 0.0)
-        elif duck.x >= width - margin:
-            duck.x, duck.vx = width - margin, -abs(duck.vx) * BOUNCE
-            _hit(duck, now, 1.0, 0.0)
-        if duck.y <= margin:
-            duck.y, duck.vy = margin, abs(duck.vy) * BOUNCE
-            _hit(duck, now, 0.0, -1.0)
-        elif duck.y >= height - margin:
-            duck.y, duck.vy = height - margin, -abs(duck.vy) * BOUNCE
-            _hit(duck, now, 0.0, 1.0)
-
-    # Circle against circle, resolved after everyone has moved so the outcome
-    # does not depend on list order. Circles and not boxes because these things
-    # rotate: an axis-aligned box around a spinning sprite is the wrong shape at
-    # most of the baked angles.
-    for i, a in enumerate(ducks):
-        if not a.enabled:
-            continue
-        for b in ducks[i + 1 :]:
-            if not b.enabled or (a.anchored and b.anchored):
-                continue
-            dx, dy = b.x - a.x, b.y - a.y
-            dist = math.hypot(dx, dy)
-            gap = a.radius + b.radius
-            if dist >= gap:
-                continue
-            if dist < 1e-6:
-                # Exactly coincident, so there is no normal to work with. Pick
-                # one — deterministically, because this must not reach for RNG.
-                nx, ny, dist = 1.0, 0.0, 1e-6
-            else:
-                nx, ny = dx / dist, dy / dist
-
-            overlap = gap - dist
-            # Separate along the normal by inverse mass — or entirely onto the
-            # loose one when the other cannot move.
-            if a.anchored:
-                b.x += nx * overlap
-                b.y += ny * overlap
-            elif b.anchored:
-                a.x -= nx * overlap
-                a.y -= ny * overlap
-            else:
-                total = a.mass + b.mass
-                a.x -= nx * overlap * (b.mass / total)
-                a.y -= ny * overlap * (b.mass / total)
-                b.x += nx * overlap * (a.mass / total)
-                b.y += ny * overlap * (a.mass / total)
-
-            # Exchange only the velocity component along the normal; leaving the
-            # tangential part alone is what makes a glancing blow graze rather
-            # than stop dead.
-            avn = a.vx * nx + a.vy * ny
-            bvn = b.vx * nx + b.vy * ny
-            if avn - bvn <= 0:  # already separating
-                continue
-            if a.anchored:
-                delta = -bvn * BOUNCE - bvn
-                b.vx += delta * nx
-                b.vy += delta * ny
-                b.spin = -b.spin
-            elif b.anchored:
-                delta = -avn * BOUNCE - avn
-                a.vx += delta * nx
-                a.vy += delta * ny
-                a.spin = -a.spin
-            else:
-                total = a.mass + b.mass
-                new_a = ((a.mass - b.mass) * avn + 2 * b.mass * bvn) / total * BOUNCE
-                new_b = ((b.mass - a.mass) * bvn + 2 * a.mass * avn) / total * BOUNCE
-                a.vx += (new_a - avn) * nx
-                a.vy += (new_a - avn) * ny
-                b.vx += (new_b - bvn) * nx
-                b.vy += (new_b - bvn) * ny
-                a.spin, b.spin = b.spin, a.spin
-
-            # Each flattens against the other, so the normals are opposite.
-            _hit(a, now, nx, ny)
-            _hit(b, now, -nx, -ny)
-
-    # Separation runs after the wall clamps, so a duck shoved by a neighbour can
-    # end up part-way out of frame. Clamp last and the walls always win — which
-    # matters most in a pile-up, exactly when there are most ducks to lose.
-    for duck in ducks:
-        if duck.anchored:
-            continue
-        duck.x = min(max(duck.x, margin), float(width) - margin)
-        duck.y = min(max(duck.y, margin), float(height) - margin)
-
-
-# ---------------------------------------------------------------------------
-# Rendering
-# ---------------------------------------------------------------------------
-
-
-def compose(ducks: list[Duck], now: float, cols: int, rows: int) -> Group:
-    """Blit the yard onto one pixel canvas, then pack it once."""
-    canvas = [["." for _ in range(cols)] for _ in range(rows * 2)]
-
-    # Hero last, so the crowd passes behind him rather than over his face. He is
-    # one of the ducks now, so this is a draw order and not a special case.
-    for duck in sorted(ducks, key=lambda d: d.is_hero):
-        if duck.is_shades:
-            continue  # a collider, drawn as part of the hero
-        sprite = duck.sprite(now)
-        blit(canvas, sprite, int(duck.x - len(sprite[0]) / 2), int(duck.y - len(sprite) / 2))
-
-    lines: list[Text] = []
-    for cells in _pack_cells(tuple("".join(row) for row in canvas)):
-        line = Text()
-        for glyph, style in cells:
-            line.append(glyph, style=style)
-        lines.append(line)
-    return Group(*lines)
+from yeaboi.ui.shared import _mayhem  # noqa: E402
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--ducks", type=int, default=12)
+    parser.add_argument("--scale", type=int, default=1, help="sprite scale; 2 for a recording")
+    parser.add_argument("--ducks", type=int, default=0, help="0 = as many as fit")
     parser.add_argument("--seed", type=int, default=3)
     parser.add_argument("--seconds", type=float, default=0, help="exit after N seconds (0 = forever)")
     parser.add_argument("--fps", type=float, default=60.0)
     args = parser.parse_args()
 
+    _mayhem.configure(args.scale)
+    if args.ducks:
+        _mayhem.fits = lambda w, h, coverage=0.0, n=args.ducks: n  # type: ignore[assignment]
+
     console = Console()
     cols, rows = console.size
-    px_h = rows * 2
-
-    # noqa S311: this is a duck, not a nonce. Reproducibility is the whole
-    # requirement — a cryptographic generator would be strictly worse.
-    rng = random.Random(args.seed)  # noqa: S311
-    ducks = make_ducks(args.ducks, cols, px_h, rng)
-
-    # Fixed timestep, decoupled from how long a frame takes to draw. A
-    # wall-clock dt would make the run unreproducible, and the point of seeding
-    # is that a seed gives the same clip every time.
     dt = 1.0 / args.fps
     now = 0.0
     start = time.monotonic()
 
+    # screen=True for the same reason the splash uses it: Rich double-buffers the
+    # alternate screen and writes one atomic frame per refresh, so the animation
+    # cannot tear. auto_refresh off so this loop alone decides when a frame exists.
     with Live(
-        compose(ducks, now, cols, rows),
+        _mayhem.render(cols, rows, 0.0, seed=args.seed),
         console=console,
         auto_refresh=False,
         screen=True,
@@ -603,11 +59,10 @@ def main() -> int:
         while True:
             if args.seconds and now >= args.seconds:
                 return 0
-            step(ducks, dt, now, cols, px_h)
             now += dt
-            live.update(compose(ducks, now, cols, rows), refresh=True)
-            # Pace against the clock rather than sleeping a flat dt, so the
-            # animation runs at real speed even when a frame costs more than dt.
+            live.update(_mayhem.render(cols, rows, now, seed=args.seed), refresh=True)
+            # Pace against the clock rather than sleeping a flat dt, so it runs at
+            # real speed even when a frame costs more than dt.
             behind = (start + now) - time.monotonic()
             if behind > 0:
                 time.sleep(behind)

--- a/scripts/demo_duck_mayhem.py
+++ b/scripts/demo_duck_mayhem.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""A yard full of ducks, for recording. Not part of the app.
+
+The idle screensaver is one calm head. This is the opposite: a dozen of them
+adrift in zero gravity, spinning, ricocheting off each other and off the big one
+anchored in the middle, quacking on every impact. It exists to be captured by
+tui-recorder and posted somewhere; nothing in yeaboi imports it.
+
+Three things shape the implementation.
+
+**It composites at pixel level, not cell level.** The sprites in _mascot are
+half-block packed — two pixel rows per terminal row — and the packing happens
+last there. Doing the same here buys positions at half-cell precision, and it is
+also the only level at which a sprite can be rotated at all. Everything below
+works on grids of letter codes ('.' being transparent), exactly the form _mascot
+keeps its sprites in, and the whole canvas is packed once at the end.
+
+**Rotation is real, and pre-baked.** Each duck is nearest-neighbour rotated into
+ROT_STEPS fixed angles once at import, then indexed per frame. Rotating on the
+fly would be the same arithmetic a thousand times a second for results that
+never change. Nearest-neighbour rather than any smoothing: the edges are drawn
+deliberately at this size, and interpolating them just makes mud.
+
+**The simulation is deterministic.** Fixed timestep, RNG seeded once at setup and
+never touched while stepping. Re-recording a seed gives the same clip, which is
+the difference between a demo you can regenerate and one you got lucky with.
+
+    uv run python scripts/demo_duck_mayhem.py                 # size to terminal
+    uv run python scripts/demo_duck_mayhem.py --seconds 8     # then exit
+    uv run python scripts/demo_duck_mayhem.py --seed 7        # a different yard
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from rich.console import Console, Group  # noqa: E402
+from rich.live import Live  # noqa: E402
+from rich.text import Text  # noqa: E402
+
+from yeaboi.ui.shared._mascot import (  # noqa: E402
+    DUCK_HEAD,
+    DUCK_HEAD_FACE,
+    DUCK_HEAD_GLASSES,
+    DUCK_HEAD_QUACK,
+    SHADES_LIFT_SEQUENCE,
+    _compose,
+    _pack_cells,
+    _shift,
+)
+
+Grid = tuple[str, ...]
+
+# ---------------------------------------------------------------------------
+# Tuning. Distances are sprite pixels, angles degrees, time seconds.
+# ---------------------------------------------------------------------------
+
+# No gravity. Ducks drift; nothing falls and nothing piles up. With gravity they
+# spent the clip settling into a twitching heap along the floor, which is the
+# opposite of mayhem.
+DRIFT_SPEED = (9.0, 20.0)  # initial speed, px/s
+SPIN_SPEED = (-150.0, 150.0)  # deg/s; sign is direction
+
+# Elastic. Any energy loss at all and a gravity-free yard visibly winds down
+# over eight seconds, with nothing to put the energy back.
+BOUNCE = 1.0
+
+QUACK_SECONDS = 0.22  # beak stays open this long after a hit
+ROT_STEPS = 24  # baked angles, i.e. 15 degrees apart
+
+# Squash and stretch on impact, recovering over SQUISH_SECONDS. Each entry is a
+# height multiplier; width takes the inverse so the duck keeps roughly his area
+# and reads as compressing rather than shrinking. The stretch is capped, because
+# a duck squashed to 58% would otherwise be nearly twice as wide as he is tall
+# and stop looking like a duck at all.
+SQUISH_SECONDS = 0.18
+SQUISH_CURVE = (0.58, 0.70, 0.82, 0.92)
+MAX_STRETCH = 1.25
+
+# The anchored duck in the middle. Twice the size, immovable, and the fixed
+# point the whole scene is arranged around.
+HERO_SCALE = 2
+HERO_SHADES_EVERY = 3.0
+HERO_SHADES_FPS = 8
+
+
+# ---------------------------------------------------------------------------
+# Grid helpers — a grid is a tuple of equal-length rows of letter codes
+# ---------------------------------------------------------------------------
+
+
+def scale(grid: Grid, factor: int) -> Grid:
+    """Nearest-neighbour upscale, the only honest way to enlarge pixel art."""
+    if factor == 1:
+        return grid
+    out: list[str] = []
+    for row in grid:
+        wide = "".join(ch * factor for ch in row)
+        out.extend([wide] * factor)
+    return tuple(out)
+
+
+def squash(grid: Grid, factor: float) -> Grid:
+    """Compress vertically by ``factor`` and widen by its inverse.
+
+    Applied *before* rotation, so the squash is along the duck's own body axis
+    and turns with him. Doing it after would need a general affine baked for
+    every (angle, impact-direction) pair, for a difference nobody watching a
+    dozen ducks at once could pick out.
+    """
+    if factor >= 1.0:
+        return grid
+    h, w = len(grid), len(grid[0])
+    new_h = max(1, round(h * factor))
+    new_w = max(1, round(w * min(1.0 / factor, MAX_STRETCH)))
+    return tuple(
+        "".join(grid[min(h - 1, y * h // new_h)][min(w - 1, x * w // new_w)] for x in range(new_w))
+        for y in range(new_h)
+    )
+
+
+def rotate(grid: Grid, degrees: float, size: int | None = None) -> Grid:
+    """Rotate about the centre onto a square canvas big enough for any angle.
+
+    Square and diagonal-sized so every baked angle comes out the same shape — a
+    sprite that changed size as it turned would need its geometry recomputed
+    every frame and would visibly breathe.
+
+    Inverse mapping (walk the destination, sample the source) rather than
+    forward: rotating source pixels *into* the destination leaves unpainted
+    holes wherever the mapping is not onto.
+    """
+    h, w = len(grid), len(grid[0])
+    # Callers pass an explicit size so every squash level bakes to the same
+    # canvas — a sprite whose footprint changed with its squash would need its
+    # geometry recomputed per frame.
+    size = size or math.ceil(math.hypot(w, h))
+    src_cx, src_cy = (w - 1) / 2, (h - 1) / 2
+    dst_c = (size - 1) / 2
+    rad = math.radians(degrees)
+    cos, sin = math.cos(rad), math.sin(rad)
+
+    out: list[str] = []
+    for dy in range(size):
+        row: list[str] = []
+        for dx in range(size):
+            ox, oy = dx - dst_c, dy - dst_c
+            sx = round(cos * ox + sin * oy + src_cx)
+            sy = round(-sin * ox + cos * oy + src_cy)
+            row.append(grid[sy][sx] if 0 <= sy < h and 0 <= sx < w else ".")
+        out.append("".join(row))
+    return tuple(out)
+
+
+# One canvas for every (squash, angle) pair: the widest the sprite ever gets,
+# on its diagonal.
+SPRITE_SIZE = math.ceil(math.hypot(len(DUCK_HEAD[0]) * MAX_STRETCH, len(DUCK_HEAD)))
+
+
+def bake(grid: Grid) -> tuple[tuple[Grid, ...], ...]:
+    """Every squash level at every angle, once, at import.
+
+    Five levels by twenty-four angles is 120 small grids per sprite — built once
+    in a few milliseconds, then indexed for the rest of the run. Doing either
+    transform live would be the same arithmetic a thousand times a second for
+    results that never change.
+    """
+    levels = (1.0, *SQUISH_CURVE)
+    return tuple(
+        tuple(rotate(squash(grid, level), i * 360.0 / ROT_STEPS, SPRITE_SIZE) for i in range(ROT_STEPS))
+        for level in levels
+    )
+
+
+ROTATED = bake(DUCK_HEAD)
+ROTATED_QUACK = bake(DUCK_HEAD_QUACK)
+# Collision radius from the *unrotated* sprite, not from the diagonal canvas it
+# is baked onto — the corners of that canvas are empty, and using them would
+# have ducks bouncing off each other's whitespace.
+DUCK_RADIUS = max(len(DUCK_HEAD[0]), len(DUCK_HEAD)) / 2.0
+
+HERO_W = len(DUCK_HEAD[0]) * HERO_SCALE
+HERO_H = len(DUCK_HEAD) * HERO_SCALE
+HERO_RADIUS = max(HERO_W, HERO_H) / 2.0
+
+
+def hero_grid(elapsed: float) -> Grid:
+    """The anchored duck, running the shades gag on a timer.
+
+    Mirrors render_head_shades' composition rather than calling it: that returns
+    a packed renderable, and everything here stays an unpacked pixel grid until
+    the final blit.
+    """
+    period = int(HERO_SHADES_EVERY * HERO_SHADES_FPS)
+    step_i = int(elapsed * HERO_SHADES_FPS) % period
+    start = period - len(SHADES_LIFT_SEQUENCE)
+    if step_i < start:
+        return scale(DUCK_HEAD, HERO_SCALE)
+    lift = SHADES_LIFT_SEQUENCE[step_i - start]
+    pad = ("." * len(DUCK_HEAD_FACE[0]),) * 4
+    face, glasses = pad + DUCK_HEAD_FACE, pad + DUCK_HEAD_GLASSES
+    return scale(_compose(face, glasses, _shift(glasses, lift)), HERO_SCALE)
+
+
+def blit(canvas: list[list[str]], sprite: Grid, left: int, top: int) -> None:
+    """Paint a sprite, skipping its transparent pixels."""
+    height, width = len(canvas), len(canvas[0])
+    for dy, row in enumerate(sprite):
+        cy = top + dy
+        if not 0 <= cy < height:
+            continue
+        for dx, ch in enumerate(row):
+            cx = left + dx
+            if ch != "." and 0 <= cx < width:
+                canvas[cy][cx] = ch
+
+
+# ---------------------------------------------------------------------------
+# Simulation. Positions are sprite centres — the only origin that still makes
+# sense once things rotate.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Duck:
+    x: float
+    y: float
+    vx: float
+    vy: float
+    angle: float = 0.0
+    spin: float = 0.0
+    quack_until: float = -1.0
+    squish_until: float = -1.0
+    radius: float = DUCK_RADIUS
+    anchored: bool = False
+    is_hero: bool = False
+
+    @property
+    def mass(self) -> float:
+        """Area, so a 2x duck weighs four of the little ones. The hero is
+        anchored so it never comes up for him — but a second big one would work."""
+        return self.radius * self.radius
+
+    def sprite(self, now: float) -> Grid:
+        if self.is_hero:
+            # Quacking beats the shades gag: he cannot be mid-cool-reveal and
+            # mid-yelp at once, and the yelp is the one a duck to the face causes.
+            return scale(DUCK_HEAD_QUACK, HERO_SCALE) if now < self.quack_until else hero_grid(now)
+        tables = ROTATED_QUACK if now < self.quack_until else ROTATED
+        level = 0
+        if now < self.squish_until:
+            # Fully squashed at the moment of impact, easing back to resting as
+            # the timer runs out.
+            remaining = (self.squish_until - now) / SQUISH_SECONDS
+            level = 1 + min(len(SQUISH_CURVE) - 1, int((1.0 - remaining) * len(SQUISH_CURVE)))
+        return tables[level][int(self.angle / (360.0 / ROT_STEPS)) % ROT_STEPS]
+
+
+def make_ducks(count: int, width: int, height: int, rng: random.Random) -> list[Duck]:
+    """Scatter drifting ducks, then anchor the hero dead centre in both axes.
+
+    RNG is used here and nowhere else, so a whole run is a pure function of the
+    seed.
+    """
+    hero = Duck(
+        x=width / 2,
+        y=height / 2,
+        vx=0.0,
+        vy=0.0,
+        radius=HERO_RADIUS,
+        anchored=True,
+        is_hero=True,
+    )
+
+    ducks: list[Duck] = []
+    margin = SPRITE_SIZE / 2
+    for _ in range(count):
+        # Rejection-sample a start clear of the hero, so nothing begins the clip
+        # already inside him and gets flung out on frame one.
+        x = y = 0.0
+        for _attempt in range(200):
+            x = rng.uniform(margin, width - margin)
+            y = rng.uniform(margin, height - margin)
+            if math.hypot(x - hero.x, y - hero.y) > hero.radius + DUCK_RADIUS + 2:
+                break
+        heading = rng.uniform(0, 2 * math.pi)
+        speed = rng.uniform(*DRIFT_SPEED)
+        ducks.append(
+            Duck(
+                x=x,
+                y=y,
+                vx=math.cos(heading) * speed,
+                vy=math.sin(heading) * speed,
+                angle=rng.uniform(0, 360),
+                spin=rng.uniform(*SPIN_SPEED),
+            )
+        )
+    ducks.append(hero)
+    return ducks
+
+
+def step(ducks: list[Duck], dt: float, now: float, width: int, height: int) -> None:
+    """Advance one fixed timestep. Mutates in place."""
+    margin = SPRITE_SIZE / 2
+    for duck in ducks:
+        if duck.anchored:
+            continue
+        duck.x += duck.vx * dt
+        duck.y += duck.vy * dt
+        duck.angle = (duck.angle + duck.spin * dt) % 360.0
+
+        # Walls, clamped on the *drawn* half-size rather than the collision
+        # radius, so a rotated duck never has a corner cut off by the frame edge.
+        if duck.x <= margin:
+            duck.x, duck.vx = margin, abs(duck.vx) * BOUNCE
+            duck.quack_until, duck.squish_until = now + QUACK_SECONDS, now + SQUISH_SECONDS
+        elif duck.x >= width - margin:
+            duck.x, duck.vx = width - margin, -abs(duck.vx) * BOUNCE
+            duck.quack_until, duck.squish_until = now + QUACK_SECONDS, now + SQUISH_SECONDS
+        if duck.y <= margin:
+            duck.y, duck.vy = margin, abs(duck.vy) * BOUNCE
+            duck.quack_until, duck.squish_until = now + QUACK_SECONDS, now + SQUISH_SECONDS
+        elif duck.y >= height - margin:
+            duck.y, duck.vy = height - margin, -abs(duck.vy) * BOUNCE
+            duck.quack_until, duck.squish_until = now + QUACK_SECONDS, now + SQUISH_SECONDS
+
+    # Circle against circle, resolved after everyone has moved so the outcome
+    # does not depend on list order. Circles and not boxes because these things
+    # rotate: an axis-aligned box around a spinning sprite is the wrong shape at
+    # most of the baked angles.
+    for i, a in enumerate(ducks):
+        for b in ducks[i + 1 :]:
+            if a.anchored and b.anchored:
+                continue
+            dx, dy = b.x - a.x, b.y - a.y
+            dist = math.hypot(dx, dy)
+            gap = a.radius + b.radius
+            if dist >= gap:
+                continue
+            if dist < 1e-6:
+                # Exactly coincident, so there is no normal to work with. Pick
+                # one — deterministically, because this must not reach for RNG.
+                nx, ny, dist = 1.0, 0.0, 1e-6
+            else:
+                nx, ny = dx / dist, dy / dist
+
+            overlap = gap - dist
+            # Separate along the normal by inverse mass — or entirely onto the
+            # loose one when the other cannot move.
+            if a.anchored:
+                b.x += nx * overlap
+                b.y += ny * overlap
+            elif b.anchored:
+                a.x -= nx * overlap
+                a.y -= ny * overlap
+            else:
+                total = a.mass + b.mass
+                a.x -= nx * overlap * (b.mass / total)
+                a.y -= ny * overlap * (b.mass / total)
+                b.x += nx * overlap * (a.mass / total)
+                b.y += ny * overlap * (a.mass / total)
+
+            # Exchange only the velocity component along the normal; leaving the
+            # tangential part alone is what makes a glancing blow graze rather
+            # than stop dead.
+            avn = a.vx * nx + a.vy * ny
+            bvn = b.vx * nx + b.vy * ny
+            if avn - bvn <= 0:  # already separating
+                continue
+            if a.anchored:
+                delta = -bvn * BOUNCE - bvn
+                b.vx += delta * nx
+                b.vy += delta * ny
+                b.spin = -b.spin
+            elif b.anchored:
+                delta = -avn * BOUNCE - avn
+                a.vx += delta * nx
+                a.vy += delta * ny
+                a.spin = -a.spin
+            else:
+                total = a.mass + b.mass
+                new_a = ((a.mass - b.mass) * avn + 2 * b.mass * bvn) / total * BOUNCE
+                new_b = ((b.mass - a.mass) * bvn + 2 * a.mass * avn) / total * BOUNCE
+                a.vx += (new_a - avn) * nx
+                a.vy += (new_a - avn) * ny
+                b.vx += (new_b - bvn) * nx
+                b.vy += (new_b - bvn) * ny
+                a.spin, b.spin = b.spin, a.spin
+
+            a.quack_until = b.quack_until = now + QUACK_SECONDS
+            # Only the crowd squashes; the hero is immovable and an immovable
+            # thing that visibly gives on impact reads as wrong.
+            a.squish_until = a.squish_until if a.is_hero else now + SQUISH_SECONDS
+            b.squish_until = b.squish_until if b.is_hero else now + SQUISH_SECONDS
+
+    # Separation runs after the wall clamps, so a duck shoved by a neighbour can
+    # end up part-way out of frame. Clamp last and the walls always win — which
+    # matters most in a pile-up, exactly when there are most ducks to lose.
+    for duck in ducks:
+        if duck.anchored:
+            continue
+        duck.x = min(max(duck.x, margin), float(width) - margin)
+        duck.y = min(max(duck.y, margin), float(height) - margin)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def compose(ducks: list[Duck], now: float, cols: int, rows: int) -> Group:
+    """Blit the yard onto one pixel canvas, then pack it once."""
+    canvas = [["." for _ in range(cols)] for _ in range(rows * 2)]
+
+    # Hero last, so the crowd passes behind him rather than over his face. He is
+    # one of the ducks now, so this is a draw order and not a special case.
+    for duck in sorted(ducks, key=lambda d: d.is_hero):
+        sprite = duck.sprite(now)
+        blit(canvas, sprite, int(duck.x - len(sprite[0]) / 2), int(duck.y - len(sprite) / 2))
+
+    lines: list[Text] = []
+    for cells in _pack_cells(tuple("".join(row) for row in canvas)):
+        line = Text()
+        for glyph, style in cells:
+            line.append(glyph, style=style)
+        lines.append(line)
+    return Group(*lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--ducks", type=int, default=12)
+    parser.add_argument("--seed", type=int, default=3)
+    parser.add_argument("--seconds", type=float, default=0, help="exit after N seconds (0 = forever)")
+    parser.add_argument("--fps", type=float, default=60.0)
+    args = parser.parse_args()
+
+    console = Console()
+    cols, rows = console.size
+    px_h = rows * 2
+
+    # noqa S311: this is a duck, not a nonce. Reproducibility is the whole
+    # requirement — a cryptographic generator would be strictly worse.
+    rng = random.Random(args.seed)  # noqa: S311
+    ducks = make_ducks(args.ducks, cols, px_h, rng)
+
+    # Fixed timestep, decoupled from how long a frame takes to draw. A
+    # wall-clock dt would make the run unreproducible, and the point of seeding
+    # is that a seed gives the same clip every time.
+    dt = 1.0 / args.fps
+    now = 0.0
+    start = time.monotonic()
+
+    with Live(
+        compose(ducks, now, cols, rows),
+        console=console,
+        auto_refresh=False,
+        screen=True,
+        vertical_overflow="crop",
+    ) as live:
+        while True:
+            if args.seconds and now >= args.seconds:
+                return 0
+            step(ducks, dt, now, cols, px_h)
+            now += dt
+            live.update(compose(ducks, now, cols, rows), refresh=True)
+            # Pace against the clock rather than sleeping a flat dt, so the
+            # animation runs at real speed even when a frame costs more than dt.
+            behind = (start + now) - time.monotonic()
+            if behind > 0:
+                time.sleep(behind)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None

--- a/scripts/demo_duck_mayhem.py
+++ b/scripts/demo_duck_mayhem.py
@@ -38,6 +38,7 @@ import random
 import sys
 import time
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
@@ -77,17 +78,39 @@ QUACK_SECONDS = 0.22  # beak stays open this long after a hit
 ROT_STEPS = 24  # baked angles, i.e. 15 degrees apart
 
 # Squash and stretch on impact, recovering over SQUISH_SECONDS. Each entry is a
-# height multiplier; width takes the inverse so the duck keeps roughly his area
-# and reads as compressing rather than shrinking. The stretch is capped, because
-# a duck squashed to 58% would otherwise be nearly twice as wide as he is tall
-# and stop looking like a duck at all.
-SQUISH_SECONDS = 0.18
-SQUISH_CURVE = (0.58, 0.70, 0.82, 0.92)
-MAX_STRETCH = 1.25
+# height multiplier; width takes the inverse, capped, so he reads as compressing
+# rather than shrinking.
+#
+# Deliberately gentle. The first version squashed to 58% and looked broken: at
+# that depth the sunglasses and beak are folded into each other, and stacked on
+# top of a rotation there is no reading of the frame in which it is a duck. The
+# eye registers a squash from very little — a fifth of the height is plenty, and
+# the point is the impact reading as an impact, not the pose being legible.
+SQUISH_SECONDS = 0.16
+SQUISH_CURVE = (0.80, 0.87, 0.93, 0.97)
+MAX_STRETCH = 1.10
+# Quantised impact directions. The squash flattens along the contact normal —
+# the face that hit the wall is the face that goes flat, like a ball — so it has
+# to be applied in world space, after the duck's own rotation. Sixteen
+# directions is 22.5 degrees apart, finer than anyone can pick out mid-bounce.
+NORMAL_STEPS = 16
 
-# The anchored duck in the middle. Twice the size, immovable, and the fixed
-# point the whole scene is arranged around.
-HERO_SCALE = 2
+# Crowd sprites are upscaled before they are rotated, and this is the single
+# thing that decides whether a rotated duck still looks like a duck.
+#
+# The sunglasses are one pixel thick in the source art. Rotate 16x14 by anything
+# that is not a multiple of 90 and that pixel lands between two others and is
+# lost, which turns the face to mush. At 2x it is two pixels thick and survives.
+#
+# It costs nothing on screen: a duck's size in the frame is its cell footprint
+# times the cell size, so doubling the sprite and halving the font leaves him
+# exactly as big while doubling the detail he is drawn with. Pair this with a
+# smaller terminal font, not with a bigger duck.
+DUCK_SCALE = 2
+
+# The anchored duck in the middle — twice the crowd again, immovable, and the
+# fixed point the whole scene is arranged around.
+HERO_SCALE = DUCK_SCALE * 2
 HERO_SHADES_EVERY = 3.0
 HERO_SHADES_FPS = 8
 
@@ -160,9 +183,35 @@ def rotate(grid: Grid, degrees: float, size: int | None = None) -> Grid:
     return tuple(out)
 
 
-# One canvas for every (squash, angle) pair: the widest the sprite ever gets,
-# on its diagonal.
-SPRITE_SIZE = math.ceil(math.hypot(len(DUCK_HEAD[0]) * MAX_STRETCH, len(DUCK_HEAD)))
+SOURCE = scale(DUCK_HEAD, DUCK_SCALE)
+SOURCE_QUACK = scale(DUCK_HEAD_QUACK, DUCK_SCALE)
+
+# One canvas for every (squash, angle) pair: the widest the sprite ever gets, on
+# its diagonal.
+SPRITE_SIZE = math.ceil(math.hypot(len(SOURCE[0]) * MAX_STRETCH, len(SOURCE)))
+
+
+@cache
+def squashed(angle_idx: int, level: int, normal_idx: int, quack: bool) -> Grid:
+    """A duck at ``angle_idx``, flattened along world direction ``normal_idx``.
+
+    Squashing along an arbitrary world axis is three steps: turn that axis
+    vertical, squash vertically, turn back. Written out, the whole transform is
+    R(normal) . S_v(f) . R(angle - normal) applied to the source.
+
+    Cached rather than pre-baked. The full table is 5 levels x 24 angles x 16
+    normals x 2 beaks — 3,840 grids, several seconds of import for a set of
+    which a given clip touches a few hundred. lru_cache pays only for what is
+    actually asked for, and every combination repeats constantly once the yard
+    is moving.
+    """
+    source = SOURCE_QUACK if quack else SOURCE
+    if level == 0:
+        return rotate(source, angle_idx * 360.0 / ROT_STEPS, SPRITE_SIZE)
+    normal = normal_idx * 360.0 / NORMAL_STEPS
+    angle = angle_idx * 360.0 / ROT_STEPS
+    upright = rotate(source, angle - normal, SPRITE_SIZE)
+    return rotate(squash(upright, SQUISH_CURVE[level - 1]), normal, SPRITE_SIZE)
 
 
 def bake(grid: Grid) -> tuple[tuple[Grid, ...], ...]:
@@ -180,16 +229,40 @@ def bake(grid: Grid) -> tuple[tuple[Grid, ...], ...]:
     )
 
 
-ROTATED = bake(DUCK_HEAD)
-ROTATED_QUACK = bake(DUCK_HEAD_QUACK)
+ROTATED = bake(SOURCE)
+ROTATED_QUACK = bake(SOURCE_QUACK)
 # Collision radius from the *unrotated* sprite, not from the diagonal canvas it
 # is baked onto — the corners of that canvas are empty, and using them would
 # have ducks bouncing off each other's whitespace.
-DUCK_RADIUS = max(len(DUCK_HEAD[0]), len(DUCK_HEAD)) / 2.0
+DUCK_RADIUS = max(len(SOURCE[0]), len(SOURCE)) / 2.0
+
+# Where the sunglasses sit inside the source art, so the collider can be put on
+# them. Derived rather than typed in, or it silently drifts if the art changes.
+_GLASSES_PX = [(x, y) for y, row in enumerate(DUCK_HEAD_GLASSES) for x, ch in enumerate(row) if ch != "."]
+GLASSES_X0, GLASSES_X1 = min(x for x, _ in _GLASSES_PX), max(x for x, _ in _GLASSES_PX)
+GLASSES_Y0, GLASSES_Y1 = min(y for _, y in _GLASSES_PX), max(y for _, y in _GLASSES_PX)
+# A circle is a poor fit for something 12 wide and 3 tall, so this splits the
+# difference — big enough to feel solid, small enough not to bounce ducks off
+# thin air either side of him.
+GLASSES_RADIUS = (GLASSES_X1 - GLASSES_X0 + 1) / 3.0 * HERO_SCALE
 
 HERO_W = len(DUCK_HEAD[0]) * HERO_SCALE
 HERO_H = len(DUCK_HEAD) * HERO_SCALE
 HERO_RADIUS = max(HERO_W, HERO_H) / 2.0
+
+
+# Blank rows above the crown for the raised pair to float into. Always present,
+# even at rest: a grid that grew when the gag started would shift the head half a
+# dozen pixels every three seconds, because compose() centres on the duck.
+HERO_PAD = 4
+
+
+def hero_lift(elapsed: float) -> int:
+    """How far the shades are currently raised, in source pixels. 0 at rest."""
+    period = int(HERO_SHADES_EVERY * HERO_SHADES_FPS)
+    step_i = int(elapsed * HERO_SHADES_FPS) % period
+    start = period - len(SHADES_LIFT_SEQUENCE)
+    return SHADES_LIFT_SEQUENCE[step_i - start] if step_i >= start else 0
 
 
 def hero_grid(elapsed: float) -> Grid:
@@ -199,15 +272,9 @@ def hero_grid(elapsed: float) -> Grid:
     a packed renderable, and everything here stays an unpacked pixel grid until
     the final blit.
     """
-    period = int(HERO_SHADES_EVERY * HERO_SHADES_FPS)
-    step_i = int(elapsed * HERO_SHADES_FPS) % period
-    start = period - len(SHADES_LIFT_SEQUENCE)
-    if step_i < start:
-        return scale(DUCK_HEAD, HERO_SCALE)
-    lift = SHADES_LIFT_SEQUENCE[step_i - start]
-    pad = ("." * len(DUCK_HEAD_FACE[0]),) * 4
+    pad = ("." * len(DUCK_HEAD_FACE[0]),) * HERO_PAD
     face, glasses = pad + DUCK_HEAD_FACE, pad + DUCK_HEAD_GLASSES
-    return scale(_compose(face, glasses, _shift(glasses, lift)), HERO_SCALE)
+    return scale(_compose(face, glasses, _shift(glasses, hero_lift(elapsed))), HERO_SCALE)
 
 
 def blit(canvas: list[list[str]], sprite: Grid, left: int, top: int) -> None:
@@ -239,9 +306,16 @@ class Duck:
     spin: float = 0.0
     quack_until: float = -1.0
     squish_until: float = -1.0
+    # Direction the last hit came from, quantised. The squash flattens along it.
+    squish_normal: int = 0
     radius: float = DUCK_RADIUS
     anchored: bool = False
     is_hero: bool = False
+    # The hero's raised sunglasses: a collider with no sprite of its own, live
+    # only while they are actually off his head. Ducks bounce off them.
+    is_shades: bool = False
+    enabled: bool = True
+    base_y: float = 0.0
 
     @property
     def mass(self) -> float:
@@ -254,14 +328,22 @@ class Duck:
             # Quacking beats the shades gag: he cannot be mid-cool-reveal and
             # mid-yelp at once, and the yelp is the one a duck to the face causes.
             return scale(DUCK_HEAD_QUACK, HERO_SCALE) if now < self.quack_until else hero_grid(now)
-        tables = ROTATED_QUACK if now < self.quack_until else ROTATED
         level = 0
         if now < self.squish_until:
-            # Fully squashed at the moment of impact, easing back to resting as
-            # the timer runs out.
+            # Flattest at the moment of impact, easing back out as the timer runs.
             remaining = (self.squish_until - now) / SQUISH_SECONDS
             level = 1 + min(len(SQUISH_CURVE) - 1, int((1.0 - remaining) * len(SQUISH_CURVE)))
-        return tables[level][int(self.angle / (360.0 / ROT_STEPS)) % ROT_STEPS]
+        angle_idx = int(self.angle / (360.0 / ROT_STEPS)) % ROT_STEPS
+        return squashed(angle_idx, level, self.squish_normal, now < self.quack_until)
+
+
+def _hit(duck: Duck, now: float, nx: float, ny: float) -> None:
+    """Record an impact: open the beak, and flatten along the contact normal."""
+    duck.quack_until = now + QUACK_SECONDS
+    if duck.is_hero or duck.is_shades:
+        return  # immovable things do not visibly give
+    duck.squish_until = now + SQUISH_SECONDS
+    duck.squish_normal = round(math.degrees(math.atan2(ny, nx)) / (360.0 / NORMAL_STEPS)) % NORMAL_STEPS
 
 
 def make_ducks(count: int, width: int, height: int, rng: random.Random) -> list[Duck]:
@@ -303,6 +385,23 @@ def make_ducks(count: int, width: int, height: int, rng: random.Random) -> list[
                 spin=rng.uniform(*SPIN_SPEED),
             )
         )
+    # The raised sunglasses, as a collider with no sprite. Its resting centre is
+    # the glasses' own centre inside the hero grid; step() lifts it from there.
+    gx = (GLASSES_X0 + GLASSES_X1) / 2 - (len(DUCK_HEAD[0]) - 1) / 2
+    gy = HERO_PAD + (GLASSES_Y0 + GLASSES_Y1) / 2 - (HERO_PAD + len(DUCK_HEAD) - 1) / 2
+    ducks.append(
+        Duck(
+            x=hero.x + gx * HERO_SCALE,
+            y=hero.y + gy * HERO_SCALE,
+            vx=0.0,
+            vy=0.0,
+            radius=GLASSES_RADIUS,
+            anchored=True,
+            is_shades=True,
+            enabled=False,
+            base_y=hero.y + gy * HERO_SCALE,
+        )
+    )
     ducks.append(hero)
     return ducks
 
@@ -310,6 +409,14 @@ def make_ducks(count: int, width: int, height: int, rng: random.Random) -> list[
 def step(ducks: list[Duck], dt: float, now: float, width: int, height: int) -> None:
     """Advance one fixed timestep. Mutates in place."""
     margin = SPRITE_SIZE / 2
+
+    # The sunglasses are only solid while they are actually off his head.
+    lift = hero_lift(now)
+    for duck in ducks:
+        if duck.is_shades:
+            duck.enabled = lift > 0
+            duck.y = duck.base_y - lift * HERO_SCALE
+
     for duck in ducks:
         if duck.anchored:
             continue
@@ -321,24 +428,26 @@ def step(ducks: list[Duck], dt: float, now: float, width: int, height: int) -> N
         # radius, so a rotated duck never has a corner cut off by the frame edge.
         if duck.x <= margin:
             duck.x, duck.vx = margin, abs(duck.vx) * BOUNCE
-            duck.quack_until, duck.squish_until = now + QUACK_SECONDS, now + SQUISH_SECONDS
+            _hit(duck, now, -1.0, 0.0)
         elif duck.x >= width - margin:
             duck.x, duck.vx = width - margin, -abs(duck.vx) * BOUNCE
-            duck.quack_until, duck.squish_until = now + QUACK_SECONDS, now + SQUISH_SECONDS
+            _hit(duck, now, 1.0, 0.0)
         if duck.y <= margin:
             duck.y, duck.vy = margin, abs(duck.vy) * BOUNCE
-            duck.quack_until, duck.squish_until = now + QUACK_SECONDS, now + SQUISH_SECONDS
+            _hit(duck, now, 0.0, -1.0)
         elif duck.y >= height - margin:
             duck.y, duck.vy = height - margin, -abs(duck.vy) * BOUNCE
-            duck.quack_until, duck.squish_until = now + QUACK_SECONDS, now + SQUISH_SECONDS
+            _hit(duck, now, 0.0, 1.0)
 
     # Circle against circle, resolved after everyone has moved so the outcome
     # does not depend on list order. Circles and not boxes because these things
     # rotate: an axis-aligned box around a spinning sprite is the wrong shape at
     # most of the baked angles.
     for i, a in enumerate(ducks):
+        if not a.enabled:
+            continue
         for b in ducks[i + 1 :]:
-            if a.anchored and b.anchored:
+            if not b.enabled or (a.anchored and b.anchored):
                 continue
             dx, dy = b.x - a.x, b.y - a.y
             dist = math.hypot(dx, dy)
@@ -395,11 +504,9 @@ def step(ducks: list[Duck], dt: float, now: float, width: int, height: int) -> N
                 b.vy += (new_b - bvn) * ny
                 a.spin, b.spin = b.spin, a.spin
 
-            a.quack_until = b.quack_until = now + QUACK_SECONDS
-            # Only the crowd squashes; the hero is immovable and an immovable
-            # thing that visibly gives on impact reads as wrong.
-            a.squish_until = a.squish_until if a.is_hero else now + SQUISH_SECONDS
-            b.squish_until = b.squish_until if b.is_hero else now + SQUISH_SECONDS
+            # Each flattens against the other, so the normals are opposite.
+            _hit(a, now, nx, ny)
+            _hit(b, now, -nx, -ny)
 
     # Separation runs after the wall clamps, so a duck shoved by a neighbour can
     # end up part-way out of frame. Clamp last and the walls always win — which
@@ -423,6 +530,8 @@ def compose(ducks: list[Duck], now: float, cols: int, rows: int) -> Group:
     # Hero last, so the crowd passes behind him rather than over his face. He is
     # one of the ducks now, so this is a draw order and not a special case.
     for duck in sorted(ducks, key=lambda d: d.is_hero):
+        if duck.is_shades:
+            continue  # a collider, drawn as part of the hero
         sprite = duck.sprite(now)
         blit(canvas, sprite, int(duck.x - len(sprite[0]) / 2), int(duck.y - len(sprite) / 2))
 

--- a/scripts/demo_screensaver.py
+++ b/scripts/demo_screensaver.py
@@ -32,10 +32,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
+from rich.align import Align  # noqa: E402
 from rich.console import Console  # noqa: E402
 from rich.live import Live  # noqa: E402
 
-from yeaboi.ui.shared._screensaver import build_screensaver  # noqa: E402
+from yeaboi.ui.shared._mascot import render_head_idle  # noqa: E402
+from yeaboi.ui.shared._screensaver import SAVER_FPS, _shades_lift, build_screensaver  # noqa: E402
 
 # build_screensaver advances at int(elapsed * 8) % 8 — eight frames, eight per
 # second, so the bob closes its cycle on the second. Loop length is not a
@@ -52,6 +54,11 @@ HEAD_MAX_H = 21
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--head", action="store_true", help="force the head-only band")
+    parser.add_argument(
+        "--bare",
+        action="store_true",
+        help="head only, no page panel — the terminal's own background shows through",
+    )
     parser.add_argument("--loops", type=float, default=0, help="exit after N animation cycles (0 = forever)")
     parser.add_argument("--fps", type=float, default=60.0, help="redraw rate")
     args = parser.parse_args()
@@ -73,8 +80,21 @@ def main() -> int:
     # the alternate screen and writes one atomic frame per refresh, so the
     # animation cannot tear. auto_refresh off so this loop is the only thing
     # deciding when a frame exists.
+    def render(elapsed: float):
+        # --bare skips build_screensaver's page panel. The panel paints NEUTRAL_BG
+        # across the whole frame, which is right inside the app and wrong for an
+        # asset that wants to sit on some other background: a transparent sprite
+        # cell is (" ", None), so with no panel the terminal's own colour shows
+        # through and the profile decides what the duck stands on.
+        if not args.bare:
+            return build_screensaver(width=width, height=height, elapsed=elapsed)
+        frame = int(elapsed * SAVER_FPS) % 8
+        # height is required for vertical centring — without it Align has no box
+        # to centre inside and the duck sits at the top of the frame.
+        return Align.center(render_head_idle(frame, _shades_lift(elapsed)), vertical="middle", height=height)
+
     with Live(
-        build_screensaver(width=width, height=height, elapsed=0.0),
+        render(0.0),
         console=console,
         auto_refresh=False,
         screen=True,
@@ -84,7 +104,7 @@ def main() -> int:
             elapsed = time.monotonic() - start
             if deadline is not None and elapsed >= deadline:
                 return 0
-            live.update(build_screensaver(width=width, height=height, elapsed=elapsed), refresh=True)
+            live.update(render(elapsed), refresh=True)
             time.sleep(frame_time)
 
 

--- a/scripts/demo_screensaver.py
+++ b/scripts/demo_screensaver.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Play the idle screensaver on demand, without waiting five minutes for it.
+
+`build_screensaver()` is already a pure function of (width, height, elapsed), so
+this drives it straight from a clock instead of going through IdleController —
+no input plumbing, no monkeypatching IDLE_SECONDS, and the frame you get is the
+frame a real idle session would draw.
+
+Which duck you get is a function of the terminal size (see build_screensaver):
+
+    >= 46 x >= 26   he waddles the floor and springs over the music tab
+    >= 46 x >= 22   full duck, standing
+    >= 22 x >= 13   head only — the breathing bob
+    smaller         a text label
+
+So `--head` just asks for a terminal in the third band. It exists because the
+head loop is the one worth recording: the bob is a clean 8-frame cycle, and a
+small grid means big cells, which is the only way to get a sharp capture off a
+1x display.
+
+    uv run python scripts/demo_screensaver.py            # size to the terminal
+    uv run python scripts/demo_screensaver.py --head     # force the head band
+    uv run python scripts/demo_screensaver.py --loops 3  # exit after 3 cycles
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from rich.console import Console  # noqa: E402
+from rich.live import Live  # noqa: E402
+
+from yeaboi.ui.shared._screensaver import build_screensaver  # noqa: E402
+
+# build_screensaver advances at int(elapsed * 8) % 8 — eight frames, eight per
+# second, so the bob closes its cycle on the second. Loop length is not a
+# guess; it is that constant read back.
+FRAME_RATE = 8.0
+FRAMES = 8
+LOOP_SECONDS = FRAMES / FRAME_RATE
+
+# Ceilings for the head band, one below each of build_screensaver's thresholds.
+HEAD_MAX_W = 45
+HEAD_MAX_H = 21
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--head", action="store_true", help="force the head-only band")
+    parser.add_argument("--loops", type=float, default=0, help="exit after N animation cycles (0 = forever)")
+    parser.add_argument("--fps", type=float, default=60.0, help="redraw rate")
+    args = parser.parse_args()
+
+    console = Console()
+    width, height = console.size
+    if args.head:
+        # Clamp rather than assume: a window sized for the head band already
+        # satisfies this, and one that is not gets the head anyway instead of
+        # silently recording the wrong duck.
+        width = min(width, HEAD_MAX_W)
+        height = min(height, HEAD_MAX_H)
+
+    deadline = args.loops * LOOP_SECONDS if args.loops else None
+    frame_time = 1.0 / args.fps
+    start = time.monotonic()
+
+    # screen=True for the same reason the splash uses it: Rich double-buffers
+    # the alternate screen and writes one atomic frame per refresh, so the
+    # animation cannot tear. auto_refresh off so this loop is the only thing
+    # deciding when a frame exists.
+    with Live(
+        build_screensaver(width=width, height=height, elapsed=0.0),
+        console=console,
+        auto_refresh=False,
+        screen=True,
+        vertical_overflow="crop",
+    ) as live:
+        while True:
+            elapsed = time.monotonic() - start
+            if deadline is not None and elapsed >= deadline:
+                return 0
+            live.update(build_screensaver(width=width, height=height, elapsed=elapsed), refresh=True)
+            time.sleep(frame_time)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,31 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.55.0",
+      "date": "2026-08-05",
+      "summary": "The idle screensaver expanded from a single duck to a yard of them — ten-odd heads adrift in zero gravity, spinning and ricocheting off each other and an anchored duck in the middle. The screensaver activates with Ctrl+Y as before, and still reads as a single resting duck on terminals smaller than 60x24, so the existing single-duck graphics cover those smaller screens.",
+      "highlights": [
+        {
+          "text": "Idle screensaver now shows a yard of ricocheting ducks with pixel-perfect collisions and real rotation",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Ducks bounce off each other and the frame edges with squash physics; anchored hero duck in the center never moves",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Sprite rotation is memoised with 48 angles and 5 squash levels for smooth performance",
+          "areas": [
+            "general"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.54.0",
       "date": "2026-08-05",
       "summary": "The planning duck is now the TUI's living mascot across every mode. He waddles into the corner whenever you enter a mode, head-bobs through every long wait (standups, 1:1s, reports, syncs, shares), and quacks a short quip when those operations complete. A sticky rubber-duck tier serves hidden confirmations — delete prompts are now unmissable even on narrow terminals, and the bubble lane stays off the right edge so your composer never overlaps with encouragement. The shared loading screens gained live progress: a braille spinner, per-stage elapsed timing, and a [n/total] footer. Retro action drafting, performance 1:1 generation, and Notion/Confluence publishing no longer freeze the screen — they run on background workers with a live busy affordance. The duck is mutable per-session via /duck in the chat, and globally via the new Duck row in Settings → System.",

--- a/src/yeaboi/ui/shared/_mascot.py
+++ b/src/yeaboi/ui/shared/_mascot.py
@@ -319,6 +319,28 @@ def render_head_shades(lift: int, *, flip: bool = False) -> Group:
     return Group(*_pack(grid))
 
 
+def render_head_idle(frame: int, lift: int | None = None, *, flip: bool = False) -> Group:
+    """Resting head and shades gag at one common height.
+
+    :func:`render_head_shades` pads :data:`_SHADES_TOP_PAD` rows above the crown
+    so the raised pair has somewhere to float; :func:`render_head` does not. Cut
+    between the two mid-animation and the duck drops two terminal rows at the
+    moment the gag ends, which is the one thing a loop cannot hide. So anything
+    that plays the gag *occasionally* has to draw its resting frames at the
+    padded height too — that is all this is.
+
+    ``lift=None`` rests, with the usual breathing bob; anything else plays the
+    gag at that lift.
+    """
+    if lift is not None:
+        return render_head_shades(lift, flip=flip)
+    pad = ("." * len(DUCK_HEAD_FACE[0]),) * _SHADES_TOP_PAD
+    grid = pad + _bob(DUCK_HEAD, HEAD_BOB[frame % FRAMES])
+    if flip:
+        grid = tuple(row[::-1] for row in grid)
+    return Group(*_pack(grid))
+
+
 def render_head(frame: int, *, flip: bool = False, beak_open: bool = False) -> Group:
     """Small head companion: a gentle breathing bob (glints are baked in).
 

--- a/src/yeaboi/ui/shared/_mayhem.py
+++ b/src/yeaboi/ui/shared/_mayhem.py
@@ -100,7 +100,7 @@ NORMAL_STEPS = 16
 # times the cell size, so doubling the sprite and halving the font leaves him
 # exactly as big while doubling the detail he is drawn with. Pair this with a
 # smaller terminal font, not with a bigger duck.
-DUCK_SCALE = 2
+DUCK_SCALE = 1
 
 # The anchored duck in the middle — twice the crowd again, immovable, and the
 # fixed point the whole scene is arranged around.
@@ -558,7 +558,14 @@ def compose(ducks: list[Duck], now: float, cols: int, rows: int) -> Group:
     return Group(*lines)
 
 
-def configure(duck_scale: int) -> None:
+# Below this many pixel-columns the hero cannot be 2x without dominating: the
+# sprite is 16 wide whatever the font, so on a ~95-column canvas — which is what
+# an ordinary 16pt terminal gives — a doubled hero is a third of the width on his
+# own and the yard reads as one giant duck with company.
+HERO_2X_MIN_WIDTH = 150
+
+
+def configure(duck_scale: int, hero_scale: int | None = None) -> None:
     """Re-derive every size-dependent constant for a different sprite scale.
 
     2x is right for a recording, where the terminal font can be made tiny to pay
@@ -568,7 +575,7 @@ def configure(duck_scale: int) -> None:
     global DUCK_SCALE, SOURCE, SOURCE_QUACK, SPRITE_SIZE, DUCK_RADIUS
     global HERO_SCALE, HERO_W, HERO_H, HERO_RADIUS, GLASSES_RADIUS
     DUCK_SCALE = duck_scale
-    HERO_SCALE = duck_scale * 2
+    HERO_SCALE = hero_scale if hero_scale is not None else duck_scale * 2
     SOURCE = scale(DUCK_HEAD, DUCK_SCALE)
     SOURCE_QUACK = scale(DUCK_HEAD_QUACK, DUCK_SCALE)
     SPRITE_SIZE = math.ceil(math.hypot(len(SOURCE[0]) * MAX_STRETCH, len(SOURCE)))
@@ -579,7 +586,7 @@ def configure(duck_scale: int) -> None:
     squashed.cache_clear()
 
 
-def fits(width: int, height: int, coverage: float = 0.34) -> int:
+def fits(width: int, height: int, coverage: float = 0.42) -> int:
     """How many ducks fill ``coverage`` of a canvas, minus the hero's share.
 
     A screensaver cannot be handed a duck count: it gets whatever terminal the
@@ -599,7 +606,7 @@ def fits(width: int, height: int, coverage: float = 0.34) -> int:
 # rising elapsed, so stepping incrementally is O(1) per frame; recomputing from
 # zero each time would be O(elapsed) and get slower the longer it ran.
 _yard: list[Duck] = []
-_yard_key: tuple[int, int, int] = (0, 0, 0)
+_yard_key: tuple[int, int, int, int] = (0, 0, 0, 0)
 _yard_at: float = 0.0
 _STEP = 1.0 / 60
 
@@ -614,8 +621,10 @@ def render(width: int, height: int, elapsed: float, *, seed: int = 3) -> Rendera
     global _yard, _yard_key, _yard_at
 
     px_h = height * 2
-    key = (width, px_h, seed)
+    hero_scale = DUCK_SCALE * 2 if width >= HERO_2X_MIN_WIDTH else DUCK_SCALE
+    key = (width, px_h, seed, hero_scale)
     if key != _yard_key or elapsed < _yard_at:
+        configure(DUCK_SCALE, hero_scale)
         # noqa S311: ducks, not nonces. Reproducibility is the requirement.
         _yard = make_ducks(fits(width, px_h), width, px_h, random.Random(seed))  # noqa: S311
         _yard_key, _yard_at = key, 0.0

--- a/src/yeaboi/ui/shared/_mayhem.py
+++ b/src/yeaboi/ui/shared/_mayhem.py
@@ -586,7 +586,7 @@ def configure(duck_scale: int, hero_scale: int | None = None) -> None:
     squashed.cache_clear()
 
 
-def fits(width: int, height: int, coverage: float = 0.42) -> int:
+def fits(width: int, height: int, coverage: float = 0.34) -> int:
     """How many ducks fill ``coverage`` of a canvas, minus the hero's share.
 
     A screensaver cannot be handed a duck count: it gets whatever terminal the

--- a/src/yeaboi/ui/shared/_mayhem.py
+++ b/src/yeaboi/ui/shared/_mayhem.py
@@ -109,6 +109,11 @@ HERO_SCALE = DUCK_SCALE * 2
 # ping-pongs, so a three-second cycle can land almost entirely outside the
 # window — the gag was rendering correctly and still looked frozen, because at
 # most one lift fell inside the take and a dozen ducks were flying over it.
+# The anchored duck holds completely still: no shades gag, no beak. He is hit
+# several times a second, so a reacting hero flaps constantly, and next to a
+# yard that is already all motion the eye has nowhere to rest. Set False to give
+# him the gag back.
+HERO_STATIC = True
 HERO_SHADES_EVERY = 1.6
 # Its own sequence rather than the app's SHADES_LIFT_SEQUENCE, and stepped more
 # than twice as fast. The app's is a slow reveal with a long hold at the top,
@@ -246,6 +251,8 @@ HERO_PAD = 4
 
 def hero_lift(elapsed: float) -> int:
     """How far the shades are currently raised, in source pixels. 0 at rest."""
+    if HERO_STATIC:
+        return 0
     period = int(HERO_SHADES_EVERY * HERO_SHADES_FPS)
     step_i = int(elapsed * HERO_SHADES_FPS) % period
     start = period - len(HERO_LIFT_SEQUENCE)
@@ -322,7 +329,7 @@ class Duck:
         if self.is_hero:
             # Quacking beats the shades gag: he cannot be mid-cool-reveal and
             # mid-yelp at once, and the yelp is the one a duck to the face causes.
-            return hero_grid(now, quacking=now < self.quack_until)
+            return hero_grid(now, quacking=not HERO_STATIC and now < self.quack_until)
         level = 0
         if now < self.squish_until:
             # Flattest at the moment of impact, easing back out as the timer runs.

--- a/src/yeaboi/ui/shared/_mayhem.py
+++ b/src/yeaboi/ui/shared/_mayhem.py
@@ -1,0 +1,629 @@
+"""A yard of ducks: the idle screensaver's busy mode.
+
+Twelve-odd duck heads adrift in zero gravity, spinning, ricocheting off each
+other and off a big anchored one in the middle, quacking and squashing on every
+impact. ``_screensaver`` calls :func:`render` for it; ``scripts/demo_duck_mayhem``
+drives the same code at a bigger sprite scale for recordings.
+
+Three things shape the implementation.
+
+**It composites at pixel level, not cell level.** The sprites in ``_mascot`` are
+half-block packed — two pixel rows per terminal row — and the packing happens
+last there. Doing the same here buys positions at half-cell precision, and it is
+the only level at which a sprite can be rotated at all. Everything below works
+on grids of letter codes ('.' being transparent), exactly the form ``_mascot``
+keeps its sprites in, and the whole canvas is packed once at the end.
+
+**Rotation is real, and cached.** Nearest-neighbour, 48 angles by 5 squash
+levels by 16 impact directions, built on demand and memoised — a full table
+would be several thousand grids of which a session touches a few hundred.
+Nearest-neighbour rather than any smoothing: the edges are drawn deliberately at
+this size, and interpolating them makes mud.
+
+**The simulation is deterministic.** Fixed timestep, RNG seeded once at setup.
+:func:`render` advances a module-level yard to whatever elapsed time it is
+handed, and rebuilds from scratch when time goes backwards — i.e. when a new
+screensaver session starts.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from functools import cache
+
+from rich.console import Group, RenderableType
+from rich.text import Text
+
+from yeaboi.ui.shared._mascot import (
+    DUCK_HEAD,
+    DUCK_HEAD_FACE,
+    DUCK_HEAD_GLASSES,
+    DUCK_HEAD_QUACK,
+    _compose,
+    _pack_cells,
+    _shift,
+)
+
+Grid = tuple[str, ...]
+
+# ---------------------------------------------------------------------------
+# Tuning. Distances are sprite pixels, angles degrees, time seconds.
+# ---------------------------------------------------------------------------
+
+# No gravity. Ducks drift; nothing falls and nothing piles up. With gravity they
+# spent the clip settling into a twitching heap along the floor, which is the
+# opposite of mayhem.
+DRIFT_SPEED = (13.0, 24.0)  # initial speed, px/s
+SPIN_SPEED = (-75.0, 75.0)  # deg/s; sign is direction
+# Half-angle of the cone each duck sets off in, aimed at the middle.
+CROSSING_SPREAD = math.radians(65)
+
+# Elastic. Any energy loss at all and a gravity-free yard visibly winds down
+# over eight seconds, with nothing to put the energy back.
+BOUNCE = 1.0
+
+QUACK_SECONDS = 0.22  # beak stays open this long after a hit
+# Rendered angles. At 24 (15 degrees apart) a duck spinning at 150 deg/s
+# changes pose six frames at a time and visibly clunks round; 48 halves the
+# step to 7.5 degrees and it reads as turning. Costs nothing but cache
+# entries, since these are built on demand rather than all up front.
+ROT_STEPS = 48
+
+# Squash and stretch on impact, recovering over SQUISH_SECONDS. Each entry is a
+# height multiplier; width takes the inverse, capped, so he reads as compressing
+# rather than shrinking.
+#
+# Deliberately gentle. The first version squashed to 58% and looked broken: at
+# that depth the sunglasses and beak are folded into each other, and stacked on
+# top of a rotation there is no reading of the frame in which it is a duck. The
+# eye registers a squash from very little — a fifth of the height is plenty, and
+# the point is the impact reading as an impact, not the pose being legible.
+SQUISH_SECONDS = 0.16
+SQUISH_CURVE = (0.80, 0.87, 0.93, 0.97)
+MAX_STRETCH = 1.10
+# Quantised impact directions. The squash flattens along the contact normal —
+# the face that hit the wall is the face that goes flat, like a ball — so it has
+# to be applied in world space, after the duck's own rotation. Sixteen
+# directions is 22.5 degrees apart, finer than anyone can pick out mid-bounce.
+NORMAL_STEPS = 16
+
+# Crowd sprites are upscaled before they are rotated, and this is the single
+# thing that decides whether a rotated duck still looks like a duck.
+#
+# The sunglasses are one pixel thick in the source art. Rotate 16x14 by anything
+# that is not a multiple of 90 and that pixel lands between two others and is
+# lost, which turns the face to mush. At 2x it is two pixels thick and survives.
+#
+# It costs nothing on screen: a duck's size in the frame is its cell footprint
+# times the cell size, so doubling the sprite and halving the font leaves him
+# exactly as big while doubling the detail he is drawn with. Pair this with a
+# smaller terminal font, not with a bigger duck.
+DUCK_SCALE = 2
+
+# The anchored duck in the middle — twice the crowd again, immovable, and the
+# fixed point the whole scene is arranged around.
+HERO_SCALE = DUCK_SCALE * 2
+# Every 1.6s, not the saver's 3. The clip is four seconds long before it
+# ping-pongs, so a three-second cycle can land almost entirely outside the
+# window — the gag was rendering correctly and still looked frozen, because at
+# most one lift fell inside the take and a dozen ducks were flying over it.
+HERO_SHADES_EVERY = 1.6
+# Its own sequence rather than the app's SHADES_LIFT_SEQUENCE, and stepped more
+# than twice as fast. The app's is a slow reveal with a long hold at the top,
+# which suits a calm idle screen and is far too languid next to a dozen ducks
+# ricocheting around — it read as the glasses being stuck rather than lifting.
+# This pops up, holds a beat, drops: eight steps at 20/s, so 0.4s end to end.
+HERO_SHADES_FPS = 20
+HERO_LIFT_SEQUENCE = (2, 4, 5, 5, 5, 3, 1, 0)
+
+
+# ---------------------------------------------------------------------------
+# Grid helpers — a grid is a tuple of equal-length rows of letter codes
+# ---------------------------------------------------------------------------
+
+
+def scale(grid: Grid, factor: int) -> Grid:
+    """Nearest-neighbour upscale, the only honest way to enlarge pixel art."""
+    if factor == 1:
+        return grid
+    out: list[str] = []
+    for row in grid:
+        wide = "".join(ch * factor for ch in row)
+        out.extend([wide] * factor)
+    return tuple(out)
+
+
+def squash(grid: Grid, factor: float) -> Grid:
+    """Compress vertically by ``factor`` and widen by its inverse.
+
+    Applied *before* rotation, so the squash is along the duck's own body axis
+    and turns with him. Doing it after would need a general affine baked for
+    every (angle, impact-direction) pair, for a difference nobody watching a
+    dozen ducks at once could pick out.
+    """
+    if factor >= 1.0:
+        return grid
+    h, w = len(grid), len(grid[0])
+    new_h = max(1, round(h * factor))
+    new_w = max(1, round(w * min(1.0 / factor, MAX_STRETCH)))
+    return tuple(
+        "".join(grid[min(h - 1, y * h // new_h)][min(w - 1, x * w // new_w)] for x in range(new_w))
+        for y in range(new_h)
+    )
+
+
+def rotate(grid: Grid, degrees: float, size: int | None = None) -> Grid:
+    """Rotate about the centre onto a square canvas big enough for any angle.
+
+    Square and diagonal-sized so every baked angle comes out the same shape — a
+    sprite that changed size as it turned would need its geometry recomputed
+    every frame and would visibly breathe.
+
+    Inverse mapping (walk the destination, sample the source) rather than
+    forward: rotating source pixels *into* the destination leaves unpainted
+    holes wherever the mapping is not onto.
+    """
+    h, w = len(grid), len(grid[0])
+    # Callers pass an explicit size so every squash level bakes to the same
+    # canvas — a sprite whose footprint changed with its squash would need its
+    # geometry recomputed per frame.
+    size = size or math.ceil(math.hypot(w, h))
+    src_cx, src_cy = (w - 1) / 2, (h - 1) / 2
+    dst_c = (size - 1) / 2
+    rad = math.radians(degrees)
+    cos, sin = math.cos(rad), math.sin(rad)
+
+    out: list[str] = []
+    for dy in range(size):
+        row: list[str] = []
+        for dx in range(size):
+            ox, oy = dx - dst_c, dy - dst_c
+            sx = round(cos * ox + sin * oy + src_cx)
+            sy = round(-sin * ox + cos * oy + src_cy)
+            row.append(grid[sy][sx] if 0 <= sy < h and 0 <= sx < w else ".")
+        out.append("".join(row))
+    return tuple(out)
+
+
+SOURCE = scale(DUCK_HEAD, DUCK_SCALE)
+SOURCE_QUACK = scale(DUCK_HEAD_QUACK, DUCK_SCALE)
+
+# One canvas for every (squash, angle) pair: the widest the sprite ever gets, on
+# its diagonal.
+SPRITE_SIZE = math.ceil(math.hypot(len(SOURCE[0]) * MAX_STRETCH, len(SOURCE)))
+
+
+@cache
+def squashed(angle_idx: int, level: int, normal_idx: int, quack: bool) -> Grid:
+    """A duck at ``angle_idx``, flattened along world direction ``normal_idx``.
+
+    Squashing along an arbitrary world axis is three steps: turn that axis
+    vertical, squash vertically, turn back. Written out, the whole transform is
+    R(normal) . S_v(f) . R(angle - normal) applied to the source.
+
+    Cached rather than pre-baked. The full table is 5 levels x 24 angles x 16
+    normals x 2 beaks — 3,840 grids, several seconds of import for a set of
+    which a given clip touches a few hundred. lru_cache pays only for what is
+    actually asked for, and every combination repeats constantly once the yard
+    is moving.
+    """
+    source = SOURCE_QUACK if quack else SOURCE
+    if level == 0:
+        return rotate(source, angle_idx * 360.0 / ROT_STEPS, SPRITE_SIZE)
+    normal = normal_idx * 360.0 / NORMAL_STEPS
+    angle = angle_idx * 360.0 / ROT_STEPS
+    upright = rotate(source, angle - normal, SPRITE_SIZE)
+    return rotate(squash(upright, SQUISH_CURVE[level - 1]), normal, SPRITE_SIZE)
+
+
+# Collision radius from the *unrotated* sprite, not from the diagonal canvas it
+# is baked onto — the corners of that canvas are empty, and using them would
+# have ducks bouncing off each other's whitespace.
+DUCK_RADIUS = max(len(SOURCE[0]), len(SOURCE)) / 2.0
+
+# Where the sunglasses sit inside the source art, so the collider can be put on
+# them. Derived rather than typed in, or it silently drifts if the art changes.
+_GLASSES_PX = [(x, y) for y, row in enumerate(DUCK_HEAD_GLASSES) for x, ch in enumerate(row) if ch != "."]
+GLASSES_X0, GLASSES_X1 = min(x for x, _ in _GLASSES_PX), max(x for x, _ in _GLASSES_PX)
+GLASSES_Y0, GLASSES_Y1 = min(y for _, y in _GLASSES_PX), max(y for _, y in _GLASSES_PX)
+# A circle is a poor fit for something 12 wide and 3 tall, so this splits the
+# difference — big enough to feel solid, small enough not to bounce ducks off
+# thin air either side of him.
+GLASSES_RADIUS = (GLASSES_X1 - GLASSES_X0 + 1) / 3.0 * HERO_SCALE
+
+HERO_W = len(DUCK_HEAD[0]) * HERO_SCALE
+HERO_H = len(DUCK_HEAD) * HERO_SCALE
+HERO_RADIUS = max(HERO_W, HERO_H) / 2.0
+
+
+# Blank rows above the crown for the raised pair to float into. Always present,
+# even at rest: a grid that grew when the gag started would shift the head half a
+# dozen pixels every three seconds, because compose() centres on the duck.
+HERO_PAD = 4
+
+
+def hero_lift(elapsed: float) -> int:
+    """How far the shades are currently raised, in source pixels. 0 at rest."""
+    period = int(HERO_SHADES_EVERY * HERO_SHADES_FPS)
+    step_i = int(elapsed * HERO_SHADES_FPS) % period
+    start = period - len(HERO_LIFT_SEQUENCE)
+    return HERO_LIFT_SEQUENCE[step_i - start] if step_i >= start else 0
+
+
+def hero_grid(elapsed: float, quacking: bool = False) -> Grid:
+    """The anchored duck: shades gag on a timer, open beak when hit, both at once.
+
+    The beak used to be a separate sprite that replaced this one, and the result
+    was that the gag never played at all — he is hit several times a second, so
+    the quack frame was up almost permanently and the sunglasses looked frozen.
+    Composing instead of choosing fixes it: the quack head is just a different
+    base to lay the glasses over.
+
+    Mirrors render_head_shades' composition rather than calling it, because that
+    returns a packed renderable and everything here stays an unpacked pixel grid
+    until the final blit. Always padded, at rest as well as mid-gag: compose()
+    centres a sprite on its duck, so a grid that changed height would bob.
+    """
+    pad = ("." * len(DUCK_HEAD_FACE[0]),) * HERO_PAD
+    base = pad + (DUCK_HEAD_QUACK if quacking else DUCK_HEAD_FACE)
+    glasses = pad + DUCK_HEAD_GLASSES
+    return scale(_compose(base, glasses, _shift(glasses, hero_lift(elapsed))), HERO_SCALE)
+
+
+def blit(canvas: list[list[str]], sprite: Grid, left: int, top: int) -> None:
+    """Paint a sprite, skipping its transparent pixels."""
+    height, width = len(canvas), len(canvas[0])
+    for dy, row in enumerate(sprite):
+        cy = top + dy
+        if not 0 <= cy < height:
+            continue
+        for dx, ch in enumerate(row):
+            cx = left + dx
+            if ch != "." and 0 <= cx < width:
+                canvas[cy][cx] = ch
+
+
+# ---------------------------------------------------------------------------
+# Simulation. Positions are sprite centres — the only origin that still makes
+# sense once things rotate.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Duck:
+    x: float
+    y: float
+    vx: float
+    vy: float
+    angle: float = 0.0
+    spin: float = 0.0
+    quack_until: float = -1.0
+    squish_until: float = -1.0
+    # Direction the last hit came from, quantised. The squash flattens along it.
+    squish_normal: int = 0
+    radius: float = DUCK_RADIUS
+    anchored: bool = False
+    is_hero: bool = False
+    # The hero's raised sunglasses: a collider with no sprite of its own, live
+    # only while they are actually off his head. Ducks bounce off them.
+    is_shades: bool = False
+    enabled: bool = True
+    base_y: float = 0.0
+
+    @property
+    def mass(self) -> float:
+        """Area, so a 2x duck weighs four of the little ones. The hero is
+        anchored so it never comes up for him — but a second big one would work."""
+        return self.radius * self.radius
+
+    def sprite(self, now: float) -> Grid:
+        if self.is_hero:
+            # Quacking beats the shades gag: he cannot be mid-cool-reveal and
+            # mid-yelp at once, and the yelp is the one a duck to the face causes.
+            return hero_grid(now, quacking=now < self.quack_until)
+        level = 0
+        if now < self.squish_until:
+            # Flattest at the moment of impact, easing back out as the timer runs.
+            remaining = (self.squish_until - now) / SQUISH_SECONDS
+            level = 1 + min(len(SQUISH_CURVE) - 1, int((1.0 - remaining) * len(SQUISH_CURVE)))
+        angle_idx = int(self.angle / (360.0 / ROT_STEPS)) % ROT_STEPS
+        return squashed(angle_idx, level, self.squish_normal, now < self.quack_until)
+
+
+def _hit(duck: Duck, now: float, nx: float, ny: float) -> None:
+    """Record an impact: open the beak, and flatten along the contact normal."""
+    duck.quack_until = now + QUACK_SECONDS
+    if duck.is_hero or duck.is_shades:
+        return  # immovable things do not visibly give
+    duck.squish_until = now + SQUISH_SECONDS
+    duck.squish_normal = round(math.degrees(math.atan2(ny, nx)) / (360.0 / NORMAL_STEPS)) % NORMAL_STEPS
+
+
+def make_ducks(count: int, width: int, height: int, rng: random.Random) -> list[Duck]:
+    """Scatter drifting ducks, then anchor the hero dead centre in both axes.
+
+    RNG is used here and nowhere else, so a whole run is a pure function of the
+    seed.
+    """
+    hero = Duck(
+        x=width / 2,
+        y=height / 2,
+        vx=0.0,
+        vy=0.0,
+        radius=HERO_RADIUS,
+        anchored=True,
+        is_hero=True,
+    )
+
+    ducks: list[Duck] = []
+    margin = SPRITE_SIZE / 2
+
+    # Stratified, not uniform: one duck per cell of a coarse grid, jittered
+    # inside it. Twelve uniform samples clump — the first take left the whole
+    # left third empty, which is what uniform random looks like at this count,
+    # and the eye reads it as a mistake rather than as chance.
+    across = math.ceil(math.sqrt(count))
+    down = math.ceil(count / across)
+    cell_w = (width - 2 * margin) / across
+    cell_h = (height - 2 * margin) / down
+
+    for i in range(count):
+        col, row = i % across, i // across
+        # Rejection-sample within the cell so nothing starts inside the hero and
+        # gets flung out on frame one. Falls back to the cell centre.
+        x = margin + (col + 0.5) * cell_w
+        y = margin + (row + 0.5) * cell_h
+        for _attempt in range(60):
+            cx = margin + (col + rng.uniform(0.15, 0.85)) * cell_w
+            cy = margin + (row + rng.uniform(0.15, 0.85)) * cell_h
+            if math.hypot(cx - hero.x, cy - hero.y) > hero.radius + DUCK_RADIUS + 2:
+                x, y = cx, cy
+                break
+        # Head broadly for the middle rather than in any direction at all. Left
+        # to chance, a duck starting in a corner spends the whole clip rattling
+        # around in it and never comes near anything — which is what left the
+        # left-hand ducks looking stranded. The spread is wide enough that they
+        # do not all converge on the hero like a target.
+        toward = math.atan2(hero.y - y, hero.x - x)
+        heading = toward + rng.uniform(-CROSSING_SPREAD, CROSSING_SPREAD)
+        speed = rng.uniform(*DRIFT_SPEED)
+        ducks.append(
+            Duck(
+                x=x,
+                y=y,
+                vx=math.cos(heading) * speed,
+                vy=math.sin(heading) * speed,
+                angle=rng.uniform(0, 360),
+                spin=rng.uniform(*SPIN_SPEED),
+            )
+        )
+    # The raised sunglasses, as a collider with no sprite. Its resting centre is
+    # the glasses' own centre inside the hero grid; step() lifts it from there.
+    gx = (GLASSES_X0 + GLASSES_X1) / 2 - (len(DUCK_HEAD[0]) - 1) / 2
+    gy = HERO_PAD + (GLASSES_Y0 + GLASSES_Y1) / 2 - (HERO_PAD + len(DUCK_HEAD) - 1) / 2
+    ducks.append(
+        Duck(
+            x=hero.x + gx * HERO_SCALE,
+            y=hero.y + gy * HERO_SCALE,
+            vx=0.0,
+            vy=0.0,
+            radius=GLASSES_RADIUS,
+            anchored=True,
+            is_shades=True,
+            enabled=False,
+            base_y=hero.y + gy * HERO_SCALE,
+        )
+    )
+    ducks.append(hero)
+    return ducks
+
+
+def step(ducks: list[Duck], dt: float, now: float, width: int, height: int) -> None:
+    """Advance one fixed timestep. Mutates in place."""
+    margin = SPRITE_SIZE / 2
+
+    # The sunglasses are only solid while they are actually off his head.
+    lift = hero_lift(now)
+    for duck in ducks:
+        if duck.is_shades:
+            duck.enabled = lift > 0
+            duck.y = duck.base_y - lift * HERO_SCALE
+
+    for duck in ducks:
+        if duck.anchored:
+            continue
+        duck.x += duck.vx * dt
+        duck.y += duck.vy * dt
+        duck.angle = (duck.angle + duck.spin * dt) % 360.0
+
+        # Walls, clamped on the *drawn* half-size rather than the collision
+        # radius, so a rotated duck never has a corner cut off by the frame edge.
+        if duck.x <= margin:
+            duck.x, duck.vx = margin, abs(duck.vx) * BOUNCE
+            _hit(duck, now, -1.0, 0.0)
+        elif duck.x >= width - margin:
+            duck.x, duck.vx = width - margin, -abs(duck.vx) * BOUNCE
+            _hit(duck, now, 1.0, 0.0)
+        if duck.y <= margin:
+            duck.y, duck.vy = margin, abs(duck.vy) * BOUNCE
+            _hit(duck, now, 0.0, -1.0)
+        elif duck.y >= height - margin:
+            duck.y, duck.vy = height - margin, -abs(duck.vy) * BOUNCE
+            _hit(duck, now, 0.0, 1.0)
+
+    # Circle against circle, resolved after everyone has moved so the outcome
+    # does not depend on list order. Circles and not boxes because these things
+    # rotate: an axis-aligned box around a spinning sprite is the wrong shape at
+    # most of the baked angles.
+    for i, a in enumerate(ducks):
+        if not a.enabled:
+            continue
+        for b in ducks[i + 1 :]:
+            if not b.enabled or (a.anchored and b.anchored):
+                continue
+            dx, dy = b.x - a.x, b.y - a.y
+            dist = math.hypot(dx, dy)
+            gap = a.radius + b.radius
+            if dist >= gap:
+                continue
+            if dist < 1e-6:
+                # Exactly coincident, so there is no normal to work with. Pick
+                # one — deterministically, because this must not reach for RNG.
+                nx, ny, dist = 1.0, 0.0, 1e-6
+            else:
+                nx, ny = dx / dist, dy / dist
+
+            overlap = gap - dist
+            # Separate along the normal by inverse mass — or entirely onto the
+            # loose one when the other cannot move.
+            if a.anchored:
+                b.x += nx * overlap
+                b.y += ny * overlap
+            elif b.anchored:
+                a.x -= nx * overlap
+                a.y -= ny * overlap
+            else:
+                total = a.mass + b.mass
+                a.x -= nx * overlap * (b.mass / total)
+                a.y -= ny * overlap * (b.mass / total)
+                b.x += nx * overlap * (a.mass / total)
+                b.y += ny * overlap * (a.mass / total)
+
+            # Exchange only the velocity component along the normal; leaving the
+            # tangential part alone is what makes a glancing blow graze rather
+            # than stop dead.
+            avn = a.vx * nx + a.vy * ny
+            bvn = b.vx * nx + b.vy * ny
+            if avn - bvn <= 0:  # already separating
+                continue
+            if a.anchored:
+                delta = -bvn * BOUNCE - bvn
+                b.vx += delta * nx
+                b.vy += delta * ny
+                b.spin = -b.spin
+            elif b.anchored:
+                delta = -avn * BOUNCE - avn
+                a.vx += delta * nx
+                a.vy += delta * ny
+                a.spin = -a.spin
+            else:
+                total = a.mass + b.mass
+                new_a = ((a.mass - b.mass) * avn + 2 * b.mass * bvn) / total * BOUNCE
+                new_b = ((b.mass - a.mass) * bvn + 2 * a.mass * avn) / total * BOUNCE
+                a.vx += (new_a - avn) * nx
+                a.vy += (new_a - avn) * ny
+                b.vx += (new_b - bvn) * nx
+                b.vy += (new_b - bvn) * ny
+                a.spin, b.spin = b.spin, a.spin
+
+            # Each flattens against the other, so the normals are opposite.
+            _hit(a, now, nx, ny)
+            _hit(b, now, -nx, -ny)
+
+    # Separation runs after the wall clamps, so a duck shoved by a neighbour can
+    # end up part-way out of frame. Clamp last and the walls always win — which
+    # matters most in a pile-up, exactly when there are most ducks to lose.
+    for duck in ducks:
+        if duck.anchored:
+            continue
+        duck.x = min(max(duck.x, margin), float(width) - margin)
+        duck.y = min(max(duck.y, margin), float(height) - margin)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def compose(ducks: list[Duck], now: float, cols: int, rows: int) -> Group:
+    """Blit the yard onto one pixel canvas, then pack it once."""
+    canvas = [["." for _ in range(cols)] for _ in range(rows * 2)]
+
+    # Hero last, so the crowd passes behind him rather than over his face. He is
+    # one of the ducks now, so this is a draw order and not a special case.
+    for duck in sorted(ducks, key=lambda d: d.is_hero):
+        if duck.is_shades:
+            continue  # a collider, drawn as part of the hero
+        sprite = duck.sprite(now)
+        blit(canvas, sprite, int(duck.x - len(sprite[0]) / 2), int(duck.y - len(sprite) / 2))
+
+    lines: list[Text] = []
+    for cells in _pack_cells(tuple("".join(row) for row in canvas)):
+        line = Text()
+        for glyph, style in cells:
+            line.append(glyph, style=style)
+        lines.append(line)
+    return Group(*lines)
+
+
+def configure(duck_scale: int) -> None:
+    """Re-derive every size-dependent constant for a different sprite scale.
+
+    2x is right for a recording, where the terminal font can be made tiny to pay
+    for it. A real screensaver runs at whatever font the user already has, so
+    the ducks have to be 1x or a dozen of them will not fit on the screen.
+    """
+    global DUCK_SCALE, SOURCE, SOURCE_QUACK, SPRITE_SIZE, DUCK_RADIUS
+    global HERO_SCALE, HERO_W, HERO_H, HERO_RADIUS, GLASSES_RADIUS
+    DUCK_SCALE = duck_scale
+    HERO_SCALE = duck_scale * 2
+    SOURCE = scale(DUCK_HEAD, DUCK_SCALE)
+    SOURCE_QUACK = scale(DUCK_HEAD_QUACK, DUCK_SCALE)
+    SPRITE_SIZE = math.ceil(math.hypot(len(SOURCE[0]) * MAX_STRETCH, len(SOURCE)))
+    DUCK_RADIUS = max(len(SOURCE[0]), len(SOURCE)) / 2.0
+    HERO_W, HERO_H = len(DUCK_HEAD[0]) * HERO_SCALE, len(DUCK_HEAD) * HERO_SCALE
+    HERO_RADIUS = max(HERO_W, HERO_H) / 2.0
+    GLASSES_RADIUS = (GLASSES_X1 - GLASSES_X0 + 1) / 3.0 * HERO_SCALE
+    squashed.cache_clear()
+
+
+def fits(width: int, height: int, coverage: float = 0.34) -> int:
+    """How many ducks fill ``coverage`` of a canvas, minus the hero's share.
+
+    A screensaver cannot be handed a duck count: it gets whatever terminal the
+    user happens to have, and twelve ducks that look like mayhem on a big screen
+    are a solid wall of green on a small one.
+    """
+    area = width * height
+    per_duck = len(SOURCE[0]) * len(SOURCE)
+    return max(2, int((area * coverage - HERO_W * HERO_H) / per_duck))
+
+
+# ---------------------------------------------------------------------------
+# The screensaver entry point
+# ---------------------------------------------------------------------------
+
+# One yard, advanced in place. build_screensaver is called once per frame with a
+# rising elapsed, so stepping incrementally is O(1) per frame; recomputing from
+# zero each time would be O(elapsed) and get slower the longer it ran.
+_yard: list[Duck] = []
+_yard_key: tuple[int, int, int] = (0, 0, 0)
+_yard_at: float = 0.0
+_STEP = 1.0 / 60
+
+
+def render(width: int, height: int, elapsed: float, *, seed: int = 3) -> RenderableType:
+    """The yard at ``elapsed`` seconds, for a ``width`` x ``height`` terminal.
+
+    Rebuilds when the terminal is resized or when time runs backwards. Backwards
+    is the ordinary case, not an error: every new screensaver session starts its
+    clock again at zero.
+    """
+    global _yard, _yard_key, _yard_at
+
+    px_h = height * 2
+    key = (width, px_h, seed)
+    if key != _yard_key or elapsed < _yard_at:
+        # noqa S311: ducks, not nonces. Reproducibility is the requirement.
+        _yard = make_ducks(fits(width, px_h), width, px_h, random.Random(seed))  # noqa: S311
+        _yard_key, _yard_at = key, 0.0
+
+    # Cap the catch-up. A session resumed after the machine slept would otherwise
+    # try to simulate hours in one frame and hang the UI.
+    target = min(elapsed, _yard_at + 2.0)
+    while _yard_at < target:
+        step(_yard, _STEP, _yard_at, width, px_h)
+        _yard_at += _STEP
+    return compose(_yard, _yard_at, width, height)

--- a/src/yeaboi/ui/shared/_screensaver.py
+++ b/src/yeaboi/ui/shared/_screensaver.py
@@ -207,6 +207,14 @@ def build_screensaver(*, width: int, height: int, elapsed: float | None = None) 
     # Roomy terminals: the duck waddles back and forth along the floor (feet
     # stepping) rather than standing still in the centre. Needs room for the 18-row
     # duck + the caption/hint + the pocket-clearance reserve.
+    # A yard of ducks, for any terminal with room to swing them. Below this the
+    # crowd has nowhere to go and it reads as a jam rather than mayhem, so the
+    # older single-duck bands still handle the small end.
+    if width >= 60 and height >= 24:
+        from yeaboi.ui.shared._mayhem import render as render_mayhem
+
+        return build_page_panel(render_mayhem(width - 6, height - 2, elapsed), height=max(1, height), padding=(0, 2))
+
     if width >= 46 and height >= 26:
         content_h = max(1, height - 2)  # inside the border
         inner_w = width - 6  # borders (2) + horizontal padding (4)

--- a/src/yeaboi/ui/shared/_screensaver.py
+++ b/src/yeaboi/ui/shared/_screensaver.py
@@ -19,9 +19,22 @@ from rich.console import Group, RenderableType
 from rich.text import Text
 
 from yeaboi.ui.shared._components import build_page_panel
-from yeaboi.ui.shared._mascot import render_full, render_head, walk_cells
+from yeaboi.ui.shared._mascot import SHADES_LIFT_SEQUENCE, render_full, render_head_idle, walk_cells
 
 IDLE_SECONDS = 5 * 60
+
+# build_screensaver advances the sprite at this rate; `frame` below is derived
+# from it. Named because the shades gag has to land on the same grid — a lift
+# sequence stepping at a different rate than the bob reads as two animations.
+SAVER_FPS = 8
+# How often the idle head lifts its shades. The mode-select companion plays the
+# same double-shades gag on click; here it is on a timer, because nobody is
+# there to click — that is what idle means.
+#
+# Anything recording this as a loop wants a whole number of these: the bob
+# closes its cycle every second, but the clip only wraps invisibly on a
+# multiple of the gag period.
+SHADES_EVERY_SECONDS = 4.0
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -171,10 +184,25 @@ _SAVER_JUMP_H = 2  # rows he springs up onto bar level as he reaches the music t
 _SAVER_JUMP_HALF = 0.06  # half-width of the hop as a fraction of the walk period
 
 
+def _shades_lift(elapsed: float) -> int | None:
+    """Where the sunglasses are in the periodic gag, or None while resting.
+
+    Steps on the same 8-per-second grid as the bob, so the two never drift
+    against each other.
+    """
+    period = int(SHADES_EVERY_SECONDS * SAVER_FPS)
+    step = int(elapsed * SAVER_FPS) % period
+    # The gag sits at the *end* of each period, so the saver opens on the resting
+    # bob rather than halfway through a lift — which is what it would do at
+    # elapsed 0, and what a recorded loop would open on.
+    start = period - len(SHADES_LIFT_SEQUENCE)
+    return SHADES_LIFT_SEQUENCE[step - start] if step >= start else None
+
+
 def build_screensaver(*, width: int, height: int, elapsed: float | None = None) -> RenderableType:
     """Build a size-aware animated saver frame without mutating app content."""
     elapsed = idle_controller.animation_elapsed() if elapsed is None else elapsed
-    frame = int(elapsed * 8) % 8
+    frame = int(elapsed * SAVER_FPS) % 8
 
     # Roomy terminals: the duck waddles back and forth along the floor (feet
     # stepping) rather than standing still in the centre. Needs room for the 18-row
@@ -219,7 +247,7 @@ def build_screensaver(*, width: int, height: int, elapsed: float | None = None) 
     if width >= 46 and height >= 22:
         art: RenderableType | None = render_full(frame)
     elif width >= 22 and height >= 13:
-        art = render_head(frame)
+        art = render_head_idle(frame, _shades_lift(elapsed))
     else:
         art = None
 

--- a/tests/unit/test_mayhem.py
+++ b/tests/unit/test_mayhem.py
@@ -1,0 +1,205 @@
+"""Tests for the screensaver's duck yard.
+
+The interesting properties are all invariants of the simulation rather than
+outputs anyone can eyeball, and every one of them broke at least once while it
+was being built: ducks escaping the frame during a pile-up, the hero drifting,
+the whole thing silently becoming non-reproducible.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+import pytest
+
+from yeaboi.ui.shared import _mayhem
+
+
+@pytest.fixture(autouse=True)
+def _reset_scale():
+    """The module keeps sprite geometry in globals, so a test that changes the
+    scale would otherwise leak into every test after it."""
+    _mayhem.configure(1)
+    yield
+    _mayhem.configure(1)
+
+
+def _yard(width=120, height=80, count=8, seed=3):
+    return _mayhem.make_ducks(count, width, height, random.Random(seed))
+
+
+def _run(ducks, width=120, height=80, steps=600):
+    now, dt = 0.0, 1 / 60
+    for _ in range(steps):
+        _mayhem.step(ducks, dt, now, width, height)
+        now += dt
+    return ducks
+
+
+class TestSimulation:
+    def test_same_seed_gives_the_same_yard(self):
+        a = _run(_yard())
+        b = _run(_yard())
+        assert [(round(d.x, 6), round(d.y, 6), round(d.angle, 6)) for d in a] == [
+            (round(d.x, 6), round(d.y, 6), round(d.angle, 6)) for d in b
+        ]
+
+    def test_different_seeds_differ(self):
+        a = _run(_yard(seed=1))
+        b = _run(_yard(seed=2))
+        assert [(d.x, d.y) for d in a] != [(d.x, d.y) for d in b]
+
+    def test_nobody_leaves_the_frame(self):
+        """Collision separation runs after the wall clamp, so a duck shoved by a
+        neighbour can be pushed through the edge. It is clamped again last."""
+        width, height = 120, 80
+        ducks = _yard(width, height)
+        margin = _mayhem.SPRITE_SIZE / 2
+        now, dt = 0.0, 1 / 60
+        for _ in range(900):
+            _mayhem.step(ducks, dt, now, width, height)
+            now += dt
+            for duck in ducks:
+                if duck.anchored:
+                    continue
+                assert margin - 0.001 <= duck.x <= width - margin + 0.001
+                assert margin - 0.001 <= duck.y <= height - margin + 0.001
+
+    def test_the_hero_does_not_move(self):
+        ducks = _yard()
+        hero = next(d for d in ducks if d.is_hero)
+        before = (hero.x, hero.y)
+        _run(ducks)
+        assert (hero.x, hero.y) == before
+
+    def test_energy_is_not_lost(self):
+        """Zero gravity and elastic bounces: nothing puts energy back, so any
+        damping anywhere makes the yard visibly wind down inside a clip."""
+        ducks = _yard()
+        loose = [d for d in ducks if not d.anchored]
+        before = sum(math.hypot(d.vx, d.vy) for d in loose)
+        _run(ducks)
+        after = sum(math.hypot(d.vx, d.vy) for d in loose)
+        assert after == pytest.approx(before, rel=0.2)
+
+    def test_ducks_start_spread_out(self):
+        """Stratified placement, not uniform: twelve uniform samples clump, and
+        the first version left a third of the yard empty."""
+        width = 200
+        loose = [d for d in _yard(width=width, count=12) if not d.anchored]
+        left = sum(1 for d in loose if d.x < width / 2)
+        assert 4 <= left <= 8
+
+    def test_ducks_head_towards_the_middle(self):
+        """A corner duck with a random heading rattles around in its corner for
+        the whole session and never meets anything."""
+        width, height = 200, 120
+        loose = [d for d in _yard(width, height, count=10) if not d.anchored]
+        for duck in loose:
+            towards = (width / 2 - duck.x) * duck.vx + (height / 2 - duck.y) * duck.vy
+            assert towards > 0
+
+
+class TestImpacts:
+    def test_a_collision_opens_beaks_and_squashes(self):
+        a = _mayhem.Duck(x=50.0, y=50.0, vx=40.0, vy=0.0)
+        b = _mayhem.Duck(x=50.0 + _mayhem.DUCK_RADIUS, y=50.0, vx=-40.0, vy=0.0)
+        _mayhem.step([a, b], 1 / 60, 10.0, 200, 200)
+        assert a.quack_until > 10.0 and b.quack_until > 10.0
+        assert a.squish_until > 10.0 and b.squish_until > 10.0
+
+    def test_squash_flattens_along_the_contact_normal(self):
+        """A ball hitting a wall goes flat against the wall, not along its own
+        axis — so the two must record opposite normals."""
+        a = _mayhem.Duck(x=50.0, y=50.0, vx=40.0, vy=0.0)
+        b = _mayhem.Duck(x=50.0 + _mayhem.DUCK_RADIUS, y=50.0, vx=-40.0, vy=0.0)
+        _mayhem.step([a, b], 1 / 60, 10.0, 200, 200)
+        half = _mayhem.NORMAL_STEPS // 2
+        assert abs(a.squish_normal - b.squish_normal) == half
+
+    def test_the_hero_never_squashes(self):
+        """An immovable thing that visibly gives on impact reads as wrong."""
+        ducks = _yard()
+        hero = next(d for d in ducks if d.is_hero)
+        _run(ducks)
+        assert hero.squish_until < 0
+
+
+class TestSprites:
+    def test_every_variant_is_the_same_size(self):
+        """Collision geometry is derived once, so a sprite whose footprint
+        changed with its angle or squash would drift out of its own hitbox."""
+        sizes = {
+            len(_mayhem.squashed(angle, level, normal, quack))
+            for angle in (0, 7, 23, 41)
+            for level in range(len(_mayhem.SQUISH_CURVE) + 1)
+            for normal in (0, 5, 11)
+            for quack in (False, True)
+        }
+        assert sizes == {_mayhem.SPRITE_SIZE}
+
+    def test_rotation_keeps_the_duck(self):
+        """Nearest-neighbour rotation drops pixels; it must not drop most of
+        them. The sunglasses vanishing is what made 1x unusable."""
+        upright = sum(row.count(ch) for row in _mayhem.squashed(0, 0, 0, False) for ch in set(row) if ch != ".")
+        for angle in (6, 12, 18, 24, 36):
+            turned = sum(row.count(ch) for row in _mayhem.squashed(angle, 0, 0, False) for ch in set(row) if ch != ".")
+            assert turned > upright * 0.7
+
+    def test_the_shades_gag_actually_lifts(self):
+        """It rendered correctly for a while and still never appeared, because
+        the open-beak frame replaced the head instead of composing into it."""
+        lifts = {_mayhem.hero_lift(t / 60) for t in range(int(_mayhem.HERO_SHADES_EVERY * 60))}
+        assert max(lifts) >= 3
+        assert 0 in lifts
+
+    def test_the_gag_plays_while_quacking(self):
+        """The hero is hit several times a second; if a quack hid the gag, the
+        sunglasses would look frozen."""
+        quacking = {_mayhem.hero_grid(t / 60, quacking=True) for t in range(int(_mayhem.HERO_SHADES_EVERY * 60))}
+        assert len(quacking) > 1
+
+    def test_hero_frames_are_all_one_size(self):
+        """compose() centres a sprite on its duck, so a grid that changed height
+        would bob him up and down on every impact."""
+        frames = [
+            _mayhem.hero_grid(t / 60, quacking=q)
+            for t in range(int(_mayhem.HERO_SHADES_EVERY * 60))
+            for q in (False, True)
+        ]
+        assert len({(len(f), len(f[0])) for f in frames}) == 1
+
+
+class TestRender:
+    def test_renders_and_advances(self):
+        _mayhem.render(120, 40, 0.0)
+        _mayhem.render(120, 40, 1.0)
+        assert _mayhem._yard_at == pytest.approx(1.0, abs=0.05)
+
+    def test_rewinding_starts_a_new_session(self):
+        """Every screensaver session restarts its clock at zero — backwards is
+        the ordinary case here, not an error."""
+        _mayhem.render(120, 40, 2.0)
+        _mayhem.render(120, 40, 0.0)
+        assert _mayhem._yard_at < 0.5
+
+    def test_a_long_gap_does_not_simulate_it_all(self):
+        """A session resumed after the machine slept would otherwise try to
+        catch up hours of simulation in one frame and hang the UI."""
+        _mayhem.render(120, 40, 0.0)
+        _mayhem.render(120, 40, 100_000.0)
+        assert _mayhem._yard_at < 10
+
+    def test_resizing_rebuilds(self):
+        _mayhem.render(120, 40, 1.0)
+        _mayhem.render(60, 20, 1.0)
+        assert _mayhem._yard_key[0] == 60
+
+    def test_bigger_terminals_hold_more_ducks(self):
+        assert _mayhem.fits(240, 160) > _mayhem.fits(80, 40)
+
+    def test_scale_changes_the_sprite_but_not_the_geometry_contract(self):
+        _mayhem.configure(2)
+        assert len(_mayhem.SOURCE[0]) == 32
+        assert _mayhem.SPRITE_SIZE == max(len(g) for g in _mayhem.squashed(3, 2, 4, False))

--- a/tests/unit/test_mayhem.py
+++ b/tests/unit/test_mayhem.py
@@ -147,18 +147,23 @@ class TestSprites:
             turned = sum(row.count(ch) for row in _mayhem.squashed(angle, 0, 0, False) for ch in set(row) if ch != ".")
             assert turned > upright * 0.7
 
-    def test_the_shades_gag_actually_lifts(self):
-        """It rendered correctly for a while and still never appeared, because
-        the open-beak frame replaced the head instead of composing into it."""
-        lifts = {_mayhem.hero_lift(t / 60) for t in range(int(_mayhem.HERO_SHADES_EVERY * 60))}
-        assert max(lifts) >= 3
-        assert 0 in lifts
+    def test_the_hero_holds_completely_still(self):
+        """He is hit several times a second, so a reacting hero flaps
+        constantly — and beside a yard that is already all motion there is
+        nowhere for the eye to rest."""
+        hero = next(d for d in _yard() if d.is_hero)
+        hero.quack_until = 1e9  # pretend he is being hit without pause
+        frames = {hero.sprite(t / 60) for t in range(240)}
+        assert len(frames) == 1
 
-    def test_the_gag_plays_while_quacking(self):
-        """The hero is hit several times a second; if a quack hid the gag, the
-        sunglasses would look frozen."""
-        quacking = {_mayhem.hero_grid(t / 60, quacking=True) for t in range(int(_mayhem.HERO_SHADES_EVERY * 60))}
-        assert len(quacking) > 1
+    def test_the_gag_still_works_when_switched_back_on(self):
+        """HERO_STATIC is a setting, not a deletion."""
+        _mayhem.HERO_STATIC = False
+        try:
+            lifts = {_mayhem.hero_lift(t / 60) for t in range(int(_mayhem.HERO_SHADES_EVERY * 60))}
+            assert max(lifts) >= 3 and 0 in lifts
+        finally:
+            _mayhem.HERO_STATIC = True
 
     def test_hero_frames_are_all_one_size(self):
         """compose() centres a sprite on its duck, so a grid that changed height


### PR DESCRIPTION
The idle screensaver was one duck. This makes it a yard of them: ten-odd heads
adrift in zero gravity, spinning, ricocheting off each other and off a big
anchored one in the middle, squashing against whatever they hit. Ctrl+Y still
opens it on demand — that shortcut already existed, this only changes what it
shows.

## What's here

`ui/shared/_mayhem.py` is the simulation. `build_screensaver` hands off to it at
60x24 and up; below that a dozen ducks have nowhere to go and it reads as a jam
rather than mayhem, so the existing single-duck bands still cover small
terminals.

`scripts/demo_duck_mayhem.py` drives the same code for recordings, which need
two things an idle screen does not: a sprite scale above what a real terminal
would use, and a fixed run length.

`_mascot.render_head_idle` is new — the resting head and the shades gag drawn at
one common height. `render_head_shades` pads above the crown for the raised
pair and `render_head` does not, so cutting between them dropped the duck two
rows the moment a gag ended.

## Things worth knowing

**It composites at pixel level.** `_mascot` half-block packs its sprites two
pixel rows to a terminal row and packs last; doing the same here buys positions
at half-cell precision, and it is the only level at which a sprite can be
rotated at all.

**Rotation is real and memoised.** 48 angles x 5 squash levels x 16 impact
directions x 2 beaks, built on demand — a full table is several thousand grids
of which a session touches a few hundred.

**Collisions are circles, not boxes.** An axis-aligned box around a spinning
sprite is the wrong shape at most angles. The radius comes from the unrotated
sprite rather than the diagonal canvas it sits on, or ducks bounce off each
other's whitespace.

**Squash flattens along the contact normal**, the way a ball goes flat against
the wall it hits, rather than along the duck's own axis.

**`render()` keeps one yard and advances it in place.** `build_screensaver` is
called once per frame with a rising elapsed, so stepping incrementally is O(1) a
frame where recomputing from zero would get slower the longer it ran. It
rebuilds on resize or when time runs backwards — backwards being ordinary, since
every session restarts its clock — and caps catch-up at two seconds, or a
session resumed after the machine slept would try to simulate hours in one frame
and hang the UI.

**Sizes come from the terminal.** A duck is 16 pixel-columns whatever the font,
and an ordinary 16pt window is about 95 of them, so the sprite scale is 1 in the
app and the hero only doubles once the canvas can carry him. The recording
script raises both, because there the font can drop to 8pt to pay for it.

**The anchored duck holds completely still** — no gag, no beak. He is hit
several times a second, and beside a yard that is already all motion there was
nowhere for the eye to rest. `HERO_STATIC` is a setting, not a deletion, and a
test covers the path so it cannot rot while switched off.

## Testing

21 tests in `tests/unit/test_mayhem.py`, covering the invariants that each broke
at least once while this was built: ducks escaping the frame during a pile-up,
the hero drifting, reproducibility quietly dying, sprite variants disagreeing on
their own footprint.

`make lint` clean. Full suite passes except two `ModuleNotFoundError: No module
named 'mcp'` collection errors, which are a missing dependency in the venv this
branch was developed against and unrelated to anything here — CI will say
whether they reproduce.

## Known rough edge

At 1x the rotation mangles the sunglasses at angles that are not multiples of
90. They are one pixel thick in the source art, and nearest-neighbour rotation
drops them. Recordings dodge it by drawing at 2x with a tiny font; the app
cannot, since it gets whatever font the user has. Restricting the in-app version
to 90-degree steps would keep every frame on-model and still spin, if that reads
better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)