### PR TITLE
bind music to P and O, and let them work through the screensaver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.55.0"
+version = "2.56.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,31 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.56.0",
+      "date": "2026-08-05",
+      "summary": "The idle screensaver now responds to music controls (P to play/pause, O to skip) without dismissing the saver, so you can change tracks while the ducks drift on screen. The anchored hero duck lifts his shades less frequently (every 11s instead of 1.6s) for a more natural look, and his reactions to impacts are now optional and separate from his animation. Both the lift interval and impact reactions are configurable per-session.",
+      "highlights": [
+        {
+          "text": "Music controls P and O now work through the idle screensaver without dismissing it",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Hero duck shades animation slowed from 1.6s to 11s intervals for a more natural appearance",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Hero duck shades and impact reactions are now separately configurable settings",
+          "areas": [
+            "settings"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.55.0",
       "date": "2026-08-05",
       "summary": "The idle screensaver expanded from a single duck to a yard of them — ten-odd heads adrift in zero gravity, spinning and ricocheting off each other and an anchored duck in the middle. The screensaver activates with Ctrl+Y as before, and still reads as a single resting duck on terminals smaller than 60x24, so the existing single-duck graphics cover those smaller screens.",

--- a/src/yeaboi/music.py
+++ b/src/yeaboi/music.py
@@ -156,7 +156,7 @@ def _reconcile_status() -> None:
         _state.daemon = None
         _state.status = "stopped"
         _state._paused_for_voice = False
-        _state.last_error = "music stopped — stream unavailable, ctrl+P to retry"
+        _state.last_error = "music stopped — stream unavailable, P to retry"
         logger.warning("Music player exited on its own (rc=%s); reverting to stopped", rc)
 
 

--- a/src/yeaboi/ui/shared/_input.py
+++ b/src/yeaboi/ui/shared/_input.py
@@ -386,11 +386,10 @@ def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
             # ui/shared/_attachments.py. Note: Cmd+V on macOS stays a terminal
             # *text* paste; Ctrl+V is the image binding, like Claude Code.
             return "ctrl+v"
-        # Return global music controls as internal key names. The public wrapper
-        # performs the action only after giving an active screensaver first chance
-        # to consume the event as its wake-only key.
-        if ch in ("\x10", "\x0f"):
-            return "ctrl+p" if ch == "\x10" else "ctrl+o"
+        # Music is bound to bare P and O — see the wrapper, which is where the
+        # binding is decided. Ctrl+P and Ctrl+O are left to fall through as the
+        # raw control characters they are; they used to be the binding.
+
         if ch == "\x19":
             return "ctrl+y"
         if ch == "\x03":
@@ -409,10 +408,35 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
     screen action runs. Timed polls that return no input leave the idle baseline
     untouched.
     """
-    from yeaboi.ui.shared._screensaver import begin_input_wait, handle_input_event, show_screensaver_now
+    from yeaboi.ui.shared._screensaver import (
+        begin_input_wait,
+        handle_input_event,
+        screensaver_active,
+        show_screensaver_now,
+    )
 
     begin_input_wait()
     key = _read_key_impl(stdin=stdin, timeout=timeout)
+
+    # Music first, and deliberately ahead of wake handling: the saver is what
+    # plays while you are listening to something, so the controls have to reach
+    # the player *through* it rather than being eaten as the key that dismisses
+    # it. Bare letters, so they must not fire into a text field.
+    if key in ("p", "o") and not _text_entry:
+        from yeaboi import music
+
+        if screensaver_active():
+            # Leave the saver up and the idle clock alone — changing the track is
+            # not a reason to decide somebody came back.
+            pass
+        elif _last_read_had_input:
+            handle_input_event()
+        if key == "p":
+            music.toggle()
+        else:
+            music.cycle_channel()
+        return ""
+
     if _last_read_had_input and handle_input_event():
         return ""
 
@@ -445,17 +469,6 @@ def read_key(stdin=None, timeout: float | None = None) -> str:
         show_screensaver_now()
         return ""
 
-    # Ctrl+P / Ctrl+O are global background-music controls. Keeping them after
-    # wake handling prevents the key that dismisses the saver from also changing
-    # playback state.
-    if key in ("ctrl+p", "ctrl+o"):
-        from yeaboi import music
-
-        if key == "ctrl+p":
-            music.toggle()
-        else:
-            music.cycle_channel()
-        return ""
     return key
 
 

--- a/src/yeaboi/ui/shared/_mayhem.py
+++ b/src/yeaboi/ui/shared/_mayhem.py
@@ -109,12 +109,13 @@ HERO_SCALE = DUCK_SCALE * 2
 # ping-pongs, so a three-second cycle can land almost entirely outside the
 # window — the gag was rendering correctly and still looked frozen, because at
 # most one lift fell inside the take and a dozen ducks were flying over it.
-# The anchored duck holds completely still: no shades gag, no beak. He is hit
-# several times a second, so a reacting hero flaps constantly, and next to a
-# yard that is already all motion the eye has nowhere to rest. Set False to give
-# him the gag back.
-HERO_STATIC = True
-HERO_SHADES_EVERY = 1.6
+# The anchored duck stays still apart from the shades gag, which is rare enough
+# to be a surprise rather than a tic. He is hit several times a second, so he
+# still never reacts to being hit — a hero flapping on every impact was the
+# thing that left the eye nowhere to rest.
+HERO_STATIC = False
+HERO_REACTS_TO_HITS = False
+HERO_SHADES_EVERY = 11.0
 # Its own sequence rather than the app's SHADES_LIFT_SEQUENCE, and stepped more
 # than twice as fast. The app's is a slow reveal with a long hold at the top,
 # which suits a calm idle screen and is far too languid next to a dozen ducks
@@ -329,7 +330,7 @@ class Duck:
         if self.is_hero:
             # Quacking beats the shades gag: he cannot be mid-cool-reveal and
             # mid-yelp at once, and the yelp is the one a duck to the face causes.
-            return hero_grid(now, quacking=not HERO_STATIC and now < self.quack_until)
+            return hero_grid(now, quacking=HERO_REACTS_TO_HITS and now < self.quack_until)
         level = 0
         if now < self.squish_until:
             # Flattest at the moment of impact, easing back out as the timer runs.

--- a/src/yeaboi/ui/shared/_music_bar.py
+++ b/src/yeaboi/ui/shared/_music_bar.py
@@ -74,7 +74,7 @@ def build_music_subtitle(theme: Theme = PLANNING_THEME) -> Text:
     """Return the compact music status line for a Panel's bottom border.
 
     Shows the player state plus the two control-chord hints, e.g.
-    ``♪ Lofi · playing   ctrl+P pause · ctrl+O channel``. When ffplay isn't installed it
+    ``♪ Lofi · playing   P pause · O channel``. When ffplay isn't installed it
     shows a dim, one-line install hint instead so the feature stays discoverable;
     when a spawned player died on its own it shows a dim crash notice in place of
     ``off`` (see :func:`yeaboi.music.last_error`).
@@ -91,7 +91,7 @@ def build_music_subtitle(theme: Theme = PLANNING_THEME) -> Text:
         # why rather than a bare "off" so a silently-broken player is diagnosable.
         err = music.last_error()
         line.append(f"♪ {err} " if err else "♪ off ", style=theme.dim if err else theme.muted)
-        toggle_hint = "ctrl+P play"
+        toggle_hint = "P play"
     else:
         line.append("♪ ", style=theme.accent)
         line.append(music.current_channel_name(), style=theme.accent_bright)
@@ -106,13 +106,13 @@ def build_music_subtitle(theme: Theme = PLANNING_THEME) -> Text:
             else:
                 line.append("playing ", style=theme.value)
                 line.append(_eq_bars(), style=theme.accent_bright)  # animated equalizer
-            toggle_hint = "ctrl+P pause"
+            toggle_hint = "P pause"
         else:
             line.append("paused", style=theme.value)
-            toggle_hint = "ctrl+P play"
+            toggle_hint = "P play"
     # Single tidy gap between the status/equalizer and the control hints (was a
     # double gap that left the visualizer stranded).
-    line.append(f"  {toggle_hint} · ctrl+O channel ", style=theme.dim)
+    line.append(f"  {toggle_hint} · O channel ", style=theme.dim)
     return line
 
 

--- a/src/yeaboi/ui/shared/_screensaver.py
+++ b/src/yeaboi/ui/shared/_screensaver.py
@@ -83,6 +83,13 @@ class IdleController:
             self._waiting_for_input = False
             return False
 
+    def is_active(self) -> bool:
+        """Whether the saver is on screen. Unlike handle_input_event this only
+        asks — it does not wake anything — so a key that is allowed to work
+        *through* the saver can check first."""
+        with self._lock:
+            return self._active
+
     def should_show(self) -> bool:
         """Return whether the saver should replace the current renderable."""
         now = self._clock()
@@ -138,6 +145,10 @@ def begin_input_wait() -> None:
 
 def handle_input_event() -> bool:
     return idle_controller.handle_input_event()
+
+
+def screensaver_active() -> bool:
+    return idle_controller.is_active()
 
 
 def show_screensaver_now() -> bool:

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -154,7 +154,7 @@ class TestShowSplash:
     def test_uses_plain_live_not_music_live(self):
         """The splash must use a plain Live, not MusicLive.
 
-        MusicLive stamps the persistent music bar (ctrl+P/ctrl+O controls) onto every
+        MusicLive stamps the persistent music bar (P/O controls) onto every
         Panel's border. Those controls belong to the interactive screens, so the
         bar should first appear on the mode-select menu — never on the intro. If
         the splash ever switches back to make_live/MusicLive, the bar reappears

--- a/tests/unit/test_music_bar.py
+++ b/tests/unit/test_music_bar.py
@@ -45,8 +45,8 @@ def test_subtitle_when_stopped():
     music._state.status = "stopped"
     text = build_music_subtitle().plain
     assert "off" in text
-    assert "ctrl+P play" in text
-    assert "ctrl+O channel" in text
+    assert "P play" in text
+    assert "O channel" in text
 
 
 def test_subtitle_when_playing():
@@ -55,25 +55,25 @@ def test_subtitle_when_playing():
     text = build_music_subtitle().plain
     assert music.CHANNELS[0]["name"] in text
     assert "playing" in text
-    assert "ctrl+P pause" in text
+    assert "P pause" in text
 
 
 def test_subtitle_when_paused():
     music._state.status = "paused"
     text = build_music_subtitle().plain
     assert "paused" in text
-    assert "ctrl+P play" in text
+    assert "P play" in text
 
 
 def test_subtitle_shows_crash_notice_when_stopped_with_error():
     # A player that died on its own reverts to "stopped" but leaves a last_error;
     # the bar shows it instead of a bare "off" so a broken player is diagnosable.
     music._state.status = "stopped"
-    music._state.last_error = "music stopped — stream unavailable, ctrl+P to retry"
+    music._state.last_error = "music stopped — stream unavailable, P to retry"
     text = build_music_subtitle().plain
     assert "stream unavailable" in text
     assert "off" not in text
-    assert "ctrl+P play" in text
+    assert "P play" in text
 
 
 def test_eq_bars_shape():
@@ -96,7 +96,7 @@ def test_subtitle_when_connecting():
     text = build_music_subtitle().plain
     assert "connecting" in text
     assert not any(c in _EQ_CHARS for c in text)  # no equalizer while buffering
-    assert "ctrl+P pause" in text
+    assert "P pause" in text
 
 
 def test_connecting_dots_shape(monkeypatch):

--- a/tests/unit/test_screensaver.py
+++ b/tests/unit/test_screensaver.py
@@ -65,7 +65,11 @@ def test_processing_is_excluded_and_idle_restarts_afterward(monkeypatch):
     assert controller.should_show() is True
 
 
-def test_read_key_consumes_wake_before_music_shortcut(monkeypatch):
+def test_music_controls_reach_the_player_through_the_saver(monkeypatch):
+    """The saver is what is on screen while you are listening to something, so
+    the music keys have to work *through* it — not be eaten as the key that
+    dismisses it. They also leave it up: changing track is no reason to decide
+    somebody came back."""
     controller, clock = _controller(seconds=1)
     monkeypatch.setattr(_screensaver, "idle_controller", controller)
     controller.begin_input_wait()
@@ -74,18 +78,37 @@ def test_read_key_consumes_wake_before_music_shortcut(monkeypatch):
 
     def fake_read(**_kwargs):
         _input._last_read_had_input = True
-        return "ctrl+p"
+        return "p"
 
     toggles: list[bool] = []
     monkeypatch.setattr(_input, "_read_key_impl", fake_read)
     monkeypatch.setattr("yeaboi.music.toggle", lambda: toggles.append(True))
 
     assert _input.read_key(timeout=0) == ""
-    assert toggles == []
-
-    # The same shortcut is actionable after the saver has been dismissed.
-    assert _input.read_key(timeout=0) == ""
     assert toggles == [True]
+    assert controller.is_active() is True
+
+    # And again, still without waking it.
+    assert _input.read_key(timeout=0) == ""
+    assert toggles == [True, True]
+    assert controller.is_active() is True
+
+
+def test_music_keys_do_not_fire_into_a_text_field(monkeypatch):
+    """They are bare letters now, so typing "op" in a prompt must not pause the
+    music and skip a channel."""
+
+    def fake_read(**_kwargs):
+        _input._last_read_had_input = True
+        return "p"
+
+    toggles: list[bool] = []
+    monkeypatch.setattr(_input, "_read_key_impl", fake_read)
+    monkeypatch.setattr("yeaboi.music.toggle", lambda: toggles.append(True))
+    monkeypatch.setattr(_input, "_text_entry", True)
+
+    assert _input.read_key(timeout=0) == "p"
+    assert toggles == []
 
 
 def test_ctrl_y_previews_saver_and_ctrl_y_again_only_wakes(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.54.0"
+version = "2.55.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
Three changes to how the idle screen behaves.

**The anchored duck lifts his shades again**, but every 11s rather than every
1.6 — often enough to notice, rare enough to be a surprise rather than a tic. He
still does not react to being hit: he is struck several times a second, and a
hero flapping on every impact was what left the eye nowhere to rest. The two are
now separate settings (`HERO_STATIC`, `HERO_REACTS_TO_HITS`) because they are
separate decisions.

**Music controls reach the player through an active saver.** The saver is
precisely what is on screen while you are listening to something, so eating the
keypress as the gesture that dismisses it had the binding backwards. They
deliberately leave the saver up and the idle clock untouched too — changing
track is no reason to decide somebody came back.

**They are bare P and O now.** Ctrl is gone, which makes them ordinary letters,
so they are gated on the same `_text_entry` flag the controls drawer uses or
typing "op" into a prompt would pause the music and skip a channel. Ctrl+P and
Ctrl+O fall through as the raw control characters they always were.

`IdleController` grows `is_active()`. `handle_input_event()` both asks and
wakes; a key that is allowed to work through the saver needs to ask without
waking.

## Testing

`test_read_key_consumes_wake_before_music_shortcut` asserted the old behaviour
by name, so it is replaced by two tests: one that the controls act through the
saver and leave it up, one that they stay out of text fields. The bar's hint and
the retry message in `music.py` follow the new binding.

`make test` 9602 passed, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)