### PR TITLE
widen the integrations charter from the provider edge to the whole chain

### DIFF
--- a/.claude/agents/cowork-builder.md
+++ b/.claude/agents/cowork-builder.md
@@ -17,8 +17,11 @@ Procedure:
 1. Read `CLAUDE.md`, `cowork/house-rules.md`, `cowork/definition-of-done.md`, and
    `cowork/workstreams/<name>.md`. Read the `.claude/skills/*/SKILL.md` for every area you will
    touch — the skills index table in `CLAUDE.md` maps areas to skills.
-2. Confirm the work is inside the charter's declared paths. **If it is not, stop and report** —
-   crossing into another workstream's files is what the path boundaries exist to prevent.
+2. Confirm the work is inside the charter's **`Owns`** paths. **If it is not, stop and report** —
+   crossing into another workstream's files is what the path boundaries exist to prevent. A
+   charter may also declare a **`Reads`** paragraph: those paths are readable for context and are
+   **never yours to edit**, whatever the item says. An item whose fix lands in a `Reads` path was
+   mis-classified — stop and report it rather than editing there.
 3. Branch off `main`: `cowork/<workstream>-<short-slug>`.
 4. Implement. Follow the repo's conventions rather than your own: the three observability pillars,
    frozen-dataclass defaults, parse → fallback → format, prompts in `prompts/`, TUI shared

--- a/.claude/agents/cowork-scout.md
+++ b/.claude/agents/cowork-scout.md
@@ -20,6 +20,12 @@ Procedure:
    Read the `.claude/skills/*/SKILL.md` files the charter names. Read `CLAUDE.md`.
 2. Survey **only the paths the charter declares**. Something valuable outside them is still a find —
    record it with the owning workstream's name so it can be routed, and do not investigate further.
+
+   If the charter declares a `**Reads**` paragraph alongside `**Owns**`, those paths are in scope
+   for *finding* and never for editing. Read them to answer the charter's questions, and classify
+   anything you find there `lane: propose` with `owner:` set to the workstream that owns the file —
+   never `auto`, whatever category it falls in, because no builder for this workstream may touch it.
+   `**Owns**` is where a builder may edit; `**Reads**` is only where you may look.
 3. Prefer evidence over impression. A find is worth reporting when you can point at a file, a
    command's output, or a specific contradiction. "Could be cleaner" is not a find.
 4. **Hunt opportunities.** After the defect pass, make one deliberate pass over the same surface for

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -46,6 +46,7 @@ runs.
 | [models.md](models.md) | The tier table. **The only file in `cowork/` that names a model.** |
 | [sweep-procedure.md](sweep-procedure.md) | The shared cron run, written once. |
 | [crew.md](crew.md) | scout / scribe / builder — who does what. |
+| [integrations-map.md](integrations-map.md) | Which provider reaches which mode, and every deliberate gap. Maintained by the integrations sweep's reach week. |
 | `workstreams/*.md` | Fifteen charters: owned paths, standing concerns, what is out of scope. Every `CAPABILITIES` row maps to exactly one; ownership never overlaps. |
 | `routines/cron/*.md` | One per scheduled routine. |
 | `routines/events/*.md` | GitHub-event triggered. |
@@ -93,7 +94,7 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 |---|---|---|---|---|
 | `cron/security-sweep.md` | `0 6 * * 1,4` Mon + Thu | security | `deep` | https://claude.ai/code/routines/trig_015JVLHWzF8urG7nDq9J4wsN |
 | `cron/planning-sweep.md` | `0 7 * * 1` Mon | planning | `standard` | https://claude.ai/code/routines/trig_01UR5H8AL5CzSydGMHCzD4aw |
-| `cron/integrations-sweep.md` | `30 6 * * 2` Tue | integrations | `standard` | https://claude.ai/code/routines/trig_01YKiiD5aUn4AtoCyUjZaFLR |
+| `cron/integrations-sweep.md` | `30 6 * * 2` Tue | integrations | `deep` | https://claude.ai/code/routines/trig_01YKiiD5aUn4AtoCyUjZaFLR |
 | `cron/standup-sweep.md` | `30 6 * * 3` Wed | standup | `standard` | https://claude.ai/code/routines/trig_01BcyJ4pNnPVPcDok47L2f9N |
 | `cron/tui-ux-sweep.md` | `0 7 * * 3` Wed | tui-ux | `standard` | https://claude.ai/code/routines/trig_01AxZUGZPkv86sbdxCuX2tep |
 | `cron/analysis-sweep.md` | `30 6 * * 4` Thu | analysis | `standard` | https://claude.ai/code/routines/trig_01YPy18KkR5qApYcGBSzr2ZA |

--- a/cowork/crew.md
+++ b/cowork/crew.md
@@ -4,7 +4,7 @@ Three sub-agents, defined in `.claude/agents/`, available in every routine run.
 
 | Agent | Tier | Does | Never does |
 |---|---|---|---|
-| `cowork-scout` | `standard` (`deep` for security) | Surveys one workstream's paths, ranks finds by impact / effort / risk, classifies each `auto` or `propose` | Edits files. Posts anywhere. |
+| `cowork-scout` | `standard` (`deep` for security and integrations) | Surveys one workstream's paths, ranks finds by impact / effort / risk, classifies each `auto` or `propose` | Edits files. Posts anywhere. |
 | `cowork-scribe` | `standard` | Every *authored* outbound write: Linear tickets + comments, GitHub issues + comments, Slack posts, Notion pages | Touches source code. Applies `claude-implement`. |
 | `cowork-builder` | `deep` | Implements one item inside its workstream's paths, runs the DoD gate, opens the PR | Posts to Linear/Slack/Notion. Leaves its paths. |
 

--- a/cowork/integrations-map.md
+++ b/cowork/integrations-map.md
@@ -1,0 +1,145 @@
+# Integrations map
+
+Which provider reaches which mode, through what, and where a mode deliberately does not consume one.
+Maintained by the **reach** week of [`routines/cron/integrations-sweep.md`](routines/cron/integrations-sweep.md);
+the charter is [`workstreams/integrations.md`](workstreams/integrations.md).
+
+This file exists because "connected" and "used" are different states and only one of them is visible.
+A credential can pass its wizard probe, be stored in `~/.yeaboi/.env`, and change nothing a user ever
+sees. The **Recorded gaps** section is the point of the file: it turns a silent absence into an
+answered question, the same job `Exempt("reason")` does in `CAPABILITIES`.
+
+**Verified 2026-08-06.** Line numbers rot; function names are the durable reference.
+
+## The chain
+
+Every provider is worth what its weakest link is worth:
+
+```
+credential (config.py getter)
+   → verification (ui/provider_select/_verification.py — wizard only)
+      → scope discovery (code_scope.py, TEAM_ANALYSIS_* vars, _available_*_sources)
+         → per-mode consumption (the matrix below)
+            → what the user finally sees
+```
+
+## Reach matrix
+
+`R` read · `W` write · `—` not consumed · `·` not applicable
+
+**Inbound only.** A cell says whether a mode *reads a provider as a source*. Publishing an export
+to Notion or Confluence is a destination, not reach — every mode with an export picker
+(`ui/shared/_export_picker.py::_MODE_STYLES`: planning, analysis, standup, retro, performance,
+reporting) can publish to both whenever the credentials resolve, and that is not recorded here.
+A `W` cell means writing back into the *source of record* — sprint creation, points, gap issues.
+
+| Provider | planning | analysis | standup | reporting | roadmap | poker | performance | retro |
+|---|---|---|---|---|---|---|---|---|
+| **Jira** | R + W | R | R | R | — | R + W | R | · |
+| **Azure DevOps (Boards)** | R + W | R | R | R | — | R + W | R | · |
+| **Azure DevOps (Repos)** | — | R | R | R | — | · | — | · |
+| **GitHub** | R | R | R + W | R | — | · | — | · |
+| **Confluence** | R + W | R | R | R | R | · | — | · |
+| **Notion** | R + W | R | R | R | R | · | — | · |
+| **Local git** | — | — | R | — | — | · | — | · |
+| **Local filesystem** | R | — | — | — | R | · | — | · |
+| **`holidays` package** | R | — | — | — | — | · | — | · |
+| **Ops / infra** | — | — | — | — | — | — | — | — |
+
+The bottom row is the charter's largest gap and is a row of dashes by construction, not by decision.
+See *The ops family, and its admission test* in the charter.
+
+## Per provider
+
+### Jira — `tools/jira.py`, `jira_sync.py`
+
+Credential `JIRA_BASE_URL` / `JIRA_EMAIL` / `JIRA_API_TOKEN` / `JIRA_PROJECT_KEY` · verified by
+`_verify_jira` (`GET /rest/api/3/myself`) · scope from `JIRA_PROJECT_KEY`.
+
+- planning — `jira_fetch_velocity`, `jira_fetch_active_sprint` in `agent/nodes.py`; writes through the
+  three `@tool`s (`jira_create_epic`/`_story`/`_sprint`, all `ToolRisk.WRITE`, all gated by
+  `human_review`) and the batch `jira_sync.sync_all_to_jira` behind the TUI review screen
+- analysis — `team_learning._fetch_jira_history` / `_fetch_jira_actuals` / `_fetch_jira_story_extras`
+- standup — `jira_recent_activity`, `jira_open_tickets`, `jira_active_sprint_progress`
+- reporting — `jira_recent_activity`, `jira_list_sprints`
+- poker — `jira_sprint_issues`, `jira_backlog_issues`, and `jira_update_issue_fields` writes points back
+- performance — `jira_recent_activity`
+- shared — `team_roster.py` uses `jira_assignee_roster`
+
+### Azure DevOps — `tools/azure_devops.py` (2.7k LOC), `azdevops_sync.py`
+
+Credential `AZURE_DEVOPS_TOKEN` / `_ORG_URL` / `_PROJECT` / `_TEAM` · verified by `_verify_azdevops`
+(`GET /{project}/_apis/wit/workitemtypes`) · scope from `TEAM_ANALYSIS_AZDO_PROJECTS` and the repo
+allowlist vars.
+
+Boards and Repos are **separate reach paths** and fail independently — standup keeps
+`SOURCE_AZDO_REPOS` distinct from `SOURCE_AZDO` precisely so a repo-API failure never hides work
+items. Mirrors Jira across planning / analysis / standup / reporting / poker / performance;
+`azdevops_sync` is the write-back pair to `jira_sync` and the two are held behaviourally symmetric by
+the charter.
+
+### GitHub — `tools/github.py`
+
+Credential `GITHUB_TOKEN` (optional — public repos work unauthenticated) · verified by
+`_verify_vc_token` (`GET api.github.com/user`) · scope from `TEAM_ANALYSIS_GITHUB_OWNERS` and
+`discover_github_repositories`.
+
+- planning — `github_read_repo` and `github_read_file` via `agent/repo_signals.py`; `github_read_readme`
+  only as a registered `@tool` the planning graph may choose, never from repo_signals
+- analysis — `github_analysis_inventory`, `github_recent_commits` / `_prs`, `github_changed_files`
+- standup — `github_recent_commits` / `_prs` / `_reviews`; **writes** gap issues via
+  `standup/gap_issues.py`
+- reporting — the same standup collector, driven by `reporting/context.py::_code_signals` with
+  `SOURCE_GITHUB` / `SOURCE_AZDO_REPOS`; merged PRs are the `code` component of
+  `activity.py::SOURCE_COMPONENTS`
+- also — `feedback.py` creates issues on `FEEDBACK_REPO` through the same shared client. Neither write
+  path is a registered `@tool`, so neither carries a `TOOL_RISK` row.
+
+### Confluence — `tools/confluence.py`
+
+Credential `CONFLUENCE_BASE_URL` / `_EMAIL` / `_API_TOKEN`, **each falling back to its `JIRA_*`
+equivalent**, plus `CONFLUENCE_SPACE_KEY` · verified by `_verify_confluence`.
+
+Read by planning (`confluence_search_docs`, `confluence_read_page`), analysis
+(`analysis/doc_quality.py`), standup (`confluence_recent_pages`), reporting
+(`context.py::_doc_signals`, which calls the same `collect_doc_pages`) and roadmap
+(`ingest_source`). Separately a publish *destination* for every mode's export picker
+(`export_targets.publish_to_confluence`) — see the matrix legend on why that is not a reach cell.
+
+The credential fallback means **configuring Jira silently enables Confluence tools**. Convenient, and
+stated nowhere on screen.
+
+### Notion — `tools/notion.py`
+
+Credential `NOTION_TOKEN` / `NOTION_ROOT_PAGE_ID` / `NOTION_EXPORT_PARENT_PAGE_ID` · verified by
+`_verify_notion` (`GET /v1/users/me`). Same five readers as Confluence, and the same separate
+publish destination via `export_targets.publish_to_notion`.
+
+### Local git, local filesystem, `holidays`
+
+No credential and no network. `local_git_recent_commits` (standup only), `tools/codebase.py` under
+`fs_policy` (planning and roadmap's PDF path), `detect_bank_holidays` (planning's sprint calendar).
+
+## Recorded gaps
+
+A deliberate absence, with the reason. Do not re-propose these.
+
+| Provider → mode | Why not |
+|---|---|
+| Jira / AzDO Boards → roadmap | Roadmap intake reads a *document* — a tracker holds what was already decided, which is the output of the pipeline roadmap feeds, not an input to it. |
+| Any provider → retro | Nothing is *read* into a retro: the board is sourced from what participants type in the session. `CAPABILITIES` records the matching TUI-only exemption. (Retro still *publishes* to Notion/Confluence — a destination, not reach.) |
+| GitHub / AzDO Repos / Confluence / Notion → performance | Performance reads the tracker only (`performance/activity.py`). A review window is assessed on delivered, attributable work items; the code and doc signals reporting gathers are per *sprint*, not per person, so they have nowhere to sit in the per-member narrative. |
+| Local git → anything but standup | It answers "what did this machine do today", which is a standup question and nobody else's. |
+| Confluence / Notion → poker | Estimation reads tickets, not prose. |
+
+## Open gaps
+
+No recorded reason yet — each is a question for the owning workstream, not a decision taken here.
+
+| Gap | Owner | Note |
+|---|---|---|
+| Ops / infra providers reach no mode | integrations | The whole bottom matrix row. Six modes have a question an ops provider would answer; see the charter's admission test. |
+| No provider is verifiable after setup | tui-ux | Five `_verify_*` probes exist and the settings screen calls none of them. |
+| Nothing tells a user what a connected provider powers | integrations | This file is the maintainer's copy of an answer no user can reach. |
+| Adding a provider costs ~13 edit sites | integrations | There is no fetcher protocol; `CoverageTracker` and the retry/classify closure inside `collector.collect_recent_activity`
+between them already define most of one. |

--- a/cowork/models.md
+++ b/cowork/models.md
@@ -13,7 +13,7 @@ repository variable — see [Workflows](#workflows)).
 |---|---|---|---|
 | `heavy` | Fable 5 | `claude-fable-5` | Long-running unattended implementation. **Never security** — see below. |
 | `deep` | Opus 5 | `claude-opus-5` | Work the repo lives with: building, reviewing, diagnosing, marketing prose, scouting security |
-| `standard` | Sonnet 5 | `claude-sonnet-5` | Bounded judgement over a known input: the other 13 scouts, the scribe, digest ranking, the DoD audit, release notes |
+| `standard` | Sonnet 5 | `claude-sonnet-5` | Bounded judgement over a known input: the other 12 scouts, the scribe, digest ranking, the DoD audit, release notes |
 | `fast` | Haiku 4.5 | `claude-haiku-4-5` | Mechanical: read a field, write a field |
 | `inherit` | — | — | Take the caller's model. The default for every agent. |
 
@@ -42,13 +42,17 @@ workstream.
 
 ### Routines
 
-The 14 sweeps take their tier from [sweep-procedure.md](sweep-procedure.md), which resolves it here.
-The rest do model-worthy work in their own session and carry a `**Model**` line.
+The 14 sweeps take their tier from [sweep-procedure.md](sweep-procedure.md), which resolves it
+here. Two of them — `security` and `integrations` — scout at `deep` instead of the shared
+`standard`; both exceptions are named in that file, and neither carries a `**Model**` line,
+because a sweep's tier belongs in one place. The rest do model-worthy work in their own
+session and carry a `**Model**` line.
 
 | Routine | Tier | Why |
 |---|---|---|
 | `cron/security-sweep.md` | `deep` | A missed guardrail gap is the one finding nobody else catches |
-| the other 13 `cron/*-sweep.md` | `standard` | Bounded survey of declared paths against a written charter |
+| `cron/integrations-sweep.md` | `deep` | Its reach axis traces one provider through six modes' code in a single run — synthesis across paths it may read and never edit, not a survey of one directory |
+| the other 12 `cron/*-sweep.md` | `standard` | Bounded survey of declared paths against a written charter |
 | `cron/marketing-weekly.md` | `deep` | Drafts prose inline rather than delegating; the prose is the output |
 | `cron/digest.md` | `standard` | Ranks ~20 issue titles and writes one message |
 | `cron/slack-relay.md` | `fast` | Grammar-first matching against an allowlist, 17 times a day; it also answers free text, but its rule for anything unsure is ask-in-thread, never act — the judgement being relayed was the human's. Raise the tier if parses misfire |
@@ -62,7 +66,7 @@ Every agent stays `model: inherit`. These are the tiers the **caller** passes on
 
 | Agent | Tier | Why |
 |---|---|---|
-| `cowork-scout` | `standard`, `deep` for security | Highest-frequency step in the system; a weak scout poisons the proposal queue |
+| `cowork-scout` | `standard`, `deep` for security and integrations | Highest-frequency step in the system; a weak scout poisons the proposal queue |
 | `cowork-builder` | `deep` | Writes code that becomes a PR |
 | `cowork-scribe` | `standard` | Formulaic, but it drives connector tools where a mistake files the wrong thing in a real tracker |
 | `code-reviewer` | `deep` | The only thing standing between the builder and a merge |

--- a/cowork/routines/cron/integrations-sweep.md
+++ b/cowork/routines/cron/integrations-sweep.md
@@ -2,12 +2,33 @@
 
 **Trigger** — cron `30 6 * * 2` (Tue 06:30 UTC)
 **Workstream** — [`workstreams/integrations.md`](../../workstreams/integrations.md)
+Follow [sweep-procedure.md](../../sweep-procedure.md) with `workstream = integrations`. Like
+`security`, this sweep scouts at `deep` rather than the shared `standard` — the reach axis
+reasons across six modes' code in one run, which is synthesis rather than a survey of one
+directory. That exception is named in `sweep-procedure.md` and the tier is in the README table;
+a sweep never carries its own `Model` line.
 
-Follow [sweep-procedure.md](../../sweep-procedure.md) with `workstream = integrations`.
+## Pick this week's axis first
 
-## Focus
+The charter covers three axes and a run does **exactly one**. Run:
 
-Rotate one provider per week — jira, azure_devops, github, confluence, notion, calendar — picking the
+```bash
+echo $(( 10#$(date -u +%V) % 3 ))
+```
+
+`0` → **Edge**, `1` → **Reach**, `2` → **Surface**. Nothing is stored between runs — the ISO week is
+the state, and it is the same number for every agent in the run. A year is 52 or 53 weeks, neither
+divisible by 3, so at each year boundary one axis repeats and one is skipped. Expected, not a bug:
+no axis ever goes more than five weeks unvisited, and the rotation evens out.
+
+One axis per run is not a budget, it is the stop condition. The charter's read scope spans seven directories plus
+`config.py`; asked all three questions at once, a scout would return more than ten finds and
+`sweep-procedure.md` would abort the run as a scoping failure. State the axis in the scout's prompt
+and tell it to ignore the other two.
+
+## Edge — the provider API
+
+Rotate one provider per run — jira, azure_devops, github, confluence, notion, calendar — picking the
 one whose cassette in `tests/contract/` is oldest.
 
 - Run `make contract` and read the cassette for the chosen provider.
@@ -16,3 +37,48 @@ one whose cassette in `tests/contract/` is oldest.
   test is green.
 - Check every list call in that provider's module for explicit pagination and for a truncation guard.
 - Check `jira_sync.py` against `azdevops_sync.py` for capability drift.
+
+## Reach — does a connected provider arrive anywhere
+
+Pick one provider and trace the whole chain, in order: credential getter in `config.py` → the
+wizard's verification probe → scope discovery → each mode that consumes it → the output a user
+finally sees.
+
+- Read the provider's row in [`integrations-map.md`](../../integrations-map.md) first and correct it
+  where the code has moved. That file is this axis's output; a run that changes nothing about it has
+  probably not read carefully enough.
+- A mode that **could** consume this provider and does not, with no reason recorded in the map's
+  *Recorded gaps* section, is a find owned by that mode — not by you. Propose it there, and record
+  the answer in the map when it comes back so the question is not re-asked in twelve weeks.
+- Check that every fetch path registers coverage (`analysis/coverage.py::CoverageTracker`, or
+  `standup/collector.py`'s error/skip classification). A source that fails silently reads as a zero,
+  and a zero is a number someone will believe.
+- Watch the canonical spelling. `azdevops`, `azdo` and `azuredevops` all name the same system in
+  different modules today.
+
+Everything under `Reads` in the charter is read-only. You may not open a PR against those paths in
+this or any run.
+
+## Surface — can a user tell
+
+The four wizard steps in `ui/provider_select/`, the Credentials tab of the settings screen, and the
+ops admission test.
+
+- Connect-time: does the step verify, or does it accept a string and fail on first use? Five
+  *provider* probes exist in `_verification.py` — `_verify_jira`, `_verify_azdevops`,
+  `_verify_notion`, `_verify_confluence`, `_verify_vc_token`, alongside two model-config ones that
+  are not providers. Check which fields are covered by one.
+- Steady-state: is there anywhere a user learns that a credential has expired, other than a failed
+  run? Is there anywhere they learn what a connected provider actually powers?
+- Blast radius: a credential that silently enables a second provider (the `CONFLUENCE_* → JIRA_*`
+  fallback) should say so on screen or not do it.
+
+Anything you find in `ui/` is **tui-ux**'s to fix — propose it with the owner set.
+
+## Every run, whichever axis
+
+Ask one standing question and file at most one find from it: **did this run surface a question a mode
+asks that no connected provider can answer?** Judge any candidate against the three-condition
+admission test in the charter — read-only, attributable, answers a question a mode already asks — and
+say in the proposal which mode consumes it first. An ops provider that fails any condition is not a
+finding, it is a dashboard.

--- a/cowork/sweep-procedure.md
+++ b/cowork/sweep-procedure.md
@@ -15,9 +15,10 @@ workstream and any per-run focus; everything else is here.
    workstream plus a weekly cadence means an unmerged PR stops this workstream indefinitely, and
    without that comment the digest would report the silence as if the scout had found nothing.
 
-3. **Scout** — spawn `cowork-scout` at the `standard` tier (`security` uses `deep`) with your
-   charter's paths. It returns ranked finds, each
-   classified `auto` or `propose` against the allowlist in house-rules. The finds include up to 3
+3. **Scout** — spawn `cowork-scout` at the `standard` tier (`security` and `integrations` use
+   `deep`) with your charter's paths. If your charter declares a `**Reads**` paragraph, pass
+   those paths too — the scout may look there, and no builder may ever edit there. It returns
+   ranked finds, each classified `auto` or `propose` against the allowlist in house-rules. The finds include up to 3
    user-facing opportunities (`type: feature|improvement`) alongside defects — see the opportunity
    pass in `.claude/agents/cowork-scout.md`; they ride the same ranking and the same propose lane.
    Nothing found is a normal outcome: exit silently.

--- a/cowork/workstreams/integrations.md
+++ b/cowork/workstreams/integrations.md
@@ -5,11 +5,44 @@ local_git, codebase, risk, llm_tools), `src/yeaboi/jira_sync.py`, `azdevops_sync
 `export_targets.py`, `ticket_text.py`, `markdown_convert.py` (Markdown → Notion blocks / Confluence
 XHTML), `tests/contract/` and its cassettes
 
+**Reads** — the consumer side of every integration, to find and never to edit:
+`analysis/engine.py`, `analysis/ai_usage.py`, `analysis/doc_quality.py` (the component/source model
+and the four hand-written credential probes); `standup/collector.py`, `code_scope.py`,
+`documentation_scope.py` (the `fetchers` dict and the retry/classify closure inside
+`collect_recent_activity`);
+`reporting/activity.py` (`SOURCE_COMPONENTS`, `_canonical_source()`); `roadmap/ingest.py`
+(`RoadmapSource` and `ingest_source()`); `agent/repo_signals.py` and the tool-calling sites in
+`agent/nodes.py`; `ui/provider_select/` (the wizard's four steps and `_verification.py`);
+`ui/mode_select/screens/_screens_secondary.py` (the Credentials settings sections); and
+`config.py`'s credential getters and `TEAM_ANALYSIS_*` scope variables.
+
+**A find in a `Reads` path is always `lane: propose`, with `owner:` set to the workstream that owns
+the file.** `**Owns**` is where a builder may edit; `**Reads**` is only where a scout may look.
+Four charters already delegate here — standup's *"Jira/AzDO fetching itself (**integrations**)"*,
+reporting's *"Tracker fetching"*, roadmap's *"Document fetching from Notion/Confluence"*, analysis's
+*"Tracker API mechanics"* — and until this paragraph existed, the files they were pointing at were
+read by no routine at all.
+
 **Skills** — `.claude/skills/agent-and-state/SKILL.md` (tool conventions)
 
-**Cadence** — Tue 06:30 UTC
+**Cadence** — Tue 06:30 UTC. Three axes on a three-week rotation — see
+[`routines/cron/integrations-sweep.md`](../routines/cron/integrations-sweep.md).
+
+## The three axes
+
+An integration is not a credential field. It is a chain: **credential → verification → scope
+discovery → per-mode consumption → what the user finally sees**, and it is only worth as much as its
+weakest link. The charter covers all of it.
+
+1. **Edge** — the provider API itself. Cassettes, pagination, auth, rate limits, write-back symmetry.
+2. **Reach** — whether a connected provider actually arrives in analysis, planning, roadmap, standup,
+   reporting and performance. A provider that reaches no mode is a dead setting.
+3. **Surface** — whether a user can tell what is connected, whether it still works, and what it
+   powers. [`integrations-map.md`](../integrations-map.md) is the record the reach axis maintains.
 
 ## Standing concerns
+
+### Edge
 
 - **Contract-test drift.** `tests/contract/` replays recorded responses. When a provider changes a
   field shape, the cassette still passes and production breaks. Compare cassettes against current
@@ -20,22 +53,110 @@ XHTML), `tests/contract/` and its cassettes
   never log the credential.
 - **Write-back symmetry** — `jira_sync.py` and `azdevops_sync.py` should stay behaviourally paired.
   A capability that exists on one and not the other is a proposal.
-- **`tools/team_learning.py` is not yours** despite living in `tools/` — it belongs to **analysis**.
+- **`risk.py` classifies `@tool`s only.** The write helpers that are plain functions — `create_task`,
+  `create_subtask`, `add_issues_to_sprint`, `add_work_items_to_iteration`, `jira_update_issue_fields`,
+  `azdevops_update_work_item_fields` — carry no `TOOL_RISK` row and never reach the `human_review`
+  gate. That is defensible, because they are not in the ReAct loop, but it should be *written down*
+  rather than inferred from their absence. The same file's claim that GitHub registers no writes is
+  worth checking against `feedback.py` and `standup/gap_issues.py`, both of which create issues
+  through the shared client.
+
+### Reach
+
+- **There is no fetcher abstraction.** A new source costs roughly thirteen edit sites spread across
+  three workstreams' paths. The only ABC in `src/yeaboi/` is
+  `standup/delivery.py::NotificationDelivery`, which is a *delivery* contract, not a fetching one.
+  `analysis/coverage.py::CoverageTracker` and the retry/classify closure inside
+  `standup/collector.py::collect_recent_activity` between them already define most of what a
+  provider protocol would need. This is the standing structural finding; it
+  crosses three charters, so it proposes.
+- **Four spellings name Azure DevOps, and only one module normalizes.** `azdevops` (analysis
+  delivery), `azdo` (analysis code — a genuinely different system), `azure_devops` (standup),
+  `azuredevops` (reporting, canonical because `DeliveredItem.source` has always persisted it). This
+  is **deliberate and documented at both sites**, so it is not a finding — but only
+  `reporting/activity.py` carries the alias set and `_canonical_source()`. Nothing tells a new source
+  which spelling to adopt, and a fifth one would be caught by no test.
+- **Coverage must stay visible.** `CoverageTracker` records succeeded / truncated / unchanged /
+  inaccessible / failed per source, so an absent source is reported rather than read as a zero. A new
+  fetch path that does not register coverage is a finding.
+- **A mode that could consume a provider and does not** — with no recorded reason — is a find owned
+  by that mode. Record the answer in `integrations-map.md` so the question is not asked again.
+
+### Surface
+
+- **Verification exists only in the wizard.** `_verify_jira`, `_verify_azdevops`, `_verify_notion`,
+  `_verify_confluence` and `_verify_vc_token` all live in `ui/provider_select/_verification.py`. The
+  settings page has no equivalent, so a credential that expires is discovered by a failed run rather
+  than by the screen that shows it.
+- **Setup steps that could self-verify** instead of failing on first use.
+- **A credential's blast radius should be legible.** The Confluence getters fall back to the `JIRA_*`
+  values, so configuring Jira silently enables Confluence tools. That is convenient and undocumented
+  on screen; either is fine, both together is not.
+
+## The ops family, and its admission test
+
+Every source yeaboi reads today is a tracker, a repo host or a wiki — `_COMPONENTS` in
+`analysis/engine.py` is `("delivery", "code", "docs")`. Nothing describes how the team **runs** what
+it ships. That is the largest single gap in this charter's surface.
+
+A provider outside delivery/code/docs qualifies when **all three** hold:
+
+1. **Read-only.** Nothing in yeaboi should mutate infrastructure, billing or access control. Every
+   write path that exists today exists because a human approved a plan first, and there is no
+   equivalent approval shape for an infrastructure change.
+2. **Attributable** — its data resolves to a team member or to a service the team owns. Otherwise it
+   cannot join the per-member table or the per-sprint narrative that every consuming mode already
+   renders, and it becomes a number with nowhere to sit.
+3. **It answers a question a mode already asks.** A provider that answers none of them is a
+   dashboard, not an integration.
+
+The questions, which are what makes this concrete:
+
+| Mode | What an ops provider would answer |
+|---|---|
+| planning | on-call load and incident history as capacity and risk inputs; deploy cadence as a sizing signal |
+| analysis | does the team's practice extend past merge — do they own what they run? |
+| roadmap | feasibility against what exists in the account, not what the document assumes |
+| standup | an incident is a blocker nobody types into a ticket |
+| reporting | what shipped is a deploy, not only a merged PR |
+| performance | on-call burden is invisible work that no tracker records |
+
+Examples that pass: AWS and GCP (deploys, per-service cost, which services a member has been
+touching), Datadog and Sentry (error budget and incidents against the sprint window), PagerDuty and
+Opsgenie (on-call load), Teleport (access grants as an onboarding and offboarding signal). Examples
+that fail: anything needing a write credential; anything reporting only at org level with no member
+or service attribution; anything whose answer no mode has a place to put.
+
+A specific provider is always a proposal, filed against this test, naming which of the three
+conditions it satisfies and which mode consumes it first.
 
 ## Auto lane, in practice
 
 A broken or flaky contract test, a missing pagination guard with a cassette to prove it, dead code in
-a retired provider path. New provider capabilities always propose.
+a retired provider path, doc drift between a tool's docstring and its behaviour. New provider
+capabilities always propose, every ops provider proposes, and nothing in a `**Reads**` path is ever
+auto — by construction, since a builder may not edit there.
 
 ## Opportunity space
 
-Where a `[feature]`/`[improvement]` find is most likely to be real here: third-party edges a user
-hits silently (truncated lists, rate limits swallowed, auth that expires without a message), setup
-steps that could self-verify instead of failing on first use, and capabilities one provider has that
-its sibling lacks for no recorded reason. The evidence bar in `cowork-scout.md` applies — name the
-friction, the gap, or the repeated step.
+Where a `[feature]`/`[improvement]` find is most likely to be real here, one per axis:
+
+- **Edge** — third-party edges a user hits silently: truncated lists, rate limits swallowed, auth
+  that expires without a message, capabilities one provider has that its sibling lacks for no
+  recorded reason.
+- **Reach** — a credential a user has configured that changes nothing they can see, and a question a
+  mode plainly wants answered that no connected provider can answer.
+- **Surface** — setup steps that could self-verify instead of failing on first use, and connection
+  state a user has to infer from a failure.
+
+The evidence bar in `cowork-scout.md` applies — name the friction, the gap, or the repeated step.
 
 ## Out of scope
 
-`tools/team_learning.py` (analysis). Slack/email delivery, which lives in `standup/delivery.py` and
-`performance/delivery.py` and belongs to those modes.
+`tools/team_learning.py` (**analysis**), despite living in `tools/`. Slack and email delivery, which
+live in `standup/delivery.py` and `performance/delivery.py` and belong to those modes.
+
+**Interpretation stays with the mode.** This charter asks whether the data arrives, whether it is
+complete, and whether the user can tell — never what a mode should conclude from it. A metric
+definition, a threshold, a marker set or a narrative is the consuming workstream's call even when the
+data reaching it is yours.

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.55.1"
+version = "2.55.2"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

The `integrations` cowork workstream audited the provider API and stopped there. Four other charters
explicitly delegate the consumer side to it — standup's *"Jira/AzDO fetching itself (**integrations**)"*,
reporting's *"Tracker fetching"*, roadmap's *"Document fetching from Notion/Confluence"*, analysis's
*"Tracker API mechanics"* — but those files were in no charter's declared paths, so no routine ever
opened them.

This widens the charter to the whole chain: **credential → verification → scope discovery →
per-mode consumption → what the user finally sees**.

- **`Reads` scope.** The charter now declares consumer-side paths a scout may read and no builder may
  ever edit. A find there is always `lane: propose` with `owner:` set to the workstream that owns the
  file. `cowork-scout`, `sweep-procedure.md` and `cowork-builder` are all taught the `Owns`/`Reads`
  split, so the invariant is enforced at every step that could break it rather than asserted only in
  the charter.
- **Three axes, three-week rotation.** Edge (provider API), Reach (does a connected provider arrive
  anywhere), Surface (can a user tell). One per run, picked by ISO week — nothing is stored between
  runs. One axis per run is the *stop condition*: asked all three questions at once over eight read
  paths, a scout returns more than ten finds and `sweep-procedure.md` aborts the run as a scoping
  failure.
- **New `cowork/integrations-map.md`.** A provider→mode reach matrix, per-provider chain notes, a
  **Recorded gaps** table (deliberate absences with reasons, so they are not re-proposed every twelve
  weeks — the same job `Exempt("reason")` does in `CAPABILITIES`) and an **Open gaps** table with
  owners. Maintained by the reach week.
- **Ops admission test.** Every source yeaboi reads today is a tracker, repo host or wiki
  (`_COMPONENTS = ("delivery", "code", "docs")`); nothing describes how the team *runs* what it ships.
  A provider outside those three qualifies only if it is read-only, attributable to a member or an
  owned service, and answers a question a mode already asks. Anything else is a dashboard, not an
  integration.
- **Tier `standard` → `deep`** for this sweep. Its reach axis reasons across six modes' code in a
  single run — synthesis, not a survey of one directory. Propagated to the README table,
  `models.md` and `crew.md`.
- **`uv.lock`** — refreshes the stale `yeaboi` version line (2.55.1 → 2.55.2) to match
  `pyproject.toml`. No dependency change.

Docs and process only — no `src/yeaboi/` changes.

## Test plan

- `make test` — 9639 passed, 47 skipped (run twice: before and after review fixes)
- `make lint` — clean
- `make security` — SAST clean, no known CVEs
- `make cowork-check` — clean (README table, routine files and tier table agree)
- `tests/unit/test_cowork_models.py` + `test_cowork_setup.py` — 422 passed

## Review

An independent fresh-context review verified the docs' factual claims against the code. It found one
`blocker` and three `should-fix`, all resolved in this branch:

- **blocker** — the reach matrix marked GitHub, AzDO Repos, Confluence and Notion as *not consumed*
  by reporting, and a *Recorded gaps* row told future scouts the question was already answered. They
  are all consumed today via `reporting/context.py::_code_signals` / `_doc_signals`. Matrix, gaps
  table and the per-provider sections corrected.
- **should-fix** — the matrix contradicted the file's own note that Confluence/Notion are a publish
  target for every mode. Added an explicit *inbound only* legend rule: a cell records reading a
  provider as a source; publishing an export is a destination, not reach.
- **should-fix** — the `deep` tier exception had not been propagated to the `cowork-scout` rows in
  `models.md` and `crew.md`. Nothing enforces those rows, so the drift would have been silent.
- **should-fix** — `cowork-builder` still said "the charter's declared paths", which with a `Reads`
  paragraph present admits exactly the edit the invariant forbids. Now `Owns` only.

Five nits also fixed: the `_verify_*` probe count, `github_read_readme`'s call site,
`collector._run` being a closure rather than a module attribute, the ISO-week year-boundary
behaviour, and the read-scope directory count.

## DoD

- Items 8 (Notion) and 9 (Slack) fire from the `pr-merged-close-loop` routine on merge.
- Surface parity, observability and web bundles do not apply — no `src/yeaboi/` or `frontend/` changes.

**Operational note:** the tier change is repo-side only. The registered routine keeps running on
`standard` until someone runs `/cowork deploy`; `/cowork status` reports it as drift in the meantime.

Closes YEA-50

🤖 Generated with [Claude Code](https://claude.com/claude-code)