### PR TITLE
block tests from opening a real browser tab

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ See README: "Testing — Contract Tests" for background on VCR.py replay.
 
 from __future__ import annotations
 
+import webbrowser
 from pathlib import Path
 
 import pytest
@@ -37,6 +38,43 @@ def _sandbox_allows_test_dirs(tmp_path_factory):
     mp.setenv("YEABOI_ALLOWED_PATHS", f"{basetemp},{fixtures_dir},{Path.cwd()}")
     yield
     mp.undo()
+
+
+class RealBrowserBlocked(BaseException):
+    """Raised when a test reaches a real ``webbrowser`` call.
+
+    Deliberately a ``BaseException``, not an ``Exception``: all three production
+    call sites wrap their ``webbrowser.open`` in ``except Exception`` and degrade
+    to a "copy this URL" branch, so an ``Exception`` here would be swallowed and
+    the guard would silently reroute the test instead of failing it.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _no_real_browser(monkeypatch):
+    """No test may open a real browser tab.
+
+    Three production paths call webbrowser (standup/gap_issues.py, feedback.py, and the
+    TUI mode_select handler); a test that forgets to patch one hijacks the developer's
+    browser on every `make test-fast`. Tests that legitimately exercise those paths patch
+    webbrowser themselves — they share this MonkeyPatch instance, so their setattr lands
+    after ours and wins.
+
+    Patching the webbrowser module once covers every call site: each importer holds a
+    reference to the same module object, including the function-local ``import webbrowser``
+    in mode_select (resolved from ``sys.modules`` at call time).
+
+    Function-scoped on purpose, unlike the session-scoped sandbox fixture above: a test
+    overriding this guard is the intended path, and that only works when it shares the
+    ``monkeypatch`` instance. Nothing reaches webbrowser from a higher-scoped fixture today.
+    """
+
+    def _blocked(url, *args, **kwargs):
+        raise RealBrowserBlocked(f"test tried to open a real browser: {url}")
+
+    # ``get`` too: ``webbrowser.get(...).open(url)`` would otherwise bypass the stubs.
+    for name in ("open", "open_new", "open_new_tab", "get"):
+        monkeypatch.setattr(webbrowser, name, _blocked)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_conftest_guards.py
+++ b/tests/unit/test_conftest_guards.py
@@ -1,0 +1,42 @@
+"""Tests for the autouse guards in tests/conftest.py.
+
+The browser guard's failure mode is invisible: if it silently stops working, nothing
+goes red — a developer's browser just starts opening again during `make test-fast`.
+These tests pin the two properties its docstring promises.
+"""
+
+from __future__ import annotations
+
+import webbrowser
+
+import pytest
+
+
+class TestNoRealBrowser:
+    def test_an_unpatched_open_is_blocked(self):
+        with pytest.raises(BaseException, match="real browser") as excinfo:
+            webbrowser.open("https://example.com")
+        # Must not be an Exception: every production call site wraps its
+        # webbrowser.open in `except Exception` and degrades to a copy-this-URL
+        # branch, which would swallow the guard and reroute the test instead.
+        assert not isinstance(excinfo.value, Exception)
+
+    def test_the_production_except_exception_does_not_swallow_it(self):
+        """Mirrors the wrapper at all three call sites (gap_issues, feedback, mode_select)."""
+        with pytest.raises(BaseException, match="real browser"):
+            try:
+                webbrowser.open("https://example.com")
+            except Exception:  # noqa: BLE001 - reproducing production shape on purpose
+                pytest.fail("except Exception swallowed the browser guard")
+
+    @pytest.mark.parametrize("name", ["open", "open_new", "open_new_tab", "get"])
+    def test_every_entry_point_is_covered(self, name):
+        with pytest.raises(BaseException, match="real browser"):
+            getattr(webbrowser, name)("https://example.com")
+
+    def test_a_tests_own_patch_still_wins(self, monkeypatch):
+        """The guard shares the monkeypatch instance, so a test's setattr lands after it."""
+        opened = []
+        monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url) or True)
+        assert webbrowser.open("https://example.com") is True
+        assert opened == ["https://example.com"]

--- a/tests/unit/test_standup_gap_issues.py
+++ b/tests/unit/test_standup_gap_issues.py
@@ -335,10 +335,13 @@ class TestFileGap:
         def _boom():
             raise RuntimeError("network down")
 
+        opened = []
         monkeypatch.setattr(gap_issues, "_repo", _boom)
+        monkeypatch.setattr(gap_issues.webbrowser, "open", lambda url: opened.append(url) or True)
         link = gap_issues.file_gap(_gap(), _review())
         # Falls through to the browser path rather than blowing up.
         assert link.state == "browser"
+        assert opened and "issues/new" in opened[0]
 
     def test_no_token_opens_a_prefilled_browser_url(self, monkeypatch, no_token):
         opened = []

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.55.1"
+version = "2.55.2"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

Three production paths call `webbrowser.open` — standup gap-issue filing (`standup/gap_issues.py:440`), feedback submission (`feedback.py:191`), and the TUI mode_select handler (`ui/mode_select/__init__.py:5004`). A test that exercises one of those paths without patching `webbrowser` opens a real tab in the developer's browser on every `make test-fast`. `test_unreachable_github_never_raises` was doing exactly that: it patches `_repo` to raise so the code falls through to the browser branch, then let the real `webbrowser.open` fire.

This adds an autouse fixture in `tests/conftest.py` that stubs `webbrowser.open` / `open_new` / `open_new_tab` / `get` to raise, so any unpatched test fails loudly instead of hijacking the browser.

Two details that make the guard actually work:

- **The raised exception is a `BaseException` subclass, not an `Exception`.** All three call sites wrap their `open()` in `except Exception` and degrade to a "couldn't open a browser, copy this URL" branch. An ordinary `Exception` would be swallowed there — the test would still pass green, just silently exercising a different production branch. That was caught in review; the first cut used `RuntimeError` and was inert.
- **The fixture is function-scoped and shares the `monkeypatch` instance**, so a test that legitimately drives one of these paths patches `webbrowser` itself and its `setattr` lands after ours and wins. That override is the intended path, which is why this doesn't mirror the session-scoped approach of the sibling sandbox fixture above it.

`get` is stubbed too, since `webbrowser.get(...).open(url)` would otherwise route around the other three.

Also included: `tests/unit/test_conftest_guards.py` pins the guard's own behaviour (the failure mode is otherwise invisible — if the fixture breaks, nothing goes red, a browser just starts opening again), and `uv.lock` is resynced to the already-committed `2.55.2` version bump in `pyproject.toml`.

## Test plan

- `make test` — 9644 passed, 47 skipped
- `make lint` — clean
- `make security` — SAST clean, no known CVEs
- Verified the guard bites: temporarily removing the new `monkeypatch.setattr` from `test_unreachable_github_never_raises` makes it fail with `RealBrowserBlocked` where it previously passed green. Restored afterwards.
- Independent fresh-context review (`code-reviewer` at deep tier); its one `should-fix` — the swallowed `RuntimeError` — is fixed here, along with the `get` coverage and guard-test nits.

## Definition of Done

Items 8 (Notion) and 9 (Slack) fire from the `pr-merged-close-loop` routine on merge. Surface parity and web bundles do not apply: this is test infrastructure only, no `src/` or `frontend/` change, no new capability.

Closes YEA-49

🤖 Generated with [Claude Code](https://claude.com/claude-code)