### PR TITLE
let voice input pick its microphone and make dictation discoverable

### DIFF
--- a/.claude/skills/project-map/SKILL.md
+++ b/.claude/skills/project-map/SKILL.md
@@ -173,6 +173,7 @@ Key flags to know about when modifying the CLI:
 | `--setup` | Re-run first-time setup wizard |
 | `--allow-path PATH` | Session-only filesystem sandbox grant (repeatable); persistent allowances via `YEABOI_ALLOWED_PATHS` |
 | `--install-skill [DIR]` | Install bundled OpenClaw skill to `~/.openclaw/skills/` (or custom dir) |
+| `--list-audio-devices` | List the microphones dictation can record from, then exit (rescans first, so a mic plugged in after launch shows up); marks the `VOICE_DEVICE` pick |
 | `--standup-run` | Headless: run a daily standup and deliver it (what the OS scheduler invokes) |
 | `--standup-interactive` | With `--standup-run`: timed prompt for the user's update + confirm before generating (TTY-aware; headless fallback) |
 | `--standup-session ID` | Session to run the standup for (default: most recent) |
@@ -233,6 +234,8 @@ The `src/yeaboi/mcp/` package exposes yeaboi to AI coding agents (Claude Code, C
 - `BETA_NOTICES_ENABLED` — default on; `false` silences the one-line beta caveat the CLI prints to stderr before a beta subcommand runs (`yeaboi perf …`). Does **not** affect the TUI's one-time notice.
 - `BETA_NOTICES_ACK` — **state, not configuration.** Comma-separated `_MODE_CARDS` keys whose one-time TUI beta notice has been dismissed; written automatically to `~/.yeaboi/.env` on Continue. Not surfaced on the Settings page (it would invite hand-editing).
 - `YEABOI_FORCE_BETA_NOTICE` — re-show an already-acknowledged TUI beta notice. `1`/`true` for all modes, or a comma-separated list of mode keys. The only way to re-check a once-ever gate for demos, screenshots or review.
+- `VOICE_MODEL` — local Whisper size for dictation (`tiny`, `base` (default), `small`, `medium`, `large-v3`, plus the `.en` variants)
+- `VOICE_DEVICE` — microphone for dictation: a PortAudio index (`2`) or a case-insensitive name substring (`shure`). Empty = system default. Set it from Settings → Voice Input → Input Device (an arrow-selectable picker with a live level test), or discover names with `yeaboi --list-audio-devices`
 - `SESSION_PRUNE_DAYS` — auto-prune sessions older than N days (default: 30, 0 = disabled)
 - `LOG_LEVEL` — file logger level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)
 - `LANGSMITH_TRACING`, `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT` — optional, enables LangSmith tracing

--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,14 @@ NOTION_ROOT_PAGE_ID=
 # Larger = more accurate but slower and a bigger one-time download.
 VOICE_MODEL=base
 
+# VOICE_DEVICE picks WHICH microphone dictation records from. PortAudio's system
+# default is often not the one you mean (a laptop lid mic over your headset, say).
+# Accepts a device index (2) or a case-insensitive part of its name (shure).
+# Empty = the system default, which is how voice behaved before this setting.
+# List what this machine has: yeaboi --list-audio-devices
+# Or pick it with a live level test in Settings -> Voice Input -> Input Device.
+VOICE_DEVICE=
+
 # On-screen tips
 # Rotating discoverability tips on the welcome screen + inline voice hints.
 # Default on; set to false to hide all tips. Toggle live by pressing "t" on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.55.2"
+version = "2.56.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ dev = [
     "matplotlib>=3.8",
     # so CI exercises the MCP server tests
     "mcp>=1.9,<2",
+    # so the voice tests exercise the real resampling maths — the hand-rolled
+    # numpy fake in tests/unit/test_voice.py cannot stand in for np.interp.
+    # numpy arrives transitively with faster-whisper at runtime; naming it here
+    # keeps the resample tests runnable without the (heavy) voice extra.
+    "numpy>=1.24,<3",
     # tests/unit/test_workflow_concurrency.py and tests/contract/ parse YAML.
     # It arrives transitively via langchain anyway; naming it here keeps a
     # dependency reshuffle from breaking unit-test *collection*.

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,49 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.56.0",
+      "date": "2026-08-07",
+      "summary": "Voice input now lets you pick which microphone to use, making it work on hardware that wasn't detected before. Most USB and Bluetooth mics refuse to open at Whisper's default 16 kHz mono format — voice input now negotiates whatever format your mic actually supports, records natively, and converts afterward, so audio gets captured even on finicky hardware. A new Settings page lets you test each microphone, and Tab during recording switches between them on the fly. The feature is now discoverable in the TUI with an input-level meter and \"no sound detected\" warning, plus a new `--list-audio-devices` CLI diagnostic.",
+      "highlights": [
+        {
+          "text": "VOICE_DEVICE config option: pick a microphone by PortAudio index or name substring",
+          "areas": [
+            "settings"
+          ]
+        },
+        {
+          "text": "Settings → Voice Input → Input Device: new picker with live microphone test",
+          "areas": [
+            "settings"
+          ]
+        },
+        {
+          "text": "Tab to switch microphones mid-recording, with device name and input-level meter",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Format negotiation: records at the microphone's native sample rate and channels, then resamples to Whisper format",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "`--list-audio-devices` CLI subcommand to discover available microphones and test the audio input",
+          "areas": [
+            "settings"
+          ]
+        },
+        {
+          "text": "\"No sound reaching the mic\" warning and better affordance positioning for voice hints",
+          "areas": [
+            "general"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.55.2",
       "date": "2026-08-06",
       "summary": "Fixed standup mode's Generate command failing with \"no such column: origin\" error. The issue was caused by a schema version collision in the session database — a migration that added edit-provenance tracking (`origin` column) was skipped due to version numbering conflicts, but code continued to query for those columns. The fix re-applies the missing migration idempotently, hardens the schema version tracking to prevent duplicates, and adds self-healing to all standalone mode stores so they can repair their own tables on opening.",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -394,6 +394,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--list-audio-devices",
+        action="store_true",
+        default=False,
+        help="List the microphones yeaboi can record from, then exit. "
+        "Set the one you want with VOICE_DEVICE (or Settings → Voice Input).",
+    )
+
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         default=False,
@@ -1191,6 +1199,48 @@ def _confirm_sudo_overwrite(dest: Path) -> bool:
         print()
         return False
     return answer in ("y", "yes")
+
+
+def _list_audio_devices() -> None:
+    """Print the available microphones — the diagnostic for "it can\'t hear me".
+
+    Rescans first: PortAudio caches its device list at init, so a mic plugged in
+    after this process started would otherwise be missing from the very listing
+    the user ran to check whether it was detected.
+    """
+    from yeaboi import voice
+
+    log = logging.getLogger(__name__)
+    log.info("Listing audio input devices")
+    available, reason = voice.is_voice_available()
+    if not available:
+        log.info("Audio device listing skipped: voice unavailable — %s", reason)
+        print(f"Voice input unavailable — {reason}")
+        return
+
+    voice.refresh_devices()
+    devices = voice.list_input_devices()
+    if not devices:
+        log.warning("Audio device listing found no input devices")
+        print("No microphones found.")
+        return
+
+    configured = voice.get_voice_device()
+    selected = voice.resolve_device(configured)
+    print("Input devices:")
+    for device in devices:
+        tags = []
+        if device["is_default"]:
+            tags.append("system default")
+        if selected is not None and device["index"] == selected:
+            tags.append(f"selected via VOICE_DEVICE={configured}")
+        suffix = f"  ({', '.join(tags)})" if tags else ""
+        print(
+            f"  {device['index']:>2}  {device['name']:<34} {device['channels']} ch  {device['samplerate']} Hz{suffix}"
+        )
+    if selected is None:
+        print("\nUsing the system default. Choose another with VOICE_DEVICE=<name or index>.")
+    log.info("Listed %d audio input device(s); VOICE_DEVICE=%r resolved to %s", len(devices), configured, selected)
 
 
 def _install_skill(target_arg: str) -> None:
@@ -2200,6 +2250,13 @@ def main(argv: list[str] | None = None) -> None:
     # Load ~/.yeaboi/.env before any credential reads.
     # override=False means shell env vars and project .env always take precedence.
     load_user_config()
+
+    # ── --list-audio-devices: print the mic table and exit ───────────────────
+    # After load_user_config() so the currently-configured VOICE_DEVICE can be
+    # marked, and before anything interactive so it never triggers the wizard.
+    if args.list_audio_devices:
+        _list_audio_devices()
+        return
 
     # ── Filesystem sandbox: session-scoped --allow-path grants ───────────────
     # Applied before any flow that might touch user-supplied paths, so every

--- a/src/yeaboi/config.py
+++ b/src/yeaboi/config.py
@@ -894,6 +894,19 @@ def get_voice_model() -> str:
     return os.getenv("VOICE_MODEL") or "base"
 
 
+def get_voice_device() -> str:
+    """Return the configured microphone preference for voice input.
+
+    Reads ``VOICE_DEVICE``: either a PortAudio device index (``"2"``) or a
+    case-insensitive substring of the device name (``"shure"``). Empty means
+    "use the system default input", which is how voice behaved before the
+    setting existed. Resolution to an actual index happens in
+    :func:`yeaboi.voice.resolve_device` — this stays a plain string read so
+    config never imports the optional audio stack.
+    """
+    return (os.getenv("VOICE_DEVICE") or "").strip()
+
+
 def get_session_prune_days() -> int:
     """Return the number of days after which old sessions are pruned.
 

--- a/src/yeaboi/poker/server.py
+++ b/src/yeaboi/poker/server.py
@@ -115,9 +115,11 @@ class _DuelCapture:
             logger.info("poker: duel host mic skipped — %s", reason)
             return reason
         try:
-            from yeaboi.voice import Recorder
+            from yeaboi.voice import Recorder, resolve_device
 
-            recorder = Recorder()
+            # Honour the configured VOICE_DEVICE here too — the host running the
+            # duel is the same person who picked a microphone in Settings.
+            recorder = Recorder(device=resolve_device())
         except Exception as exc:  # mic permission / device errors must never 500
             logger.warning("poker: duel host mic failed to start: %s", exc)
             return "microphone could not start (see logs)"

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -1439,6 +1439,7 @@ def _collect_settings_data() -> dict:
         # default that lets CLI/MCP/headless runs scan GitHub without --github-owner.
         "TEAM_ANALYSIS_GITHUB_OWNERS",
         "VOICE_MODEL",
+        "VOICE_DEVICE",
         "AWS_REGION",
         "AWS_PROFILE",
         "LOG_LEVEL",
@@ -1633,7 +1634,7 @@ def _feedback_compose_key(
         from yeaboi.ui.shared._voice_input import record_voice_input
 
         spoken = record_voice_input(
-            live, console, read_key, lambda status, tick: _compose_voice_frame(compose, status, tick, render)
+            live, console, read_key, lambda border, line: _compose_voice_frame(compose, line, render)
         )
         compose["status"] = ""
         if spoken:
@@ -1645,15 +1646,13 @@ def _feedback_compose_key(
     return compose
 
 
-def _compose_voice_frame(compose: dict, status: str, tick: float, render):
+def _compose_voice_frame(compose: dict, line: str, render):
     """Renderable for the recording/transcribing indicator, shown IN the bubble.
 
     record_voice_input owns the screen while it runs, so it paints through this —
-    keeping the duck and his bubble on screen instead of a centred popup.
+    keeping the duck and his bubble on screen instead of a centred popup. The
+    bubble has no border of its own to tint, so only the status line is used.
     """
-    from yeaboi.ui.shared._voice_input import voice_indicator
-
-    _border, line = voice_indicator(status, tick)
     compose["status"] = line.strip()
     return render(update=False)
 
@@ -1768,6 +1767,125 @@ def _confirm_move_data(console: Console, live, read_key, frame_time, supports_ti
             return sel == 0
         elif k in ("esc", "q"):
             return False
+
+
+def _test_microphone(console: Console, live, read_key, frame_time, supports_timeout, device: dict, render) -> str:
+    """Open the highlighted mic and animate its level until a key is pressed.
+
+    This is the answer to "is this the input that actually hears me?" — the one
+    question a device *name* cannot settle, since a laptop lid, a muted USB
+    interface and a disconnected Bluetooth headset all still enumerate.
+    Returns a notice for the picker ("" when the test ran fine).
+    """
+    from yeaboi import music, voice
+
+    music.pause_for_voice()
+    try:
+        # monitor=True: this runs for as long as the user leaves the page open,
+        # and a retained take grows ~11 MB a minute at 48 kHz stereo for a WAV
+        # that is discarded the moment the test ends. Only level() is wanted.
+        recorder = voice.Recorder(device=device["index"], monitor=True)
+    except Exception as exc:  # noqa: BLE001 - shown to the user, not raised
+        logger.warning("Settings: mic test failed for %s", device["name"], exc_info=True)
+        music.resume_after_voice()
+        return f"{device['name']} would not open — {exc}"
+    logger.info("Settings: testing microphone %s (index %s)", device["name"], device["index"])
+    try:
+        while True:
+            live.update(render(testing=True, level=recorder.level()))
+            try:
+                k = read_key(timeout=frame_time) if supports_timeout else read_key()
+            except TypeError:
+                k = read_key()
+            if not k:
+                continue
+            if parse_click(k) is not None:
+                continue  # a stray mouse event must not end the test
+            if k == "esc":
+                # Same reason as the picker's own cancel below: the Esc
+                # chokepoint armed the app-wide back tab's retract before we saw
+                # the key, and this Esc only ends the test.
+                from yeaboi.ui.shared._music_bar import cancel_back_retract
+
+                cancel_back_retract()
+            logger.info("Settings: mic test finished for %s", device["name"])
+            return ""
+    finally:
+        recorder.stop()
+        music.resume_after_voice()
+
+
+def _pick_voice_device(console: Console, live, read_key, frame_time, supports_timeout) -> str | None:
+    """Microphone picker for Settings → Voice Input.
+
+    Returns the chosen device name, ``""`` for "use the system default", or None
+    when the user backs out. A modal sub-loop (like _confirm_move_data) rather
+    than another state in the settings loop: the settings loop already routes
+    arrows, scroll, Tab and Esc, and a picker layered into it would have to be
+    intercepted ahead of every one of them.
+    """
+    from yeaboi import voice
+    from yeaboi.ui.mode_select.screens._screens_secondary import _build_voice_device_screen, voice_picker_keypress
+
+    # Rescan first: PortAudio caches its device list at startup, so the mic the
+    # user just plugged in is exactly the one that would otherwise be missing.
+    voice.refresh_devices()
+    devices = voice.list_input_devices()
+    pref = voice.get_voice_device()
+    current = voice.device_name(voice.resolve_device(pref)) if pref else ""
+    state = {"devices": devices, "sel": 0}
+    for _i, _d in enumerate(devices):
+        if _d["name"] == current:
+            state["sel"] = _i
+    notice = ""
+    logger.info("Settings: microphone picker opened — %d input(s)", len(devices))
+
+    def _render(testing: bool = False, level: float = 0.0):
+        w, h = console.size
+        return _build_voice_device_screen(
+            devices,
+            state["sel"],
+            current=current,
+            width=w,
+            height=h,
+            testing=testing,
+            level=level,
+            notice=notice,
+        )
+
+    while True:
+        live.update(_render())
+        try:
+            k = read_key(timeout=frame_time) if supports_timeout else read_key()
+        except TypeError:
+            k = read_key()
+        if not k:  # idle tick
+            continue
+        if parse_click(k) is not None:
+            continue  # the picker is keyboard-driven; clicks would need regions
+        notice = ""
+        action = voice_picker_keypress(k, state)
+        if action == "cancel":
+            # The Esc chokepoint armed the app-wide back tab's retract before we
+            # saw the key; this Esc only closes the picker, so put it back.
+            from yeaboi.ui.shared._music_bar import cancel_back_retract
+
+            cancel_back_retract()
+            return None
+        if action == "system":
+            return ""
+        if action == "select":
+            if not devices:
+                # Nothing to choose. Returning "" here would quietly save
+                # "system default" from a page that just said there is no
+                # microphone at all — a confirmation for a choice never made.
+                notice = "No microphone to select. Esc goes back."
+                continue
+            return devices[state["sel"]]["name"]
+        if action == "test" and devices:
+            notice = _test_microphone(
+                console, live, read_key, frame_time, supports_timeout, devices[state["sel"]], _render
+            )
 
 
 def _confirm_stop_ollama(console: Console, live, read_key, frame_time, supports_timeout) -> bool:
@@ -2938,7 +3056,7 @@ def _standup_read_line(
 
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_standup_input_screen
     from yeaboi.ui.shared._attachments import handle_ctrl_v, unsupported_notice
-    from yeaboi.ui.shared._voice_input import DoubleTapSpace, record_voice_input, voice_indicator
+    from yeaboi.ui.shared._voice_input import DoubleTapSpace, record_voice_input
 
     value = initial
     notice = ""
@@ -2970,9 +3088,8 @@ def _standup_read_line(
     # Voice overlay re-renders THIS screen (not a popup) with the pulsing
     # indicator. record_voice_input() calls this and does the live.update itself,
     # so we only return the renderable.
-    def _render_status(status_name: str, tick: float):
+    def _render_status(border: str, line: str):
         w, h = console.size
-        border, line = voice_indicator(status_name, tick)
         return _build_standup_input_screen(
             prompt,
             value,
@@ -12982,7 +13099,23 @@ def select_mode(
                     included — its move-or-leave decision happens on save (see
                     _settings_save_data_dir), not on a screen of its own.
                     """
-                    nonlocal _s_edit
+                    nonlocal _s_edit, _settings_data
+                    if env == "VOICE_DEVICE":
+                        # A device list is a choice, not free text — you cannot type a
+                        # name you have not seen. Returns before set_text_entry(True),
+                        # so the picker keeps the app-wide bare-key bindings.
+                        _picked = _pick_voice_device(console, live, read_key, _FRAME_TIME, _supports_timeout)
+                        if _picked is None:
+                            return
+                        from yeaboi.config import apply_config_value
+
+                        apply_config_value(env, _picked)
+                        _settings_data = _collect_settings_data()
+                        _msg = f"Microphone set to {_picked}" if _picked else "Microphone: using the system default"
+                        _settings_data["_message"] = _msg
+                        _settings_voice().say(_msg)
+                        logger.info("Settings: VOICE_DEVICE set to %r", _picked)
+                        return
                     # Hidden fields start blank (type a new value); others start at the
                     # current value so you edit in place.
                     _start = "" if masked else (_settings_data.get(env, "") or "")

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import textwrap
 
 import rich.box
+from rich.cells import cell_len
 from rich.console import Group
 from rich.padding import Padding
 from rich.panel import Panel
@@ -5625,6 +5626,7 @@ def _build_standup_input_screen(
     """
     from yeaboi.ui.session.screens._screens_input import _image_hint, _voice_hint
     from yeaboi.ui.shared._components import STANDUP_THEME, standup_title
+    from yeaboi.ui.shared._voice_input import voice_chip
 
     theme = theme or STANDUP_THEME
     title = title if title is not None else standup_title()
@@ -5636,10 +5638,32 @@ def _build_standup_input_screen(
     label.append(prompt, style=f"bold {theme.accent}")
     if default:
         label.append(f"   (default: {default})", style=theme.dim)
+    label.no_wrap = True
+    label.overflow = "ellipsis"
+
+    def _box_top(inner_w: int) -> Text:
+        """Top border with the dictation chip inlaid, Panel-title style.
+
+        This box is hand-drawn, so there is no Panel title to hang the chip on —
+        but the border is the one row that is never cropped, which is the whole
+        reason the chip moved off the hint line. Putting it on the *label* would
+        just have reproduced the original bug: the label is no_wrap/ellipsis, so
+        a trailing chip is the first thing dropped on a narrow terminal. The chip
+        is omitted when the border is too short to hold it and still read as a
+        border.
+        """
+        chip, chip_style = voice_chip()
+        # 6 = the two ─ before the chip, a space either side, and 2 ─ after.
+        if inner_w < cell_len(chip) + 6:
+            return Text(_PAD + "  ╭" + "─" * inner_w + "╮", style=box_style)
+        top = Text(_PAD + "  ╭─ ", style=box_style)
+        top.append(chip, style=chip_style)
+        top.append(" " + "─" * (inner_w - cell_len(chip) - 3) + "╮", style=box_style)
+        return top
 
     if box_rows <= 1:
         field_inner = f" {value}█ "
-        box_top = Text(_PAD + "  ╭" + "─" * max(len(field_inner), 40) + "╮", style=box_style)
+        box_top = _box_top(max(len(field_inner), 40))
         box_mid = Text(_PAD + "  │", style=box_style)
         box_mid.append(field_inner.ljust(max(len(field_inner), 40)), style=f"bold {theme.accent_bright}")
         box_mid.append("│", style=box_style)
@@ -5661,7 +5685,7 @@ def _build_standup_input_screen(
         chunks = chunks[-rows:]  # keep the cursor row visible when the text overflows
         while len(chunks) < rows:
             chunks.append("")
-        box_lines = [Text(_PAD + "  ╭" + "─" * inner_w + "╮", style=box_style)]
+        box_lines = [_box_top(inner_w)]
         for chunk in chunks:
             row = Text(_PAD + "  │", style=box_style)
             row.append(f" {chunk}".ljust(inner_w), style=f"bold {theme.accent_bright}")
@@ -5671,7 +5695,14 @@ def _build_standup_input_screen(
 
     # While recording/transcribing, the voice status replaces the usual hint.
     if status:
-        hint_line = Text(_PAD + "  " + status, style=box_style or theme.accent, justify="left")
+        # One row, always: pad_rows below budgets exactly one for this line.
+        hint_line = Text(
+            _PAD + "  " + status,
+            style=box_style or theme.accent,
+            justify="left",
+            no_wrap=True,
+            overflow="ellipsis",
+        )
     else:
         newline_hint = "  ·  Alt+Enter (or Ctrl+N) for a new line" if box_rows > 1 else ""
         hints = (
@@ -6306,6 +6337,14 @@ def _build_settings_screen(
             _row("Dictation", f"available — {backend_label()}", value_style=theme.good, wrap=True)
         else:
             _row("Dictation", f"unavailable — {_voice_reason}", value_style=theme.warn, wrap=True)
+        # Enter on this row opens the device picker (see _pick_voice_device) rather
+        # than the free-text editor every other row uses.
+        _row(
+            "Input Device",
+            config_data.get("VOICE_DEVICE", "") or "system default",
+            value_style="" if config_data.get("VOICE_DEVICE", "") else theme.dim,
+            env="VOICE_DEVICE",
+        )
         _row("Model Size", config_data.get("VOICE_MODEL", "") or "base (default)", env="VOICE_MODEL")
 
     def _sec_bedrock() -> None:
@@ -6583,3 +6622,135 @@ def _build_settings_screen(
     panel._box_tail = box_tail  # the full-width boxes stacked under the columns
     panel._box_fields = box_fields  # per section, its editable (env, label, masked) in order
     return panel
+
+
+# ---------------------------------------------------------------------------
+# Voice input — microphone picker
+# ---------------------------------------------------------------------------
+
+# How many device rows fit before the list scrolls. Hosts with a virtual audio
+# driver installed can report a dozen inputs.
+_MIC_ROWS = 8
+
+
+def voice_picker_keypress(key: str, state: dict) -> str:
+    """Advance the microphone picker one keypress; returns the action to take.
+
+    Split out as a pure function — the picker itself runs a Rich ``Live`` loop,
+    which is untestable, but the thing worth testing is exactly this: which key
+    moves, which selects, which tests, which backs out. Mutates ``state["sel"]``
+    and returns one of ``"select" | "cancel" | "test" | "system" | "none"``.
+    """
+    count = max(1, len(state.get("devices", [])))
+    if key in ("up", "k"):
+        state["sel"] = (state.get("sel", 0) - 1) % count
+        return "none"
+    if key in ("down", "j"):
+        state["sel"] = (state.get("sel", 0) + 1) % count
+        return "none"
+    if key in ("enter", " "):
+        return "select"
+    if key == "t":
+        return "test"
+    if key == "d":
+        return "system"  # clear the preference — back to the system default
+    if key in ("esc", "q"):
+        return "cancel"
+    return "none"
+
+
+def _build_voice_device_screen(
+    devices: list[dict],
+    selected: int,
+    *,
+    current: str = "",
+    width: int = 80,
+    height: int = 24,
+    testing: bool = False,
+    level: float = 0.0,
+    notice: str = "",
+) -> Panel:
+    """Build the microphone picker page.
+
+    ``devices`` are :func:`yeaboi.voice.list_input_devices` dicts. ``testing``
+    switches the highlighted row\'s meter live — the only way to answer "is this
+    the mic that actually hears me?" without leaving the app.
+
+    # See docs: "TUI system" — Settings sub-page
+    """
+    from yeaboi.ui.shared._components import SETTINGS_THEME, build_key_hints, build_scrollbar, settings_title
+    from yeaboi.ui.shared._voice_input import level_meter
+
+    theme = SETTINGS_THEME
+    lines: list = [Text(""), settings_title(width=width), Text("")]
+    lines.append(Text(PAD + "Microphone", style="bold white", justify="left"))
+    lines.append(
+        Text(
+            PAD + ("Recording from this input. VOICE_DEVICE remembers it." if devices else ""),
+            style=theme.muted,
+            justify="left",
+        )
+    )
+    lines.append(Text(""))
+
+    if not devices:
+        lines.append(
+            Text(
+                PAD + "  No microphones detected. Plug one in and reopen this page — the list is rescanned.",
+                style=theme.warn,
+                justify="left",
+            )
+        )
+    else:
+        # Window the list around the selection so a long device table scrolls —
+        # a host with a virtual audio driver can report a dozen inputs. The
+        # scrollbar is what says the window is a window; without it the rows
+        # beyond it simply look absent.
+        max_start = max(0, len(devices) - _MIC_ROWS)
+        start = max(0, min(selected - _MIC_ROWS // 2, max_start))
+        rows: list[Text] = []
+        for index, device in enumerate(devices[start : start + _MIC_ROWS], start=start):
+            focused = index == selected
+            row = Text(PAD + ("  ▸ " if focused else "    "), style=theme.accent if focused else theme.dim)
+            row.append(device["name"], style="bold white" if focused else theme.muted)
+            tags = []
+            if device["is_default"]:
+                tags.append("system default")
+            if current and current == device["name"]:
+                tags.append("selected")
+            row.append(f"   {device['channels']} ch · {device['samplerate']} Hz", style=theme.dim)
+            if tags:
+                row.append(f"   {', '.join(tags)}", style=theme.good if "selected" in tags else theme.dim)
+            if focused and testing:
+                row.append(f"   {level_meter(level)}", style=theme.good)
+            row.no_wrap = True
+            row.overflow = "ellipsis"
+            rows.append(row)
+        scrollbar = build_scrollbar(_MIC_ROWS, len(devices), start, max_start)
+        if scrollbar is None:
+            lines.extend(rows)
+        else:
+            rows.extend(Text("") for _ in range(max(0, _MIC_ROWS - len(rows))))
+            shell = Table.grid(expand=True, padding=0)
+            shell.add_column(ratio=1)
+            shell.add_column(width=1)
+            shell.add_row(Group(*rows), scrollbar)
+            lines.append(shell)
+
+    lines.append(Text(""))
+    if notice:
+        lines.append(Text(PAD + "  " + notice, style=theme.warn, justify="left", no_wrap=True, overflow="ellipsis"))
+    elif testing:
+        lines.append(
+            Text(PAD + "  Speak now — the bar moves when this mic hears you. Any key stops.", style=theme.good)
+        )
+    else:
+        lines.append(Text(""))
+
+    hint = build_key_hints(
+        [("↑/↓", "choose"), ("t", "test mic"), ("Enter", "use"), ("d", "system default"), ("Esc", "back")], pad=PAD
+    )
+    lines.append(Text(""))
+    lines.append(hint)
+
+    return build_page_panel(Group(*lines), theme=theme, border_style=theme.sep, height=height)

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -445,10 +445,11 @@ class _ChatDriver:
             self.notice = f"Screenshot attached as {chip}"
 
     def _voice(self) -> None:
-        from yeaboi.ui.shared._voice_input import record_voice_input, voice_indicator
+        from yeaboi.ui.shared._voice_input import record_voice_input
 
-        def render_status(status: str, tick: float):
-            border, line = voice_indicator(status, tick)
+        def render_status(border: str, line: str):
+            # record_voice_input owns the indicator state (level, elapsed time,
+            # which mic opened) and hands us the finished pair to render.
             w, h = self.console.size
             return build_chat_screen(
                 self.transcript,

--- a/src/yeaboi/ui/session/chat/_screen.py
+++ b/src/yeaboi/ui/session/chat/_screen.py
@@ -41,6 +41,7 @@ from yeaboi.ui.shared._components import (
     build_scrollbar,
 )
 from yeaboi.ui.shared._scroll import publish_geometry
+from yeaboi.ui.shared._voice_input import input_box_title
 
 from ._commands import SlashCommand
 from ._composer import ChatComposer
@@ -319,7 +320,7 @@ def build_chat_screen(
 
     input_box = Panel(
         input_content,
-        title=" Message ",
+        title=input_box_title("Message", box_w),
         title_align="left",
         border_style=border_color,
         box=rich.box.ROUNDED,

--- a/src/yeaboi/ui/session/phases/_phases_intake.py
+++ b/src/yeaboi/ui/session/phases/_phases_intake.py
@@ -76,7 +76,7 @@ def _phase_description_input(
     live.update(_build_description_screen(input_lines, cursor_row, cursor_col, width=w, height=h))
 
     # Voice input: double-tap Space to dictate (see DoubleTapSpace for why).
-    from yeaboi.ui.shared._voice_input import DoubleTapSpace, record_voice_input, voice_indicator
+    from yeaboi.ui.shared._voice_input import DoubleTapSpace, record_voice_input
 
     _dts = DoubleTapSpace()
 
@@ -91,9 +91,9 @@ def _phase_description_input(
         nonlocal paste_notice
         paste_notice = msg
 
-    def _voice_render(status, tick):
+    def _voice_render(_border, _line):
+        # record_voice_input hands us a finished (border, status line) pair.
         _bw, _bh = console.size
-        _border, _line = voice_indicator(status, tick)
         return _build_description_screen(
             input_lines,
             cursor_row,
@@ -609,13 +609,12 @@ def _question_input_loop(
     live.update(_render())
 
     # Voice input: double-tap Space to dictate (free-text questions only).
-    from yeaboi.ui.shared._voice_input import DoubleTapSpace, record_voice_input, voice_indicator
+    from yeaboi.ui.shared._voice_input import DoubleTapSpace, record_voice_input
 
     _dts = DoubleTapSpace()
 
-    def _voice_render(status, tick):
+    def _voice_render(_border, _line):
         _bw, _bh = console.size
-        _border, _line = voice_indicator(status, tick)
         if use_accordion:
             return _build_accordion_question_screen(
                 question_text,

--- a/src/yeaboi/ui/session/screens/_accordion.py
+++ b/src/yeaboi/ui/session/screens/_accordion.py
@@ -28,6 +28,7 @@ from yeaboi.prompts.intake import QUESTION_SHORT_LABELS
 from yeaboi.ui.session._utils import _pad_left, _wrap_text
 from yeaboi.ui.session.screens._screens import _INPUT_BOX_W_MAX, _PAD, _planning_title
 from yeaboi.ui.shared._components import PLANNING_THEME, build_page_panel
+from yeaboi.ui.shared._voice_input import input_box_title
 
 # ---------------------------------------------------------------------------
 # Accordion item renderers
@@ -257,7 +258,7 @@ def _render_active_item(
 
         input_box = Panel(
             input_content,
-            title=" Answer ",
+            title=input_box_title("Answer", box_w),
             title_align="left",
             border_style=border_override or "white",
             box=rich.box.ROUNDED,
@@ -429,6 +430,10 @@ def _build_accordion_question_screen(
         sub.append(f"  {progress}", style="dim")
     if edit_hint:
         sub.append(f"  \u2502  {edit_hint}", style="dim")
+    # header_h below assumes this subtitle is exactly one row; the voice status
+    # line is long enough to wrap it onto a second and crop the viewport.
+    sub.no_wrap = True
+    sub.overflow = "ellipsis"
 
     active_q = questionnaire.current_question
     box_w = min(_INPUT_BOX_W_MAX, int(width * 0.75))

--- a/src/yeaboi/ui/session/screens/_screens_input.py
+++ b/src/yeaboi/ui/session/screens/_screens_input.py
@@ -16,6 +16,7 @@ from rich.text import Text
 
 from yeaboi.ui.session._utils import _pad_left, _wrap_text
 from yeaboi.ui.shared._components import PAD, PLANNING_THEME, build_page_panel, planning_title
+from yeaboi.ui.shared._voice_input import input_box_title
 
 _PAD = PAD
 
@@ -24,13 +25,15 @@ _INPUT_BOX_W_MAX = 74
 
 
 def _voice_hint() -> str:
-    """Return a discoverability suffix for voice input on text-entry screens.
+    """Return the *install* hint for voice input on text-entry screens.
 
-    Advertises the feature so users know it exists. When the voice extra is
-    installed it prompts to speak; otherwise it shows how to enable it — hiding
-    it entirely meant the feature was invisible to anyone who hadn't set it up.
-    Returns "" when tips are switched off, so disabling tips hides this inline
-    hint too (the double-tap Space shortcut still works regardless).
+    When voice is installed this is empty: the input box's title chip (see
+    :func:`~yeaboi.ui.shared._voice_input.input_box_title`) advertises the
+    gesture now, and it does so where nothing can crop it — this hint sat at the
+    tail of a no_wrap/ellipsis line and was the first thing cut on an 80-column
+    terminal. What the chip cannot carry is the install-method-aware command, so
+    that case still renders here. Returns "" when tips are switched off (the
+    double-tap Space shortcut still works regardless).
     """
     from yeaboi.config import is_tips_enabled
     from yeaboi.voice import is_voice_available, voice_install_command
@@ -40,7 +43,7 @@ def _voice_hint() -> str:
 
     available, _reason = is_voice_available()
     if available:
-        return " · \U0001f3a4 double-tap Space to speak"
+        return ""
     return f" · \U0001f3a4 dictate: {voice_install_command()}"
 
 
@@ -157,7 +160,7 @@ def _build_description_screen(
 
     input_box = Panel(
         text_content,
-        title=" Project Description ",
+        title=input_box_title("Project Description", box_w),
         title_align="left",
         border_style=border_override or "white",
         box=rich.box.ROUNDED,
@@ -166,7 +169,9 @@ def _build_description_screen(
     )
 
     if status_line:
-        submit_hint = Text(_PAD + status_line, style="bold white", justify="left")
+        # no_wrap: the voice status line is long, and the height maths below
+        # counts it as exactly one row.
+        submit_hint = Text(_PAD + status_line, style="bold white", justify="left", no_wrap=True, overflow="ellipsis")
     else:
         submit_hint = Text(
             _PAD + "Enter submit \u00b7 \u2303N new line \u00b7 Esc go back" + _voice_hint() + _image_hint(),
@@ -340,7 +345,7 @@ def _build_question_screen(
 
     # Inline voice-recording indicator replaces the hint so the user stays here.
     if status_line:
-        hint = Text(_PAD + status_line, style="bold white", justify="left")
+        hint = Text(_PAD + status_line, style="bold white", justify="left", no_wrap=True, overflow="ellipsis")
 
     if input_value:
         display = input_value + "\u2588"
@@ -363,7 +368,7 @@ def _build_question_screen(
 
     input_box = Panel(
         input_content,
-        title=" Answer ",
+        title=input_box_title("Answer", box_w),
         title_align="left",
         border_style=border_override or "white",
         box=rich.box.ROUNDED,

--- a/src/yeaboi/ui/shared/_voice_input.py
+++ b/src/yeaboi/ui/shared/_voice_input.py
@@ -21,6 +21,7 @@ import threading
 import time
 
 from rich.align import Align
+from rich.cells import cell_len
 from rich.console import Console, Group
 from rich.live import Live
 from rich.text import Text
@@ -29,11 +30,24 @@ from yeaboi.ui.shared._components import build_popup
 
 logger = logging.getLogger(__name__)
 
-_REC_BORDER = "rgb(80,200,100)"
+# Amber. The border used to be green while the *pulse* animated through red,
+# which put the recording state within a few points of _ERR_BORDER below — a
+# composer that flushed red read as "something crashed" rather than "I am
+# listening". Amber is unambiguous against both the error red and the working
+# blue, and the pulse now stays inside that hue instead of crossing into it.
+_REC_BORDER = "rgb(240,165,70)"
 _WORK_BORDER = "rgb(110,140,220)"
 _ERR_BORDER = "rgb(220,80,80)"
 
 _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+_METER_CELLS = 8
+# A peak below this counts as silence. Room-tone on a live mic sits well under
+# it; anything you actually say clears it easily.
+_SILENCE_LEVEL = 0.02
+# How long the meter must stay flat before we say so. Long enough not to fire in
+# the pause before someone starts talking.
+_SILENCE_SECONDS = 2.5
 
 # Voice input is triggered by a quick double-tap of the space bar — chosen over a
 # Ctrl/Cmd chord because macOS terminals never receive Cmd (so Ctrl was the only
@@ -64,53 +78,240 @@ class DoubleTapSpace:
         return False
 
 
-def voice_indicator(status: str, tick: float) -> tuple[str, str]:
+# The chip lives in the input box\'s title, which is the only part of an input
+# screen that is never cropped — the hint line below the box is rendered
+# no_wrap/ellipsis, so on an 80-column terminal the dictation hint at its tail
+# was cut off entirely and the feature looked like it did not exist.
+_CHIP_ON = "🎤 Space Space"
+_CHIP_OFF = "🎤 off"
+_CHIP_ON_STYLE = "rgb(110,110,125)"
+_CHIP_OFF_STYLE = "rgb(80,80,92)"
+
+# Memoised: titles are rebuilt every frame and is_voice_available() walks
+# sys.path twice. Tests that monkeypatch availability call reset_voice_chip().
+_chip_cache: tuple[str, str] | None = None
+
+
+def reset_voice_chip() -> None:
+    """Forget the cached availability chip.
+
+    Called by tests that monkeypatch availability. Nothing in production calls
+    it: the voice extra cannot appear part-way through a process, so the cache
+    is valid for the life of the run.
+    """
+    global _chip_cache
+    _chip_cache = None
+
+
+def voice_chip() -> tuple[str, str]:
+    """Return ``(chip_text, style)`` advertising dictation on an input box.
+
+    Shown whether or not the optional extra is installed — an affordance is UI,
+    not a tip, so unlike :func:`_voice_hint` it ignores TIPS_ENABLED. The "off"
+    form is what tells someone the feature exists at all.
+    """
+    global _chip_cache
+    if _chip_cache is None:
+        from yeaboi.voice import is_voice_available
+
+        available, _reason = is_voice_available()
+        _chip_cache = (_CHIP_ON, _CHIP_ON_STYLE) if available else (_CHIP_OFF, _CHIP_OFF_STYLE)
+    return _chip_cache
+
+
+def input_box_title(label: str, box_width: int = 0) -> Text:
+    """Panel title for a text-input box: ``label`` plus the dictation chip.
+
+    ``box_width`` is the box\'s declared width. Rich grows a Panel *past* its
+    declared width when the title is wider than the body (panel.py), and these
+    boxes are padded into a fixed column — so a title that would not fit drops
+    the chip rather than pushing the border off the page. Rich would otherwise
+    hard-cut it with no ellipsis.
+    """
+    plain = Text(f" {label} ")
+    chip, style = voice_chip()
+    candidate = Text(f" {label}  ")
+    candidate.append(chip, style=style)
+    candidate.append(" ")
+    # +4: Rich pads the title a cell either side, then reserves two more before
+    # it starts widening the panel.
+    if box_width and candidate.cell_len + 4 > box_width:
+        return plain
+    return candidate
+
+
+def level_meter(level: float) -> str:
+    """An 8-cell input-level bar for a 0..1 peak amplitude.
+
+    Public because the Settings mic picker draws the same bar; a sibling module
+    reaching for an underscore-private is the coupling this name avoids. Kept
+    here rather than beside ``build_meter`` in ``_components`` because that one
+    is a *progress* bar (▰/▱, a value out of a total) — this is a live signal
+    level, square-rooted because speech peaks land around 0.1–0.4 on a healthy
+    mic and a linear bar would barely move, reading as a dead microphone.
+    """
+    filled = int(round(min(1.0, max(0.0, level) ** 0.5) * _METER_CELLS))
+    return "▇" * filled + "▁" * (_METER_CELLS - filled)
+
+
+def _clock(seconds: float) -> str:
+    return f"{int(seconds) // 60}:{int(seconds) % 60:02d}"
+
+
+def _fit(candidates: list[str], width: int) -> str:
+    """First candidate that fits ``width``, else the shortest one.
+
+    The status line is rendered no_wrap/ellipsis by every screen that shows it,
+    so an over-long line loses its *tail* — which is where "press any key to
+    stop" lives. Dropping a part deliberately beats being cropped arbitrarily.
+    """
+    if not width:
+        return candidates[0]
+    for candidate in candidates:
+        if cell_len(candidate) <= width:
+            return candidate
+    return candidates[-1]
+
+
+def voice_indicator(
+    status: str,
+    tick: float,
+    *,
+    level: float = 0.0,
+    elapsed: float = 0.0,
+    device: str = "",
+    silent: bool = False,
+    preparing: bool = False,
+    width: int = 0,
+) -> tuple[str, str]:
     """Return ``(border_style, status_line)`` for an inline recording indicator.
 
-    Callers use ``border_style`` for their input-box border and render
-    ``status_line`` in place of the usual submit hint. ``tick`` drives the
-    animation (pulsing dot while recording, spinner while transcribing).
+    ``record_voice_input`` calls this and hands the pair to its caller — screens
+    never compute it themselves, because only the recording loop knows the live
+    level, the elapsed time and which microphone actually opened.
+
+    ``tick`` drives the animation (pulsing dot and border while recording, a
+    spinner while transcribing). ``width`` is the space the line has; :func:`_fit`
+    picks the longest form that fits rather than letting the caller\'s ellipsis
+    eat the "any key to stop" that ends it.
     """
     if status == "recording":
-        # Triangle-wave pulse (0..1) without importing math — brightens the red.
+        # Triangle-wave pulse (0..1) without importing math — brightens the amber.
         p = abs((tick * 1.5 % 1.0) - 0.5) * 2
-        r = 200 + int(55 * p)
-        gb = 70 + int(40 * p)
+        r = 225 + int(30 * p)
+        g = 150 + int(35 * p)
+        b = 60 + int(35 * p)
         dot = "●" if int(tick * 3) % 2 == 0 else "○"
-        return f"rgb({r},{gb},{gb})", f"{dot} Recording…  press any key to stop  ·  Esc cancels"
+        head = f"{dot} REC {_clock(elapsed)}  {level_meter(level)}"
+        border = f"rgb({r},{g},{b})"
+        if silent:
+            # The meter is flat: say which mic is quiet and what to do about it.
+            quiet = f"no sound from {device}" if device else "no sound reaching the mic"
+            # Every candidate keeps a way out. This is the branch a confused
+            # user actually lands on, so dropping "Esc" here — while the
+            # non-silent branch below preserves it down to its narrowest form —
+            # would strand exactly the person who most needs it.
+            return border, _fit(
+                [
+                    f"{head}  {quiet} — Tab tries the next mic  ·  Esc cancels",
+                    f"{head}  no sound — Tab tries the next mic  ·  Esc cancels",
+                    f"{head}  no sound  ·  Tab next mic  ·  Esc",
+                    f"{head}  no sound  ·  Esc",
+                ],
+                width,
+            )
+        named = f"{head}  {device}" if device else head
+        return border, _fit(
+            [
+                f"{named}  ·  any key to stop  ·  Tab switch mic  ·  Esc cancels",
+                f"{head}  ·  any key to stop  ·  Tab switch mic  ·  Esc cancels",
+                f"{head}  ·  any key to stop  ·  Esc cancels",
+                f"{head}  any key stops  ·  Esc",
+                # Last resort on a terminal narrower than the app supports: the
+                # head alone still says it is recording, and for how long.
+                head,
+            ],
+            width,
+        )
     if status == "transcribing":
         spin = _SPINNER[int(tick * 12) % len(_SPINNER)]
+        if preparing:
+            return _WORK_BORDER, f"{spin} Preparing the speech model (first run downloads it)…"
         return _WORK_BORDER, f"{spin} Transcribing your speech…"
     return "", ""
 
 
 def _center(console: Console, message: str, border_style: str) -> Group:
-    """Fallback overlay: a popup centred over a full screen."""
-    _w, h = console.size
-    popup = build_popup(message, width=52, border_style=border_style)
+    """Fallback overlay: a popup centred over a full screen.
+
+    Sized to the message rather than a fixed 52 — the recording line and the real
+    PortAudio error strings are both longer than that, and a popup that wraps
+    also breaks the 5-row assumption the vertical centring below depends on.
+    """
+    w, h = console.size
+    width = max(52, min(w - 8, len(message) + 8))
+    popup = build_popup(message, width=width, border_style=border_style)
     top_pad = max(0, (h - 5) // 2)
     return Group(*[Text("") for _ in range(top_pad)], Align.center(popup))
+
+
+def _next_device(current: int | None) -> tuple[int | None, str] | None:
+    """The input device after ``current`` in the host\'s list, or None if there is
+    only one to choose from.
+
+    ``current`` is ``None`` whenever VOICE_DEVICE is unset — i.e. the default
+    state, and the state a user is in when the silence warning tells them to
+    press Tab. That must resolve to the *system default's own index* first: with
+    a plain "not found → start at the top", the first Tab lands on ``devices[0]``,
+    which is usually the system default itself. Switching restarts the take, so
+    the one remedy the feature advertises would have cost the user their
+    recording to move to the microphone they were already on.
+    """
+    from yeaboi.voice import list_input_devices
+
+    devices = list_input_devices()
+    if len(devices) < 2:
+        return None
+    indices = [d["index"] for d in devices]
+    if current is None:
+        current = next((d["index"] for d in devices if d["is_default"]), None)
+    try:
+        position = indices.index(current)
+    except ValueError:  # no default reported either — start at the top
+        position = -1
+    chosen = devices[(position + 1) % len(devices)]
+    return chosen["index"], chosen["name"]
 
 
 def record_voice_input(live: Live, console: Console, _key, render_status=None) -> str | None:
     """Record from the mic and return the transcribed text, or None.
 
-    ``render_status(status, tick)`` — optional callback returning a renderable
-    for status in {"recording", "transcribing"}; when omitted, a centred popup
-    is used. Records until any key is pressed (Esc cancels), transcribes in a
-    background thread while animating, and returns the transcript. Returns None
-    on cancel, no speech, or error (errors are logged and shown briefly).
-    """
-    from yeaboi.voice import Recorder, is_model_loaded, is_voice_available, transcribe, voice_install_command
+    ``render_status(border, line)`` — optional callback returning a renderable
+    for the caller\'s own screen, given a border style for its input box and a
+    status line to show in place of the usual submit hint. When omitted, a
+    centred popup is used instead. The loop owns the whole indicator (level,
+    elapsed time, device name, silence warning) and hands the caller a finished
+    pair, because none of that state exists on the screen side.
 
-    def _paint(status: str, tick: float) -> None:
+    Records until any key is pressed (Esc cancels, Tab switches microphone),
+    transcribes in a background thread while animating, and returns the
+    transcript. Returns None on cancel, no speech, or error (errors are logged
+    and shown briefly).
+    """
+    from yeaboi.voice import (
+        Recorder,
+        is_model_loaded,
+        is_voice_available,
+        resolve_device,
+        transcribe,
+        voice_install_command,
+    )
+
+    def _paint(border: str, line: str) -> None:
         if render_status is not None:
-            live.update(render_status(status, tick))
-        elif status == "recording":
-            live.update(_center(console, "\U0001f3a4  Recording…  press any key to stop", _REC_BORDER))
+            live.update(render_status(border, line))
         else:
-            msg = "⏳  Transcribing…" if is_model_loaded() else "⏳  Preparing speech model (first run downloads it)…"
-            live.update(_center(console, msg, _WORK_BORDER))
+            live.update(_center(console, line, border))
 
     available, reason = is_voice_available()
     if not available:
@@ -126,18 +327,50 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
     music.pause_for_voice()
 
     logger.info("Voice input: starting recording")
+    device = resolve_device()
     try:
-        recorder = Recorder()
-    except Exception:
+        recorder = Recorder(device=device)
+    except Exception as exc:  # noqa: BLE001 - reported to the user below
         logger.warning("Failed to start microphone", exc_info=True)
         music.resume_after_voice()
-        _flash(live, console, _key, "Could not access microphone", _ERR_BORDER)
+        # Show the *real* reason. "Could not access microphone" was the same
+        # message whether the mic was busy, denied by the OS, or simply refusing
+        # the format — none of which the user could act on.
+        _flash(live, console, _key, _mic_error(exc), _ERR_BORDER)
         return None
 
     # ── Recording: animate until any key is pressed ───────────────────────
     cancelled = False
     tick = 0.0
-    _paint("recording", tick)
+    started = time.monotonic()
+    heard_at = started  # last moment the meter showed sound
+    warned = False  # the silence warning is logged once, never per frame
+
+    def _width() -> int:
+        """Room the status line actually gets, read fresh each frame.
+
+        Every screen indents the line and draws a page border around it, so the
+        raw console width overstates it. Recomputed per frame rather than
+        snapshotted: a terminal resized mid-take would otherwise keep fitting
+        the line to a width that no longer exists.
+        """
+        return max(20, console.size[0] - 12)
+
+    def _frame() -> None:
+        level = recorder.level()
+        silent = (time.monotonic() - heard_at) >= _SILENCE_SECONDS
+        border, line = voice_indicator(
+            "recording",
+            tick,
+            level=level,
+            elapsed=time.monotonic() - started,
+            device=recorder.device_name,
+            silent=silent,
+            width=_width(),
+        )
+        _paint(border, line)
+
+    _frame()
     try:
         while True:
             try:
@@ -146,7 +379,44 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
                 key = _key()  # key reader without timeout support
             if key == "":
                 tick += 0.06
-                _paint("recording", tick)
+                if recorder.level() > _SILENCE_LEVEL:
+                    heard_at = time.monotonic()
+                elif not warned and (time.monotonic() - heard_at) >= _SILENCE_SECONDS:
+                    logger.warning("Voice input: no audio level from %s", recorder.device_name)
+                    warned = True
+                _frame()
+                continue
+            if key == "tab":
+                # Switch microphone mid-take. The take restarts: devices can
+                # negotiate different sample rates, so the frames captured so far
+                # cannot be concatenated with what the next one produces.
+                nxt = _next_device(device)
+                if nxt is None:
+                    continue
+                previous = device
+                recorder.stop()
+                device, name = nxt
+                logger.info("Voice input: switching microphone to %s (index %s)", name, device)
+                try:
+                    recorder = Recorder(device=device)
+                except Exception:  # noqa: BLE001 - recovered by reopening the previous mic
+                    # Actually fall back: a mic that is busy or unplugged must not
+                    # cost the user the session. The take is gone either way (the
+                    # old stream is closed above), but they keep a working mic and
+                    # can carry on speaking rather than being dropped back to the
+                    # screen with nothing.
+                    logger.warning("Could not switch to microphone %s; reopening previous", name, exc_info=True)
+                    device = previous
+                    try:
+                        recorder = Recorder(device=device)
+                    except Exception:  # noqa: BLE001 - both mics gone; nothing left to record with
+                        logger.warning("Could not reopen the previous microphone either", exc_info=True)
+                        music.resume_after_voice()
+                        _flash(live, console, _key, f"Could not switch to {name}", _ERR_BORDER)
+                        return None
+                started = heard_at = time.monotonic()
+                warned = False
+                _frame()
                 continue
             cancelled = key == "esc"
             break
@@ -176,8 +446,9 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
             done.set()
 
     threading.Thread(target=_worker, daemon=True).start()
+    preparing = not is_model_loaded()
     while not done.is_set():
-        _paint("transcribing", tick)
+        _paint(*voice_indicator("transcribing", tick, preparing=preparing, width=_width()))
         time.sleep(0.08)
         tick += 0.08
 
@@ -193,6 +464,14 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
 
     logger.info("Voice input: inserted %d chars", len(text))
     return text
+
+
+def _mic_error(exc: Exception) -> str:
+    """Actionable one-liner for a microphone that would not open."""
+    from yeaboi.voice import device_name, resolve_device
+
+    detail = str(exc).strip() or exc.__class__.__name__
+    return f"Mic '{device_name(resolve_device())}' would not start — {detail}. Pick another in Settings → Voice Input."
 
 
 def _flash(live: Live, console: Console, _key, message: str, border_style: str) -> None:

--- a/src/yeaboi/voice.py
+++ b/src/yeaboi/voice.py
@@ -1,8 +1,10 @@
 """Voice input — record from the microphone and transcribe locally (offline).
 
 This module lets users *speak* their answers instead of typing them. It is used
-by the TUI text-entry loops (project description, intake question answers, and
-the artifact editor) which trigger recording on Ctrl+R.
+by the TUI text-entry loops (planning chat, project description, intake question
+answers, standup fields and the artifact editor), which start recording on a
+double-tap of the space bar — see :class:`~yeaboi.ui.shared._voice_input.DoubleTapSpace`
+for why that gesture and not a modifier chord.
 
 # See docs: "Voice Input" — voice is an optional, provider-agnostic helper.
 # It does NOT go through the LangGraph agent or the get_llm() provider factory.
@@ -26,6 +28,13 @@ Design notes / architectural decisions:
   ``importlib.util.find_spec`` so a per-render hint check never triggers the
   heavy ``faster_whisper`` / ``ctranslate2`` import; real mic/model failures are
   handled gracefully at record/transcribe time.
+- **The microphone is chosen, not assumed.** PortAudio\'s default input is
+  frequently not the one the user means, and it caches its device list at
+  init — so a mic plugged in mid-session is invisible until the library is
+  cycled (:func:`refresh_devices`). Device selection lives in
+  :func:`resolve_device` / ``VOICE_DEVICE``, and :class:`Recorder` falls back to
+  the device\'s own sample rate and channel count when it refuses 16 kHz mono,
+  with :func:`transcribe` converting. Before that, such a mic simply failed.
 - **Model cache.** The Whisper model is loaded once per size and reused — the
   first transcription downloads the model (~75 MB "tiny" … ~460 MB "small");
   subsequent ones are fast.
@@ -47,9 +56,10 @@ import logging
 import os
 import pathlib
 import sys
+import threading
 import wave
 
-from yeaboi.config import get_voice_model
+from yeaboi.config import get_voice_device, get_voice_model
 
 logger = logging.getLogger(__name__)
 
@@ -132,38 +142,267 @@ def backend_label() -> str:
     return f"local Whisper ({get_voice_model()})"
 
 
+# ---------------------------------------------------------------------------
+# Input devices
+# ---------------------------------------------------------------------------
+
+# Number of InputStreams currently open, so refresh_devices() can refuse to
+# cycle PortAudio underneath a live recording (see refresh_devices).
+_open_streams = 0
+_stream_lock = threading.Lock()
+
+
+def refresh_devices() -> bool:
+    """Re-scan the host's audio devices. Returns True if a rescan actually ran.
+
+    PortAudio enumerates devices **once**, when it initialises, and caches that
+    list for the life of the process. So a USB or Bluetooth microphone plugged
+    in after yeaboi started is invisible to ``query_devices`` — which is the
+    single most common cause of "it doesn't detect my external mic". The only
+    way to see it is to cycle the library, which sounddevice exposes as the
+    private ``_terminate``/``_initialize`` pair; being private API, every call
+    here is defensive.
+
+    The teardown is process-wide, so it must not run while any stream is open —
+    the poker duel holds a Recorder on a server thread for a whole duel, and
+    cycling PortAudio under it would kill that recording. The count is therefore
+    checked *and* the cycle performed under one hold of ``_stream_lock``: with a
+    check-then-act, a Recorder opened in the gap would have PortAudio torn down
+    underneath it, which is exactly the case the guard exists to prevent.
+    ``Recorder.__init__`` takes the same lock, so it blocks here rather than
+    racing.
+    """
+    with _stream_lock:
+        if _open_streams:
+            logger.info("Skipping audio device rescan: %d stream(s) open", _open_streams)
+            return False
+        try:
+            import sounddevice as sd
+
+            sd._terminate()
+            sd._initialize()
+        except Exception:  # noqa: BLE001 - private API; a failed rescan is not fatal
+            logger.warning("Audio device rescan failed", exc_info=True)
+            return False
+    logger.info("Audio devices rescanned")
+    return True
+
+
+def list_input_devices() -> list[dict]:
+    """Return the host's usable input devices.
+
+    Each entry is ``{"index", "name", "channels", "samplerate", "is_default"}``.
+    Devices with no input channels (speakers, virtual outputs) are filtered out.
+    Returns an empty list if sounddevice is missing or the query fails, so
+    callers can render "no microphones found" rather than crash.
+    """
+    try:
+        import sounddevice as sd
+
+        devices = sd.query_devices()
+        try:
+            default_index = sd.default.device[0]
+        except Exception:  # noqa: BLE001 - no default configured on this host
+            default_index = None
+    except Exception:  # noqa: BLE001 - sounddevice absent or PortAudio unhappy
+        logger.warning("Could not list audio input devices", exc_info=True)
+        return []
+
+    out: list[dict] = []
+    for index, device in enumerate(devices):
+        if int(device.get("max_input_channels", 0)) <= 0:
+            continue
+        out.append(
+            {
+                "index": index,
+                "name": str(device.get("name", f"device {index}")),
+                "channels": int(device.get("max_input_channels", 1)),
+                "samplerate": int(device.get("default_samplerate", SAMPLE_RATE) or SAMPLE_RATE),
+                "is_default": index == default_index,
+            }
+        )
+    return out
+
+
+def resolve_device(pref: str | None = None) -> int | None:
+    """Resolve a VOICE_DEVICE preference to a PortAudio device index.
+
+    Accepts an index (``"2"``) or a case-insensitive name substring
+    (``"shure"``) so users can type something memorable instead of an index
+    that renumbers whenever a device is unplugged. Returns ``None`` for "use
+    PortAudio's default", which is exactly the behaviour before this setting
+    existed — an unset or unmatched preference must never block recording.
+    """
+    pref = (pref if pref is not None else get_voice_device()).strip()
+    if not pref:
+        return None
+
+    devices = list_input_devices()
+    if pref.lstrip("-").isdigit():
+        index = int(pref)
+        if any(d["index"] == index for d in devices):
+            return index
+        logger.warning("Configured voice device index %s not found; using the system default", index)
+        return None
+
+    needle = pref.casefold()
+    for device in devices:
+        if needle in device["name"].casefold():
+            return device["index"]
+    logger.warning("Configured voice device %r not found; using the system default", pref)
+    return None
+
+
+def device_name(index: int | None) -> str:
+    """Human-readable name for a device index (the system default when None)."""
+    for device in list_input_devices():
+        if device["index"] == index or (index is None and device["is_default"]):
+            return device["name"]
+    return "system default"
+
+
 class Recorder:
     """Records microphone audio into memory until :meth:`stop` is called.
 
     Uses a ``sounddevice.InputStream`` with a callback that appends each audio
     block to a list — this lets the caller stop recording on an arbitrary event
     (e.g. a keypress) rather than committing to a fixed duration up front.
+
+    Two things it does beyond opening a stream:
+
+    - **Device selection.** ``device`` is a PortAudio index (``None`` = the
+      system default). Callers resolve a user preference with
+      :func:`resolve_device`.
+    - **Format negotiation.** 16 kHz mono is what Whisper wants, but plenty of
+      USB and Bluetooth microphones simply refuse it — PortAudio then raises out
+      of the constructor and, before this, the whole feature looked broken on
+      that hardware. So a rejection is retried at the device\'s own default
+      format and the resulting WAV carries its real rate/channel count;
+      :func:`transcribe` converts. Recording native and converting once beats
+      not recording at all.
+    - **Monitor mode.** ``monitor=True`` keeps :meth:`level` live but discards
+      every block instead of retaining it. The Settings mic test runs for as
+      long as the user leaves the page open, and a retained take at 48 kHz
+      stereo grows by ~11 MB a minute for a WAV nobody ever asks for.
     """
 
-    def __init__(self, samplerate: int = SAMPLE_RATE, channels: int = CHANNELS) -> None:
+    def __init__(
+        self,
+        samplerate: int = SAMPLE_RATE,
+        channels: int = CHANNELS,
+        device: int | None = None,
+        monitor: bool = False,
+    ) -> None:
         import numpy as np  # noqa: F401 - imported to fail fast if numpy is absent
         import sounddevice as sd
 
+        self.device = device
+        self.device_name = device_name(device)
         self.samplerate = samplerate
         self.channels = channels
+        self.monitor = monitor
         self._frames: list = []
-        self._stream = sd.InputStream(
+        self._level = 0.0
+        self._counted = False
+
+        # The whole open-and-count runs under _stream_lock so refresh_devices()
+        # cannot cycle PortAudio between the stream being created and the
+        # counter that tells it not to. Counting *before* start() rather than
+        # after closes the same gap from the other side: a stream that exists
+        # but is not yet counted is still a stream a teardown would break.
+        with _stream_lock:
+            try:
+                self._stream = self._open(sd, samplerate, channels)
+            except Exception as rejected:  # noqa: BLE001 - re-raised below if unrecoverable
+                # The net is deliberately wide: PortAudio surfaces an unsupported
+                # format as PortAudioError on some hosts and ValueError on others.
+                fallback = self._device_format(sd)
+                if fallback is None or fallback == (samplerate, channels):
+                    raise
+                logger.info(
+                    "Mic %r rejected %d Hz/%d ch (%s); retrying at %d Hz/%d ch",
+                    self.device_name,
+                    samplerate,
+                    channels,
+                    rejected,
+                    *fallback,
+                )
+                self.samplerate, self.channels = fallback
+                self._stream = self._open(sd, *fallback)
+
+            global _open_streams
+            _open_streams += 1
+            self._counted = True
+            try:
+                self._stream.start()
+            except Exception:
+                # Undo the count, or a stream that never ran would block every
+                # future rescan for the life of the process, and close the
+                # stream itself — the constructor is about to raise, so nobody
+                # is left holding a reference to close it later.
+                _open_streams -= 1
+                self._counted = False
+                try:
+                    self._stream.close()
+                except Exception:  # noqa: BLE001 - already failing; the original error is what matters
+                    logger.warning("Could not close a stream that failed to start", exc_info=True)
+                raise
+        logger.info(
+            "Voice recording started: %s, %d Hz, %d ch%s",
+            self.device_name,
+            self.samplerate,
+            self.channels,
+            " (monitor only)" if monitor else "",
+        )
+
+    def _open(self, sd, samplerate: int, channels: int):
+        return sd.InputStream(
             samplerate=samplerate,
             channels=channels,
             dtype="int16",
+            device=self.device,
             callback=self._callback,
         )
-        self._stream.start()
-        logger.info("Voice recording started: %d Hz, %d ch", samplerate, channels)
+
+    def _device_format(self, sd) -> tuple[int, int] | None:
+        """The device\'s own preferred (samplerate, channels), or None."""
+        try:
+            info = sd.query_devices(self.device) if self.device is not None else sd.query_devices(kind="input")
+            rate = int(info.get("default_samplerate") or 0)
+            channels = min(2, int(info.get("max_input_channels", 0)))
+        except Exception:  # noqa: BLE001 - no device info to fall back on
+            logger.warning("Could not read the microphone's default format", exc_info=True)
+            return None
+        if rate <= 0 or channels <= 0:
+            return None
+        return rate, channels
 
     def _callback(self, indata, frames, time_info, status) -> None:
         if status:  # pragma: no cover - hardware-dependent (overflows etc.)
             logger.debug("Audio input status: %s", status)
+        # Peak of this block, normalised to 0..1, for the recording level meter.
+        # Computed here rather than at render time because this is the only place
+        # the raw audio exists — and never logged, since this runs per block.
+        self._level = float(abs(indata).max()) / 32768.0
+        if self.monitor:
+            return  # level only — see the class docstring on monitor mode
         # Copy — sounddevice reuses the underlying buffer across callbacks.
         self._frames.append(indata.copy())
 
+    def level(self) -> float:
+        """Peak amplitude (0..1) of the most recent audio block.
+
+        Drives the meter that tells the user their microphone is actually being
+        heard — a flat meter is the difference between "yeaboi is broken" and
+        "that mic is not the one picking you up".
+        """
+        return self._level
+
     def stop(self) -> bytes:
         """Stop the stream and return the recording as WAV-encoded bytes.
+
+        The WAV carries the *negotiated* rate and channel count, not necessarily
+        16 kHz mono — see the class docstring.
 
         Returns empty bytes if nothing was captured (e.g. immediate stop).
         """
@@ -174,6 +413,12 @@ class Recorder:
             self._stream.close()
         except Exception:  # pragma: no cover - defensive; stream already closed
             logger.warning("Error closing audio stream", exc_info=True)
+        finally:
+            with _stream_lock:
+                global _open_streams
+                if self._counted:
+                    _open_streams -= 1
+                    self._counted = False
 
         if not self._frames:
             logger.info("Voice recording stopped: no audio captured")
@@ -208,8 +453,54 @@ def _get_model():
     return model
 
 
+def _downmix(samples, channels: int):
+    """Average a interleaved multi-channel float array down to mono.
+
+    Whisper wants one channel. Many USB interfaces will only open as stereo (see
+    :class:`Recorder`\'s format negotiation), so the recording that reaches us is
+    not necessarily mono even though we asked for mono.
+    """
+    import numpy as np
+
+    usable = (len(samples) // channels) * channels  # drop a torn trailing frame
+    return np.asarray(samples[:usable], dtype=np.float32).reshape(-1, channels).mean(axis=1)
+
+
+def _resample(samples, src_rate: int, dst_rate: int):
+    """Resample a mono float array from ``src_rate`` to ``dst_rate``.
+
+    Linear interpolation via ``np.interp`` — speech at 16 kHz does not justify a
+    polyphase filter, and this keeps the dependency set at numpy (already a
+    faster-whisper transitive dep) rather than adding scipy or an ffmpeg shell-out.
+    Downsampling is preceded by a moving-average low pass, because decimating
+    48 kHz straight to 16 kHz folds everything above 8 kHz back into the speech
+    band as aliasing noise, which measurably degrades the transcript.
+    """
+    import numpy as np
+
+    samples = np.asarray(samples, dtype=np.float32)
+    n_out = int(len(samples) * dst_rate / src_rate)
+    # Guard before filtering: np.convolve(mode="same") returns max(len(signal),
+    # len(kernel)) samples, so a kernel wider than a near-empty take would grow it.
+    if n_out <= 0 or len(samples) < 2:
+        return np.zeros(0, dtype=np.float32)
+
+    if src_rate > dst_rate:
+        width = int(round(src_rate / dst_rate))
+        if 1 < width < len(samples):
+            kernel = np.ones(width, dtype=np.float32) / width
+            samples = np.convolve(samples, kernel, mode="same")
+    positions = np.linspace(0, len(samples) - 1, n_out)
+    return np.interp(positions, np.arange(len(samples)), samples).astype(np.float32)
+
+
 def transcribe(wav_bytes: bytes) -> str:
     """Transcribe WAV audio to text locally via faster-whisper.
+
+    Accepts any sample rate / channel count: the recorder falls back to whatever
+    format the microphone will actually open with (many USB and Bluetooth mics
+    refuse 16 kHz mono), so conversion to the 16 kHz mono the model expects
+    happens here rather than being assumed at capture time.
 
     Returns the transcript (stripped), or an empty string if there is no audio.
     Raises on model-load/transcription errors so the caller can surface them.
@@ -219,11 +510,20 @@ def transcribe(wav_bytes: bytes) -> str:
 
     import numpy as np
 
-    # Decode the WAV int16 PCM back to the float32 mono array the model expects,
+    # Decode the WAV int16 PCM back to the float32 array the model expects,
     # avoiding any ffmpeg/PyAV decode dependency.
     with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
+        rate = wav.getframerate()
+        channels = wav.getnchannels()
         frames = wav.readframes(wav.getnframes())
     samples = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+    # Both conversions are skipped for already-conforming audio, so the common
+    # path stays exactly as cheap as it was before.
+    if channels > 1:
+        samples = _downmix(samples, channels)
+    if rate != SAMPLE_RATE:
+        logger.info("Resampling recording: %d Hz, %d ch -> %d Hz mono", rate, channels, SAMPLE_RATE)
+        samples = _resample(samples, rate, SAMPLE_RATE)
 
     model = _get_model()
     logger.info("Transcribing %d samples with local Whisper", len(samples))

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -65,6 +65,11 @@ class TestParsing:
         assert args.standup_run is True
         assert args.standup_session == "abc"
 
+    def test_list_audio_devices_parses(self):
+        args = build_parser().parse_args(["--list-audio-devices"])
+        assert args.list_audio_devices is True
+        assert build_parser().parse_args([]).list_audio_devices is False
+
     def test_report_parses(self):
         args = build_parser().parse_args(["report", "--period", "quarter", "--format", "json"])
         assert args.command == "report"

--- a/tests/unit/test_poker_server.py
+++ b/tests/unit/test_poker_server.py
@@ -549,9 +549,12 @@ class TestDuelEndpoints:
             _admin_post(srv, "/api/admin/duel/open", {"seconds": 60})
         assert exc.value.code == 400
 
-    def test_open_shape_and_missing_mic_notice(self, running_server):
-        # The test env has no voice extra — the host mic is a notice, never an error.
+    def test_open_shape_and_missing_mic_notice(self, running_server, monkeypatch):
+        # A missing host mic is a notice, never an error. Pinned rather than left
+        # to the environment: this used to rely on the voice extra being absent,
+        # so the suite went red on any machine that had actually installed it.
         srv, _ = running_server
+        monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (False, "voice extra not installed"))
         _split_reveal(srv)
         resp = _admin_post(srv, "/api/admin/duel/open", {"seconds": 60})
         assert resp["ok"]

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -245,7 +245,7 @@ CAPABILITIES: dict[str, dict] = {
         "engines": Exempt("TUI utility page — writes ~/.yeaboi/.env via config"),
         "mcp_tools": Exempt("TUI utility page; MCP servers must not rewrite host credentials"),
         "tui_mode": "settings",
-        "cli": {"--setup", "--theme", "--allow-path"},
+        "cli": {"--setup", "--theme", "--allow-path", "--list-audio-devices"},
         "skill": Exempt("TUI utility page"),
     },
 }

--- a/tests/unit/test_tips_ui.py
+++ b/tests/unit/test_tips_ui.py
@@ -67,11 +67,11 @@ def test_standup_input_screen_image_hint_gated(monkeypatch):
     assert "Ctrl+V" not in _rendered(show_image_hint=False)
 
 
-def test_voice_hint_present_when_available_and_enabled(monkeypatch):
+def test_voice_hint_is_empty_when_voice_is_installed(monkeypatch):
+    """The box-title chip carries the gesture; this line only carries installs."""
     monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
-    hint = _voice_hint()
-    assert "double-tap Space" in hint
+    assert _voice_hint() == ""
 
 
 def test_voice_hint_shows_install_when_unavailable(monkeypatch):

--- a/tests/unit/test_voice.py
+++ b/tests/unit/test_voice.py
@@ -15,9 +15,11 @@ import types
 import wave
 
 import pytest
+from rich.console import Console
+from rich.text import Text
 
 from yeaboi import voice
-from yeaboi.config import get_voice_model
+from yeaboi.config import get_voice_device, get_voice_model
 
 # ---------------------------------------------------------------------------
 # Fakes for the optional dependencies
@@ -27,9 +29,10 @@ from yeaboi.config import get_voice_model
 class _FakeNdarray:
     """Minimal stand-in for a numpy array covering the ops voice.py uses."""
 
-    def __init__(self, data: bytes = b"", n: int = 0) -> None:
+    def __init__(self, data: bytes = b"", n: int = 0, peak: int = 0) -> None:
         self._data = data
         self._n = n
+        self._peak = peak
 
     def copy(self) -> _FakeNdarray:
         return self
@@ -45,6 +48,13 @@ class _FakeNdarray:
 
     def tobytes(self) -> bytes:
         return self._data
+
+    # Recorder._callback computes abs(block).max() for the level meter.
+    def __abs__(self) -> _FakeNdarray:
+        return self
+
+    def max(self):
+        return self._peak
 
 
 def _fake_numpy() -> types.ModuleType:
@@ -72,9 +82,64 @@ class _FakeInputStream:
         self.closed = True
 
 
-def _fake_sounddevice() -> types.ModuleType:
+# A plausible PortAudio device table: the built-in mic, a 2-channel USB
+# interface, and an output-only device that must be filtered out of the input
+# list. Real query_devices() dicts carry many more keys; these are the ones
+# voice.py reads.
+_FAKE_DEVICES = [
+    {
+        "name": "MacBook Pro Microphone",
+        "max_input_channels": 1,
+        "max_output_channels": 0,
+        "default_samplerate": 48000.0,
+    },
+    {"name": "Shure MV7 (USB)", "max_input_channels": 2, "max_output_channels": 0, "default_samplerate": 44100.0},
+    {
+        "name": "Studio Display Speakers",
+        "max_input_channels": 0,
+        "max_output_channels": 2,
+        "default_samplerate": 48000.0,
+    },
+]
+
+
+def _fake_sounddevice(*, devices=None, default_input: int = 0, reject=None) -> types.ModuleType:
+    """Fake sounddevice module.
+
+    ``reject`` is an optional ``(kwargs) -> bool`` predicate; when it returns
+    True the InputStream constructor raises PortAudioError. That stands in for
+    the real failure this feature exists to survive — a USB mic that refuses
+    16 kHz mono and only speaks its own default rate.
+    """
     mod = types.ModuleType("sounddevice")
-    mod.InputStream = _FakeInputStream
+    devs = list(_FAKE_DEVICES if devices is None else devices)
+
+    class PortAudioError(Exception):
+        pass
+
+    class _Stream(_FakeInputStream):
+        def __init__(self, **kwargs) -> None:
+            if reject is not None and reject(kwargs):
+                raise PortAudioError("Invalid sample rate [PaErrorCode -9997]")
+            super().__init__(**kwargs)
+
+    def query_devices(index=None, kind=None):
+        # Real sounddevice returns a DeviceList for the no-arg call, a single
+        # dict when given an index, and the *default* device for that kind when
+        # given only kind= — voice.py uses all three shapes.
+        if index is not None:
+            return devs[index]
+        if kind == "input":
+            return devs[default_input]
+        return list(devs)
+
+    mod.InputStream = _Stream
+    mod.PortAudioError = PortAudioError
+    mod.query_devices = query_devices
+    mod.default = types.SimpleNamespace(device=(default_input, 1))
+    mod.calls = []  # records _terminate/_initialize for the refresh test
+    mod._terminate = lambda: mod.calls.append("terminate")
+    mod._initialize = lambda: mod.calls.append("initialize")
     return mod
 
 
@@ -113,33 +178,79 @@ def _clear_model_cache():
     voice._MODEL_CACHE.clear()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_stream_count(monkeypatch):
+    """Start every test with the open-stream counter at zero.
+
+    ``voice._open_streams`` is process-global: it exists so refresh_devices()
+    can refuse to tear PortAudio down under a live recording. That makes it the
+    one piece of state in this module that outlives a test — anything that
+    constructs a Recorder and does not stop it (a poker duel left open, say)
+    leaves the count at 1, and every later ``refresh_devices()`` in the session
+    returns False. Several tests below assert on exactly that return value, so
+    pinning the baseline keeps them measuring the code rather than whatever ran
+    before them.
+    """
+    monkeypatch.setattr(voice, "_open_streams", 0)
+
+
 @pytest.fixture
 def _inject(monkeypatch):
     """Inject fake optional modules; returns a helper to toggle presence."""
 
-    def install(*, numpy=True, sounddevice=True, faster_whisper_captured=None, segments=("  hello ", "world  ")):
+    def install(
+        *,
+        numpy=True,
+        sounddevice=True,
+        faster_whisper_captured=None,
+        segments=("  hello ", "world  "),
+        devices=None,
+        default_input=0,
+        reject=None,
+    ):
+        """Install the fakes; returns the fake sounddevice module (or None).
+
+        Pass ``numpy=False`` to let the *real* numpy through — the hand-rolled
+        fake cannot stand in for np.interp, so the resampling tests need it.
+        """
         if numpy:
             monkeypatch.setitem(sys.modules, "numpy", _fake_numpy())
+        sd = None
         if sounddevice:
-            monkeypatch.setitem(sys.modules, "sounddevice", _with_spec(_fake_sounddevice()))
+            sd = _fake_sounddevice(devices=devices, default_input=default_input, reject=reject)
+            monkeypatch.setitem(sys.modules, "sounddevice", _with_spec(sd))
         else:
             monkeypatch.setitem(sys.modules, "sounddevice", None)
         if faster_whisper_captured is not None:
             monkeypatch.setitem(
                 sys.modules, "faster_whisper", _with_spec(_fake_faster_whisper(faster_whisper_captured, segments))
             )
+        return sd
 
     return install
 
 
-def _wav_bytes(pcm: bytes = b"\x01\x00\x02\x00") -> bytes:
+def _wav_bytes(pcm: bytes = b"\x01\x00\x02\x00", *, rate: int = 16000, channels: int = 1) -> bytes:
     buf = io.BytesIO()
     with wave.open(buf, "wb") as w:
-        w.setnchannels(1)
+        w.setnchannels(channels)
         w.setsampwidth(2)
-        w.setframerate(16000)
+        w.setframerate(rate)
         w.writeframes(pcm)
     return buf.getvalue()
+
+
+def _tone_wav(rate: int, channels: int, seconds: float = 0.05) -> bytes:
+    """A real int16 sine take, for the resampling tests (needs real numpy)."""
+    import math
+    import struct
+
+    n = int(rate * seconds)
+    samples = []
+    for i in range(n):
+        value = int(20000 * math.sin(2 * math.pi * 440 * i / rate))
+        samples.extend([value] * channels)
+    return _wav_bytes(struct.pack(f"<{len(samples)}h", *samples), rate=rate, channels=channels)
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +270,33 @@ class TestVoiceModel:
     def test_backend_label(self, monkeypatch):
         monkeypatch.setenv("VOICE_MODEL", "tiny")
         assert voice.backend_label() == "local Whisper (tiny)"
+
+
+class TestVoiceDeviceSetting:
+    """get_voice_device stays a plain string read — resolution to a PortAudio
+    index happens in voice.resolve_device, so config never imports the audio
+    stack."""
+
+    def test_unset_means_the_system_default(self, monkeypatch):
+        monkeypatch.delenv("VOICE_DEVICE", raising=False)
+        assert get_voice_device() == ""
+
+    def test_reads_a_name_substring(self, monkeypatch):
+        monkeypatch.setenv("VOICE_DEVICE", "shure")
+        assert get_voice_device() == "shure"
+
+    def test_reads_an_index(self, monkeypatch):
+        monkeypatch.setenv("VOICE_DEVICE", "2")
+        assert get_voice_device() == "2"
+
+    def test_surrounding_whitespace_is_stripped(self, monkeypatch):
+        """A value hand-edited into ~/.yeaboi/.env often carries a stray space."""
+        monkeypatch.setenv("VOICE_DEVICE", "  Shure MV7  ")
+        assert get_voice_device() == "Shure MV7"
+
+    def test_whitespace_only_is_the_system_default(self, monkeypatch):
+        monkeypatch.setenv("VOICE_DEVICE", "   ")
+        assert get_voice_device() == ""
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +368,146 @@ class TestIsVoiceAvailable:
 
 
 # ---------------------------------------------------------------------------
+# Input devices
+# ---------------------------------------------------------------------------
+
+
+class TestListInputDevices:
+    def test_filters_out_output_only_devices(self, _inject):
+        _inject()
+        names = [d["name"] for d in voice.list_input_devices()]
+        assert names == ["MacBook Pro Microphone", "Shure MV7 (USB)"]
+
+    def test_marks_the_system_default(self, _inject):
+        _inject(default_input=1)
+        defaults = [d["name"] for d in voice.list_input_devices() if d["is_default"]]
+        assert defaults == ["Shure MV7 (USB)"]
+
+    def test_reports_channels_and_rate(self, _inject):
+        _inject()
+        usb = voice.list_input_devices()[1]
+        assert usb["index"] == 1
+        assert usb["channels"] == 2
+        assert usb["samplerate"] == 44100
+
+    def test_missing_sounddevice_returns_empty(self, _inject):
+        _inject(sounddevice=False)
+        assert voice.list_input_devices() == []
+
+
+class TestResolveDevice:
+    def test_blank_preference_means_system_default(self, _inject):
+        _inject()
+        assert voice.resolve_device("") is None
+
+    def test_resolves_by_name_substring_case_insensitively(self, _inject):
+        _inject()
+        assert voice.resolve_device("shure") == 1
+
+    def test_resolves_by_index(self, _inject):
+        _inject()
+        assert voice.resolve_device("1") == 1
+
+    def test_unknown_name_falls_back_to_default(self, _inject):
+        _inject()
+        assert voice.resolve_device("Blue Yeti") is None
+
+    def test_out_of_range_index_falls_back_to_default(self, _inject):
+        _inject()
+        assert voice.resolve_device("9") is None
+
+    def test_output_only_device_is_not_selectable(self, _inject):
+        _inject()
+        assert voice.resolve_device("Studio Display") is None
+
+    def test_reads_the_env_var_when_no_preference_passed(self, monkeypatch, _inject):
+        _inject()
+        monkeypatch.setenv("VOICE_DEVICE", "MV7")
+        assert voice.resolve_device() == 1
+
+
+class TestDeviceName:
+    def test_names_an_index(self, _inject):
+        _inject()
+        assert voice.device_name(1) == "Shure MV7 (USB)"
+
+    def test_none_names_the_default(self, _inject):
+        _inject(default_input=1)
+        assert voice.device_name(None) == "Shure MV7 (USB)"
+
+    def test_unknown_index_is_described_generically(self, _inject):
+        _inject(sounddevice=False)
+        assert voice.device_name(3) == "system default"
+
+
+class TestListAudioDevicesCommand:
+    """`yeaboi --list-audio-devices` — the "why can\'t it hear my mic" diagnostic."""
+
+    def test_reports_when_voice_is_not_installed(self, monkeypatch, capsys):
+        from yeaboi import cli
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "Install voice extra: …"))
+        cli._list_audio_devices()
+        assert "unavailable" in capsys.readouterr().out
+
+    def test_lists_devices_and_marks_the_selection(self, monkeypatch, capsys, _inject):
+        from yeaboi import cli
+
+        _inject()
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        monkeypatch.setenv("VOICE_DEVICE", "MV7")
+        cli._list_audio_devices()
+        out = capsys.readouterr().out
+        assert "MacBook Pro Microphone" in out
+        assert "system default" in out
+        assert "selected via VOICE_DEVICE=MV7" in out
+        assert "Studio Display Speakers" not in out  # output-only
+
+    def test_rescans_before_listing(self, monkeypatch, _inject):
+        """A mic plugged in after launch is invisible without the rescan."""
+        from yeaboi import cli
+
+        sd = _inject()
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        cli._list_audio_devices()
+        assert sd.calls == ["terminate", "initialize"]
+
+    def test_says_so_when_there_are_no_microphones(self, monkeypatch, capsys, _inject):
+        from yeaboi import cli
+
+        _inject(devices=[])
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        cli._list_audio_devices()
+        assert "No microphones found" in capsys.readouterr().out
+
+
+class TestRefreshDevices:
+    def test_cycles_portaudio(self, _inject):
+        sd = _inject()
+        assert voice.refresh_devices() is True
+        assert sd.calls == ["terminate", "initialize"]
+
+    def test_refuses_while_a_stream_is_open(self, _inject):
+        sd = _inject()
+        rec = voice.Recorder()
+        try:
+            assert voice.refresh_devices() is False
+            assert sd.calls == []  # PortAudio left alone under a live recording
+        finally:
+            rec.stop()
+        assert voice.refresh_devices() is True
+
+    def test_survives_a_failing_rescan(self, _inject):
+        sd = _inject()
+
+        def _boom():
+            raise RuntimeError("PortAudio busy")
+
+        sd._terminate = _boom
+        assert voice.refresh_devices() is False
+
+
+# ---------------------------------------------------------------------------
 # Recorder
 # ---------------------------------------------------------------------------
 
@@ -251,6 +529,107 @@ class TestRecorder:
     def test_no_audio_returns_empty(self, _inject):
         _inject()
         assert voice.Recorder().stop() == b""
+
+    def test_opens_the_requested_device(self, _inject):
+        _inject()
+        rec = voice.Recorder(device=1)
+        assert rec._stream.kwargs["device"] == 1
+        assert rec.device_name == "Shure MV7 (USB)"
+        rec.stop()
+
+    def test_level_tracks_the_latest_block(self, _inject):
+        _inject()
+        rec = voice.Recorder()
+        assert rec.level() == 0.0
+        rec._callback(_FakeNdarray(b"\x01\x00", peak=16384), 1, None, None)
+        assert rec.level() == 0.5  # exact in binary; pytest.approx needs real numpy
+        rec._callback(_FakeNdarray(b"\x01\x00", peak=0), 1, None, None)
+        assert rec.level() == 0.0
+        rec.stop()
+
+
+class TestRecorderFormatNegotiation:
+    """A mic that refuses 16 kHz mono must still record, at its own format."""
+
+    def test_falls_back_to_the_device_default_format(self, _inject):
+        _inject(reject=lambda kw: kw.get("samplerate") == voice.SAMPLE_RATE)
+        rec = voice.Recorder(device=1)  # Shure: 44100 Hz, 2 ch
+        assert (rec.samplerate, rec.channels) == (44100, 2)
+        assert rec._stream.kwargs["samplerate"] == 44100
+        rec.stop()
+
+    def test_negotiated_format_is_written_into_the_wav(self, _inject):
+        _inject(reject=lambda kw: kw.get("samplerate") == voice.SAMPLE_RATE)
+        rec = voice.Recorder(device=1)
+        rec._callback(_FakeNdarray(b"\x01\x00\x02\x00"), 1, None, None)
+        with wave.open(io.BytesIO(rec.stop()), "rb") as wf:
+            assert wf.getframerate() == 44100
+            assert wf.getnchannels() == 2
+
+    def test_caps_the_fallback_at_two_channels(self, _inject):
+        _inject(
+            devices=[
+                {
+                    "name": "Big Interface",
+                    "max_input_channels": 18,
+                    "max_output_channels": 0,
+                    "default_samplerate": 48000.0,
+                }
+            ],
+            reject=lambda kw: kw.get("samplerate") == voice.SAMPLE_RATE,
+        )
+        rec = voice.Recorder(device=0)
+        assert rec.channels == 2  # 18-channel interfaces would waste 16 of them
+        rec.stop()
+
+    def test_reraises_when_there_is_nothing_else_to_try(self, _inject):
+        _inject(
+            devices=[{"name": "Broken", "max_input_channels": 0, "max_output_channels": 0, "default_samplerate": 0}],
+            reject=lambda kw: True,
+        )
+        with pytest.raises(Exception, match="Invalid sample rate"):
+            voice.Recorder(device=0)
+
+    def test_a_failed_open_does_not_leak_the_stream_count(self, _inject):
+        _inject(reject=lambda kw: True)
+        with pytest.raises(Exception, match="Invalid sample rate"):
+            voice.Recorder()
+        assert voice.refresh_devices() is True  # counter never incremented
+
+    def test_a_failed_start_does_not_leak_the_stream_count(self, monkeypatch, _inject):
+        """The count goes up *before* start() so a rescan cannot tear PortAudio
+        down under a stream that exists but has not started — which means a
+        start() that raises has to put it back, or every later rescan is blocked
+        for the life of the process."""
+        sd = _inject()
+
+        def _no_start(self):
+            raise OSError("could not start stream")
+
+        opened = []
+        real_init = sd.InputStream.__init__
+
+        def _track(self, **kwargs):
+            real_init(self, **kwargs)
+            opened.append(self)
+
+        monkeypatch.setattr(sd.InputStream, "__init__", _track)
+        monkeypatch.setattr(sd.InputStream, "start", _no_start)
+        with pytest.raises(OSError, match="could not start"):
+            voice.Recorder()
+        assert voice._open_streams == 0
+        assert voice.refresh_devices() is True
+        assert opened and all(s.closed for s in opened)  # and the stream is not leaked
+
+    def test_a_live_stream_still_blocks_a_rescan(self, _inject):
+        """The counter moved earlier in __init__; the guard must still hold."""
+        _inject()
+        recorder = voice.Recorder()
+        try:
+            assert voice.refresh_devices() is False
+        finally:
+            recorder.stop()
+        assert voice.refresh_devices() is True
 
 
 # ---------------------------------------------------------------------------
@@ -282,6 +661,55 @@ class TestTranscribe:
         first_model = voice._MODEL_CACHE["base"]
         voice.transcribe(_wav_bytes())
         assert voice._MODEL_CACHE["base"] is first_model  # not reloaded
+
+    def test_conforming_audio_skips_conversion(self, monkeypatch, _inject):
+        """16 kHz mono takes the identity path — no downmix, no resample."""
+        _inject(faster_whisper_captured={})
+        called = []
+        monkeypatch.setattr(voice, "_resample", lambda *a: called.append("resample"))
+        monkeypatch.setattr(voice, "_downmix", lambda *a: called.append("downmix"))
+        assert voice.transcribe(_wav_bytes()) == "hello world"
+        assert called == []
+
+
+class TestResampling:
+    """A mic that only speaks 48 kHz stereo must still transcribe.
+
+    These use the *real* numpy (``numpy=False`` skips the fake), because the
+    point is the arithmetic.
+    """
+
+    def test_48k_stereo_becomes_16k_mono(self, _inject):
+        captured: dict = {}
+        _inject(numpy=False, faster_whisper_captured=captured)
+        assert voice.transcribe(_tone_wav(48000, 2)) == "hello world"
+        # 0.05 s of audio at the model's rate, whatever it was recorded at.
+        assert captured["n_samples"] == pytest.approx(16000 * 0.05, abs=2)
+
+    def test_44k1_mono_becomes_16k(self, _inject):
+        captured: dict = {}
+        _inject(numpy=False, faster_whisper_captured=captured)
+        voice.transcribe(_tone_wav(44100, 1))
+        assert captured["n_samples"] == pytest.approx(16000 * 0.05, abs=2)
+
+    def test_upsamples_from_8k(self, _inject):
+        captured: dict = {}
+        _inject(numpy=False, faster_whisper_captured=captured)
+        voice.transcribe(_tone_wav(8000, 1))
+        assert captured["n_samples"] == pytest.approx(16000 * 0.05, abs=2)
+
+    def test_downmix_averages_channels(self, _inject):
+        _inject(numpy=False)
+        mono = voice._downmix([1.0, 3.0, 2.0, 4.0], 2)
+        assert list(mono) == [2.0, 3.0]
+
+    def test_downmix_drops_a_torn_trailing_frame(self, _inject):
+        _inject(numpy=False)
+        assert len(voice._downmix([1.0, 3.0, 2.0], 2)) == 1
+
+    def test_resample_of_too_short_audio_is_empty(self, _inject):
+        _inject(numpy=False)
+        assert len(voice._resample([1.0], 48000, 16000)) == 0
 
 
 class TestTranscribeMedia:
@@ -340,6 +768,20 @@ def _console():
     return Console(file=io.StringIO(), width=80)
 
 
+def _render(panel, width: int = 100) -> str:
+    """Render a Panel to plain text for screen assertions."""
+    from rich.console import Console
+
+    buf = io.StringIO()
+    Console(file=buf, width=width, force_terminal=False, color_system=None).print(panel)
+    return buf.getvalue()
+
+
+def _stub_render(**_kwargs):
+    """Stand-in for the picker's own _render, which the mic test paints through."""
+    return Text("")
+
+
 class _KeySequence:
     def __init__(self, keys):
         self._keys = list(keys)
@@ -389,6 +831,12 @@ class TestDoubleTapInDescriptionLoop:
         monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
 
         class _Rec:
+            def __init__(self, **kwargs):
+                self.device_name = "Fake Mic"
+
+            def level(self):
+                return 0.4
+
             def stop(self):
                 return b"AUDIO"
 
@@ -410,14 +858,488 @@ class TestDoubleTapInDescriptionLoop:
         assert desc.strip() == "Hi four developers"
 
 
+class TestInputBoxTitle:
+    """The mic chip in the input box title — the one place nothing crops."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_chip(self):
+        from yeaboi.ui.shared import _voice_input
+
+        _voice_input.reset_voice_chip()
+        yield
+        _voice_input.reset_voice_chip()
+
+    def test_advertises_the_gesture_when_installed(self, monkeypatch):
+        from yeaboi.ui.shared._voice_input import input_box_title
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        assert "Space Space" in input_box_title("Message", 60).plain
+
+    def test_says_off_when_not_installed(self, monkeypatch):
+        from yeaboi.ui.shared._voice_input import input_box_title
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "install it"))
+        title = input_box_title("Message", 60).plain
+        assert "off" in title
+        assert "Space Space" not in title
+
+    def test_ignores_the_tips_setting(self, monkeypatch):
+        """An affordance is UI, not a tip — tips-off users must still see it."""
+        from yeaboi.ui.shared._voice_input import input_box_title
+
+        monkeypatch.setenv("TIPS_ENABLED", "false")
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        assert "\U0001f3a4" in input_box_title("Message", 60).plain
+
+    def test_drops_the_chip_when_the_box_is_too_narrow(self, monkeypatch):
+        """Rich grows a Panel past its declared width for an oversized title."""
+        from yeaboi.ui.shared._voice_input import input_box_title
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        assert input_box_title("Project Description", 30).plain == " Project Description "
+        assert "Space Space" in input_box_title("Project Description", 74).plain
+
+    def test_unclamped_when_no_width_is_given(self, monkeypatch):
+        from yeaboi.ui.shared._voice_input import input_box_title
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        assert "Space Space" in input_box_title("Message").plain
+
+    def test_availability_is_probed_once(self, monkeypatch):
+        """Titles rebuild every frame; is_voice_available walks sys.path twice."""
+        from yeaboi.ui.shared._voice_input import input_box_title
+
+        calls = []
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (calls.append(1), (True, ""))[1])
+        for _ in range(5):
+            input_box_title("Message", 60)
+        assert len(calls) == 1
+
+    def test_the_chip_never_widens_the_panel(self, monkeypatch):
+        """The box is padded into a fixed column; an over-wide title would ragged it."""
+        import rich.box
+        from rich.cells import cell_len
+        from rich.panel import Panel
+        from rich.text import Text
+
+        from yeaboi.ui.shared._voice_input import input_box_title
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        for box_w in (40, 50, 60, 74, 90):
+            panel = Panel(
+                Text("x"),
+                title=input_box_title("Message", box_w),
+                title_align="left",
+                box=rich.box.ROUNDED,
+                width=box_w,
+                padding=(1, 2),
+            )
+            top = _render(panel, width=200).split("\n")[0]
+            assert cell_len(top) == box_w, f"panel overflowed at width {box_w}"
+
+
+class TestStandupBoxChip:
+    """The standup field is hand-drawn, so its chip rides the box border."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_chip(self):
+        from yeaboi.ui.shared import _voice_input
+
+        _voice_input.reset_voice_chip()
+        yield
+        _voice_input.reset_voice_chip()
+
+    def _screen(self, monkeypatch, *, width: int, box_rows: int = 1, available=True) -> str:
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_standup_input_screen
+
+        reason = "" if available else "not installed"
+        monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (available, reason))
+        return _render(
+            _build_standup_input_screen("What did you do yesterday?", "", box_rows=box_rows, width=width, height=30),
+            width=width,
+        )
+
+    def test_the_chip_rides_the_border_not_the_label(self, monkeypatch):
+        """On the label it would sit at the tail of a no_wrap/ellipsis line —
+        the exact position the chip was moved off in the first place."""
+        out = self._screen(monkeypatch, width=100)
+        chip_line = next(line for line in out.splitlines() if "Space Space" in line)
+        assert "╭" in chip_line  # it is the box's top border
+        assert "What did you do yesterday?" not in chip_line  # not the prompt label
+
+    def test_the_chip_survives_a_narrow_terminal(self, monkeypatch):
+        assert "Space Space" in self._screen(monkeypatch, width=72)
+
+    def test_large_box_gets_the_chip_too(self, monkeypatch):
+        out = self._screen(monkeypatch, width=100, box_rows=4)
+        chip_line = next(line for line in out.splitlines() if "Space Space" in line)
+        assert "╭" in chip_line
+
+    def test_says_off_when_voice_is_not_installed(self, monkeypatch):
+        out = self._screen(monkeypatch, width=100, available=False)
+        assert "🎤 off" in out
+
+    def test_the_inlaid_border_keeps_the_box_square(self, monkeypatch):
+        """The chip eats border dashes, so a mis-counted width (the emoji is two
+        cells) would leave the top edge longer or shorter than the bottom."""
+        from rich.cells import cell_len
+
+        out = self._screen(monkeypatch, width=100)
+        top = next(line for line in out.splitlines() if "Space Space" in line)
+        bottom = next(line for line in out.splitlines() if "╰" in line)
+        assert cell_len(top[top.index("╭") : top.index("╮") + 1]) == cell_len(
+            bottom[bottom.index("╰") : bottom.index("╯") + 1]
+        )
+
+
+class TestVoiceDevicePicker:
+    """Settings → Voice Input → Input Device."""
+
+    DEVICES = [
+        {"index": 0, "name": "MacBook Pro Microphone", "channels": 1, "samplerate": 48000, "is_default": True},
+        {"index": 1, "name": "Shure MV7 (USB)", "channels": 2, "samplerate": 44100, "is_default": False},
+    ]
+
+    def _state(self, sel: int = 0) -> dict:
+        return {"devices": self.DEVICES, "sel": sel}
+
+    def test_arrows_move_and_wrap(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import voice_picker_keypress
+
+        state = self._state()
+        assert voice_picker_keypress("down", state) == "none"
+        assert state["sel"] == 1
+        voice_picker_keypress("down", state)
+        assert state["sel"] == 0  # wraps
+        voice_picker_keypress("up", state)
+        assert state["sel"] == 1
+
+    def test_enter_selects_and_esc_cancels(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import voice_picker_keypress
+
+        assert voice_picker_keypress("enter", self._state()) == "select"
+        assert voice_picker_keypress(" ", self._state()) == "select"
+        assert voice_picker_keypress("esc", self._state()) == "cancel"
+
+    def test_t_tests_and_d_clears_to_the_system_default(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import voice_picker_keypress
+
+        assert voice_picker_keypress("t", self._state()) == "test"
+        assert voice_picker_keypress("d", self._state()) == "system"
+
+    def test_unknown_keys_do_nothing(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import voice_picker_keypress
+
+        state = self._state()
+        assert voice_picker_keypress("x", state) == "none"
+        assert state["sel"] == 0
+
+    def test_arrows_survive_an_empty_device_list(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import voice_picker_keypress
+
+        state = {"devices": [], "sel": 0}
+        assert voice_picker_keypress("down", state) == "none"
+        assert state["sel"] == 0
+
+    def test_screen_lists_devices_and_marks_the_selection(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_voice_device_screen
+
+        out = _render(_build_voice_device_screen(self.DEVICES, 1, current="Shure MV7 (USB)", width=100, height=26))
+        assert "MacBook Pro Microphone" in out
+        assert "Shure MV7" in out
+        assert "system default" in out
+        assert "selected" in out
+        assert "test mic" in out  # the hint row
+
+    def test_screen_shows_a_level_meter_while_testing(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_voice_device_screen
+
+        idle = _render(_build_voice_device_screen(self.DEVICES, 0, width=100, height=26))
+        testing = _render(_build_voice_device_screen(self.DEVICES, 0, width=100, height=26, testing=True, level=1.0))
+        assert "▇" not in idle
+        assert "▇" in testing
+        assert "Speak now" in testing
+
+    def test_screen_explains_an_empty_list(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_voice_device_screen
+
+        assert "No microphones detected" in _render(_build_voice_device_screen([], 0, width=100, height=26))
+
+    def test_modal_returns_the_chosen_device(self, _inject):
+        from yeaboi.ui.mode_select import _pick_voice_device
+
+        _inject()
+        keys = iter(["down", "enter"])
+        assert (
+            _pick_voice_device(_console(), _FakeLive(), lambda timeout=None: next(keys, "esc"), 0.05, True)
+            == "Shure MV7 (USB)"
+        )
+
+    def test_modal_esc_changes_nothing(self, _inject):
+        from yeaboi.ui.mode_select import _pick_voice_device
+
+        _inject()
+        keys = iter(["esc"])
+        assert _pick_voice_device(_console(), _FakeLive(), lambda timeout=None: next(keys, "esc"), 0.05, True) is None
+
+    def test_modal_d_clears_back_to_the_system_default(self, _inject):
+        from yeaboi.ui.mode_select import _pick_voice_device
+
+        _inject()
+        keys = iter(["d"])
+        assert _pick_voice_device(_console(), _FakeLive(), lambda timeout=None: next(keys, "esc"), 0.05, True) == ""
+
+    def test_modal_rescans_before_listing(self, _inject):
+        """A mic plugged in mid-session is the whole reason this page exists."""
+        from yeaboi.ui.mode_select import _pick_voice_device
+
+        sd = _inject()
+        keys = iter(["esc"])
+        _pick_voice_device(_console(), _FakeLive(), lambda timeout=None: next(keys, "esc"), 0.05, True)
+        assert sd.calls == ["terminate", "initialize"]
+
+    def test_modal_starts_on_the_configured_device(self, monkeypatch, _inject):
+        from yeaboi.ui.mode_select import _pick_voice_device
+
+        _inject()
+        monkeypatch.setenv("VOICE_DEVICE", "MV7")
+        keys = iter(["enter"])  # no movement — whatever is highlighted on open
+        assert (
+            _pick_voice_device(_console(), _FakeLive(), lambda timeout=None: next(keys, "esc"), 0.05, True)
+            == "Shure MV7 (USB)"
+        )
+
+    def test_screen_shows_a_notice(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_voice_device_screen
+
+        out = _render(
+            _build_voice_device_screen(self.DEVICES, 0, width=100, height=26, notice="AirPods would not open")
+        )
+        assert "AirPods would not open" in out
+
+    def test_screen_scrolls_a_long_device_list(self):
+        """A host with a virtual audio driver can report a dozen inputs."""
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_voice_device_screen
+
+        many = [
+            {"index": i, "name": f"Interface {i}", "channels": 1, "samplerate": 48000, "is_default": i == 0}
+            for i in range(14)
+        ]
+        out = _render(_build_voice_device_screen(many, 13, width=100, height=26))
+        assert "Interface 13" in out  # the selection is windowed into view
+        assert "Interface 0" not in out  # …and the top has scrolled away
+        assert "\u2503" in out  # the scrollbar thumb says there is more
+
+    def test_screen_has_no_scrollbar_when_everything_fits(self):
+        from yeaboi.ui.mode_select.screens._screens_secondary import _build_voice_device_screen
+
+        assert "\u2503" not in _render(_build_voice_device_screen(self.DEVICES, 0, width=100, height=26))
+
+    def test_modal_enter_on_an_empty_list_does_not_save_anything(self, _inject):
+        """Returning "" would confirm a choice the page just said cannot be made."""
+        from yeaboi.ui.mode_select import _pick_voice_device
+
+        _inject(devices=[{"name": "Speakers", "max_input_channels": 0, "max_output_channels": 2}])
+        keys = iter(["enter", "esc"])
+        assert _pick_voice_device(_console(), _FakeLive(), lambda timeout=None: next(keys, "esc"), 0.05, True) is None
+
+
+class TestMicrophoneTest:
+    """Settings → Voice Input → Input Device → "t"."""
+
+    DEVICE = {"index": 1, "name": "Shure MV7 (USB)", "channels": 2, "samplerate": 44100, "is_default": False}
+
+    def test_runs_until_a_key_is_pressed_and_reports_no_problem(self, _inject):
+        from yeaboi.ui.mode_select import _test_microphone
+
+        _inject()
+        keys = iter(["", "", "enter"])
+        assert (
+            _test_microphone(
+                _console(), _FakeLive(), lambda timeout=None: next(keys, "enter"), 0.05, True, self.DEVICE, _stub_render
+            )
+            == ""
+        )
+
+    def test_does_not_buffer_audio(self, _inject):
+        """Monitor mode: the page can sit open for minutes and keeps no take."""
+        from yeaboi import voice
+
+        _inject()
+        recorder = voice.Recorder(device=1, monitor=True)
+        recorder._callback(_FakeNdarray(b"\x01\x00", 1, peak=9000), 1, None, None)
+        recorder._callback(_FakeNdarray(b"\x02\x00", 1, peak=9000), 1, None, None)
+        assert recorder.level() > 0  # the meter still moves…
+        assert recorder._frames == []  # …but nothing is retained
+        assert recorder.stop() == b""
+
+    def test_the_settings_test_uses_monitor_mode(self, monkeypatch, _inject):
+        from yeaboi import voice
+        from yeaboi.ui.mode_select import _test_microphone
+
+        _inject()
+        seen = {}
+        real = voice.Recorder
+
+        def _spy(**kwargs):
+            seen.update(kwargs)
+            return real(**kwargs)
+
+        monkeypatch.setattr(voice, "Recorder", _spy)
+        keys = iter(["enter"])
+        _test_microphone(
+            _console(), _FakeLive(), lambda timeout=None: next(keys, "enter"), 0.05, True, self.DEVICE, _stub_render
+        )
+        assert seen["monitor"] is True
+
+    def test_a_mic_that_will_not_open_returns_a_notice(self, monkeypatch, _inject):
+        from yeaboi import voice
+        from yeaboi.ui.mode_select import _test_microphone
+
+        _inject()
+
+        def _boom(**_kwargs):
+            raise OSError("Device unavailable")
+
+        monkeypatch.setattr(voice, "Recorder", _boom)
+        notice = _test_microphone(
+            _console(), _FakeLive(), lambda timeout=None: "enter", 0.05, True, self.DEVICE, _stub_render
+        )
+        assert "Shure MV7 (USB)" in notice
+        assert "Device unavailable" in notice
+
+    def test_a_mouse_event_does_not_end_the_test(self, _inject):
+        from yeaboi.ui.mode_select import _test_microphone
+
+        _inject()
+        keys = iter(["\x1b[<0;10;5M", "enter"])
+        assert (
+            _test_microphone(
+                _console(), _FakeLive(), lambda timeout=None: next(keys, "enter"), 0.05, True, self.DEVICE, _stub_render
+            )
+            == ""
+        )
+
+    def test_the_test_stops_the_recorder(self, monkeypatch, _inject):
+        """The stream must not outlive the page — it would block every rescan."""
+        from yeaboi import voice
+        from yeaboi.ui.mode_select import _test_microphone
+
+        _inject()
+        _test_microphone(_console(), _FakeLive(), lambda timeout=None: "enter", 0.05, True, self.DEVICE, _stub_render)
+        assert voice._open_streams == 0
+
+
+class TestNextDevice:
+    """Tab-to-switch, and the default-resolution it depends on."""
+
+    def test_unset_preference_skips_past_the_system_default(self, _inject):
+        """The bug this guards: VOICE_DEVICE unset means current is None, and a
+        plain "not found → start at the top" lands back on the default itself —
+        so the remedy the silence warning advertises would restart the take to
+        move to the microphone the user was already on."""
+        from yeaboi.ui.shared._voice_input import _next_device
+
+        _inject()  # device 0 is the system default
+        assert _next_device(None) == (1, "Shure MV7 (USB)")
+
+    def test_advances_from_an_explicit_index(self, _inject):
+        from yeaboi.ui.shared._voice_input import _next_device
+
+        _inject()
+        assert _next_device(1) == (0, "MacBook Pro Microphone")
+
+    def test_wraps_around(self, _inject):
+        from yeaboi.ui.shared._voice_input import _next_device
+
+        _inject()
+        assert _next_device(0) == (1, "Shure MV7 (USB)")
+
+    def test_none_when_there_is_nothing_to_switch_to(self, _inject):
+        from yeaboi.ui.shared._voice_input import _next_device
+
+        _inject(devices=[_FAKE_DEVICES[0]])
+        assert _next_device(None) is None
+
+    def test_falls_back_to_the_top_when_no_default_is_reported(self, _inject):
+        from yeaboi.ui.shared._voice_input import _next_device
+
+        _inject(devices=[dict(d) for d in _FAKE_DEVICES], default_input=99)
+        assert _next_device(None) == (0, "MacBook Pro Microphone")
+
+
 class TestVoiceIndicator:
-    def test_recording_has_red_border_and_stop_hint(self):
+    def test_recording_shows_rec_and_stop_hint(self):
         from yeaboi.ui.shared._voice_input import voice_indicator
 
-        border, line = voice_indicator("recording", 0.0)
+        border, line = voice_indicator("recording", 0.0, width=100)
         assert border.startswith("rgb(")
-        assert "Recording" in line
+        assert "REC" in line
         assert "any key to stop" in line
+
+    def test_recording_is_amber_not_the_error_red(self):
+        """Red is this TUI's error colour — a red composer read as a crash."""
+        from yeaboi.ui.shared._voice_input import _ERR_BORDER, voice_indicator
+
+        for tick in (0.0, 0.2, 0.5, 0.9):
+            border, _line = voice_indicator("recording", tick)
+            assert border != _ERR_BORDER
+            r, g, b = (int(v) for v in border.removeprefix("rgb(").removesuffix(")").split(","))
+            assert g > 120 and r > g > b  # amber: warm, but nothing like (220,80,80)
+
+    def test_recording_shows_elapsed_time_and_device(self):
+        from yeaboi.ui.shared._voice_input import voice_indicator
+
+        _border, line = voice_indicator("recording", 0.0, elapsed=64.0, device="Shure MV7", width=120)
+        assert "1:04" in line
+        assert "Shure MV7" in line
+
+    def test_meter_follows_the_input_level(self):
+        from yeaboi.ui.shared._voice_input import voice_indicator
+
+        _b, quiet = voice_indicator("recording", 0.0, level=0.0, width=120)
+        _b, loud = voice_indicator("recording", 0.0, level=1.0, width=120)
+        assert quiet.count("▇") == 0
+        assert loud.count("▇") == 8
+
+    def test_silence_names_the_device_and_the_remedy(self):
+        from yeaboi.ui.shared._voice_input import voice_indicator
+
+        _b, line = voice_indicator("recording", 0.0, device="AirPods Pro", silent=True, width=120)
+        assert "no sound from AirPods Pro" in line
+        assert "Tab" in line
+
+    def test_the_silent_form_always_keeps_a_way_out(self):
+        """This is the branch a confused user lands on — it must never be the
+        one that drops the exit affordance."""
+        from yeaboi.ui.shared._voice_input import voice_indicator
+
+        for width in (30, 45, 60, 80, 100, 140):
+            _b, line = voice_indicator("recording", 0.0, device="A Very Long Device Name", silent=True, width=width)
+            assert "Esc" in line, f"no way out at width {width}: {line!r}"
+
+    def test_narrow_terminals_get_a_short_form(self):
+        from yeaboi.ui.shared._voice_input import voice_indicator
+
+        _b, narrow = voice_indicator("recording", 0.0, device="A Very Long Device Name", width=50)
+        _b, mid = voice_indicator("recording", 0.0, device="A Very Long Device Name", width=80)
+        _b, wide = voice_indicator("recording", 0.0, device="A Very Long Device Name", width=140)
+        assert "A Very Long Device Name" not in narrow  # dropped, not cropped
+        assert "A Very Long Device Name" in wide
+        assert "any key stops" in narrow  # how to get out always survives
+        assert len(narrow) < len(mid) < len(wide)
+
+    def test_every_form_fits_the_width_it_was_given(self):
+        from rich.cells import cell_len
+
+        from yeaboi.ui.shared._voice_input import voice_indicator
+
+        for width in range(40, 160, 7):
+            for silent in (False, True):
+                _b, line = voice_indicator(
+                    "recording", 0.0, device="Scarlett 2i2 USB (2-in 2-out)", silent=silent, width=width
+                )
+                assert cell_len(line) <= width, f"{width}: {line!r}"
 
     def test_transcribing_has_spinner(self):
         from yeaboi.ui.shared._voice_input import voice_indicator
@@ -425,6 +1347,12 @@ class TestVoiceIndicator:
         border, line = voice_indicator("transcribing", 0.5)
         assert "Transcribing" in line
         assert border  # non-empty style
+
+    def test_first_run_says_the_model_is_downloading(self):
+        from yeaboi.ui.shared._voice_input import voice_indicator
+
+        _border, line = voice_indicator("transcribing", 0.5, preparing=True)
+        assert "downloads" in line
 
     def test_unknown_status_is_empty(self):
         from yeaboi.ui.shared._voice_input import voice_indicator
@@ -446,6 +1374,12 @@ class TestRecordVoiceInput:
         monkeypatch.setattr(voice, "is_voice_available", lambda: available)
 
         class _Rec:
+            def __init__(self, **kwargs):
+                self.device_name = "Fake Mic"
+
+            def level(self):
+                return 0.4
+
             def stop(self):
                 return b"AUDIO" if frames_have_audio else b""
 
@@ -486,6 +1420,155 @@ class TestRecordVoiceInput:
         mod = self._patch_voice(monkeypatch, transcript="hi")
         mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["", "enter"]))
         assert events == ["pause", "resume"]
+
+    def test_render_status_receives_a_finished_border_and_line(self, monkeypatch):
+        """Screens no longer compute the indicator — the loop hands them the pair."""
+        mod = self._patch_voice(monkeypatch, transcript="hi")
+        seen: list[tuple[str, str]] = []
+
+        def _render(border, line):
+            seen.append((border, line))
+            return "frame"
+
+        wide = Console(file=io.StringIO(), width=140)
+        mod.record_voice_input(_FakeLive(), wide, _KeySequence(["", "enter"]), render_status=_render)
+        assert seen
+        assert all(border.startswith("rgb(") for border, _ in seen)
+        assert any("REC" in line for _, line in seen)
+        assert any("Fake Mic" in line for _, line in seen)  # the mic that opened is named
+
+    def test_mic_failure_names_the_device_and_the_remedy(self, monkeypatch, _inject):
+        """ "Could not access microphone" was the same message for every cause."""
+        from yeaboi.ui.shared._voice_input import _mic_error
+
+        _inject()
+        monkeypatch.setenv("VOICE_DEVICE", "MV7")
+        message = _mic_error(RuntimeError("Invalid number of channels [PaErrorCode -9998]"))
+        assert "Shure MV7 (USB)" in message
+        assert "PaErrorCode" in message  # the real reason, not a generic one
+        assert "Settings" in message  # and where to fix it
+
+    def test_mic_failure_falls_back_to_the_exception_type(self, _inject):
+        from yeaboi.ui.shared._voice_input import _mic_error
+
+        _inject()
+        assert "OSError" in _mic_error(OSError())
+
+    def test_tab_switches_to_the_next_microphone(self, monkeypatch):
+        from yeaboi.ui.shared import _voice_input
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        monkeypatch.setattr(voice, "resolve_device", lambda *a: 0)
+        monkeypatch.setattr(
+            voice,
+            "list_input_devices",
+            lambda: [
+                {"index": 0, "name": "Built-in", "channels": 1, "samplerate": 48000, "is_default": True},
+                {"index": 1, "name": "Shure MV7", "channels": 2, "samplerate": 44100, "is_default": False},
+            ],
+        )
+        opened: list[int | None] = []
+
+        class _Rec:
+            def __init__(self, device=None, **kwargs):
+                opened.append(device)
+                self.device_name = f"device {device}"
+
+            def level(self):
+                return 0.4
+
+            def stop(self):
+                return b"AUDIO"
+
+        monkeypatch.setattr(voice, "Recorder", _Rec)
+        monkeypatch.setattr(voice, "transcribe", lambda wav: "after the switch")
+        result = _voice_input.record_voice_input(_FakeLive(), _console(), _KeySequence(["tab", "enter"]))
+        assert opened == [0, 1]  # restarted on the next device
+        assert result == "after the switch"
+
+    def test_a_dead_second_mic_falls_back_to_the_previous_one(self, monkeypatch):
+        """Tab onto a busy mic must not end the session — the take is already
+        gone, but the user keeps a working microphone and can carry on."""
+        from yeaboi.ui.shared import _voice_input
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        monkeypatch.setattr(voice, "resolve_device", lambda *a: 0)
+        monkeypatch.setattr(
+            voice,
+            "list_input_devices",
+            lambda: [
+                {"index": 0, "name": "Built-in", "channels": 1, "samplerate": 48000, "is_default": True},
+                {"index": 1, "name": "Busy USB", "channels": 2, "samplerate": 44100, "is_default": False},
+            ],
+        )
+        opened: list[int | None] = []
+
+        class _Rec:
+            def __init__(self, device=None, **kwargs):
+                opened.append(device)
+                if device == 1:
+                    raise OSError("Device busy")
+                self.device_name = f"device {device}"
+
+            def level(self):
+                return 0.4
+
+            def stop(self):
+                return b"AUDIO"
+
+        monkeypatch.setattr(voice, "Recorder", _Rec)
+        monkeypatch.setattr(voice, "transcribe", lambda wav: "kept going")
+        result = _voice_input.record_voice_input(_FakeLive(), _console(), _KeySequence(["tab", "enter"]))
+        assert opened == [0, 1, 0]  # tried the next mic, then reopened the previous
+        assert result == "kept going"  # …and the user was not dropped back to the screen
+
+    def test_both_mics_dead_gives_up_cleanly(self, monkeypatch):
+        from yeaboi import music
+        from yeaboi.ui.shared import _voice_input
+
+        events = []
+        monkeypatch.setattr(music, "pause_for_voice", lambda: events.append("pause"))
+        monkeypatch.setattr(music, "resume_after_voice", lambda: events.append("resume"))
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        monkeypatch.setattr(voice, "resolve_device", lambda *a: 0)
+        monkeypatch.setattr(
+            voice,
+            "list_input_devices",
+            lambda: [
+                {"index": 0, "name": "Built-in", "channels": 1, "samplerate": 48000, "is_default": True},
+                {"index": 1, "name": "Busy USB", "channels": 2, "samplerate": 44100, "is_default": False},
+            ],
+        )
+        calls = {"n": 0}
+
+        class _Rec:
+            def __init__(self, device=None, **kwargs):
+                calls["n"] += 1
+                if calls["n"] > 1:  # the switch and the fallback both fail
+                    raise OSError("Device busy")
+                self.device_name = f"device {device}"
+
+            def level(self):
+                return 0.4
+
+            def stop(self):
+                return b"AUDIO"
+
+        monkeypatch.setattr(voice, "Recorder", _Rec)
+        assert _voice_input.record_voice_input(_FakeLive(), _console(), _KeySequence(["tab", "x"])) is None
+        assert events == ["pause", "resume"]  # music restored even so
+
+    def test_tab_is_a_no_op_with_only_one_microphone(self, monkeypatch):
+        from yeaboi.ui.shared import _voice_input
+
+        mod = self._patch_voice(monkeypatch, transcript="unchanged")
+        monkeypatch.setattr(
+            voice,
+            "list_input_devices",
+            lambda: [{"index": 0, "name": "Built-in", "channels": 1, "samplerate": 48000, "is_default": True}],
+        )
+        assert mod is _voice_input
+        assert _voice_input.record_voice_input(_FakeLive(), _console(), _KeySequence(["tab", "enter"])) == "unchanged"
 
     def test_resumes_music_when_mic_fails(self, monkeypatch):
         from yeaboi import music

--- a/uv.lock
+++ b/uv.lock
@@ -3385,6 +3385,7 @@ charts = [
 dev = [
     { name = "matplotlib" },
     { name = "mcp" },
+    { name = "numpy" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -3447,6 +3448,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.9,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.9,<2" },
     { name = "notion-client" },
+    { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.24,<3" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "prompt-toolkit" },
     { name = "pygithub" },


### PR DESCRIPTION
## Summary

Dictation was hard to use on real hardware and hard to find at all.

Three problems, all fixed here:

1. **The microphone was never chosen.** yeaboi always recorded from PortAudio's system default, which is frequently not the mic the user means. Worse, PortAudio enumerates devices *once* at init, so a USB or Bluetooth mic plugged in after launch was invisible — the single most common cause of "it doesn't detect my external mic". There was also no way to tell whether the mic being used could hear you.
2. **Many mics refuse 16 kHz mono.** That is what Whisper wants, but plenty of USB and Bluetooth interfaces will not open with it. PortAudio raised out of the `InputStream` constructor and the whole feature looked broken on that hardware.
3. **The feature was invisible.** The "double-tap Space to speak" hint sat at the tail of a `no_wrap`/`ellipsis` line, so it was the first thing cropped on an 80-column terminal.

### What landed

- **`VOICE_DEVICE`** — a PortAudio index (`2`) or a case-insensitive name substring (`shure`); empty means the system default, exactly as before. Resolved in `voice.resolve_device`, so `config.py` never imports the optional audio stack.
- **Device enumeration + `refresh_devices()`**, which cycles PortAudio so a mic plugged in mid-session becomes visible. It refuses to run while a stream is open — the poker duel holds a `Recorder` on a server thread for a whole duel — and the check and the cycle happen under one lock hold so a `Recorder` opened in the gap cannot have PortAudio torn down under it.
- **`Recorder`** takes a device and falls back to the device's own sample rate and channel count when it refuses 16 kHz mono; the WAV carries the negotiated format and `transcribe()` downmixes and resamples. Recording native and converting once beats not recording at all. A new `monitor=True` mode keeps the level meter live while retaining nothing.
- **The recording indicator** gains an input-level meter, an elapsed clock, the name of the mic that actually opened, and a "no sound reaching the mic" warning — plus **Tab to switch microphone mid-take**.
- **Settings → Voice Input → Input Device** — an arrow-selectable picker with a live mic test, which is the only way to answer "is this the input that actually hears me?" (a laptop lid, a muted USB interface and a disconnected Bluetooth headset all still enumerate).
- **`yeaboi --list-audio-devices`** — the CLI diagnostic, which rescans first.
- **The affordance moved off the croppable hint line**: into the Panel title where there is one, and inlaid into the box's top border where the field is hand-drawn (the standup input). `_voice_hint()` now carries only the install-method-aware command, which a chip cannot express.

### Review findings addressed

The independent pre-ship review raised 8 should-fix items; all are fixed in this branch. Three were real bugs worth calling out:

- **`_next_device(None)` switched to the same microphone and destroyed the take.** With `VOICE_DEVICE` unset — the default state, and the state you are in when the silence warning tells you to press Tab — `current` is `None`, so the old "not found → start at the top" landed on `devices[0]`, usually the system default itself. Switching restarts the take, so the one remedy the feature advertises cost the user their recording to move to the mic they were already on. Now the default's own index is resolved first. The regression test is verified to fail against the old logic.
- **The mic test buffered audio indefinitely** — ~11 MB/min at 48 kHz stereo, on the page users leave open while plugging hardware in, for a WAV that was discarded. Hence `monitor` mode.
- **`refresh_devices` was check-then-act outside the lock**, and the stream count was incremented *after* `start()`. Both closed.

Also fixed: the Tab-failure path claimed to "fall back to the previous mic" but discarded the session — it now actually reopens the previous device; the windowed device list had no scrollbar (`tui-standards` rule 6); `VOICE_DEVICE` was missing from `.env.example`; and the standup chip had been put back in exactly the croppable position this change exists to escape, under a comment claiming the opposite.

One thing the review did not flag, found while fixing it: a failed `InputStream.start()` leaked the stream object itself, not just the counter.

## Test plan

- `make test` — **9830 passed, 47 skipped**, exit 0
- `make lint` — clean
- `make security` — SAST clean, no known CVEs
- ~30 new tests in `tests/unit/test_voice.py` (133 in that file total): device enumeration and resolution, format negotiation, downmix/resample arithmetic against real numpy, the mic picker and its live test, `_next_device`, `get_voice_device`, the stream-count invariants, and the inlaid box border staying square against a two-cell emoji
- No `frontend/` changes, so no `make web` needed

## Definition of Done

- Surface parity: `--list-audio-devices` added to the `settings` capability's CLI set; that capability already carries a `FeatureTip`, and voice has its own ambient tip
- Items 8 (Notion) and 9 (Slack) fire from the `pr-merged-close-loop` routine on merge
- Item 10 (review feedback) is not done here — `claude-review.yml` runs after CI succeeds, so its review does not exist yet

Note: **YEA-16** ("missing voice icon on text box") is subsumed by the chip work here but is a separate ticket, so `Closes YEA-54` will not close it — it needs closing by hand.

Closes YEA-54

🤖 Generated with [Claude Code](https://claude.com/claude-code)