### PR TITLE
narrow the planning chat to intake and hand off to the card pipeline

### DIFF
--- a/src/yeaboi/agent/chat_intake.py
+++ b/src/yeaboi/agent/chat_intake.py
@@ -33,8 +33,8 @@ GREETING_TEXT = (
     "I'll figure out whether this needs a Small plan (a ticket or two) or a "
     "Large one (epics and sprints) as we go — or force it any time with "
     "/small or /large. Prefer a questionnaire? /form opens one — and /finish "
-    "fills in defaults and builds the whole plan in one go. Type /help to see "
-    "every command."
+    "answers the rest with defaults. Once the questions are done I'll build the "
+    "plan and walk you through it stage by stage. Type /help to see every command."
 )
 
 SIZE_QUESTION_TEXT = (

--- a/src/yeaboi/agent/state.py
+++ b/src/yeaboi/agent/state.py
@@ -1305,9 +1305,12 @@ class ScrumState(_RequiredState, total=False):
     # exchange for transcript rebuild/export: [{"role": "user"|"ai", "text": str}].
     _chat_greeting_done: bool
     _chat_preamble: list[dict]
-    # /finish fast mode: the chat driver auto-accepts every review gate while
-    # this is set. Persisted so a fast run resumed mid-pipeline keeps
-    # auto-running; the driver clears it when the plan completes.
+    # /finish fast mode. The chat owns intake only, so in production this now
+    # spans a single deterministic turn ("defaults all" → the summary) and the
+    # driver pops it at the hand-off to the card pipeline — whose review gates
+    # never read it, and which stops at every one of them. It stays a state
+    # field, not a driver attribute, because the end-to-end chat path
+    # (stop_after_intake=False) still auto-accepts reviews while it is set.
     _chat_fast_forward: bool
 
     # Project analysis — structured synthesis of intake answers.

--- a/src/yeaboi/ui/session/__init__.py
+++ b/src/yeaboi/ui/session/__init__.py
@@ -168,6 +168,18 @@ def run_session(
         remove_session_logger()
 
 
+def _intake_complete(graph_state: dict) -> bool:
+    """True once the questionnaire is answered AND its summary has been accepted.
+
+    The single predicate behind two decisions — whether to open the chat at all
+    (a resumed session past intake goes straight to the card pipeline) and
+    whether the chat handed off or the user walked away mid-questionnaire. One
+    definition so the two can never disagree.
+    """
+    qs = graph_state.get("questionnaire")
+    return isinstance(qs, QuestionnaireState) and qs.completed and graph_state.get("pending_review") != "project_intake"
+
+
 def _run_session_body(
     live,
     console,
@@ -226,19 +238,22 @@ def _run_session_body(
         questionnaire.intake_mode = intake_mode
         graph_state["questionnaire"] = questionnaire
 
-    # ── Live chat: the conversational front end over the same graph ────────
-    # Every interactive planning run — new ("chat" asks the size in
-    # conversation; a preset mode from the roadmap hand-off is announced) and
-    # resumed (the transcript is rebuilt from persisted messages) — goes
-    # through the chat driver. The legacy phase pipeline remains only for
-    # export_only (headless auto-answer) and questionnaire imports.
-    if not export_only and questionnaire is None:
+    # ── Live chat: the questionnaire, and only the questionnaire ───────────
+    # The conversational front end owns the greeting, the size pick ("chat"
+    # asks it in conversation; a preset mode from the roadmap hand-off is
+    # announced), the intake Q&A and the summary confirmation. The moment the
+    # summary is accepted it hands the state back and the phase loop below
+    # takes over unchanged — reviews, exports and tracker sync stay on the card
+    # pipeline. Skipped entirely for export_only (headless auto-answer),
+    # questionnaire imports, and any resume that is already past intake.
+    chat_ran = False
+    if not export_only and questionnaire is None and not _intake_complete(graph_state):
         if graph_state.get("_intake_mode") == "chat":
             graph_state["_intake_mode"] = ""  # "" = ask the size in chat
         from yeaboi.ui.session.chat import run_chat_session
 
-        logger.info("Phase transition: chat")
-        final_state = run_chat_session(
+        logger.info("Phase transition: chat_intake")
+        graph_state = run_chat_session(
             live,
             console,
             graph,
@@ -249,23 +264,25 @@ def _run_session_body(
             dry_run=dry_run,
             initial_description=initial_description,
         )
-        if final_state is None:
+        if graph_state is None:
             return
-        if project_id and final_state.get("sprints"):
-            from yeaboi.persistence import generate_scrum_md
+        chat_ran = True
+        # No save point here: the chat replaces Phases A–C, and the driver's
+        # own _save() already runs on every exit path before it returns the
+        # state — a second upsert would write the same rows again.
+        if not _intake_complete(graph_state):
+            # Left mid-questionnaire — back to the project dashboard.
+            logger.info("Chat exited before intake completed")
+            return
 
-            generate_scrum_md(project_id)
-            logger.info("SCRUM.md generated: project_id=%s", project_id)
-        logger.info("Session complete")
-        return
-
-    logger.info("Phase transition: description_input")
     # ── Phase A: Description Input ─────────────────────────────────────
     # Multi-line text input for the initial project description.
     # This is the first thing the user types — their project overview.
-    # Skipped when resuming a project that already has messages.
+    # Skipped when resuming a project that already has messages, and when the
+    # chat already collected the description (and, in dry-run, the state).
     # In dry-run mode, the input is pre-filled with an example description.
-    if questionnaire is None and resume_graph_state is None:
+    if questionnaire is None and resume_graph_state is None and not chat_ran:
+        logger.info("Phase transition: description_input")
         desc_result = _phase_description_input(
             live, console, _key, dry_run=dry_run, scope_id=project_id, initial_text=initial_description
         )

--- a/src/yeaboi/ui/session/chat/_commands.py
+++ b/src/yeaboi/ui/session/chat/_commands.py
@@ -43,7 +43,7 @@ class ChatContext:
     intake_active: Callable[[], bool]  # questionnaire exists and not completed/confirmed
     questionnaire_exists: Callable[[], bool]
     enter_form: Callable[[], None]  # full-screen questionnaire takeover (/form)
-    fast_forward: Callable[[], None]  # defaults + auto-accept everything (/finish)
+    fast_forward: Callable[[], None]  # default every remaining answer (/finish)
     plan_complete: Callable[[], bool]  # sprints exist — nothing left to fast-forward
     toggle_duck: Callable[[], None]  # mute/unmute the companion duck's bubble (/duck)
 
@@ -91,8 +91,8 @@ def _cmd_form(ctx: ChatContext, args: str) -> None:
 
 
 def _cmd_finish(ctx: ChatContext, args: str) -> None:
-    # The driver sends the "defaults all" literal to the node and flags the
-    # session so every later review gate auto-accepts — see _fast_forward.
+    # The driver sends the "defaults all" literal to the node, which answers
+    # every remaining question and shows the summary — see _fast_forward.
     ctx.fast_forward()
 
 
@@ -164,7 +164,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         "finish",
-        "use defaults for everything and build the full plan with no more stops",
+        "answer the remaining questions with defaults",
         _cmd_finish,
         # Available pre-questionnaire too (the greeting advertises it) — the
         # driver defers until the description exists, like /form.

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -107,8 +107,16 @@ def run_chat_session(
     bell: bool = True,
     dry_run: bool = False,
     initial_description: str = "",
+    stop_after_intake: bool = True,
 ) -> dict | None:
-    """Run the whole planning conversation. Returns the final state (or None on quit pre-description)."""
+    """Run the intake conversation. Returns the final state (or None on quit pre-description).
+
+    stop_after_intake (the production default): the chat owns the greeting, the
+    size pick, the questions and the summary confirmation, then hands the state
+    back so the card pipeline can run the reviews. False keeps the original
+    end-to-end chat (the pipeline/review/epic/capacity path below) — used by the
+    tests that cover it.
+    """
     driver = _ChatDriver(
         live,
         console,
@@ -119,6 +127,7 @@ def run_chat_session(
         bell=bell,
         dry_run=dry_run,
         initial_description=initial_description,
+        stop_after_intake=stop_after_intake,
     )
     # The chat is one big typing surface — suppress bare-letter chrome
     # shortcuts ("c" controls etc.) for the whole session.
@@ -142,6 +151,7 @@ class _ChatDriver:
         bell: bool,
         dry_run: bool,
         initial_description: str,
+        stop_after_intake: bool = True,
     ) -> None:
         self.live = live
         self.console = console
@@ -152,6 +162,7 @@ class _ChatDriver:
         self.bell = bell
         self.dry_run = dry_run
         self.initial_description = initial_description
+        self.stop_after_intake = stop_after_intake
 
         self.transcript = ChatTranscript()
         self.composer = ChatComposer()
@@ -361,7 +372,13 @@ class _ChatDriver:
         logger.info("Chat: form takeover end (filled=%d)", filled)
 
     def _fast_forward(self) -> None:
-        """/finish — defaults for everything, then build the plan with no more stops."""
+        """/finish — default every remaining answer so the questions are done in one go.
+
+        It ends at the summary: the review gates after it belong to the card
+        pipeline, which stops at each one. _chat_fast_forward is still set
+        because the end-to-end chat path (stop_after_intake=False) reads it;
+        the handoff in run() pops it.
+        """
         if self.state.get("sprints"):
             self._note("The plan is already complete — /export saves it.")
             return
@@ -378,11 +395,11 @@ class _ChatDriver:
             # The intake node handles the literal — one deterministic turn
             # that defaults every remaining question and shows the summary.
             self._run_turn("defaults all", echo_user=True)
-            self._note("One **accept** on the summary builds the whole plan — no more stops.")
+            self._note("That's every question answered — **accept** the summary and I'll start building.")
         elif qs is not None and qs.awaiting_confirmation:
-            self._note("Fast mode on — accept the summary and the whole plan builds with no more stops.")
+            self._note("The questions are already done — **accept** the summary and I'll start building.")
         else:
-            self._note("Fast mode on — remaining reviews will be auto-accepted.")
+            self._note("Nothing left to fast-forward.")
         self._save()
 
     def _switch_size(self, target_mode: str) -> None:
@@ -495,6 +512,18 @@ class _ChatDriver:
         messages = list(self.state.get("messages", []))
         if text:
             messages.append(HumanMessage(content=text))
+        if intake_turn:
+            # The intake confirmation is the one turn the chat sends while a
+            # review gate is still open — project_intake consumes the reply
+            # itself rather than a review card doing it. Its confirm branch
+            # returns no "pending_review", and pending_review is a plain
+            # LastValue channel (agent/state.py), so whatever is in the input
+            # state survives the invoke: leave it set and the gate never
+            # closes, _stage() stays "intake" forever and the handoff below
+            # never fires. The card path pops it for exactly this reason
+            # (phases/_phases_review.py). Safe to drop unconditionally — the
+            # node re-sets it when the summary needs showing again ("edit").
+            self.state.pop("pending_review", None)
         invoke_state = {**self.state, "messages": messages}
         if images:
             if intake_turn:
@@ -1376,6 +1405,14 @@ class _ChatDriver:
 
         while not self.quit:
             stage = self._stage()
+            if self.stop_after_intake and stage != "intake":
+                # The questionnaire is accepted — the card pipeline owns
+                # everything from here (reviews, exports, tracker sync,
+                # capacity), so hand the state back before any of the branches
+                # below can fire.
+                self.state.pop("_chat_fast_forward", None)
+                logger.info("Chat handing off after intake (next stage=%s)", stage)
+                break
             if stage == "capacity":
                 self._capacity_popup()
                 continue
@@ -1481,7 +1518,7 @@ class _ChatDriver:
         from yeaboi.prompts.intake import QUESTION_DEFAULTS, is_choice_question
 
         if q > 20:
-            return "/finish builds the rest with defaults"
+            return "/finish answers the rest with defaults"
         if is_choice_question(q):
             return "Type the number — or ↑/↓ then Enter"
         if q in QUESTION_DEFAULTS:

--- a/src/yeaboi/ui/session/chat/_screen.py
+++ b/src/yeaboi/ui/session/chat/_screen.py
@@ -69,7 +69,7 @@ _TIPS_PAIRS = [
     ("␣␣", "double-tap Space to speak"),
     ("/form", "fill it out as a form"),
     ("alt+enter", "new line"),
-    ("/finish", "defaults + build, no stops"),
+    ("/finish", "answer the rest with defaults"),
     ("/export", "save plan + chat"),
 ]
 

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -71,7 +71,7 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
     ),
     FeatureTip(
         "planning",
-        "\U0001f5fa️ Tip: Planning is one continuous chat — /form gives a classic form, /finish builds it in one go",
+        "\U0001f5fa️ Tip: Planning starts as a chat — /form gives a classic form, /finish defaults the rest",
         mode_key="project-planning",
         is_new=True,
     ),

--- a/tests/unit/test_chat_driver.py
+++ b/tests/unit/test_chat_driver.py
@@ -1,5 +1,6 @@
 """Tests for the chat driver — greeting flow, review replies, guardrails."""
 
+import time
 from io import StringIO
 from unittest.mock import patch
 
@@ -27,6 +28,24 @@ class FakeGraph:
         return self.results.pop(0) if self.results else state
 
 
+class MergingFakeGraph(FakeGraph):
+    """FakeGraph with LangGraph's merge semantics for the keys that survive.
+
+    The plain fake returns its scripted dict verbatim, so a key the script
+    omits reads as "the node cleared it". A real graph does the opposite: the
+    state channels here are LastValue, so a key the node does not return keeps
+    its incoming value. That difference is load-bearing for exactly one
+    transition — accepting the intake summary, where project_intake returns no
+    `pending_review` — so the hand-off must be tested against a fake that
+    models it. Anything else would be asserting a property of the fixture.
+    """
+
+    def invoke(self, state: dict) -> dict:
+        self.invocations.append(state)
+        scripted = self.results.pop(0) if self.results else {}
+        return {**state, **scripted}
+
+
 def _keys(sequence: list[str]):
     remaining = list(sequence)
 
@@ -40,7 +59,24 @@ def _console(width: int = 100) -> Console:
     return Console(file=StringIO(), width=width, height=40, force_terminal=True, color_system="truecolor")
 
 
-def _driver(graph, keys, state=None, *, dry_run: bool = False, width: int = 100) -> _ChatDriver:
+def _driver(
+    graph,
+    keys,
+    state=None,
+    *,
+    dry_run: bool = False,
+    width: int = 100,
+    stop_after_intake: bool = True,
+) -> _ChatDriver:
+    """Build a driver in the production configuration.
+
+    stop_after_intake defaults to True because that is what run_chat_session
+    passes; a helper defaulting the other way would leave the branch's own risk
+    — a flag that changes the run loop's exit condition — as the one thing the
+    suite never exercises by default. The tests that cover the end-to-end chat
+    path (pipeline stages, review cards, the epic step, capacity) pass
+    stop_after_intake=False explicitly, which is the only caller of it now.
+    """
     return _ChatDriver(
         FakeLive(),
         _console(width),
@@ -51,6 +87,7 @@ def _driver(graph, keys, state=None, *, dry_run: bool = False, width: int = 100)
         bell=False,
         dry_run=dry_run,
         initial_description="",
+        stop_after_intake=stop_after_intake,
     )
 
 
@@ -384,7 +421,7 @@ class TestIntakeCoaching:
         driver._idle_since = time.monotonic() - 10.0
         driver._idle_tick()
         assert driver.duck._line is not None
-        assert driver.duck._line.text == "/finish builds the rest with defaults"
+        assert driver.duck._line.text == "/finish answers the rest with defaults"
         assert driver._hinted_q == 25
 
     def test_hint_fires_at_most_once_per_question(self):
@@ -876,7 +913,9 @@ class TestFastForward:
             "_chat_greeting_done": True,
         }
         graph = ExplodingGraph()
-        driver = _driver(graph, _keys(["esc", "esc"]), state)
+        # End-to-end chat path: the pipeline stage only runs in the chat when
+        # the driver is not handing off after intake.
+        driver = _driver(graph, _keys(["esc", "esc"]), state, stop_after_intake=False)
         driver.run()
         assert graph.calls == 1  # one attempt, then the pause — no hot loop
         assert any("send any message to retry" in m.text for m in driver.transcript.messages)
@@ -967,7 +1006,160 @@ class TestFastForward:
             "_chat_fast_forward": True,
             "_chat_greeting_done": True,
         }
-        driver = _driver(FakeGraph([]), _keys(["esc", "esc"]), state)
+        # The "fast mode done" note belongs to the end-to-end chat path — the
+        # one that auto-accepts reviews and reaches plan completion in chat.
+        driver = _driver(FakeGraph([]), _keys(["esc", "esc"]), state, stop_after_intake=False)
         driver.run()
         assert "_chat_fast_forward" not in driver.state
         assert any("Fast mode done" in m.text for m in driver.transcript.messages)
+
+
+def _bounded_keys(sequence: list[str], deadline_seconds: float = 5.0):
+    """_keys, but it raises if the driver is still asking long after the script.
+
+    The run loop polls for a key every frame and reads "" as "nothing
+    pressed", so a driver that fails to exit spins forever instead of failing
+    — which is exactly what a regression in the intake hand-off looks like.
+    Raising turns that hang into a normal test failure with a traceback.
+
+    The bound is wall-clock, not a poll count: the streamed accept turn
+    legitimately polls a couple of hundred times while the worker thread
+    runs, and how many depends on scheduling, so any count tight enough to
+    catch a spin is also tight enough to fail a healthy run on a loaded
+    machine. In wall-clock the two are nowhere near each other — a hand-off
+    run finishes in ~0.04s, a spin polls indefinitely.
+    """
+    remaining = list(sequence)
+    started = [0.0]
+
+    def _key(timeout: float = 0.0) -> str:
+        if remaining:
+            return remaining.pop(0)
+        now = time.monotonic()
+        if not started[0]:
+            started[0] = now
+        elif now - started[0] > deadline_seconds:
+            raise AssertionError("driver never exited — the intake hand-off did not fire")
+        return ""
+
+    return _key
+
+
+class TestIntakeHandoff:
+    """The production default: the chat ends when the summary is accepted and
+    the card pipeline takes over. Nothing past intake may run here."""
+
+    def _confirmation_state(self) -> dict:
+        qs = QuestionnaireState(intake_mode="small_project")
+        qs.awaiting_confirmation = True
+        qs.current_question = 31
+        return {
+            "messages": [HumanMessage(content="desc"), AIMessage(content="Here is the summary.")],
+            "questionnaire": qs,
+            "pending_review": "project_intake",
+            "_intake_mode": "small_project",
+            "_chat_greeting_done": True,
+        }
+
+    def _accepted_state(self) -> dict:
+        done = QuestionnaireState(intake_mode="small_project")
+        done.completed = True
+        done.current_question = 31
+        return {
+            "messages": [
+                HumanMessage(content="desc"),
+                AIMessage(content="Here is the summary."),
+                HumanMessage(content="accept"),
+                AIMessage(content="Building."),
+            ],
+            "questionnaire": done,
+            "_intake_mode": "small_project",
+            "_chat_greeting_done": True,
+        }
+
+    def test_accepting_the_summary_hands_off_without_running_the_pipeline(self):
+        # MergingFakeGraph, not FakeGraph: project_intake's confirm branch
+        # returns no "pending_review", so on a real graph the gate closes only
+        # because the driver popped it before invoking. A verbatim fake would
+        # make this pass either way.
+        graph = MergingFakeGraph([self._accepted_state()])
+        keys = _bounded_keys([*"accept", "enter"])
+        driver = _driver(graph, keys, self._confirmation_state())
+
+        final = driver.run()
+
+        # Exactly one invoke — the accept. The pipeline stages that would
+        # follow belong to the card phases now.
+        assert len(graph.invocations) == 1
+        assert final["questionnaire"].completed is True
+        assert "pending_review" not in final
+        assert driver.quit is False
+
+    def test_the_accept_turn_clears_the_gate_before_invoking(self):
+        # The pop must happen on the way in, not be inferred from the result:
+        # pending_review is a LastValue channel, so a value still present in
+        # the invoke state comes straight back out and the gate never closes.
+        # Driven through _run_turn directly so a regression fails here on one
+        # assertion, before the run loop has a chance to spin on it.
+        graph = MergingFakeGraph([self._accepted_state()])
+        driver = _driver(graph, _keys([]), self._confirmation_state())
+
+        assert driver._run_turn("accept", echo_user=True) is True
+
+        assert "pending_review" not in graph.invocations[0]
+        assert "pending_review" not in driver.state
+        assert driver._stage() != "intake"
+
+    def test_handoff_clears_fast_forward(self):
+        state = self._confirmation_state()
+        state["_chat_fast_forward"] = True
+        graph = MergingFakeGraph([self._accepted_state()])
+        driver = _driver(graph, _bounded_keys([*"accept", "enter"]), state)
+
+        final = driver.run()
+
+        # The card pipeline stops at every review gate — a stale fast-forward
+        # flag must not ride along and imply otherwise.
+        assert "_chat_fast_forward" not in final
+
+    def test_quitting_at_the_summary_leaves_intake_incomplete(self):
+        # Esc Esc at the confirmation gate: the session must go back to the
+        # dashboard, not fall through into the pipeline.
+        driver = _driver(FakeGraph([]), _keys(["esc", "esc"]), self._confirmation_state())
+
+        final = driver.run()
+
+        assert final["questionnaire"].completed is False
+        assert final["pending_review"] == "project_intake"
+
+    def test_questions_still_run_in_chat(self):
+        # The questionnaire itself is untouched by the handoff — a mid-intake
+        # answer goes through the graph and the next question lands in chat.
+        # Driven a turn at a time rather than through run(), which would sit in
+        # the input loop waiting for the next answer.
+        qs = QuestionnaireState(intake_mode="small_project")
+        qs.current_question = 6
+        state = {
+            "messages": [HumanMessage(content="desc"), AIMessage(content="Q6?")],
+            "questionnaire": qs,
+            "_intake_mode": "small_project",
+            "_chat_greeting_done": True,
+        }
+        next_qs = QuestionnaireState(intake_mode="small_project")
+        next_qs.current_question = 7
+        after = {
+            "messages": [*state["messages"], HumanMessage(content="four"), AIMessage(content="Q7?")],
+            "questionnaire": next_qs,
+            "_intake_mode": "small_project",
+            "_chat_greeting_done": True,
+        }
+        graph = FakeGraph([after])
+        driver = _driver(graph, _keys([]), state)
+
+        assert driver._stage() == "intake"
+        assert driver._run_turn("four", echo_user=True) is True
+
+        assert len(graph.invocations) == 1
+        assert any("Q7?" in m.text for m in driver.transcript.messages)
+        # Still intake — the handoff must not fire until the summary is accepted.
+        assert driver._stage() == "intake"

--- a/tests/unit/test_session_handoff.py
+++ b/tests/unit/test_session_handoff.py
@@ -1,0 +1,168 @@
+"""The chat → card-pipeline hand-off in ui/session/__init__.py.
+
+Lives in tests/unit/ rather than beside the rest of the session tests in
+tests/test_session.py because that file sits at the tests/ root, which no gate
+runs: `make test` and `make test-fast` both enumerate tests/unit,
+tests/integration and tests/contract explicitly. A hand-off test that never
+executes is worse than none — it reads as covered.
+"""
+
+from io import StringIO
+from unittest.mock import MagicMock
+
+from rich.console import Console
+
+
+def _make_console(width: int = 100, height: int = 30) -> Console:
+    c = Console(file=StringIO(), width=width, force_terminal=True, color_system="truecolor")
+    c._size = (width, height)
+    return c
+
+
+class TestIntakeComplete:
+    """_intake_complete is the single predicate behind two decisions — whether
+    to open the chat at all, and whether it handed off or the user walked away.
+    Both read it, so every branch is exercised here on its own."""
+
+    def _qs(self, *, completed: bool, awaiting: bool = False):
+        from yeaboi.agent.state import QuestionnaireState
+
+        qs = QuestionnaireState(intake_mode="small_project")
+        qs.completed = completed
+        qs.awaiting_confirmation = awaiting
+        return qs
+
+    def test_no_questionnaire_is_not_complete(self):
+        from yeaboi.ui.session import _intake_complete
+
+        assert _intake_complete({}) is False
+        assert _intake_complete({"questionnaire": None}) is False
+
+    def test_non_questionnaire_value_is_not_complete(self):
+        # Persisted state can round-trip a dict where a QuestionnaireState is
+        # expected; the isinstance guard must not be an AttributeError.
+        from yeaboi.ui.session import _intake_complete
+
+        assert _intake_complete({"questionnaire": {"completed": True}}) is False
+
+    def test_mid_questionnaire_is_not_complete(self):
+        from yeaboi.ui.session import _intake_complete
+
+        assert _intake_complete({"questionnaire": self._qs(completed=False)}) is False
+
+    def test_awaiting_the_summary_is_not_complete(self):
+        from yeaboi.ui.session import _intake_complete
+
+        state = {
+            "questionnaire": self._qs(completed=False, awaiting=True),
+            "pending_review": "project_intake",
+        }
+        assert _intake_complete(state) is False
+
+    def test_completed_and_accepted_is_complete(self):
+        from yeaboi.ui.session import _intake_complete
+
+        assert _intake_complete({"questionnaire": self._qs(completed=True)}) is True
+
+    def test_completed_but_gate_still_open_is_not_complete(self):
+        # The second conjunct on its own: answers locked in, yet the intake
+        # review gate is still posted. Accepting the summary must clear it
+        # (the chat driver pops it before the confirm invoke), so this state
+        # means the gate was never closed — not that intake is done.
+        from yeaboi.ui.session import _intake_complete
+
+        state = {"questionnaire": self._qs(completed=True), "pending_review": "project_intake"}
+        assert _intake_complete(state) is False
+
+    def test_a_later_pipeline_gate_does_not_reopen_intake(self):
+        # Only the intake gate counts — a resumed session paused at a story
+        # review is past intake and belongs to the card pipeline.
+        from yeaboi.ui.session import _intake_complete
+
+        state = {"questionnaire": self._qs(completed=True), "pending_review": "story_writer"}
+        assert _intake_complete(state) is True
+
+
+class TestChatToPipelineHandoff:
+    """The chat runs the questionnaire; the card pipeline runs everything after."""
+
+    def _completed_state(self) -> dict:
+        from yeaboi.agent.state import QuestionnaireState
+
+        qs = QuestionnaireState(intake_mode="small_project")
+        qs.completed = True
+        return {"messages": [], "questionnaire": qs, "_intake_mode": "small_project"}
+
+    def _run_body(self, monkeypatch, *, chat_result, resume_state=None):
+        """Run _run_session_body with the chat and every phase stubbed out."""
+        import yeaboi.ui.session as session_mod
+
+        calls: list[str] = []
+        monkeypatch.setattr(session_mod, "create_graph", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(session_mod, "save_project_snapshot", lambda *a, **k: None)
+
+        def fake_chat(*_a, **_kw):
+            calls.append("chat")
+            return chat_result
+
+        monkeypatch.setattr("yeaboi.ui.session.chat.run_chat_session", fake_chat)
+
+        def fake_description(*_a, **_kw):
+            calls.append("description")
+            return None
+
+        def fake_pipeline(_live, _console, _graph, graph_state, *_a, **_kw):
+            calls.append("pipeline")
+            return graph_state
+
+        def fake_intake_questions(_live, _console, _graph, graph_state, *_a, **_kw):
+            calls.append("intake_questions")
+            return graph_state
+
+        monkeypatch.setattr(session_mod, "_phase_description_input", fake_description)
+        monkeypatch.setattr(session_mod, "_phase_pipeline", fake_pipeline)
+        monkeypatch.setattr(session_mod, "_phase_intake_questions", fake_intake_questions)
+
+        session_mod._run_session_body(
+            MagicMock(),
+            _make_console(),
+            "chat",
+            "",  # project_id — empty so nothing persists
+            lambda: "",
+            lambda *_a, **_kw: "",
+            questionnaire=None,
+            resume_graph_state=resume_state,
+            export_only=False,
+            bell=False,
+            dry_run=False,
+        )
+        return calls
+
+    def test_completed_intake_hands_off_to_the_card_pipeline(self, monkeypatch):
+        calls = self._run_body(monkeypatch, chat_result=self._completed_state())
+        # The chat collected the description, so the old description editor
+        # must stay skipped — and the pipeline must actually run.
+        assert calls == ["chat", "pipeline"]
+
+    def test_leaving_mid_questionnaire_returns_to_the_dashboard(self, monkeypatch):
+        from yeaboi.agent.state import QuestionnaireState
+
+        qs = QuestionnaireState(intake_mode="small_project")  # not completed
+        state = {"messages": [], "questionnaire": qs}
+        calls = self._run_body(monkeypatch, chat_result=state)
+        assert calls == ["chat"]
+
+    def test_summary_not_yet_accepted_is_not_complete(self, monkeypatch):
+        state = self._completed_state()
+        state["pending_review"] = "project_intake"
+        state["questionnaire"].completed = False
+        calls = self._run_body(monkeypatch, chat_result=state)
+        assert calls == ["chat"]
+
+    def test_resume_past_intake_skips_the_chat(self, monkeypatch):
+        calls = self._run_body(monkeypatch, chat_result=None, resume_state=self._completed_state())
+        assert calls == ["pipeline"]
+
+    def test_quit_during_the_greeting_returns_none(self, monkeypatch):
+        calls = self._run_body(monkeypatch, chat_result=None)
+        assert calls == ["chat"]

--- a/tests/unit/test_tips.py
+++ b/tests/unit/test_tips.py
@@ -193,7 +193,7 @@ def test_build_tips_text_marks_beta(monkeypatch):
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
     lines = _tips.build_tips_text().splitlines()
     perf_line = next(line for line in lines if "Performance preps 1:1s" in line)
-    planning_line = next(line for line in lines if "Planning is one continuous chat" in line)
+    planning_line = next(line for line in lines if "Planning starts as a chat" in line)
     assert "(BETA)" in perf_line
     assert "(BETA)" not in planning_line
     _clear_cache()


### PR DESCRIPTION
## Summary

The planning chat owned the whole run end to end — greeting, size pick, intake, summary, then every pipeline stage, review gate, the epic step, capacity and exports. This narrows it to **intake only**.

The chat still owns the greeting, the size pick, the intake Q&A and the summary confirmation. The moment the summary is accepted it hands the state back to `_run_session_body`, and the pre-existing card phase pipeline runs everything after — reviews, exports, tracker sync — unchanged.

- **`_intake_complete()`** (`ui/session/__init__.py`) is the single predicate behind two decisions: whether to open the chat at all (a resume already past intake goes straight to the pipeline), and whether the chat handed off or the user walked away mid-questionnaire (→ back to the project dashboard). One definition so the two can never disagree.
- **`stop_after_intake`** on the driver (default `True`) is the hand-off. `False` keeps the original end-to-end chat path, which the tests covering it still exercise.
- **`/finish` no longer means "build the whole plan with no stops."** It answers the remaining questions with defaults and ends at the summary; the card pipeline stops at each review gate. Copy updated in the greeting, the command list, the chat tips strip, the idle hint and the feature tip.

### The bug this turned up

The hand-off did not work on the real graph, only in dry-run. `project_intake`'s confirm branch returns no `pending_review`, and `pending_review` is a plain `LastValue` channel — so a value left in the invoke state comes straight back out. `_stage()` would report `"intake"` forever, the hand-off would never fire, and a resumed session would reopen the chat into the same dead end. The card path already pops it (`phases/_phases_review.py`); the chat now does the same before the confirm invoke.

The branch's original tests could not catch this: `FakeGraph` returns its scripted dict verbatim, so omitting `pending_review` read as "the node cleared it" — asserting a property of the fixture. Added `MergingFakeGraph`, which models LastValue merge semantics, and the hand-off tests now run against it.

## Not addressed here

**Post-plan free-refinement chat is gone.** On `main`, once `sprints` existed the chat stayed open for refine-by-chatting plus the completion recap. `_run_session_body` has no chat after `_phase_pipeline` — it writes SCRUM.md and returns to the dashboard. Per-artifact refinement still exists at each card review gate, but the free-form post-plan conversation does not. That is a consequence of moving the pipeline back to the cards, not an oversight; flagging it explicitly rather than burying it.

Relatedly, `_capacity_popup`, `_epic_step`, `_run_pipeline_stage`, `_auto_accept_review`, `_review_reply`, `_tracker_sync` and `_maybe_celebrate_completion` are now reachable only via `stop_after_intake=False`. Deleting ~450 lines of driver code is a larger change than this branch should carry — worth a follow-up once the shape settles.

## Test plan

- `make test` — 9749 passed, 47 skipped
- `make lint` — clean
- `uv run ruff format --check src/ tests/` — clean (the CI gate `make lint` does not cover)
- `make security` — SAST clean, no known CVEs
- New `tests/unit/test_session_handoff.py`: 7 direct cases over `_intake_complete` (no questionnaire, non-`QuestionnaireState` value, mid-questionnaire, awaiting summary, accepted, completed-but-gate-open, later pipeline gate) plus 5 over the `_run_session_body` hand-off.
  **These deliberately live in `tests/unit/`**: the branch originally put them in `tests/test_session.py`, which sits at the `tests/` root — and both `make test` and `make test-fast` enumerate `tests/unit`, `tests/integration`, `tests/contract` explicitly, so nothing there ever runs.
- New `TestIntakeHandoff` in `tests/unit/test_chat_driver.py`, verified to fail without the `pending_review` fix and pass with it.
- The `_driver()` test helper now defaults to the production `stop_after_intake=True`; the end-to-end chat tests pass `False` explicitly.

No `frontend/` changes, so no `make web`. No new capability, so no `CAPABILITIES` row — the existing planning `FeatureTip` was re-worded and its test updated.

Closes YEA-56

🤖 Generated with [Claude Code](https://claude.com/claude-code)