### PR TITLE
fix the daily digest's slack dialect and respecify its body as a worked example

### DIFF
--- a/.claude/agents/cowork-scribe.md
+++ b/.claude/agents/cowork-scribe.md
@@ -78,18 +78,42 @@ Approve by adding the `claude-implement` label. Reject by closing this issue.
 Impact, effort and risk come from the scout's find — surface them, never re-score them. The closing
 line carries both verbs because an issue that only says how to approve leaves rejecting to silence.
 
-**Slack** — plain sentences, no preamble, no emoji headers. One message per event. Links are inline
-and named, never bare URLs. Lines that carry a proposal or a ship note lead with the same
-`[type][workstream]` tag as the issue title, then one short clause — a scannable line, never a
-run-on paragraph. The daily digest's headings — one per proposal type, plus the `feature-candidate`
-heading — are bold text (`*Bugs*`), never emoji: that is what "no emoji headers" rules out, not the
-headings themselves.
+**Slack** — plain sentences, no preamble. One message per event. Lines that carry a proposal or a
+ship note lead with the same `[type][workstream]` tag as the issue title, then one short clause — a
+scannable line, never a run-on paragraph.
+
+**The dialect is standard Markdown, not Slack mrkdwn.** The connector takes `**bold**`, `_italic_`,
+`` `code` ``, `1.` ordered lists and `[title](url)` links. Slack's own mrkdwn — `*bold*`,
+`<url|title>` — is *not* what it accepts, and the two disagree in the worst possible way: mrkdwn's
+`*bold*` is Markdown's *italic*. This file used to specify headings as `*Bugs*`, so the daily digest
+shipped italic headings and leaked stray `_` characters mid-line for weeks, with nothing in the
+system able to notice. Write the Markdown form.
+
+Links are **embedded in the text they name** — `[the issue title](url)` — never a bare URL and never
+a URL trailing in parentheses after the thing it belongs to, which is what pushes a digest line over
+two wraps. Escape any `[` or `]` *inside* link text as `\[` `\]`: issue titles routinely carry
+`claude[bot]`. Balanced brackets are legal in CommonMark link text, so that usually survives
+unescaped; what kills the link is an *unbalanced* bracket, or a bracketed run that matches a real
+reference definition. Escaping means never having to work out which case today's title is. The
+`[type][workstream]` tag sits *outside* the link for the same reason — outside, it is not link text
+at all and needs no escaping.
+
+Emoji are anchors, not decoration. The daily digest's section headings — one per proposal type, plus
+`feature-candidate`, marketing, the two health sections and the Monday calibration section — are
+**one fixed emoji plus bold text**
+(`🐛 **Bugs**`), the emoji constant per section so a returning reader finds a section by shape
+before they read a word; `cron/digest.md` owns the table. Everywhere else, and in prose anywhere,
+no emoji: a ship note is one line and a decorated one line is just a decorated one line. Never spend
+✅ or ❌ decoratively in any message — those two are the approval verbs, and a reader who sees them
+in a heading has to work out whether they mean something.
 
 The daily digest is the one event with a thread: after its single channel message, post one reply
 per listed item **into that message's thread**, shaped `#<issue-number> — <verbatim title> —
 <issue link>`, the number first. The shape is a contract, not a style — `cron/slack-relay.md`
 parses these replies to map a ✅/❌ reaction onto an issue, so a reply that drops the leading
-number is an approval that cannot land.
+number is an approval that cannot land. **The reply is exempt from every formatting rule above**:
+no list marker, no emoji, no embedded link, no bold. It is parsed before it is read, and prettifying
+it breaks approvals rather than the look of anything.
 
 **Notion** — search before creating; update an existing page rather than making a near-duplicate.
 Nest under 🤙 yeaboi. Title pages so they sort usefully (`Draft — <subject> — <YYYY-MM-DD>`).

--- a/cowork/routines/cron/digest.md
+++ b/cowork/routines/cron/digest.md
@@ -42,38 +42,153 @@ The single decision point. It is the only routine that posts proposals to Slack.
    the feedback system's fallback and is never emitted by a cowork scout, so an `other` or untyped
    proposal falls into the remainder count below.
 
-3. **Post one Slack message** to `#yeaboi-claude` via `cowork-scribe`:
-   - up to **3 proposals per type**, each type under a bold heading carrying its open count —
-     `*Bugs* (12 open — top 3)`, and drop the `— top 3` when the bucket is listed in full, because
-     `(2 open — top 3)` reads as a promise the section did not keep — and each proposal one line
-     underneath: `<issue title> — why-now
-     clause (issue link)`. The title comes from the issue verbatim and already leads with its
-     `[type][workstream]` tag — never add a second one, and never strip the tag because the heading
-     appears to make it redundant: the tag is what `cowork-scribe`'s title contract guarantees, and
-     it is what survives the line being quoted anywhere else. For an old issue whose title lacks the
-     tag, prepend it from the issue's labels. The why-now is one clause, not a sentence chain — if a
-     line wraps twice it is too long
-   - the count of everything else, **by workstream** — the other axis, on purpose. The headings above
-     already carry the per-type counts, so a per-type remainder would only restate them; the
-     per-workstream remainder is the one place a reader learns which surface the backlog is piling
-     up on. Omit the line entirely when the sections above listed everything — a remainder of zero
-     is not a fact anyone needs
-   - the oldest 3 `feature-candidate` issues, under their own heading — these came from users, so
-     they are listed separately rather than ranked against scout finds, and by age rather than by
-     impact: a reported bug that has waited a month is the fact worth surfacing
-   - this week's marketing draft link, if one exists and no earlier digest has carried it
-   - the reminder that approval is ✅ on an item's thread reply (relayed within the hour — or
-     `/cowork run slack-relay` for right now) or adding `claude-implement` on GitHub, and rejection
-     is ❌ or closing the issue — the digest still names the verbs, because a reader who has
-     forgotten them has nowhere else to look
+3. **Post one Slack message** to `#yeaboi-claude` via `cowork-scribe`, in **standard Markdown** —
+   the connector is not Slack mrkdwn, and `cowork-scribe`'s Slack format block says why that
+   distinction is the difference between a bold heading and an italic one. This is the shape,
+   literally:
+
+   ```
+   🔒 **Security** (1 open)
+
+   1. **[security][web-ux]** [Third-party CDN script (unpkg lenis) on all 20 docs pages, no SRI](https://github.com/dinho149/yeaboi.ai/issues/172)
+      — a compromised CDN can inject JS into every docs page
+
+   ───────────────────────────
+
+   🐛 **Bugs** (12 open — top 3)
+
+   1. **[bug][platform]** [auto-version.yml rejects claude\[bot\] PRs](https://github.com/dinho149/yeaboi.ai/issues/146)
+      — blocks version bumps on every cowork PR, stalling #145, #156, #184
+
+   2. **[bug][poker]** [concurrent finalize can double-write tracker points](https://github.com/dinho149/yeaboi.ai/issues/143)
+      — can silently corrupt a team's point tracker
+
+   3. **[bug][web-ux]** [share gate 500s when the invite code carries a trailing space](https://github.com/dinho149/yeaboi.ai/issues/139)
+      — locks a remote teammate out of every share
+
+   ───────────────────────────
+
+   💡 **Feature candidates** (7 open — oldest 3)
+
+   1. **[bug][standup]** [Standup export drops the last member on a 12-person team](https://github.com/dinho149/yeaboi.ai/issues/131)
+      — reported 34 days ago, still open
+
+   2. **[improvement][usage]** [Usage page should total the month, not just the week](https://github.com/dinho149/yeaboi.ai/issues/128)
+      — reported 41 days ago, still open
+
+   3. **[feature][general]** [Let me pin a mode as the default on launch](https://github.com/dinho149/yeaboi.ai/issues/119)
+      — reported 52 days ago, still open
+   ```
+
+   Every section in it is listed in full to its own heading's promise: three items under
+   `— top 3`, three under `— oldest 3`. That is the point of the count, and an example that
+   promised twelve and showed two would be teaching the anti-pattern the heading rule forbids.
+
+   The rules that shape it:
+
+   - **At most 3 proposals per type**, ranked by the step-2 order. The cap is a rule, not an
+     artefact of the heading template: it is what keeps a fourteen-bug morning from burying the one
+     security find, and it is what fixes the thread at eighteen proposal replies. `cowork/README.md`
+     states the same cap; if you change one, change both.
+   - **Headings** are `<emoji> **<Section>** (<n> open — top 3)`. Drop the `— top 3` when the bucket
+     is listed in full, because `(2 open — top 3)` reads as a promise the section did not keep. The
+     emoji is fixed per section (table below) so a returning reader finds a section by shape before
+     reading a word; it is an anchor, and picking a fresh one each morning defeats the point.
+   - **Items are an ordered list**, numbering restarting at `1.` in every section. The ordinal is a
+     position in today's message, nothing more — the issue number lives in the link and in the thread
+     reply. Put a blank line between items: that is what makes the list *loose* and gives a two-line
+     item room to read as one item. Lines that are not list items at all fold into a single
+     paragraph, which is exactly how this message used to render — three bugs in one grey block.
+   - **Line one** is the tag, then the linked title:
+     `**[type][workstream]** [<title without its tag>](<issue url>)`. The link wraps the title —
+     never a URL trailing in parentheses after it, which is what crammed the old body.
+     Escape any `[` or `]` surviving *inside* the link text as `\[` `\]` — issue titles routinely
+     carry `claude[bot]`. Balanced brackets are legal in CommonMark link text, so `claude[bot]`
+     usually survives unescaped; what kills the link is an *unbalanced* bracket, or a title whose
+     bracketed run happens to match a real reference definition. Escaping is how you stop having to
+     work out which case today's title is. The tag sits *outside* the link for the same reason —
+     outside, it is not link text at all and needs no escaping, which is also why the unescaped
+     `**[bug][platform]**` in the example above is safe where the same characters inside the
+     parentheses would not be. The tag comes from the issue verbatim — never add a second one, and never strip it
+     because the heading appears to make it redundant: the tag is what `cowork-scribe`'s title
+     contract guarantees, and it is what survives the line being quoted anywhere else. For an old
+     issue whose title lacks the tag, prepend it from the issue's labels.
+   - **Line two is the why-now clause**, indented under the title and prefixed `— `. One clause, not
+     a sentence chain — it owns a line now, which makes a long one more tempting and no more
+     readable. If it wraps, it is too long.
+
+     A plain newline is enough to get the second line, because a Slack message has no paragraph
+     model to collapse it into — the text is rendered with the breaks it was sent with. That is the
+     same fact the divider rule below leans on from the other side. It is, though, the one part of
+     this shape that depends on the connector rather than on Markdown: if a digest ever arrives with
+     the why-now folded onto the title's line, end line one with a trailing `\` (a CommonMark hard
+     break) rather than re-deriving the cause. Nothing checks this statically.
+   - **A divider between every section** — `───────────────────────────`, typed box-drawing
+     characters. Not Markdown `---`: Slack has no horizontal-rule element for a converter to map it
+     onto, so it is dropped silently or rendered as three literal dashes. Characters always survive.
+
+   The emoji, one per section, fixed:
+
+   | Section | Emoji |
+   |---|---|
+   | Security | 🔒 |
+   | Bugs | 🐛 |
+   | Features | ✨ |
+   | Improvements | ⚡ |
+   | Chores | 🧹 |
+   | Docs | 📖 |
+   | Feature candidates | 💡 |
+   | Marketing | 📣 |
+   | Blocked | 🚧 |
+   | Silent | 🔇 |
+   | Calibration | 📊 |
+
+   None of them is ✅ or ❌. Those two are the approval verbs, and a reader who meets one as
+   decoration has to stop and work out whether it means something.
+
+   Then, each under its own divider, in this order after the type sections. The first two carry a
+   heading; the remainder line and the reminder deliberately do not, for the reasons given:
+
+   - 💡 **Feature candidates** — the oldest 3 `feature-candidate` issues, same two-line item shape,
+     with the age as the why-now. These came from users, so they are listed separately rather than
+     ranked against scout finds, and by age rather than by impact: a reported bug that has waited a
+     month is the fact worth surfacing.
+
+     **Their tag is built from different labels, because they are filed by a different system.** A
+     `feature-candidate` issue comes from the in-app feedback form (`src/yeaboi/feedback.py`), which
+     titles it `[<Type>] <title>` and labels it `type:<kind>` + `area:<area>` — there is **no
+     `workstream:` label on it**, so the proposal rule's "prepend it from the issue's labels" has
+     nothing to prepend. Use `**[<type>][<area>]**` from those two labels, and strip the `[<Type>] `
+     prefix off the title, since that prefix *is* the first half of the tag. The second half is an
+     **area**, not a workstream — they are different vocabularies that happen to share most of their
+     words (`usage` and `settings` are areas but live under the `tui-ux` workstream), and mapping
+     one onto the other would be inventing a fact the issue does not carry.
+   - 📣 **Marketing** — this week's draft link, if one exists and no earlier digest has carried it.
+   - the count of everything else, **by workstream** — no heading, one line under its own divider,
+     because it is a footnote to the sections above and a heading would give it their weight. The
+     other axis, on purpose: the headings already carry the per-type counts, so a per-type remainder
+     would only restate them; the per-workstream remainder is the one place a reader learns which
+     surface the backlog is piling up on. Omit the line entirely when the sections above listed
+     everything — a remainder of zero is not a fact anyone needs.
+   - the two health sections from step 5 — 🚧 **Blocked on an open PR** and 🔇 **Silent 21+ days** —
+     sharing one divider, because they are two halves of one health report and splitting them reads
+     as two unrelated topics. Then, on Mondays only, 📊 **Calibration** from step 6 under a divider
+     of its own.
+   - last, under a final divider, the reminder that approval is ✅ on an item's thread reply
+     (relayed within the hour — or `/cowork run slack-relay` for right now) or adding
+     `claude-implement` on GitHub, and rejection is ❌ or closing the issue. Its own divider because
+     it is instructions rather than content, and it should not read as one more section of backlog.
+     The digest still names the verbs, because a reader who has forgotten them has nowhere else to
+     look.
 
    Then **one reply in that message's thread per listed item** — every listed proposal and every
    `feature-candidate` line — formatted `#<issue-number> — <verbatim title> — <issue link>`, the
-   number leading so `cron/slack-relay.md` can parse it. The thread replies are what make a single
-   reaction mean a single issue; without them ✅ on the digest would be ambiguous across every item
-   it lists. Per-type sections raise the ceiling to eighteen proposal replies plus three
-   `feature-candidate` replies — a longer thread, not a second message, and the reply shape is a
-   parsed contract that does not change with the volume.
+   number leading so `cron/slack-relay.md` can parse it. **Plain text: no list marker, no emoji, no
+   embedded link, no bold** — none of the formatting above applies here, because this line is parsed
+   before it is read. The thread replies are what make a single reaction mean a single issue; without
+   them ✅ on the digest would be ambiguous across every item it lists. Per-type sections raise the
+   ceiling to eighteen proposal replies plus three `feature-candidate` replies — a longer thread, not
+   a second message, and the reply shape is a parsed contract that does not change with the volume.
 
    One **channel-level** message, never a second on the same day — the channel-noise rule holds;
    the per-item replies live inside its thread, not in the channel.
@@ -91,12 +206,27 @@ The single decision point. It is the only routine that posts proposals to Slack.
    experience, not generated by a scout, and closing someone's bug report on a timer is not triage.
    They stay open until a human acts.
 
-5. **Report the health line** — if any workstream has filed nothing in 21 days, say so in the digest.
-   A silent scout is usually a broken scout, not a clean codebase.
+5. **Report the health lines** — if any workstream has filed nothing in 21 days, say so in the
+   digest. A silent scout is usually a broken scout, not a clean codebase.
 
-   Separate the two ways a workstream goes quiet. Run `gh pr list --label cowork --state open --json
-   number,labels,createdAt,url` first: a workstream with an open PR is **blocked**, not silent — it
-   is forbidden from scouting until that PR merges. Name it and its PR, and do not count it against
+   Separate the two ways a workstream goes quiet, under two headings — 🚧 **Blocked on an open PR**
+   and 🔇 **Silent 21+ days** — each an ordered list, one workstream per item, in the same two-line
+   shape as a proposal. These were one prose paragraph, which is why nobody read past the first name.
+
+   The two lines carry different facts, because the two states are different facts:
+
+   - **Blocked** — line one is the workstream and its linked PR, `**<workstream>** [PR #123 —
+     <title>](<pr url>)`; line two is `— ` and what is actually holding that PR up, from the
+     `pr_feedback.py` run below (red CI, or *n* unanswered findings).
+   - **Silent** — a silent workstream has no PR and nothing blocking it, which is the whole problem,
+     so there is nothing to link. Line one is `**<workstream>**` and the date it last filed
+     (`— last filed <YYYY-MM-DD>`, or `never`); line two is `— ` and the number of days that is,
+     which is the number the 21-day line is about. Do not invent a blocker to fill the shape: "no
+     open PR, nothing filed in 34 days" is the finding.
+
+   Run `gh pr list --label cowork --state open --json number,labels,createdAt,url` first: a
+   workstream with an open PR is **blocked**, not silent — it is forbidden from scouting until that
+   PR merges. Name it and its PR, and do not count it against
    the 21-day line. Silence with no open PR is the case worth worrying about.
 
    Say *what* is blocking each one, because the two causes need different people. Run
@@ -105,7 +235,8 @@ The single decision point. It is the only routine that posts proposals to Slack.
    A workstream stalled three weeks on two unanswered findings reads as "blocked on PR #123" without
    this, which is indistinguishable from a slow build and gets treated like one.
 
-6. **Report the calibration line** — for each workstream, the approval rate over the last 90 days:
+6. **Report the calibration line** under a 📊 **Calibration** heading — for each workstream, the
+   approval rate over the last 90 days:
    proposals that received `claude-implement` ÷ proposals filed. One
    `gh issue list --label "workstream:<name>" --state all --limit 200 --json number,labels,createdAt`
    per workstream — pass the limit, because `gh` defaults to 30 and a truncated set makes a

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -238,6 +238,80 @@ class TestLabels:
                 continue
             assert {kind, f"{kind}s"} & sections, f"digest.md's section order omits type:{kind}"
 
+    # Sections the digest heads that are not one of the PROPOSAL_TYPES: user
+    # feedback, the marketing draft, and the health/calibration reporting.
+    NON_TYPE_SECTIONS = ("Feature candidates", "Marketing", "Blocked", "Silent", "Calibration")
+
+    @staticmethod
+    def _emoji_table() -> dict[str, str]:
+        """The digest's ``| Section | Emoji |`` table, as ``{name: emoji}``."""
+        digest = (setup.ROUTINES_DIR / "cron" / "digest.md").read_text(encoding="utf-8")
+        # Deliberately permissive on the name (a section could gain a digit or a
+        # hyphen) and strict about there being exactly two cells, so a row that
+        # drifts out of the shape fails here rather than vanishing from the set.
+        pairs = re.findall(r"^\s*\|\s*([^|\-][^|]*?)\s*\|\s*([^|\s]+)\s*\|\s*$", digest, re.M)
+        rows = [(name, emoji) for name, emoji in pairs if name != "Section"]
+        names = [name for name, _ in rows]
+        assert len(names) == len(set(names)), f"digest.md's emoji table repeats a section: {names}"
+        return dict(rows)
+
+    def test_the_digest_declares_an_emoji_for_every_section(self):
+        # Each digest section is headed by one fixed emoji, so a returning
+        # reader finds a section by shape before reading a word. That only
+        # works if the emoji is constant, which means it has to be written
+        # down — and the table is the other half of the section order above:
+        # an eighth PROPOSAL_TYPES entry gets a section from that test and an
+        # anchor from this one.
+        rows = self._emoji_table()
+        assert rows, "digest.md no longer declares an emoji table"
+        for kind in setup.PROPOSAL_TYPES:
+            if kind == "other":
+                continue
+            assert {kind, f"{kind}s"} & {name.lower() for name in rows}, f"digest.md's emoji table omits type:{kind}"
+        # The type sections are only half the message; a dropped row here is a
+        # heading with nothing to anchor it and nothing to notice.
+        for section in self.NON_TYPE_SECTIONS:
+            assert section in rows, f"digest.md's emoji table omits the {section} section"
+        # Two sections sharing an emoji defeats the whole point of having one —
+        # you can no longer find a section by shape.
+        assert len(set(rows.values())) == len(rows), f"digest.md reuses a section emoji: {rows}"
+        # The approval verbs are never spent as decoration: a reader who meets
+        # one in a heading has to stop and work out whether it means something.
+        assert not {"\u2705", "\u274c"} & set(rows.values()), "digest.md uses an approval verb as a section emoji"
+
+    def test_every_digest_heading_uses_its_declared_emoji(self):
+        # The table above is only worth having if the headings obey it. Nothing
+        # at run time would notice a heading that quietly lost its emoji, or an
+        # example that drifted onto a different one from the table it sits next
+        # to — the digest is a prompt, so the worked example is what actually
+        # gets copied.
+        digest = (setup.ROUTINES_DIR / "cron" / "digest.md").read_text(encoding="utf-8")
+        rows = self._emoji_table()
+
+        fences = re.findall(r"^\s*```\n(.*?)^\s*```", digest, re.M | re.S)
+        assert fences, "digest.md no longer shows the message shape as a worked example"
+        example = "\n".join(fences)
+
+        # A heading in the example: "<emoji> **<Section>** (<n> open…)".
+        headings = re.findall(r"^\s*(\S+)\s+\*\*([^*]+)\*\*\s*\(", example, re.M)
+        assert len(headings) >= 2, "the worked example no longer shows more than one section"
+        for emoji, name in headings:
+            section = next((s for s in rows if name.startswith(s)), None)
+            assert section, f"the worked example heads a section the emoji table omits: {name!r}"
+            assert emoji == rows[section], (
+                f"the worked example heads {name!r} with {emoji!r}, table says {rows[section]!r}"
+            )
+        # …and the same line with the emoji stripped is the failure this catches.
+        bare = re.findall(r"^\s*\*\*([^*]+)\*\*\s*\(", example, re.M)
+        assert not bare, f"a worked-example heading lost its emoji anchor: {bare}"
+
+        # The sections that live in prose rather than in the example still have
+        # to pair with their emoji somewhere, or the anchor was never written.
+        for section in self.NON_TYPE_SECTIONS:
+            assert f"{rows[section]} **{section}" in digest, (
+                f"digest.md never heads the {section} section with {rows[section]!r}"
+            )
+
     def test_there_are_fifteen_workstreams(self):
         # The count is load-bearing: CLAUDE.md, cowork/README.md and the digest's
         # health check all say fifteen.


### PR DESCRIPTION
## Summary

The daily cowork digest was rendering badly and reading badly. Two independent causes, both fixed in the specs that produce it.

**The dialect was wrong.** `cron/digest.md` and `cowork-scribe.md` both specified Slack's own mrkdwn (`*bold*`), but the connector these agents actually post through takes **standard Markdown** — where `*bold*` means *italic*. So the digest shipped italic section headings and leaked stray `_` characters mid-line, for weeks, with nothing in the system able to notice: no test, no lint, no runtime check ever sees a Slack message. Both files now state the dialect explicitly and say why the distinction is the difference between a bold heading and an italic one.

**The body was a wall.** Items were plain lines that Markdown folded into single grey paragraphs, links trailed as bare URLs in parentheses after the titles they belonged to, and the health and calibration reporting was prose nobody read past the first name. The body is respecified as a **literal worked example plus the rules that shape it**:

- emoji-anchored headings, one fixed emoji per section, so a returning reader finds a section by shape before reading a word
- loose ordered lists (blank line between items) so a two-line item reads as one item
- two-line items: `**[type][workstream]** [title](url)` then the why-now clause
- box-drawing dividers between sections — Slack has no horizontal rule for Markdown `---` to map onto, but characters always survive
- the two health states (blocked vs silent) as headed lists, each with its own defined two-line shape

**Feature candidates get their own tag rule**, because they are filed by a different system: `src/yeaboi/feedback.py` titles them `[<Type>] <title>` and labels them `type:` + `area:` — there is no `workstream:` label to prepend, and `area` is a different vocabulary that only looks like the workstream one. The spec now derives their tag from the labels the issue actually carries instead of asking an agent to invent the missing half.

Two invariants are held deliberately:

- **The thread reply is exempt from all of it** — no list marker, no emoji, no embedded link, no bold. `cron/slack-relay.md` parses that line to map a ✅/❌ reaction onto an issue, so prettifying it breaks approvals rather than the look of anything.
- **The approval verbs are never spent as decoration.** A reader who meets ✅ in a heading has to stop and work out whether it means something.

Two tests hold the emoji anchors, since nothing at run time would notice them drifting: every section declares a unique emoji (and never an approval verb), and every heading — in the worked example *and* in prose — uses the emoji the table declares. Both were mutation-tested: stripping an emoji from the worked example, pointing it at the wrong emoji, deleting a table row, reusing an emoji across two sections, and dropping the emoji from a prose heading each fail.

## Review findings addressed

The independent `code-reviewer` pass raised 6 should-fix and 4 nit findings. All ten are fixed in this branch — none deferred:

- the worked example promised `top 3` and showed 2, teaching the anti-pattern the heading rule forbids → every example section now lists in full to its own count
- feature-candidate item shape was underivable from the data → tag rule written against the labels `feedback.py` actually applies
- the explicit "up to 3 proposals per type" cap had been lost into a heading template → restored as a rule, cross-referenced to `cowork/README.md`
- the two-line item silently depended on a line break surviving → the reason is now recorded, along with the `\` hard-break remedy and the note that nothing checks it statically
- the bracket-escaping rationale was factually wrong (balanced brackets are legal in CommonMark link text; unbalanced ones and real reference definitions are the failure) → corrected in both files, keeping the escape
- the test guarded the table but not the headings it exists for → second test added
- plus the section-list intro contradiction, the undefined silent-item shape, regex fragility, and the scribe's incomplete section enumeration

## Test plan

- `make test` — 9940 passed, 47 skipped
- `make lint` — clean
- `make security` — SAST clean, no known CVEs
- `uv run python scripts/cowork_setup.py --check --local` — clean (README / routine / tier table still agree)
- mutation-tested both new assertions (5 mutations, all caught, file restored)

## Definition of Done

Docs-and-spec change plus tests. Items that do not apply: no `frontend/` changes so no `make web`; no new capability, so no `CAPABILITIES` row or `FeatureTip`; no surface-parity, logging, or `paths.py` obligations.

Closes YEA-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)