### PR TITLE
relaunch onto the new version after an in-app ctrl+U upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.57.0"
+version = "2.58.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,37 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.58.0",
+      "date": "2026-08-08",
+      "summary": "The in-app `ctrl+U` upgrade now seamlessly restarts the app onto the newly installed version, preserving CLI flags like `--dry-run` and `--theme` so you stay where you were. The upgrade screen counts down 3 seconds and relaunches automatically, or press Esc/Q to decline and stay on the current version. The restarted app skips the splash animation and shows a `✓ updated` confirmation on the version row. Honest fallbacks appear if the upgrade fails, the restart can't be resolved, or you're on a non-POSIX system.",
+      "highlights": [
+        {
+          "text": "Seamless self-restart after upgrade: auto-relaunch in 3s onto the new version with Esc to decline",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Preserved context: CLI flags like --dry-run, --theme stay active through the restart",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Confirmation chip: ✓ updated appears on the version row after a successful restart",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Honest fallbacks: upgrade failures and restart impossibilities show the old \"restart manually\" screen",
+          "areas": [
+            "general"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.57.0",
       "date": "2026-08-07",
       "summary": "Planning mode got eight quality-of-life improvements that speed up intake and make the chat feel more responsive. Type a digit (1/2/3) to instantly pick and submit on size and review choices, no Enter needed — the feature even works on multi-choice rows. The progress subtitle now reads \"Question X of Y\" over the set this run actually asks (not the full question bank), and a new `/questions` command lists planned topics with status markers. Large responses (intake summaries, review walls) skip the fake typewriter effect and land directly as artifact cards. The review verdict is now a selectable row — Accept / Edit an answer / Override velocity / Tell me what's off — mapped to node literals so digits and raw text never reach the graph. A clock-derived duck quip rotates every 5 seconds of a long wait, with a quack every fourth slot and one shades gag on really long ones. Small projects are hard-capped at 2 stories total and trimmed post-validate with a warning. Fast mode gained a visible subtitle and an `/finish` toggle to auto-accept remaining questions and exit the chat.",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -2338,7 +2338,14 @@ def main(argv: list[str] | None = None) -> None:
 
     # See docs: "Architecture" — splash replaces the static welcome panel.
     # The animated intro runs before any interactive UI (wizard / mode select).
-    show_splash(console)
+    # Skipped when this process was relaunched by the ctrl+U in-app update: the
+    # user just watched the upgrade land and doesn't need the ~2s intro again.
+    # select_mode's Live(screen=True) enters the alternate screen on its own, so
+    # the only thing lost is the animation.
+    from yeaboi import update_check
+
+    if not update_check.is_fresh_restart():
+        show_splash(console)
 
     # ── First-run setup wizard ────────────────────────────────────────────────
     # Triggers when ~/.scrum-agent/.env is absent (first run) or --setup is passed.
@@ -2560,6 +2567,15 @@ def main(argv: list[str] | None = None) -> None:
                         console.print(f"[dim]{_msg}[/dim]")
             except Exception:
                 pass
+        # The ctrl+U update flow asks for a relaunch onto the version it just
+        # installed. It has to happen HERE: os.execv replaces the process image
+        # without running atexit handlers, so it's only safe now that the finally
+        # above has taken the terminal out of raw mode, stopped mouse tracking and
+        # left the alternate screen. restart_in_place only returns on failure.
+        if update_check.restart_requested():
+            if not update_check.restart_in_place():
+                console.print("[dim]Update installed — restart yeaboi to use the new version.[/dim]")
+            return
         if mode_result is None:
             return
         # mode_result is non-None only for offline import (questionnaire path)

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -10830,14 +10830,28 @@ def _play_duck_shades(console, live, selected, *, tip_offset, start_time, select
         time.sleep(_FRAME_TIME * 3)  # ~20fps — a readable lift/drop over ~0.5s
 
 
-def _run_update_flow(console, live, read_key, frame_time, supports_timeout) -> None:
+# How long the success screen counts down before relaunching. Long enough to read
+# "updated to vX" and hit esc, short enough that the restart still feels automatic.
+_UPDATE_RESTART_SECONDS = 3.0
+
+# Upper bound on the keystrokes drained after the upgrade finishes. Bounded so a
+# held-down key (auto-repeat keeps refilling the buffer) can't spin here forever;
+# 64 is far more than an impatient user types during a 30s upgrade.
+_UPDATE_DRAIN_LIMIT = 64
+
+
+def _run_update_flow(console, live, read_key, frame_time, supports_timeout) -> bool:
     """Run the in-app upgrade (the ctrl+U shortcut): show a spinner while the
-    detected ``uv/pipx upgrade`` command runs on a worker thread, then a success or
-    failure result the user dismisses with any key.
+    detected ``uv/pipx upgrade`` command runs on a worker thread, then the result.
 
     Only invoked when an update is available (the caller gates on it). The upgrade
-    runs in a subprocess; the freshly-installed code takes effect on the next
-    launch, so the success screen tells the user to restart.
+    runs in a subprocess, so the freshly-installed code only takes effect in a NEW
+    process: on success this counts down :data:`_UPDATE_RESTART_SECONDS` and then
+    returns True, meaning "unwind the TUI so cli.main can relaunch us". Esc (or q)
+    during the countdown declines, and a failure — or an install we can't work out
+    how to relaunch — falls back to the old dismiss-with-any-key result.
+
+    Returns True when the caller should unwind for a restart, False to stay put.
     """
 
     from yeaboi import update_check
@@ -10870,12 +10884,52 @@ def _run_update_flow(console, live, read_key, frame_time, supports_timeout) -> N
     ok = bool(result.get("ok"))
     detail = result.get("detail", "") or ""
     logger.info("update: upgrade %s", "succeeded" if ok else "failed")
+    # The spinner loop above never reads keys, so anything typed during the (often
+    # 5-30s) upgrade is still queued on the tty. Left there, the first read below
+    # would return a stale keystroke and fire the restart instantly — the user would
+    # never see which version landed, nor get the esc window this screen is for.
+    if supports_timeout:
+        for _ in range(_UPDATE_DRAIN_LIMIT):
+            if not read_key(timeout=0):
+                break
+    # Only offer the restart when we can actually perform one — an install whose
+    # console script we can't resolve gets the honest "restart it yourself" screen.
+    can_restart = ok and update_check.resolve_relaunch_command() is not None
+    deadline = time.monotonic() + _UPDATE_RESTART_SECONDS
     while True:
         w, h = console.size
-        live.update(_build_update_screen(w, h, latest=latest, command=command, done=True, ok=ok, detail=detail))
+        # Clamp to 1: the loop exits the moment the deadline passes, so a rendered
+        # "restarting in 0…" would only ever be a stray final frame.
+        remaining = max(1, math.ceil(deadline - time.monotonic())) if can_restart else None
+        live.update(
+            _build_update_screen(
+                w,
+                h,
+                latest=latest,
+                command=command,
+                done=True,
+                ok=ok,
+                detail=detail,
+                restart_in=remaining,
+                can_restart=can_restart,
+            )
+        )
         k = read_key(timeout=frame_time) if supports_timeout else read_key()
-        if k:
-            return
+        if not can_restart:
+            if k:
+                return False
+            continue
+        if k in ("esc", "q"):
+            logger.info("update: restart declined, staying on the running version")
+            return False
+        # Mouse traffic isn't an answer to this screen — a stray wheel nudge must
+        # not cut the window the user has to read the version and hit esc.
+        if k in ("scroll_up", "scroll_down") or (isinstance(k, str) and k.startswith("click:")):
+            k = ""
+        # Any other key restarts immediately — no need to sit through the countdown.
+        if k or time.monotonic() >= deadline:
+            update_check.request_restart(latest)
+            return True
 
 
 def _run_poker_setup(console: Console, live, read_key, frame_time: float, supports_timeout: bool) -> dict | None:
@@ -11906,7 +11960,14 @@ def select_mode(
                     from yeaboi.update_check import get_update_status
 
                     if get_update_status()["update_available"]:
-                        _run_update_flow(console, live, read_key, _FRAME_TIME, _supports_timeout)
+                        if _run_update_flow(console, live, read_key, _FRAME_TIME, _supports_timeout):
+                            # Unwind the whole TUI: cli.main relaunches us onto the
+                            # new version once its finally has restored the terminal
+                            # (os.execv skips atexit, so it can't be done from here).
+                            # Deliberately not the q/esc quit path — this isn't a
+                            # quit, so a local Ollama server should stay up for the
+                            # process that's about to take over.
+                            return None
                         select_time = time.monotonic()
                 elif isinstance(key, str) and key.startswith("click:"):
                     # Click-to-select: a click on a mode's block highlights it

--- a/src/yeaboi/ui/mode_select/screens/_screens.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens.py
@@ -485,9 +485,10 @@ def _build_update_box(*, cols: int) -> Panel | None:
 
     Styled warmer and heavier than the tip bubble (amber border + keycap) so it
     reads as *more pressing* than an ambient tip: it tells the user a new version
-    is out and that ``ctrl+U`` installs it in place. Returns None when there's
-    nothing to advertise, so the companion lane just shows the tip + duck. Reads
-    the check state lazily like :func:`_build_version_row` (monkeypatchable seam).
+    is out and that ``ctrl+U`` installs it and relaunches onto it. Returns None when
+    there's nothing to advertise, so the companion lane just shows the tip + duck.
+    Reads the check state lazily like :func:`_build_version_row` (monkeypatchable
+    seam).
     """
     from yeaboi.update_check import get_update_status
 
@@ -524,8 +525,11 @@ def _build_version_row(width: int, *, suppress_upgrade: bool = False) -> Text:
     :func:`_build_update_box` is carrying it instead (wide/companion layout). Reads
     the check state lazily (like ``_build_tip_rows`` reads tips config) so no call
     site changes and tests can monkeypatch ``yeaboi.update_check.get_update_status``.
+    When this process was relaunched by the ctrl+U update instead, there is nothing
+    to advertise, so the row carries a ✓ updated chip confirming the version that
+    actually took.
     """
-    from yeaboi.update_check import get_update_status
+    from yeaboi.update_check import get_update_status, is_fresh_restart
 
     status = get_update_status()
     dim = f"rgb({_TIP_DOT_DIM[0]},{_TIP_DOT_DIM[1]},{_TIP_DOT_DIM[2]})"
@@ -544,6 +548,14 @@ def _build_version_row(width: int, *, suppress_upgrade: bool = False) -> Text:
         if width >= 72:
             row.append("  ·  ", style=dim)
             row.append(status["upgrade_command"], style=accent)
+    elif not status["update_available"] and is_fresh_restart() and width >= 72:
+        # This process was relaunched by the ctrl+U update — confirm the version
+        # that actually took, so the restart visibly did something. Dropped first
+        # on narrow terminals, like the upgrade command above. A newer release
+        # discovered since the restart still wins the slot, in this layout via the
+        # explicit check (the branch above is off when _build_update_box has it).
+        row.append("  ·  ", style=dim)
+        row.append("✓ updated", style=accent)
     row.append("  ·  ", style=dim)
     row.append("c", style=key_style)
     row.append(" changelog", style=dim)
@@ -1219,14 +1231,20 @@ def _build_update_screen(
     done: bool = False,
     ok: bool = False,
     detail: str = "",
+    restart_in: int | None = None,
+    can_restart: bool = False,
 ) -> Panel:
     """Modal shown by the ctrl+U update flow: a spinner while ``uv/pipx upgrade``
     runs, then a success or failure result.
 
     While running (``done=False``) it shows ``spinner`` + "updating to vX". On
-    success it says the new version is installed and to restart; on failure it
-    shows the manual command so the user can run it themselves. Any key dismisses
-    the result (handled by the caller).
+    success the app relaunches itself onto the new version, so the screen counts
+    ``restart_in`` down and offers esc as the way out. ``can_restart`` defaults to
+    False — the honest screen, asking for a manual restart — so that only a caller
+    that has actually resolved a relaunch command (see
+    ``update_check.resolve_relaunch_command``) can promise one. On failure it shows the manual
+    upgrade command so the user can run it themselves. Any key dismisses the
+    result (handled by the caller).
     """
     amber = f"rgb({_TIP_DOT_ON[0]},{_TIP_DOT_ON[1]},{_TIP_DOT_ON[2]})"
     rows: list[RenderableType] = []
@@ -1239,8 +1257,12 @@ def _build_update_screen(
     elif ok:
         rows.append(Align.center(Text(f"✓  updated to v{latest}", style=f"bold {amber}")))
         rows.append(Text(""))
-        rows.append(Align.center(Text("restart yeaboi to use the new version", style="rgb(198,198,208)")))
-        rows.append(Align.center(Text("press any key", style="rgb(120,130,140)")))
+        if can_restart:
+            rows.append(Align.center(Text(f"restarting in {max(0, restart_in or 0)}…", style="rgb(198,198,208)")))
+            rows.append(Align.center(Text("esc to stay on this one", style="rgb(120,130,140)")))
+        else:
+            rows.append(Align.center(Text("restart yeaboi to use the new version", style="rgb(198,198,208)")))
+            rows.append(Align.center(Text("press any key", style="rgb(120,130,140)")))
         border = amber
     else:
         rows.append(Align.center(Text("update failed", style="bold rgb(226,110,90)")))

--- a/src/yeaboi/update_check.py
+++ b/src/yeaboi/update_check.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+import shutil
 import sys
 import threading
 import urllib.request
@@ -24,6 +26,20 @@ _PYPI_URL = "https://pypi.org/pypi/yeaboi/json"
 # dict writes are atomic under the GIL, so no lock is needed.
 _state: dict = {"latest": "", "checked": False}
 _started = False
+
+# Set on the process that is ABOUT to be replaced by :func:`restart_in_place`, and
+# read back by the fresh process from its environment. Carries the version we
+# upgraded to, so the relaunch can skip the splash and confirm what it is running.
+_RESTART_ENV = "YEABOI_RESTARTED"
+
+# The marker this process was launched with, captured on first read (see
+# :func:`restarted_version`). None means "not read out of the environment yet".
+_restarted_from: str | None = None
+
+# Pending in-app restart request: the version we upgraded to, or "" for none.
+# Written by the ctrl+U flow deep inside the TUI, read by ``cli.main`` once the
+# terminal has been restored — see :func:`request_restart`.
+_restart_to = ""
 
 
 def parse_version(version: str) -> tuple[int, ...] | None:
@@ -76,7 +92,8 @@ def run_upgrade(*, timeout: float = 300.0) -> tuple[bool, str]:
     Powers the in-app ``ctrl+U`` update shortcut. Best-effort and never raises: a
     launch failure or non-zero exit returns ``(False, <detail>)`` so the caller can
     fall back to showing the manual command. On success the freshly-installed code
-    only takes effect after a restart — the caller is responsible for saying so.
+    only takes effect in a NEW process — the caller restarts via
+    :func:`restart_in_place` (or, when that isn't possible, says so).
     """
     import shlex
     import subprocess
@@ -97,6 +114,133 @@ def run_upgrade(*, timeout: float = 300.0) -> tuple[bool, str]:
         return True, (proc.stdout or "").strip()
     logger.warning("upgrade exited %s via '%s'", proc.returncode, command)
     return False, (proc.stderr or proc.stdout or "").strip()
+
+
+def resolve_relaunch_command() -> list[str] | None:
+    """The argv that re-launches *this* install, or None when we can't work it out.
+
+    Backs :func:`restart_in_place`. Prefers ``sys.argv[0]`` (the console script uv
+    or pipx generated — still valid after an in-place upgrade, since the upgrade
+    rewrites the venv behind it), falling back to a PATH lookup for when the process
+    was started by bare name and ``argv[0]`` isn't a path we can exec. The original
+    flags ride along, so a restart preserves ``--dry-run``/``--theme``.
+
+    Returns None on non-POSIX: ``os.execv`` on Windows does not replace the process,
+    it spawns and detaches, which would leave two apps fighting over one terminal.
+    The TUI is POSIX-only anyway (``ui/shared/_input.py`` imports ``termios``), so
+    this is a guard rather than a limitation.
+    """
+    if os.name != "posix":
+        return None
+    argv0 = sys.argv[0] if sys.argv else ""
+    candidate = ""
+    if argv0:
+        try:
+            path = Path(argv0)
+            # A .py argv[0] means ``python -m yeaboi`` / a direct script run, not the
+            # console script: exec'ing it either fails ENOEXEC or (with a shebang)
+            # re-runs us outside the venv the upgrade just rewrote. Fall through to
+            # the PATH lookup, which finds the real console script.
+            if path.is_file() and path.suffix != ".py":
+                candidate = str(path.resolve())
+        except OSError:
+            candidate = ""
+        if not candidate:
+            candidate = shutil.which(Path(argv0).name) or ""
+    if not candidate:
+        candidate = shutil.which("yeaboi") or ""
+    if not candidate:
+        logger.warning("cannot resolve a relaunch command (argv0=%r)", argv0)
+        return None
+    return [candidate, *sys.argv[1:]]
+
+
+def request_restart(version: str) -> None:
+    """Record that the app should relaunch itself once the TUI has torn down.
+
+    The ctrl+U flow runs several frames deep inside the mode-select ``Live``
+    context, and ``os.execv`` does NOT run ``atexit`` handlers — exec'ing from there
+    would hand the new process a terminal still in raw mode, with mouse tracking on
+    and the alternate screen active. Only ``cli.main``'s ``finally`` unwinds all of
+    that, so the flow leaves the request here and unwinds; ``cli.main`` calls
+    :func:`restart_in_place` after the terminal is clean.
+    """
+    global _restart_to
+    _restart_to = version or "1"
+    logger.info("restart requested after upgrade to v%s", version)
+
+
+def restart_requested() -> str:
+    """The version a restart was requested for, or "" when none is pending."""
+    return _restart_to
+
+
+def restarted_version() -> str:
+    """The version this process was relaunched onto, or "" for a normal launch.
+
+    Read from the environment the previous process image set just before exec'ing,
+    so it survives the process replacement that module state cannot — then *popped*
+    and cached, because the marker describes this process and nothing else. Left in
+    the environment it would be inherited by every child we spawn (the upgrade
+    subprocess, a board server, cloudflared), and a nested yeaboi would come up
+    believing it was the relaunch.
+    """
+    global _restarted_from
+    if _restarted_from is None:
+        _restarted_from = os.environ.pop(_RESTART_ENV, "")
+    return _restarted_from
+
+
+def is_fresh_restart() -> bool:
+    """True when this process is the relaunch AND it really is on the new version.
+
+    The marker carries the version we upgraded to, so comparing it against the
+    running version self-heals: a stale or foreign ``YEABOI_RESTARTED`` in the
+    environment, or an upgrade that didn't actually move the version, just falls
+    back to a normal launch rather than silently suppressing the splash forever.
+    """
+    marker = restarted_version()
+    return bool(marker) and marker == _current_version()
+
+
+def restart_in_place() -> bool:
+    """Replace this process with a fresh yeaboi. Only returns when it *failed*.
+
+    ``os.execv`` swaps the process image, so the freshly installed code really is
+    what runs next and there's no orphaned parent holding the terminal. Call it only
+    after the terminal has been restored — exec skips ``atexit``.
+
+    Returns False (having changed nothing the caller can't recover from) when there's
+    no resolvable relaunch command or exec itself fails, so the caller can fall back
+    to telling the user to restart by hand.
+    """
+    command = resolve_relaunch_command()
+    if command is None:
+        return False
+    # exec does not flush Python's buffers — anything still pending would be lost.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:  # noqa: BLE001 - a closed stream must not block the restart
+            pass
+    # The kernel's input buffer survives exec. Anything typed during the upgrade and
+    # not consumed by the countdown would be replayed into the fresh process's
+    # mode-select loop, where a buffered "q" quits the app we just restarted.
+    try:
+        import termios
+
+        termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)
+    except Exception:  # noqa: BLE001 - no tty / no termios: there is nothing to drain
+        pass
+    os.environ[_RESTART_ENV] = _restart_to or "1"
+    logger.info("restarting in place: %s", command)
+    try:
+        os.execv(command[0], command)  # noqa: S606 - argv is our own console script + our own flags
+    except OSError as exc:
+        logger.warning("restart failed to exec %s: %s", command[0], exc)
+        os.environ.pop(_RESTART_ENV, None)
+        return False
+    return False  # unreachable: a successful execv never returns
 
 
 def fetch_latest_version(timeout: float = 3.0) -> str | None:

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1086,3 +1086,63 @@ class TestStandupCLI:
         assert calls["session_id"] == "s1"
         # "all" expands to every channel
         assert set(calls["channels"]) == {"terminal", "desktop", "slack", "email"}
+
+
+class TestUpdateRestartWiring:
+    """main()'s half of the ctrl+U relaunch: skip the splash, exec after cleanup.
+
+    The flow itself can't call ``os.execv`` — it runs deep inside select_mode's Live
+    context, where exec (which skips ``atexit``) would hand the new process a
+    terminal still in raw mode. It leaves a request on ``update_check``; these pin
+    that main acts on it, and only once the terminal has been restored.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_restart_by_default(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.update_check.is_fresh_restart", lambda: False)
+        monkeypatch.setattr("yeaboi.update_check.restart_requested", lambda: "")
+
+    @patch("yeaboi.cli.select_mode", return_value=None)
+    @patch("yeaboi.cli.show_splash")
+    def test_splash_plays_on_a_normal_launch(self, mock_splash, mock_select):
+        main(argv=[])
+        mock_splash.assert_called_once()
+
+    @patch("yeaboi.cli.select_mode", return_value=None)
+    @patch("yeaboi.cli.show_splash")
+    def test_splash_skipped_when_this_process_is_the_relaunch(self, mock_splash, mock_select, monkeypatch):
+        # The user just watched the upgrade land; select_mode's Live(screen=True)
+        # enters the alt-screen itself, so only the animation is lost.
+        monkeypatch.setattr("yeaboi.update_check.is_fresh_restart", lambda: True)
+        main(argv=[])
+        mock_splash.assert_not_called()
+
+    @patch("yeaboi.cli.select_mode", return_value=None)
+    @patch("yeaboi.cli.show_splash")
+    def test_no_restart_requested_never_execs(self, mock_splash, mock_select, monkeypatch):
+        called = []
+        monkeypatch.setattr("yeaboi.update_check.restart_in_place", lambda: called.append(True) or False)
+        main(argv=[])
+        assert called == []
+
+    @patch("yeaboi.cli.select_mode", return_value=None)
+    @patch("yeaboi.cli.show_splash")
+    def test_restart_happens_only_after_the_terminal_is_restored(self, mock_splash, mock_select, monkeypatch):
+        order: list[str] = []
+        monkeypatch.setattr("yeaboi.update_check.restart_requested", lambda: "2.13.0")
+        monkeypatch.setattr("yeaboi.update_check.restart_in_place", lambda: order.append("exec") or True)
+        monkeypatch.setattr("yeaboi.ui.shared._input.exit_raw_mode", lambda: order.append("raw-off"))
+        monkeypatch.setattr("yeaboi.ui.shared._input.disable_mouse_tracking", lambda: order.append("mouse-off"))
+        main(argv=[])
+        assert "exec" in order
+        assert order.index("exec") > order.index("raw-off")
+        assert order.index("exec") > order.index("mouse-off")
+
+    @patch("yeaboi.cli.select_mode", return_value=None)
+    @patch("yeaboi.cli.show_splash")
+    def test_failed_exec_falls_back_to_telling_the_user(self, mock_splash, mock_select, monkeypatch, capsys):
+        # restart_in_place only returns when it could not replace the process.
+        monkeypatch.setattr("yeaboi.update_check.restart_requested", lambda: "2.13.0")
+        monkeypatch.setattr("yeaboi.update_check.restart_in_place", lambda: False)
+        main(argv=[])
+        assert "restart yeaboi" in capsys.readouterr().out.lower()

--- a/tests/unit/test_update_check.py
+++ b/tests/unit/test_update_check.py
@@ -16,6 +16,10 @@ def _reset_state(monkeypatch):
     """Isolate the module-level check state between tests."""
     monkeypatch.setattr(update_check, "_state", {"latest": "", "checked": False})
     monkeypatch.setattr(update_check, "_started", False)
+    monkeypatch.setattr(update_check, "_restart_to", "")
+    # restarted_version() caches the marker on first read; without this the value
+    # one test popped out of its fake environ would answer every later test.
+    monkeypatch.setattr(update_check, "_restarted_from", None)
 
 
 class TestParseVersion:
@@ -243,3 +247,141 @@ class TestRunUpgrade:
         ok, msg = update_check.run_upgrade()
         assert ok is False
         assert "uv not found" in msg
+
+
+class TestRelaunchCommand:
+    """resolve_relaunch_command — how the app re-launches itself after an upgrade."""
+
+    def test_uses_argv0_when_it_is_a_real_file(self, monkeypatch, tmp_path):
+        script = tmp_path / "yeaboi"
+        script.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(update_check.os, "name", "posix")
+        monkeypatch.setattr(update_check.sys, "argv", [str(script), "--dry-run"])
+        assert update_check.resolve_relaunch_command() == [str(script.resolve()), "--dry-run"]
+
+    def test_falls_back_to_path_lookup_when_argv0_is_a_bare_name(self, monkeypatch):
+        monkeypatch.setattr(update_check.os, "name", "posix")
+        monkeypatch.setattr(update_check.sys, "argv", ["yeaboi", "--theme", "dark"])
+        monkeypatch.setattr(update_check.shutil, "which", lambda name: "/usr/local/bin/yeaboi")
+        assert update_check.resolve_relaunch_command() == ["/usr/local/bin/yeaboi", "--theme", "dark"]
+
+    def test_unresolvable_returns_none(self, monkeypatch):
+        monkeypatch.setattr(update_check.os, "name", "posix")
+        monkeypatch.setattr(update_check.sys, "argv", ["yeaboi"])
+        monkeypatch.setattr(update_check.shutil, "which", lambda name: None)
+        assert update_check.resolve_relaunch_command() is None
+
+    def test_non_posix_never_execs(self, monkeypatch):
+        # os.execv on Windows spawns instead of replacing — two apps, one terminal.
+        monkeypatch.setattr(update_check.os, "name", "nt")
+        monkeypatch.setattr(update_check.sys, "argv", ["yeaboi"])
+        monkeypatch.setattr(update_check.shutil, "which", lambda name: "C:\\yeaboi.exe")
+        assert update_check.resolve_relaunch_command() is None
+
+
+class TestRestartRequest:
+    """The flag the ctrl+U flow leaves for cli.main to act on."""
+
+    def test_none_pending_by_default(self):
+        assert update_check.restart_requested() == ""
+
+    def test_request_records_the_version(self):
+        update_check.request_restart("2.13.0")
+        assert update_check.restart_requested() == "2.13.0"
+
+    def test_versionless_request_still_reads_as_pending(self):
+        update_check.request_restart("")
+        assert update_check.restart_requested() == "1"
+
+
+@pytest.fixture
+def _fake_environ(monkeypatch):
+    """Give the module a throwaway environ.
+
+    ``restart_in_place`` sets the marker on the REAL ``os.environ`` (exec inherits
+    it, which is the whole point), so without this the marker leaks into every
+    later test in the session — and a leaked marker silently skips the splash.
+    """
+    env: dict[str, str] = {}
+    monkeypatch.setattr(update_check.os, "environ", env)
+    return env
+
+
+class TestRestartInPlace:
+    """restart_in_place — replaces the process, and only returns when it failed."""
+
+    def test_execs_the_relaunch_command_with_the_version_in_the_env(self, monkeypatch, _fake_environ):
+        update_check.request_restart("2.13.0")
+        monkeypatch.setattr(update_check, "resolve_relaunch_command", lambda: ["/bin/yeaboi", "--dry-run"])
+        seen: dict = {}
+
+        def _fake_execv(path, argv):
+            seen["path"] = path
+            seen["argv"] = argv
+            seen["env"] = update_check.os.environ.get(update_check._RESTART_ENV)
+
+        monkeypatch.setattr(update_check.os, "execv", _fake_execv)
+        update_check.restart_in_place()
+        assert seen["path"] == "/bin/yeaboi"
+        assert seen["argv"] == ["/bin/yeaboi", "--dry-run"]
+        assert seen["env"] == "2.13.0"
+
+    def test_no_relaunch_command_returns_false_without_exec(self, monkeypatch):
+        monkeypatch.setattr(update_check, "resolve_relaunch_command", lambda: None)
+
+        def _boom(*a, **k):
+            raise AssertionError("must not exec without a resolved command")
+
+        monkeypatch.setattr(update_check.os, "execv", _boom)
+        assert update_check.restart_in_place() is False
+
+    def test_exec_failure_reports_false_and_clears_the_marker(self, monkeypatch, _fake_environ):
+        update_check.request_restart("2.13.0")
+        monkeypatch.setattr(update_check, "resolve_relaunch_command", lambda: ["/bin/yeaboi"])
+
+        def _boom(path, argv):
+            raise OSError("exec format error")
+
+        monkeypatch.setattr(update_check.os, "execv", _boom)
+        assert update_check.restart_in_place() is False
+        # The marker must not linger — this process is carrying on as the old version.
+        assert update_check.os.environ.get(update_check._RESTART_ENV) is None
+
+
+class TestRestartedVersion:
+    """The marker the relaunched process reads back out of its environment."""
+
+    def test_empty_on_a_normal_launch(self, _fake_environ):
+        assert update_check.restarted_version() == ""
+
+    def test_reports_the_version_after_a_restart(self, _fake_environ):
+        _fake_environ[update_check._RESTART_ENV] = "2.13.0"
+        assert update_check.restarted_version() == "2.13.0"
+
+    def test_the_marker_is_taken_out_of_the_environment(self, _fake_environ):
+        # It describes THIS process. Left in place every child we spawn inherits it,
+        # and a nested yeaboi would come up believing it was the relaunch.
+        _fake_environ[update_check._RESTART_ENV] = "2.13.0"
+        assert update_check.restarted_version() == "2.13.0"
+        assert update_check._RESTART_ENV not in _fake_environ
+        # Still answers after the pop — the value is cached, not re-read.
+        assert update_check.restarted_version() == "2.13.0"
+
+
+class TestIsFreshRestart:
+    """The predicate the splash skip and the ✓ updated chip both gate on."""
+
+    def test_false_on_a_normal_launch(self, _fake_environ):
+        assert update_check.is_fresh_restart() is False
+
+    def test_true_when_the_marker_matches_the_running_version(self, monkeypatch, _fake_environ):
+        monkeypatch.setattr(update_check, "_current_version", lambda: "2.13.0")
+        _fake_environ[update_check._RESTART_ENV] = "2.13.0"
+        assert update_check.is_fresh_restart() is True
+
+    def test_false_when_the_marker_is_for_another_version(self, monkeypatch, _fake_environ):
+        # A stale/foreign marker, or an upgrade that didn't move the version, must
+        # fall back to a normal launch rather than suppress the splash forever.
+        monkeypatch.setattr(update_check, "_current_version", lambda: "2.12.0")
+        _fake_environ[update_check._RESTART_ENV] = "2.13.0"
+        assert update_check.is_fresh_restart() is False

--- a/tests/unit/test_update_flow.py
+++ b/tests/unit/test_update_flow.py
@@ -1,0 +1,165 @@
+"""Tests for the ctrl+U update flow's restart handoff (_run_update_flow).
+
+The flow itself can't reach ``os.execv`` — it runs several frames deep inside the
+mode-select ``Live`` context, where exec would strand the terminal in raw mode. It
+returns True to unwind, having left a request on ``update_check`` for ``cli.main``
+to act on once the terminal is restored. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from yeaboi import update_check
+from yeaboi.ui import mode_select
+
+
+class _FakeConsole:
+    size = (100, 30)
+
+
+class _FakeLive:
+    """Captures the kwargs of every frame the flow renders."""
+
+    def __init__(self) -> None:
+        self.frames: list[dict] = []
+
+    def update(self, renderable) -> None:  # renderable is the captured kwargs dict
+        self.frames.append(renderable)
+
+
+@pytest.fixture(autouse=True)
+def _flow_seams(monkeypatch):
+    """Freeze the flow's slow/global edges: no real countdown, no real screens."""
+    monkeypatch.setattr(mode_select, "_UPDATE_RESTART_SECONDS", 0.05)
+    monkeypatch.setattr(mode_select, "_build_update_screen", lambda w, h, **kw: kw)
+    monkeypatch.setattr(update_check, "_restart_to", "")
+    monkeypatch.setattr(
+        update_check,
+        "get_update_status",
+        lambda: {
+            "current": "2.12.0",
+            "latest": "2.13.0",
+            "update_available": True,
+            "upgrade_command": "uv tool upgrade yeaboi",
+            "is_dev": False,
+        },
+    )
+
+
+def _run(
+    monkeypatch,
+    *,
+    ok: bool,
+    keys: list[str],
+    stale: list[str] | None = None,
+    relaunch: list[str] | None = None,
+):
+    """Drive the flow with a canned upgrade result and a scripted key stream.
+
+    ``stale`` is what the user typed *during* the upgrade — still queued on the tty
+    when it finishes. The flow drains that before the countdown, so the fake serves
+    it first and then reports the buffer empty exactly once; only after that does
+    ``keys`` (what they press at the result screen) become readable.
+    """
+    monkeypatch.setattr(update_check, "run_upgrade", lambda **kw: (ok, "detail line"))
+    monkeypatch.setattr(update_check, "resolve_relaunch_command", lambda: relaunch)
+    buffered = list(stale or [])
+    pending = list(keys)
+    drained = False
+
+    def _read_key(timeout=None):
+        nonlocal drained
+        if not drained:
+            if buffered:
+                return buffered.pop(0)
+            drained = True
+            return ""
+        return pending.pop(0) if pending else ""
+
+    live = _FakeLive()
+    result = mode_select._run_update_flow(_FakeConsole(), live, _read_key, 0.001, True)
+    return result, live
+
+
+class TestRestartHandoff:
+    def test_countdown_expiry_requests_the_restart(self, monkeypatch):
+        # No keys at all — the countdown runs out and the flow unwinds on its own.
+        result, live = _run(monkeypatch, ok=True, keys=[], relaunch=["/bin/yeaboi"])
+        assert result is True
+        assert update_check.restart_requested() == "2.13.0"
+        assert any(f.get("restart_in") is not None for f in live.frames if f.get("done"))
+
+    def test_any_key_restarts_without_waiting(self, monkeypatch):
+        result, _live = _run(monkeypatch, ok=True, keys=["enter"], relaunch=["/bin/yeaboi"])
+        assert result is True
+        assert update_check.restart_requested() == "2.13.0"
+
+    def test_esc_declines_and_stays_put(self, monkeypatch):
+        result, _live = _run(monkeypatch, ok=True, keys=["esc"], relaunch=["/bin/yeaboi"])
+        assert result is False
+        assert update_check.restart_requested() == ""
+
+    def test_q_declines_too(self, monkeypatch):
+        result, _live = _run(monkeypatch, ok=True, keys=["q"], relaunch=["/bin/yeaboi"])
+        assert result is False
+        assert update_check.restart_requested() == ""
+
+    def test_mouse_traffic_does_not_cut_the_countdown_short(self, monkeypatch):
+        # A stray wheel nudge must leave the esc window intact — it isn't an answer.
+        result, live = _run(
+            monkeypatch,
+            ok=True,
+            keys=["scroll_down", "click:4:9", "scroll_up"],
+            relaunch=["/bin/yeaboi"],
+        )
+        assert result is True
+        # More frames than keys means the countdown kept running past them.
+        assert len([f for f in live.frames if f.get("done")]) > 3
+
+
+class TestNoRestartOffered:
+    def test_failed_upgrade_never_restarts(self, monkeypatch):
+        result, live = _run(monkeypatch, ok=False, keys=["enter"], relaunch=["/bin/yeaboi"])
+        assert result is False
+        assert update_check.restart_requested() == ""
+        assert all(f.get("can_restart") is False for f in live.frames if f.get("done"))
+
+    def test_unresolvable_relaunch_falls_back_to_the_manual_screen(self, monkeypatch):
+        result, live = _run(monkeypatch, ok=True, keys=["enter"], relaunch=None)
+        assert result is False
+        assert update_check.restart_requested() == ""
+        done = [f for f in live.frames if f.get("done")]
+        assert done and all(f["can_restart"] is False and f["restart_in"] is None for f in done)
+
+
+class TestBufferedKeystrokes:
+    """Keys typed during the upgrade must not answer the screen that follows it."""
+
+    def test_a_stale_key_does_not_cut_the_countdown_short(self, monkeypatch):
+        # Without the drain the first read returns this esc and declines a restart
+        # the user was never shown — they'd never even see which version landed.
+        result, live = _run(monkeypatch, ok=True, keys=[], stale=["esc", "j"], relaunch=["/bin/yeaboi"])
+        assert result is True
+        assert update_check.restart_requested() == "2.13.0"
+        assert len([f for f in live.frames if f.get("done")]) > 1
+
+    def test_live_keys_still_answer_after_the_drain(self, monkeypatch):
+        result, _live = _run(monkeypatch, ok=True, keys=["esc"], stale=["j"], relaunch=["/bin/yeaboi"])
+        assert result is False
+        assert update_check.restart_requested() == ""
+
+    def test_the_drain_is_bounded(self, monkeypatch):
+        # Auto-repeat refills the buffer faster than we empty it; the drain has to
+        # give up rather than spin. What happens next is the countdown's business.
+        monkeypatch.setattr(mode_select, "_UPDATE_DRAIN_LIMIT", 3)
+        monkeypatch.setattr(update_check, "run_upgrade", lambda **kw: (True, ""))
+        monkeypatch.setattr(update_check, "resolve_relaunch_command", lambda: ["/bin/yeaboi"])
+        reads: list = []
+
+        def _read_key(timeout=None):
+            reads.append(timeout)
+            return "j"
+
+        assert mode_select._run_update_flow(_FakeConsole(), _FakeLive(), _read_key, 0.001, True) is True
+        assert reads[:3] == [0, 0, 0]  # exactly _UPDATE_DRAIN_LIMIT drain reads

--- a/tests/unit/test_version_row.py
+++ b/tests/unit/test_version_row.py
@@ -24,10 +24,24 @@ def _status(**overrides) -> dict:
     return base
 
 
+@pytest.fixture(autouse=True)
+def _not_restarted(monkeypatch):
+    """Default every test to a normal launch — the ✓ updated chip is opt-in."""
+    monkeypatch.setattr("yeaboi.update_check.is_fresh_restart", lambda: False)
+
+
 @pytest.fixture
 def _patch_status(monkeypatch):
     def _apply(**overrides):
         monkeypatch.setattr("yeaboi.update_check.get_update_status", lambda: _status(**overrides))
+
+    return _apply
+
+
+@pytest.fixture
+def _patch_restarted(monkeypatch):
+    def _apply(fresh: bool):
+        monkeypatch.setattr("yeaboi.update_check.is_fresh_restart", lambda: fresh)
 
     return _apply
 
@@ -152,10 +166,25 @@ class TestUpdateScreen:
         assert "updating to v2.13.0" in out
         assert "*" in out
 
-    def test_success_tells_user_to_restart(self):
-        out = _render(_screens._build_update_screen(80, 24, latest="2.13.0", command="x", done=True, ok=True), width=80)
+    def test_success_counts_down_to_the_restart(self):
+        out = _render(
+            _screens._build_update_screen(
+                80, 24, latest="2.13.0", command="x", done=True, ok=True, restart_in=2, can_restart=True
+            ),
+            width=80,
+        )
         assert "v2.13.0" in out
-        assert "restart" in out
+        assert "restarting in 2" in out
+        assert "esc to stay" in out
+
+    def test_success_without_a_relaunch_command_asks_for_a_manual_restart(self):
+        out = _render(
+            _screens._build_update_screen(80, 24, latest="2.13.0", command="x", done=True, ok=True, can_restart=False),
+            width=80,
+        )
+        assert "restart yeaboi" in out
+        assert "press any key" in out
+        assert "restarting in" not in out
 
     def test_failure_shows_manual_command(self):
         out = _render(
@@ -166,3 +195,43 @@ class TestUpdateScreen:
         )
         assert "failed" in out
         assert "uv tool upgrade yeaboi" in out
+
+
+class TestRestartedConfirmation:
+    """After a ctrl+U restart the row confirms the version that actually took."""
+
+    def test_confirms_the_new_version(self, _patch_status, _patch_restarted):
+        _patch_status(current="2.13.0")
+        _patch_restarted(True)
+        out = _render(_screens._build_version_row(100))
+        assert "✓ updated" in out
+        assert "v2.13.0" in out
+
+    def test_silent_on_a_normal_launch(self, _patch_status):
+        _patch_status(current="2.13.0")
+        out = _render(_screens._build_version_row(100))
+        assert "✓ updated" not in out
+
+    def test_silent_when_an_upgrade_is_still_pending(self, _patch_status, _patch_restarted):
+        # Mid-restart the check can already know about a NEWER release; the pending
+        # upgrade is the more useful thing to show, so it wins the slot.
+        _patch_status(current="2.13.0", latest="2.14.0", update_available=True)
+        _patch_restarted(True)
+        out = _render(_screens._build_version_row(100))
+        assert "✓ updated" not in out
+        assert "v2.14.0" in out
+
+    def test_silent_when_an_upgrade_is_pending_in_the_companion_layout(self, _patch_status, _patch_restarted):
+        # suppress_upgrade means _build_update_box is carrying the pending upgrade;
+        # the row must not answer it with "you're up to date" two columns away.
+        _patch_status(current="2.13.0", latest="2.14.0", update_available=True)
+        _patch_restarted(True)
+        out = _render(_screens._build_version_row(100, suppress_upgrade=True))
+        assert "✓ updated" not in out
+
+    def test_dropped_on_a_narrow_terminal(self, _patch_status, _patch_restarted):
+        _patch_status(current="2.13.0")
+        _patch_restarted(True)
+        out = _render(_screens._build_version_row(60), width=60)
+        assert "✓ updated" not in out
+        assert "c changelog" in out


### PR DESCRIPTION
## Summary

The in-app `ctrl+U` upgrade installed a new version into the venv and then told the user to **restart by hand** — the process they were looking at carried on running the old code, so a "successful" upgrade changed nothing until they quit and relaunched. This closes that loop.

After a successful upgrade the success screen counts down 3s and the app relaunches **itself** onto the version it just installed, preserving the original CLI flags (`--dry-run`, `--theme`, …). `esc`/`q` declines and stays on the running version; any other key restarts immediately; mouse traffic is not an answer, so a stray wheel nudge can't cut the esc window short.

**Why the restart lives in `cli.main` and not in the flow.** `os.execv` replaces the process image without running `atexit` handlers. `_run_update_flow` sits several frames inside `select_mode`'s `Live` context, so exec'ing from there would hand the new process a terminal still in raw mode, with mouse tracking on and the alternate screen active. The flow instead leaves a request as module state on `update_check` (`request_restart` / `restart_requested`) and returns `None` from `select_mode`; `cli.main` calls `restart_in_place()` only after its `finally` has done `disable_mouse_tracking` / `exit_raw_mode` / `music.shutdown()` / `set_alt_screen(False)`. This is deliberately *not* the q/esc quit path — this isn't a quit, so a local Ollama server stays up for the process about to take over.

**Confirming the restart did something.** The relaunched process skips the splash animation it just watched (`select_mode`'s `Live(screen=True)` enters the alt-screen itself, so only the animation is lost) and shows a `✓ updated` chip on the version row. Both gate on `is_fresh_restart()`, which requires the `YEABOI_RESTARTED` marker to *equal* the running version — a stale or foreign marker, or an upgrade that didn't move the version, self-heals back to a normal launch rather than suppressing the splash forever. The marker is popped on first read so children (the upgrade subprocess, board servers, cloudflared) don't inherit it.

**Honest fallbacks, everywhere it can't deliver.** A failed upgrade, a non-POSIX host (`os.execv` there spawns rather than replaces — two apps, one terminal), or an install whose console script can't be resolved all fall back to the old "restart yeaboi to use the new version" screen. `_build_update_screen` defaults to `can_restart=False`, so only a caller that has actually resolved a relaunch command can promise one.

**Buffered keystrokes.** `uv tool upgrade` routinely takes 5–30s and the spinner loop never reads keys, so anything typed in that window sits in the tty buffer. It is drained (bounded, so auto-repeat can't spin) before the countdown starts — otherwise the first read returns a stale key and fires the restart before the user sees which version landed. The kernel buffer also survives `exec`, so the tty is flushed before it: a buffered `q` would otherwise quit the app it just restarted.

## Test plan

- `make test` — **9975 passed, 47 skipped** (unit + integration + contract)
- `make lint` — clean; `ruff format --check src/ tests/` clean (what CI runs)
- `make security` — ruff/bandit SAST clean, `pip-audit` reports no known vulnerabilities
- New tests: `tests/unit/test_update_flow.py` (restart handoff, esc/q decline, mouse-ignoring, failed-upgrade and unresolvable-relaunch fallbacks, the buffered-keystroke drain and its bound), `tests/unit/test_update_check.py` (relaunch-command resolution incl. non-POSIX and `.py` argv[0], exec + env marker lifecycle, exec-failure cleanup, `is_fresh_restart` self-healing, marker pop), `tests/unit/test_version_row.py` (`✓ updated` chip: shown, silent on normal launch, loses the slot to a pending upgrade in both layouts, dropped on narrow terminals), `tests/integration/test_cli.py` (splash skip, and that the exec happens **after** raw-mode/mouse teardown and never when no restart was requested)
- Independent `code-reviewer` pass on the diff: 3 should-fix findings, all fixed in this branch (the keystroke drain, the missing `cli.main` wiring tests, and a `ruff format` violation CI would have caught); 4 of the 6 nits also taken (honest `can_restart` default, env-marker pop, `.py` argv[0] guard, chip vs. pending upgrade in the companion layout).

Not applicable: **surface parity** — the `ctrl+U` self-update has no `CAPABILITIES` row today and this adds no engine/CLI/MCP/plugin surface, so the two-way set-equality checks are unaffected. **Web bundles** — nothing under `frontend/` is touched.

Closes YEA-60

🤖 Generated with [Claude Code](https://claude.com/claude-code)