### PR TITLE
let dictation install itself from inside the app

### DIFF
--- a/.claude/skills/project-map/SKILL.md
+++ b/.claude/skills/project-map/SKILL.md
@@ -174,6 +174,7 @@ Key flags to know about when modifying the CLI:
 | `--allow-path PATH` | Session-only filesystem sandbox grant (repeatable); persistent allowances via `YEABOI_ALLOWED_PATHS` |
 | `--install-skill [DIR]` | Install bundled OpenClaw skill to `~/.openclaw/skills/` (or custom dir) |
 | `--list-audio-devices` | List the microphones dictation can record from, then exit (rescans first, so a mic plugged in after launch shows up); marks the `VOICE_DEVICE` pick |
+| `--install-voice` | Install the dictation packages + speech model into the running environment, then exit — the headless twin of the in-app offer (`voice_install.py`). No MCP tool by design |
 | `--standup-run` | Headless: run a daily standup and deliver it (what the OS scheduler invokes) |
 | `--standup-interactive` | With `--standup-run`: timed prompt for the user's update + confirm before generating (TTY-aware; headless fallback) |
 | `--standup-session ID` | Session to run the standup for (default: most recent) |
@@ -235,6 +236,8 @@ The `src/yeaboi/mcp/` package exposes yeaboi to AI coding agents (Claude Code, C
 - `BETA_NOTICES_ACK` — **state, not configuration.** Comma-separated `_MODE_CARDS` keys whose one-time TUI beta notice has been dismissed; written automatically to `~/.yeaboi/.env` on Continue. Not surfaced on the Settings page (it would invite hand-editing).
 - `YEABOI_FORCE_BETA_NOTICE` — re-show an already-acknowledged TUI beta notice. `1`/`true` for all modes, or a comma-separated list of mode keys. The only way to re-check a once-ever gate for demos, screenshots or review.
 - `VOICE_MODEL` — local Whisper size for dictation (`tiny`, `base` (default), `small`, `medium`, `large-v3`, plus the `.en` variants)
+- `VOICE_INSTALL_OFFER` — `on` (default) / `off`: whether double-tapping Space may offer to install dictation in place. `n` at the offer sets `off`; `YEABOI_FORCE_VOICE_OFFER=1` overrides it for one run
+- `VOICE_EXTRA_INSTALLED` — set once yeaboi has installed dictation itself, so a `uv tool upgrade` that wipes it can be explained rather than silently regressed
 - `VOICE_DEVICE` — microphone for dictation: a PortAudio index (`2`) or a case-insensitive name substring (`shure`). Empty = system default. Set it from Settings → Voice Input → Input Device (an arrow-selectable picker with a live level test), or discover names with `yeaboi --list-audio-devices`
 - `SESSION_PRUNE_DAYS` — auto-prune sessions older than N days (default: 30, 0 = disabled)
 - `LOG_LEVEL` — file logger level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)

--- a/.env.example
+++ b/.env.example
@@ -123,7 +123,8 @@ NOTION_ROOT_PAGE_ID=
 
 # Voice input (optional — double-tap Space in any text field to dictate)
 # Transcription runs locally & offline via faster-whisper (works with ANY LLM
-# provider, no API key). Install with: uv sync --extra voice
+# provider, no API key). Nothing to install by hand: the first double-tap offers
+# to set it up in place (or run: yeaboi --install-voice).
 # (self-contained on macOS/Windows; Linux also needs: apt install libportaudio2).
 # VOICE_MODEL is the local Whisper model size, not a cloud model name.
 # Options: tiny, base (default), small, medium, large-v3 (+ .en variants).
@@ -137,6 +138,12 @@ VOICE_MODEL=base
 # List what this machine has: yeaboi --list-audio-devices
 # Or pick it with a live level test in Settings -> Voice Input -> Input Device.
 VOICE_DEVICE=
+
+# VOICE_INSTALL_OFFER controls whether double-tapping Space may offer to install
+# dictation. Set to "off" by pressing n at the offer; set it back to "on" here or
+# in Settings -> Voice Input. YEABOI_FORCE_VOICE_OFFER=1 overrides an "off" for
+# one run, so the prompt can be demoed without editing this file.
+VOICE_INSTALL_OFFER=on
 
 # On-screen tips
 # Rotating discoverability tips on the welcome screen + inline voice hints.

--- a/README.md
+++ b/README.md
@@ -42,20 +42,32 @@ yeaboi                          # launch the interactive TUI
 
 > **Note on names:** the package was previously published as **`scrum-agent`**. It is now **`yeaboi`** on PyPI, matching the command. A final `scrum-agent` release remains as a thin redirect that installs `yeaboi`, and the legacy `scrum-agent` command still works as an alias for that release — but new installs should use `yeaboi`.
 
-Optional extras (voice input, extra LLM providers) can be requested at install time:
+**Voice input needs no separate install.** Double-tap Space in any text field and yeaboi
+offers to set dictation up in place — it installs the packages into the environment it is
+already running in, downloads the speech model with a progress bar, and drops straight
+into recording. No restart, no second terminal. (`yeaboi --install-voice` does the same
+thing headlessly, for CI and dev containers.)
+
+It is kept out of the base install rather than bundled because the speech engine
+(`ctranslate2`, `onnxruntime`) publishes wheels only for 64-bit macOS, glibc ≥ 2.28 Linux
+and Windows — making it a hard dependency would break `pip install yeaboi` outright on
+Alpine/musl, older glibc, 32-bit and armv7 hosts. On those platforms yeaboi says so
+instead of offering an install that cannot work.
+
+Optional extras can still be requested at install time if you prefer:
 
 ```bash
-uv tool install "yeaboi[voice]"                # 🎤 dictate answers (double-tap Space) — offline, works with any LLM
+uv tool install "yeaboi[voice]"                # 🎤 dictation, pre-installed rather than on demand
 uv tool install "yeaboi[all-providers]"        # OpenAI, Google, and Bedrock providers
 pipx install "yeaboi[voice]"                   # equivalent with pipx
 ```
 
 > **Voice input** transcribes on-device with [faster-whisper](https://github.com/SYSTRAN/faster-whisper)
-> — **no API key**, works with every LLM provider (Anthropic, Bedrock, …). On **macOS/Windows** the
-> `[voice]` extra is fully self-contained (the `sounddevice` wheel bundles PortAudio). On **Linux**, also
-> install the system library: `sudo apt install libportaudio2`. A small Whisper model downloads on first
-> use (~140 MB for the default `base`; set `VOICE_MODEL` to `tiny`/`small`/`medium`/`large-v3` to trade
-> size for accuracy).
+> — **no API key**, works with every LLM provider (Anthropic, Bedrock, …). On **macOS/Windows** it is
+> fully self-contained (the `sounddevice` wheel bundles PortAudio). On **Linux**, also install the
+> system library: `sudo apt install libportaudio2` — yeaboi will not run `sudo` for you. A small
+> Whisper model downloads on first use (~140 MB for the default `base`; set `VOICE_MODEL` to
+> `tiny`/`small`/`medium`/`large-v3` to trade size for accuracy).
 
 > **Homebrew is not supported.** A required dependency (`sqlite-vec`) ships no
 > source distribution, which Homebrew's source-build model can't handle, so

--- a/cowork/workstreams/tui-ux.md
+++ b/cowork/workstreams/tui-ux.md
@@ -3,7 +3,7 @@
 **Owns** — `src/yeaboi/ui/` **except `ui/session/`** (which is **planning**'s), `src/yeaboi/repl/`,
 `src/yeaboi/ui/shared/_tips.py`, `src/yeaboi/usage_export.py`, `formatters.py` (the REPL-side
 formatter layer), and the terminal-affordance helpers the TUI reaches out through — `clipboard.py`,
-`voice.py`, `music.py`, `os_open.py` — plus the matching render tests. Includes the two TUI utility
+`voice.py`, `voice_install.py`, `music.py`, `os_open.py` — plus the matching render tests. Includes the two TUI utility
 mode cards, **`usage` and `settings`**.
 
 **Skills** — `.claude/skills/tui-standards/SKILL.md` (mandatory — read it before any edit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "2.58.0"
+version = "2.59.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,43 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "2.59.0",
+      "date": "2026-08-08",
+      "summary": "Double-tapping Space now installs dictation automatically if the voice packages are missing — no need to reinstall yeaboi with the `voice` extra or restart. The in-app offer lets you Enter to install and download the Whisper model with a real progress bar, Esc to skip for this session, or `n` to never ask again. The install happens instantly in the running app, ready to record right away. A headless `--install-voice` command brings the same feature to CI containers and headless terminals with plain output that survives piping. Every surface now renders voice readiness from one shared vocabulary — `ready`, `installable`, `declined`, or `unsupported` — so the input chip, welcome tip, settings row, and setup wizard always agree about the same machine.",
+      "highlights": [
+        {
+          "text": "In-app voice installation: double-tap Space opens an offer to install and download Whisper model with progress bar",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Choose Enter to install, Esc to skip this session, or n to never ask again — sticky per-machine verdicts",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Installs directly into the running interpreter, downloads the Whisper model with real byte-percentage progress, ready to record",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "`yeaboi --install-voice` headless command for CI, containers, and terminals where full-screen UI can't run",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "One shared voice_state() vocabulary: ready/installable/declined/unsupported renders consistently across all surfaces",
+          "areas": [
+            "settings"
+          ]
+        }
+      ]
+    },
+    {
       "version": "2.58.0",
       "date": "2026-08-08",
       "summary": "The in-app `ctrl+U` upgrade now seamlessly restarts the app onto the newly installed version, preserving CLI flags like `--dry-run` and `--theme` so you stay where you were. The upgrade screen counts down 3 seconds and relaunches automatically, or press Esc/Q to decline and stay on the current version. The restarted app skips the splash animation and shows a `✓ updated` confirmation on the version row. Honest fallbacks appear if the upgrade fails, the restart can't be resolved, or you're on a non-POSIX system.",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -402,6 +402,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--install-voice",
+        action="store_true",
+        default=False,
+        help="Install the dictation packages and speech model into this environment, then exit. "
+        "The same thing double-tapping Space offers inside the app — this is the non-TUI path "
+        "for CI, dev containers and terminals the full-screen UI cannot drive.",
+    )
+
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         default=False,
@@ -1199,6 +1208,85 @@ def _confirm_sudo_overwrite(dest: Path) -> bool:
         print()
         return False
     return answer in ("y", "yes")
+
+
+def _install_voice() -> int:
+    """Install dictation from the command line, printing plain progress.
+
+    Deliberately not a Rich ``Live``: this runs where the TUI cannot, so the
+    output has to survive a pipe, a CI log and a terminal with no cursor
+    control. Returns a process exit code.
+
+    There is no MCP tool for this on purpose — installing arbitrary packages
+    into the host environment on an LLM's say-so is not a capability worth
+    shipping. Both entry points are human-initiated.
+    """
+    from yeaboi import voice, voice_install
+
+    log = logging.getLogger(__name__)
+    log.info("Installing voice input from the CLI")
+
+    if voice.is_voice_available()[0]:
+        print("Dictation is already installed.")
+    else:
+        # ignore_verdict: typing this command *is* the retry. A stored failure
+        # from a month ago (a wheel that had not landed yet, a mirror that had
+        # not synced) must not be the reason the explicit escape hatch refuses.
+        plan = voice_install.install_plan(ignore_verdict=True)
+        if plan.blocked:
+            print(f"Cannot install dictation here — {plan.blocked}")
+            return 1
+        print(f"Installing dictation: {plan.display_command}")
+        echoed: list[str] = []
+        ok, message = voice_install.install_packages(lambda phrase: _echo_once(echoed, phrase))
+        if not ok:
+            print(message)
+            return 1
+        from yeaboi.config import mark_voice_extra_installed
+
+        mark_voice_extra_installed()
+        print("Packages installed.")
+        if plan.follow_up:
+            print(f"To keep dictation across upgrades: {plan.follow_up}")
+
+    from yeaboi.config import get_voice_model
+
+    size = get_voice_model()
+    if voice_install.model_is_cached(size):
+        print(f"Speech model '{size}' is already downloaded.")
+    else:
+        print(f"Downloading the '{size}' speech model to {voice_install.model_cache_dir()}…")
+        ok, message = voice_install.download_model(size, _echo_progress)
+        if not ok:
+            # A missing model is a warning, not a failure: it downloads lazily on
+            # the first dictation exactly as it always did. Fall through to the
+            # probe rather than returning — the exit code still has to report
+            # whether dictation can actually run here.
+            print(message)
+        else:
+            print("\nSpeech model downloaded.")
+
+    ready, reason = voice.probe_voice_backend(force=True)
+    print("Dictation is ready — double-tap Space in any text field." if ready else f"Not ready — {reason}")
+    return 0 if ready else 1
+
+
+def _echo_once(echoed: list[str], phrase: str) -> None:
+    """Print an installer phrase, skipping consecutive repeats.
+
+    narrate() keeps emitting the same phrase for every line of a package's
+    download, which on a terminal reads as a stutter rather than progress.
+    """
+    if phrase and (not echoed or echoed[-1] != phrase):
+        echoed.append(phrase)
+        print(f"  {phrase}")
+
+
+def _echo_progress(status: str, fraction: float | None) -> None:
+    """One-line download progress that degrades to nothing on a dumb pipe."""
+    if fraction is None:
+        return
+    print(f"\r  {int(fraction * 100):3d}%  {status}", end="", flush=True)
 
 
 def _list_audio_devices() -> None:
@@ -2257,6 +2345,17 @@ def main(argv: list[str] | None = None) -> None:
     if args.list_audio_devices:
         _list_audio_devices()
         return
+
+    # ── --install-voice: set dictation up headlessly and exit ────────────────
+    # Logging is configured first, unlike the exits above it: this is the CI and
+    # dev-container surface, where the log file is the only diagnostic and the
+    # installer's raw child output (logged at DEBUG) is the whole point of it.
+    # Without this the records go to a handler-less root logger and vanish.
+    if args.install_voice:
+        from yeaboi.logging_setup import configure_logging
+
+        configure_logging()
+        raise SystemExit(_install_voice())
 
     # ── Filesystem sandbox: session-scoped --allow-path grants ───────────────
     # Applied before any flow that might touch user-supplied paths, so every

--- a/src/yeaboi/config.py
+++ b/src/yeaboi/config.py
@@ -274,6 +274,63 @@ def mark_beta_notice_seen(mode_key: str) -> None:
     logger.info("Beta notice acknowledged for %s (persisted to %s)", mode_key, config_file)
 
 
+# The in-app dictation install offer. Two tiers of "no": Esc declines for the
+# session (in-memory, in the UI module), `n` declines for good — which is this.
+VOICE_OFFER_KEY = "VOICE_INSTALL_OFFER"
+FORCE_VOICE_OFFER_ENV = "YEABOI_FORCE_VOICE_OFFER"
+VOICE_INSTALLED_KEY = "VOICE_EXTRA_INSTALLED"
+
+
+def is_voice_install_offer_enabled() -> bool:
+    """True when double-tapping Space may offer to install dictation.
+
+    Defaults on. ``YEABOI_FORCE_VOICE_OFFER`` overrides a permanent decline, for
+    the same reason :func:`is_beta_notice_seen` has its override: a once-ever
+    gate is otherwise impossible to demo, screenshot or review after the first
+    dismissal.
+    """
+    if os.getenv(FORCE_VOICE_OFFER_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv(VOICE_OFFER_KEY, "").strip().lower() not in {"0", "off", "false", "no"}
+
+
+def set_voice_install_offer(enabled: bool) -> None:
+    """Persist whether the dictation install offer may appear.
+
+    Same inverted ordering as :func:`mark_beta_notice_seen`: ``os.environ`` first,
+    disk second, because a user who just said "never" must not be asked again in
+    this session even if the config file cannot be written.
+    """
+    value = "on" if enabled else "off"
+    os.environ[VOICE_OFFER_KEY] = value
+    try:
+        config_file = set_config_value(VOICE_OFFER_KEY, value)
+    except OSError as exc:
+        logger.warning("Could not persist the voice install offer setting: %s", exc)
+        return
+    logger.info("Voice install offer set to %s (persisted to %s)", value, config_file)
+
+
+def voice_extra_was_installed() -> bool:
+    """True if yeaboi has installed the dictation packages here before.
+
+    An in-place ``uv pip install`` is not recorded in uv's tool receipt, so a
+    later ``uv tool upgrade`` rebuilds the venv and silently drops dictation.
+    This flag is what lets the offer say *"an upgrade removed dictation"* rather
+    than starting the conversation over as if nothing had happened.
+    """
+    return os.getenv(VOICE_INSTALLED_KEY, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def mark_voice_extra_installed() -> None:
+    """Record that the dictation packages were installed from inside the app."""
+    os.environ[VOICE_INSTALLED_KEY] = "1"
+    try:
+        set_config_value(VOICE_INSTALLED_KEY, "1")
+    except OSError as exc:
+        logger.warning("Could not persist the voice-installed marker: %s", exc)
+
+
 # Proxy environment variables to check (both uppercase and lowercase conventions).
 _PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy")
 

--- a/src/yeaboi/paths.py
+++ b/src/yeaboi/paths.py
@@ -87,6 +87,7 @@ STATES_DIR = DATA_DIR / "states"
 PROJECTS_FILE = DATA_DIR / "projects.json"
 REPORTING_THEMES_FILE = DATA_DIR / "reporting_themes.json"  # user-defined Reporting palettes
 REPORTING_PREFS_FILE = DATA_DIR / "reporting_prefs.json"  # persisted Reporting deck-style preferences
+VOICE_INSTALL_FILE = DATA_DIR / "voice_install.json"  # sticky "this machine cannot run dictation" verdicts
 
 # Legacy paths (for backward compatibility / migration)
 LEGACY_DB_PATH = ROOT_DIR / "sessions.db"
@@ -221,6 +222,17 @@ def get_reporting_prefs_path() -> Path:
     """Return the path of the persisted Reporting deck-style preferences (may not exist yet)."""
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     return REPORTING_PREFS_FILE
+
+
+def get_voice_install_path() -> Path:
+    """Return the path of the sticky voice-install verdict file (may not exist yet).
+
+    Only *permanent* failures are recorded here (no wheel for this platform, a
+    PEP 668 system Python) so the in-app install offer stops inviting a doomed
+    install. Retryable failures — offline, disk full — are never persisted.
+    """
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    return VOICE_INSTALL_FILE
 
 
 def _safe_key(key: str, fallback: str) -> str:

--- a/src/yeaboi/redaction.py
+++ b/src/yeaboi/redaction.py
@@ -82,6 +82,12 @@ _TOKEN_PATTERNS: tuple[str, ...] = (
     r"secret_[A-Za-z0-9]{30,}",
     r"hooks\.slack\.com/services/[\w/]+",
     r"(?i:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}",
+    # user:password inside a URL. Lookarounds so the scheme and host survive and
+    # only the credentials go: the voice installer logs the package-index URL,
+    # and a corporate mirror routinely carries a token there
+    # (https://svc:AKCp8…@nexus.corp/simple). Also covers Jira, SMTP and webhook
+    # URLs pasted anywhere else.
+    r"(?<=://)[^/\s:@]+:[^/\s@]{4,}(?=@)",
 )
 
 # Compiled-regex cache: (env value snapshot) -> compiled alternation.

--- a/src/yeaboi/setup_wizard.py
+++ b/src/yeaboi/setup_wizard.py
@@ -212,6 +212,42 @@ def _collect_api_key(console: Console, provider: dict[str, str]) -> str | None:
         return key  # valid format, or user explicitly declined retry
 
 
+def _print_voice_tip(console: Console) -> None:
+    """Mention dictation once, after setup. Silent when tips are switched off.
+
+    Renders from :func:`~yeaboi.voice.voice_state`, the same four-word vocabulary
+    the chip, the welcome tip and the Settings row use. This surface is the one
+    a user meets first, so it is the worst place to promise something the others
+    have already worked out is impossible — on musl or 32-bit it must not print
+    an install command that cannot succeed.
+    """
+    from yeaboi.config import is_tips_enabled
+    from yeaboi.voice import unsupported_blocker, voice_install_command, voice_state
+
+    if not is_tips_enabled():
+        return
+    state = voice_state()
+    if state == "ready":
+        console.print("[dim]🎤 Voice input is ready — double-tap Space in any text field to dictate.[/dim]")
+        return
+    if state == "unsupported":
+        console.print(f"[dim]🎤 Dictation can't run on this machine — {unsupported_blocker()}.[/dim]")
+        return
+    if state == "installable":
+        # No command: the gesture is the install, and naming one here sends the
+        # user to a second terminal for something one keystroke already does.
+        console.print(
+            "[dim]🎤 Tip: dictate your answers — double-tap Space in any text field and yeaboi "
+            "offers to set it up (offline, any LLM provider).[/dim]"
+        )
+        return
+    cmd = voice_install_command()
+    console.print(
+        "[dim]🎤 Tip: dictate your answers — install with [/dim]"
+        f"[cyan]{cmd}[/cyan][dim] (offline, any LLM provider).[/dim]"
+    )
+
+
 def run_setup_wizard(console: Console) -> bool:
     """Interactive credential setup wizard.
 
@@ -311,18 +347,7 @@ def run_setup_wizard(console: Console) -> bool:
     # Onboarding tip: voice input is optional and off by default. Mention it so
     # new users discover they can dictate answers instead of typing. Skipped
     # entirely when the user has switched tips off.
-    from yeaboi.config import is_tips_enabled
-    from yeaboi.voice import is_voice_available, voice_install_command
-
-    if is_tips_enabled():
-        if is_voice_available():
-            console.print("[dim]🎤 Voice input is ready — double-tap Space in any text field to dictate.[/dim]")
-        else:
-            cmd = voice_install_command()
-            console.print(
-                "[dim]🎤 Tip: enable voice input to dictate answers — "
-                f"run [/dim][cyan]{cmd}[/cyan][dim] (works offline, any LLM provider).[/dim]"
-            )
+    _print_voice_tip(console)
 
     logger.info("Setup wizard completed successfully")
     return True

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -6328,15 +6328,39 @@ def _build_settings_screen(
         # Local, offline dictation (double-tap Space in any text field) — works with every
         # LLM provider, no API key. See docs: "Voice Input".
         _heading("Voice Input")
-        from yeaboi.voice import backend_label, is_voice_available
+        from yeaboi.voice import backend_label, unsupported_blocker, voice_install_command, voice_state
 
-        _voice_ok, _voice_reason = is_voice_available()
-        # Read-only status; the unavailable text carries an install command, so it
-        # wraps onto continuation lines rather than cropping mid-command.
-        if _voice_ok:
+        # Read-only status, worded from the one shared vocabulary so this page
+        # cannot disagree with the chip and the tip about the same machine. Any
+        # text carrying an install command wraps rather than cropping mid-command.
+        _voice_state = voice_state()
+        if _voice_state == "ready":
             _row("Dictation", f"available — {backend_label()}", value_style=theme.good, wrap=True)
+        elif _voice_state == "installable":
+            _row(
+                "Dictation",
+                "not installed — double-tap Space in any text field, then Enter",
+                value_style=theme.warn,
+                wrap=True,
+            )
+        elif _voice_state == "unsupported":
+            _row("Dictation", f"unavailable — {unsupported_blocker()}", value_style=theme.warn, wrap=True)
         else:
-            _row("Dictation", f"unavailable — {_voice_reason}", value_style=theme.warn, wrap=True)
+            _row(
+                "Dictation",
+                f"not installed — offer dismissed; {voice_install_command()}",
+                value_style=theme.warn,
+                wrap=True,
+            )
+        # Editable rather than a button: the user ruled out a Settings *action*,
+        # but a permanent "never" needs some way back that is not an env var.
+        _row(
+            "Install Offer",
+            "off"
+            if config_data.get("VOICE_INSTALL_OFFER", "").strip().lower() in {"off", "false", "0", "no"}
+            else "on",
+            env="VOICE_INSTALL_OFFER",
+        )
         # Enter on this row opens the device picker (see _pick_voice_device) rather
         # than the free-text editor every other row uses.
         _row(

--- a/src/yeaboi/ui/session/screens/_screens_input.py
+++ b/src/yeaboi/ui/session/screens/_screens_input.py
@@ -31,19 +31,27 @@ def _voice_hint() -> str:
     :func:`~yeaboi.ui.shared._voice_input.input_box_title`) advertises the
     gesture now, and it does so where nothing can crop it — this hint sat at the
     tail of a no_wrap/ellipsis line and was the first thing cut on an 80-column
-    terminal. What the chip cannot carry is the install-method-aware command, so
-    that case still renders here. Returns "" when tips are switched off (the
-    double-tap Space shortcut still works regardless).
+    terminal. It is also empty when voice is merely *installable*, because the
+    double-tap now offers the install in place — there is nothing to copy. What
+    remains here are the two cases the chip cannot express: a user who declined
+    permanently (who still needs the command) and a machine that cannot run
+    dictation at all. Returns "" when tips are switched off (the double-tap
+    Space shortcut still works regardless).
     """
     from yeaboi.config import is_tips_enabled
-    from yeaboi.voice import is_voice_available, voice_install_command
+    from yeaboi.voice import voice_install_command, voice_state
 
     if not is_tips_enabled():
         return ""
 
-    available, _reason = is_voice_available()
-    if available:
+    state = voice_state()
+    if state in {"ready", "installable"}:
+        # "installable" is silent for the same reason "ready" is: the chip on the
+        # input box already carries the gesture, and double-tapping Space now
+        # offers the install itself. There is no command for the user to copy.
         return ""
+    if state == "unsupported":
+        return " · \U0001f3a4 dictation needs 64-bit macOS, Windows or glibc Linux"
     return f" · \U0001f3a4 dictate: {voice_install_command()}"
 
 

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -164,19 +164,28 @@ def get_tips() -> tuple[FeatureTip, ...]:
     The first entry is the voice tip and the last is the music tip; both adapt to
     whether their optional dependency is installed (dictation extra / the ffplay
     binary), showing an install hint otherwise. Between them come the feature tips
-    (one per capability) and the generic meta tips. Memoised because availability
-    is fixed for the life of the process.
+    (one per capability) and the generic meta tips. Memoised because the tips are
+    rebuilt on every welcome-screen frame; the memo is dropped by
+    :func:`yeaboi.voice_install.refresh_imports` when an in-app install changes
+    the answer part-way through a run.
     """
     from yeaboi.music import is_music_available
-    from yeaboi.voice import is_voice_available, voice_install_command
+    from yeaboi.voice import unsupported_blocker, voice_install_command, voice_state
 
-    available, _reason = is_voice_available()
-    voice_tip = FeatureTip(
-        "voice",
-        "\U0001f3a4 Tip: double-tap Space in any text field to dictate"
-        if available
-        else f"\U0001f3a4 Tip: enable dictation with — {voice_install_command()}",
-    )
+    state = voice_state()
+    if state == "unsupported":
+        # The actual blocker, not a fixed platform sentence: on Linux this is
+        # usually a missing libportaudio2 and carries the command that fixes it,
+        # which is worth more than restating the wheel matrix.
+        voice_text = f"\U0001f3a4 Tip: dictation can't run here — {unsupported_blocker()}"
+    else:
+        voice_text = {
+            "ready": "\U0001f3a4 Tip: double-tap Space in any text field to dictate",
+            # The gesture is the install: naming a shell command here would send
+            # the user to a second terminal for something one keystroke does.
+            "installable": "\U0001f3a4 Tip: double-tap Space in any text field — one keystroke sets dictation up",
+        }.get(state, f"\U0001f3a4 Tip: enable dictation with — {voice_install_command()}")
+    voice_tip = FeatureTip("voice", voice_text)
     music_available, _music_reason = is_music_available()
     music_tip = FeatureTip(
         "music",

--- a/src/yeaboi/ui/shared/_voice_input.py
+++ b/src/yeaboi/ui/shared/_voice_input.py
@@ -49,6 +49,17 @@ _SILENCE_LEVEL = 0.02
 # the pause before someone starts talking.
 _SILENCE_SECONDS = 2.5
 
+# An unanswered offer is a decline. Without a ceiling the modal would hold the
+# caller's key loop for as long as the app is open — a user who double-tapped
+# Space by accident and walked away should get their text field back.
+_OFFER_TIMEOUT_SECONDS = 120.0
+_OFFER_POLL_SECONDS = 0.2
+
+# Esc during the offer declines for this process only. People hit Space Space
+# repeatedly while composing, and re-asking on every tap is nagging; re-asking
+# on the next launch is not.
+_offer_declined_session = False
+
 # Voice input is triggered by a quick double-tap of the space bar — chosen over a
 # Ctrl/Cmd chord because macOS terminals never receive Cmd (so Ctrl was the only
 # option and read as ambiguous), and terminals can't detect key-release, ruling
@@ -88,34 +99,48 @@ _CHIP_ON_STYLE = "rgb(110,110,125)"
 _CHIP_OFF_STYLE = "rgb(80,80,92)"
 
 # Memoised: titles are rebuilt every frame and is_voice_available() walks
-# sys.path twice. Tests that monkeypatch availability call reset_voice_chip().
+# sys.path twice. Dropped by reset_voice_chip() once an in-app install lands.
 _chip_cache: tuple[str, str] | None = None
 
 
 def reset_voice_chip() -> None:
     """Forget the cached availability chip.
 
-    Called by tests that monkeypatch availability. Nothing in production calls
-    it: the voice extra cannot appear part-way through a process, so the cache
-    is valid for the life of the run.
+    Called by :func:`yeaboi.voice_install.refresh_imports` after an in-app
+    install — the voice extra *can* now appear part-way through a process, which
+    is exactly what this cache was originally allowed to assume away — and by
+    tests that monkeypatch availability.
     """
-    global _chip_cache
+    global _chip_cache, _offer_declined_session
     _chip_cache = None
+    _offer_declined_session = False
 
 
 def voice_chip() -> tuple[str, str]:
     """Return ``(chip_text, style)`` advertising dictation on an input box.
 
     Shown whether or not the optional extra is installed — an affordance is UI,
-    not a tip, so unlike :func:`_voice_hint` it ignores TIPS_ENABLED. The "off"
-    form is what tells someone the feature exists at all.
+    not a tip, so unlike :func:`_voice_hint` it ignores TIPS_ENABLED. Three
+    states, not two: when voice is *installable* the gesture is live (it opens
+    the in-app install offer), so the chip keeps the shortcut and only dims. Only
+    a machine that cannot run dictation, or a user who declined for good, sees
+    "off" — otherwise the chip would deny a feature one keystroke away.
     """
     global _chip_cache
     if _chip_cache is None:
-        from yeaboi.voice import is_voice_available
+        from yeaboi.voice import voice_state
 
-        available, _reason = is_voice_available()
-        _chip_cache = (_CHIP_ON, _CHIP_ON_STYLE) if available else (_CHIP_OFF, _CHIP_OFF_STYLE)
+        state = voice_state()
+        if state == "ready":
+            _chip_cache = (_CHIP_ON, _CHIP_ON_STYLE)
+        elif state == "installable":
+            # The gesture works — it opens the install offer — so the chip must
+            # not say "off". Dimmer, because it is live but not yet set up. Same
+            # cell width as the ready form, so input_box_title's arithmetic and
+            # the Settings box-top measurement are both unaffected.
+            _chip_cache = (_CHIP_ON, _CHIP_OFF_STYLE)
+        else:
+            _chip_cache = (_CHIP_OFF, _CHIP_OFF_STYLE)
     return _chip_cache
 
 
@@ -241,6 +266,143 @@ def voice_indicator(
     return "", ""
 
 
+def _bar(fraction: float, cells: int = 10) -> str:
+    """A plain-text progress bar for the download line.
+
+    Not :func:`yeaboi.ui.shared._components.build_meter`: that returns a
+    two-colour ``Text``, and this line is a single-style plain string threaded
+    through every caller's ``render_status``, so the glyphs have to be inline.
+    Out-of-range fractions clamp rather than raise — the parent computes them
+    from bytes on disk, which can briefly exceed the announced total.
+    """
+    filled = int(round(min(1.0, max(0.0, fraction)) * cells))
+    return "▰" * filled + "▱" * (cells - filled)
+
+
+def install_offer_line(*, size_mb: int = 0, reinstall: bool = False, width: int = 0) -> str:
+    """The one-line "shall I set dictation up?" prompt.
+
+    The size is computed, not hardcoded: ``VOICE_MODEL=large-v3`` is a 3.3 GB
+    agreement and a fixed "~140 MB" would be a lie to exactly the user who most
+    needs the number. ``reinstall`` is for the case where a ``uv tool upgrade``
+    rebuilt the venv and dropped the packages — saying so turns a baffling
+    regression into an explained one.
+    """
+    size = f"~{size_mb} MB" if size_mb else ""
+    if reinstall:
+        head = "🎤 An upgrade removed dictation"
+        return _fit(
+            [
+                f"{head} — Enter reinstalls ({size})  ·  Esc not now  ·  n never",
+                f"{head} — Enter reinstalls  ·  Esc not now  ·  n never",
+                f"{head}  ·  Enter  ·  Esc  ·  n never",
+                "Dictation was removed  ·  Enter  ·  Esc",
+                "Dictation? Enter · Esc",
+                "Dictate? Enter · Esc",
+            ],
+            width,
+        )
+    return _fit(
+        [
+            f"🎤 Set up dictation now? {size}, about two minutes  ·  Enter installs  ·  Esc not now  ·  n never",
+            f"🎤 Set up dictation? {size} one-off  ·  Enter installs  ·  Esc not now  ·  n never",
+            "🎤 Set up dictation?  Enter installs  ·  Esc not now  ·  n never",
+            "🎤 Set up dictation?  Enter  ·  Esc  ·  n never",
+            "Set up dictation?  Enter  ·  Esc",
+            # A 20-column terminal still has to be able to say yes and no.
+            "Dictation? Enter · Esc",
+            "Dictate? Enter · Esc",
+        ],
+        width,
+    )
+
+
+def install_status_line(
+    stage: str,
+    *,
+    tick: float = 0.0,
+    fraction: float | None = None,
+    detail: str = "",
+    elapsed: float = 0.0,
+    size: str = "",
+    can_cancel: bool = True,
+    width: int = 0,
+) -> tuple[str, str]:
+    """Return ``(border_style, status_line)`` for one frame of the setup flow.
+
+    Sibling of :func:`voice_indicator`, and deliberately the same shape: the
+    install runs inside ``record_voice_input``'s own loop, so every frame has to
+    be expressible as the ``(border, line)`` pair each caller already knows how
+    to render. A multi-line installer pane would have meant a new callback
+    threaded through six screen builders.
+
+    ``can_cancel`` is False when the caller's key reader cannot poll with a
+    timeout — advertising an Esc that physically cannot fire is worse than
+    dropping it.
+    """
+    spin = _SPINNER[int(tick * 12) % len(_SPINNER)]
+    esc = "  ·  Esc cancels" if can_cancel else ""
+    short_esc = "  ·  Esc" if can_cancel else ""
+
+    if stage == "install":
+        head = f"{spin} Installing dictation {_clock(elapsed)}"
+        return _WORK_BORDER, _fit(
+            [
+                f"{head}  ·  {detail}{esc}" if detail else f"{head}{esc}",
+                f"{head}{esc}",
+                f"{spin} Installing dictation{short_esc}",
+                f"{spin} Installing dictation",
+                f"{spin} Installing…",
+            ],
+            width,
+        )
+    if stage == "download":
+        if fraction is None:
+            return _WORK_BORDER, _fit(
+                [
+                    f"⬇ Speech model — {detail or 'connecting'}…{esc}",
+                    f"⬇ Speech model…{short_esc}",
+                    "⬇ Speech model…",
+                ],
+                width,
+            )
+        pct = f"{int(fraction * 100)}%"
+        head = f"⬇ Speech model  {_bar(fraction)}  {pct}"
+        return _WORK_BORDER, _fit(
+            [
+                f"{head}  ·  {size}{esc}" if size else f"{head}{esc}",
+                f"{head}{esc}",
+                f"⬇ Speech model {pct}{short_esc}",
+                f"⬇ Speech model {pct}",
+            ],
+            width,
+        )
+    if stage == "load":
+        return _WORK_BORDER, _fit(
+            [
+                f"{spin} Loading the speech model…{esc}",
+                f"{spin} Loading the speech model…{short_esc}",
+                f"{spin} Loading the speech model…",
+                f"{spin} Loading the model…",
+                f"{spin} Loading…",
+            ],
+            width,
+        )
+    # "ready" — one beat of confirmation before the REC frame takes over.
+    return _REC_BORDER, _fit(["✓ Dictation is ready — start speaking", "✓ Dictation is ready"], width)
+
+
+def _status_width(console: Console) -> int:
+    """Room the status line actually gets, read fresh each frame.
+
+    Every screen indents the line and draws a page border around it, so the raw
+    console width overstates it. Recomputed per frame rather than snapshotted: a
+    terminal resized mid-take would otherwise keep fitting the line to a width
+    that no longer exists.
+    """
+    return max(20, console.size[0] - 12)
+
+
 def _center(console: Console, message: str, border_style: str) -> Group:
     """Fallback overlay: a popup centred over a full screen.
 
@@ -283,6 +445,244 @@ def _next_device(current: int | None) -> tuple[int | None, str] | None:
     return chosen["index"], chosen["name"]
 
 
+def _key_supports_timeout(_key) -> bool:
+    """Can this key reader poll without blocking?
+
+    Production always passes ``read_key``, which can. A test double or a legacy
+    caller may not, and a blocking reader would freeze the install animation for
+    minutes — so those runs animate on a plain sleep and stop advertising an Esc
+    that physically cannot fire.
+    """
+    import inspect
+
+    try:
+        return "timeout" in inspect.signature(_key).parameters
+    except (TypeError, ValueError):  # builtins and C callables have no signature
+        return False
+
+
+def _read(_key, timeout: float) -> str:
+    """Poll for a key, tolerating readers without timeout support."""
+    try:
+        return _key(timeout=timeout)
+    except TypeError:
+        return _key()
+
+
+def _run_install(live: Live, console: Console, _key, paint, plan) -> tuple[bool, str]:
+    """Install the packages, fetch the model, warm it — animating throughout.
+
+    Modelled on the Ollama model pull in ``ui/provider_select`` (worker thread,
+    single-key progress dict, ``Esc`` sets a cancel Event): the loop that draws
+    must never be the loop that waits on a subprocess. Returns ``(ok, message)``;
+    ``message`` is a warning when ``ok`` is True (the model download failed but
+    dictation still works, just cold on first use).
+    """
+    from yeaboi import voice_install
+    from yeaboi.config import get_voice_model, mark_voice_extra_installed
+    from yeaboi.ui.shared._animations import FRAME_TIME_30FPS
+    from yeaboi.ui.shared._music_bar import duck_working_thread
+    from yeaboi.ui.shared._screensaver import suppress_screensaver
+
+    size = get_voice_model()
+    cancel = threading.Event()
+    can_cancel = _key_supports_timeout(_key)
+    # Single-key dict writes are atomic under the GIL, so the worker and the
+    # render loop need no lock between them.
+    prog: dict = {"stage": "install", "detail": "", "fraction": None, "size": ""}
+    outcome: dict = {"ok": False, "message": ""}
+
+    def _worker() -> None:
+        # duck_working_thread does not catch, so without this an unexpected
+        # exception would print a traceback straight through the Rich Live and
+        # leave outcome at its default — the user gets "see the log" and the log
+        # has nothing in it.
+        try:
+            _install_and_fetch()
+        except Exception:  # noqa: BLE001 - a worker thread must not take the TUI with it
+            logger.exception("Voice install failed unexpectedly")
+            outcome.update(ok=False, message="Dictation setup hit an unexpected error — see the log")
+
+    def _install_and_fetch() -> None:
+        ok, message = voice_install.install_packages(
+            lambda phrase: prog.__setitem__("detail", phrase), cancel, plan=plan
+        )
+        if not ok:
+            outcome.update(ok=False, message=message)
+            return
+        mark_voice_extra_installed()
+
+        prog.update(stage="download", detail="", fraction=None, size="")
+
+        def _on_progress(status: str, fraction: float | None) -> None:
+            prog["fraction"] = fraction
+            prog["size"] = status
+
+        model_ok, model_message = voice_install.download_model(size, _on_progress, cancel)
+        if not model_ok and cancel.is_set():
+            outcome.update(ok=False, message=model_message)
+            return
+        if model_ok:
+            # Only warm a model that is already on disk. warm_model() loads it
+            # in-process, and WhisperModel downloads the weights itself when
+            # they are missing — with no progress, no byte count and no cancel,
+            # under a status line still offering Esc. It would also undo the
+            # whole point of running the fetch in a child: on an AVX-less host
+            # the child dies of SIGILL, and importing ctranslate2 here would
+            # then take the TUI down with the same instruction.
+            prog["stage"] = "load"
+            voice_install.warm_model(size)
+        # A failed model fetch is a warning, not a failure: the packages are in,
+        # so the model simply downloads lazily on the first dictation as before.
+        outcome.update(ok=True, message="" if model_ok else model_message)
+
+    started = time.monotonic()
+    tick = 0.0
+    with suppress_screensaver():
+        thread = duck_working_thread(_worker, name="voice-install")
+        thread.start()
+        while thread.is_alive():
+            # Nothing reads the cancel Event during "load" — it is an in-process
+            # model load, not a child — so the line must stop offering Esc there
+            # rather than ignoring it.
+            stage = prog["stage"]
+            stage_cancellable = can_cancel and stage != "load"
+            paint(
+                *install_status_line(
+                    stage,
+                    tick=tick,
+                    fraction=prog["fraction"],
+                    detail=prog["detail"],
+                    size=prog["size"],
+                    elapsed=time.monotonic() - started,
+                    can_cancel=stage_cancellable,
+                    width=_status_width(console),
+                )
+            )
+            tick += FRAME_TIME_30FPS
+            frame_started = time.monotonic()
+            if can_cancel:
+                try:
+                    if _read(_key, FRAME_TIME_30FPS) == "esc":
+                        cancel.set()
+                except KeyboardInterrupt:
+                    cancel.set()
+            # Floor the frame time rather than trusting the key reader to supply
+            # it. A reader that returns early — a non-blocking stub, a terminal
+            # replaying buffered input — would otherwise spin this loop flat out
+            # for the whole install, burning a core and calling live.update
+            # millions of times. Measured on a stub reader: 2.1M frames in 44s.
+            remaining = FRAME_TIME_30FPS - (time.monotonic() - frame_started)
+            if remaining > 0:
+                time.sleep(remaining)
+        thread.join(timeout=1.0)
+
+    return outcome["ok"], outcome["message"]
+
+
+def _offer_install(live: Live, console: Console, _key, paint, reason: str) -> bool:
+    """Offer to set dictation up here and now. True if it is ready afterwards.
+
+    This is what a double-tap of Space does when the optional packages are
+    missing. Previously the app printed a command for the user to run in another
+    terminal, which meant quitting mid-thought, reinstalling, and coming back —
+    so in practice dictation stayed off.
+
+    Key handling is deliberately narrow. ``Space`` is ignored: the user just
+    double-tapped it, and key repeat must not authorise a 300 MB install.
+    ``Tab`` means "next microphone" everywhere else and there is no microphone
+    yet. Clicks and unknown keys are no-ops, because a modal that vanishes on a
+    typo is worse than one that waits — and all three exits are named on screen.
+    """
+    global _offer_declined_session
+
+    from yeaboi import voice, voice_install
+    from yeaboi.config import set_voice_install_offer, voice_extra_was_installed
+    from yeaboi.ui.shared._click import parse_click
+
+    state = voice.voice_state()
+    if state == "unsupported":
+        # Covers both "no wheel for this machine" and "packages are in, the
+        # audio backend is dead" — the latter carries its own apt hint, and an
+        # install could not have helped with either.
+        _flash(live, console, _key, f"Dictation can't run here — {voice.unsupported_blocker()}", _ERR_BORDER)
+        return False
+    if state == "declined":
+        # They said "never". Honour it, and still show the manual command.
+        _flash(live, console, _key, reason, _ERR_BORDER)
+        return False
+    if _offer_declined_session:
+        _flash(
+            live,
+            console,
+            _key,
+            "Dictation isn't set up yet — Space Space, then Enter, installs it",
+            _WORK_BORDER,
+        )
+        return False
+
+    plan = voice_install.install_plan()
+    if plan.blocked:
+        logger.info("Voice install offer withheld: %s", plan.blocked)
+        _flash(live, console, _key, f"Dictation can't be installed here — {plan.blocked}", _ERR_BORDER)
+        return False
+
+    size_mb = voice_install.size_estimate_mb()
+    reinstall = voice_extra_was_installed()
+    deadline = time.monotonic() + _OFFER_TIMEOUT_SECONDS
+    accepted = False
+    while time.monotonic() < deadline:
+        paint(
+            _REC_BORDER,
+            install_offer_line(size_mb=size_mb, reinstall=reinstall, width=_status_width(console)),
+        )
+        polled_at = time.monotonic()
+        try:
+            key = _read(_key, _OFFER_POLL_SECONDS)
+        except KeyboardInterrupt:
+            key = "esc"
+        # Same floor as the install loop: a key reader that returns early must
+        # not turn a two-minute unanswered prompt into a two-minute busy-wait.
+        # Applied to every key that does not exit the loop, not just the empty
+        # one — bracketed paste hands over characters as fast as the reader pops
+        # them, so a pasted paragraph would otherwise be one full live.update
+        # per character with no ceiling. The three answering keys skip it, so
+        # Enter still feels instant.
+        idle = _OFFER_POLL_SECONDS - (time.monotonic() - polled_at)
+        if key not in {"enter", "\r", "\n", "esc", "n"} and idle > 0:
+            time.sleep(idle)
+        if key in {"enter", "\r", "\n"}:
+            accepted = True
+            break
+        if key == "esc":
+            break
+        if key == "n":
+            logger.info("Voice install offer declined permanently")
+            set_voice_install_offer(False)
+            return False
+        if parse_click(key) is not None or key in {"", " ", "tab"}:
+            continue
+        # Anything else: keep the offer up rather than dismissing on a typo.
+
+    if not accepted:
+        logger.info("Voice install offer declined for this session")
+        _offer_declined_session = True
+        return False
+
+    logger.info("Voice install accepted: %s", plan.display_command)
+    ok, message = _run_install(live, console, _key, paint, plan)
+    if not ok:
+        _flash(live, console, _key, message or "Dictation setup failed — see the log", _ERR_BORDER)
+        return False
+    if message:
+        logger.info("Voice install finished with a warning: %s", message)
+    paint(*install_status_line("ready", width=_status_width(console)))
+    # A self-dismissing beat, not _flash: _flash waits for a key, which would
+    # make the user press something before they could start speaking.
+    time.sleep(0.6)
+    return True
+
+
 def record_voice_input(live: Live, console: Console, _key, render_status=None) -> str | None:
     """Record from the mic and return the transcribed text, or None.
 
@@ -301,7 +701,7 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
     from yeaboi.voice import (
         Recorder,
         is_model_loaded,
-        is_voice_available,
+        probe_voice_backend,
         resolve_device,
         transcribe,
         voice_install_command,
@@ -313,11 +713,19 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
         else:
             live.update(_center(console, line, border))
 
-    available, reason = is_voice_available()
+    # The strict probe, not the per-frame one: this is the moment a ~100 ms
+    # PortAudio check is invisible and an honest error is worth having.
+    available, reason = probe_voice_backend()
     if not available:
         logger.info("Voice input unavailable: %s", reason)
-        _flash(live, console, _key, reason, _ERR_BORDER)
-        return None
+        if not _offer_install(live, console, _key, _paint, reason):
+            return None
+        available, reason = probe_voice_backend(force=True)
+        if not available:
+            # Installed, but this interpreter still cannot see or open it.
+            logger.warning("Voice still unavailable after an in-app install: %s", reason)
+            _flash(live, console, _key, reason, _ERR_BORDER)
+            return None
 
     # Silence any background music so it doesn't bleed into the recording. Resumed
     # the moment recording stops (below), including on the mic-failure path.
@@ -347,14 +755,8 @@ def record_voice_input(live: Live, console: Console, _key, render_status=None) -
     warned = False  # the silence warning is logged once, never per frame
 
     def _width() -> int:
-        """Room the status line actually gets, read fresh each frame.
-
-        Every screen indents the line and draws a page border around it, so the
-        raw console width overstates it. Recomputed per frame rather than
-        snapshotted: a terminal resized mid-take would otherwise keep fitting
-        the line to a width that no longer exists.
-        """
-        return max(20, console.size[0] - 12)
+        """Room this screen gives the status line — see :func:`_status_width`."""
+        return _status_width(console)
 
     def _frame() -> None:
         level = recorder.level()

--- a/src/yeaboi/update_check.py
+++ b/src/yeaboi/update_check.py
@@ -76,6 +76,13 @@ def detect_upgrade_command() -> str:
 
     uv tool venvs live under ``~/.local/share/uv/tools/``; pipx venvs under
     ``~/.local/pipx/venvs/``. Falls back to the documented uv install method.
+
+    One asymmetry, and it is deliberate: dictation installed from inside the app
+    goes in with ``uv pip install``, which uv's *tool receipt* does not record —
+    so a plain ``uv tool upgrade`` rebuilds the venv and silently drops it. When
+    voice is live on a uv-tool install we upgrade through
+    ``uv tool install --force`` instead, which does carry the extra across. pipx
+    needs no equivalent: ``pipx inject`` is recorded, and survives.
     """
     try:
         exe = Path(sys.executable).resolve().as_posix()
@@ -83,7 +90,19 @@ def detect_upgrade_command() -> str:
         exe = sys.executable or ""
     if "/pipx/venvs/" in exe:
         return "pipx upgrade yeaboi"
+    if "/uv/tools/" in exe and _voice_is_live():
+        return "uv tool install --force 'yeaboi[voice]'"
     return "uv tool upgrade yeaboi"
+
+
+def _voice_is_live() -> bool:
+    """Whether dictation currently works here. Never raises."""
+    try:
+        from yeaboi.voice import is_voice_available
+
+        return is_voice_available()[0]
+    except Exception:  # noqa: BLE001 - an upgrade hint must never be the thing that breaks
+        return False
 
 
 def run_upgrade(*, timeout: float = 300.0) -> tuple[bool, str]:

--- a/src/yeaboi/voice.py
+++ b/src/yeaboi/voice.py
@@ -113,19 +113,169 @@ def _installed(module_name: str) -> bool:
         return False
 
 
-def is_voice_available() -> tuple[bool, str]:
-    """Return (available, reason) describing whether voice input can be used.
-
-    Voice needs the optional audio + transcription packages installed. No API
-    key is required — transcription is fully local. ``reason`` is empty when
-    available, otherwise a short human-readable explanation for the UI.
-    """
+def _module_check() -> tuple[bool, str]:
+    """Are both optional packages on the import path? Two find_spec calls, no more."""
     if not _installed("sounddevice"):
         # Linux wheels need the system PortAudio lib too.
         return False, f"Install voice extra: {voice_install_command()} (Linux also: apt install libportaudio2)"
     if not _installed("faster_whisper"):
         return False, f"Install voice extra: {voice_install_command()}"
     return True, ""
+
+
+def is_voice_available() -> tuple[bool, str]:
+    """Return (available, reason) describing whether voice input can be used.
+
+    Voice needs the optional audio + transcription packages installed. No API
+    key is required — transcription is fully local. ``reason`` is empty when
+    available, otherwise a short human-readable explanation for the UI.
+
+    Cheap by contract: this is called on every input-box render, so it only asks
+    the import system. It will *report* a strict failure that
+    :func:`probe_voice_backend` has already found (a present-but-unusable
+    PortAudio), but it never goes looking for one.
+    """
+    available, reason = _module_check()
+    if available and _backend_probe is not None and not _backend_probe[0]:
+        return _backend_probe
+    return available, reason
+
+
+# Result of the last strict backend probe, cached for the life of the process.
+# See probe_voice_backend for why this is separate from the cheap find_spec path.
+_backend_probe: tuple[bool, str] | None = None
+
+
+def reset_probe() -> None:
+    """Forget the cached strict probe result.
+
+    Called by :func:`yeaboi.voice_install.refresh_imports` after an in-app
+    install, and by tests that fake availability.
+    """
+    global _backend_probe
+    _backend_probe = None
+
+
+def _silence_stderr():  # noqa: ANN202 - contextmanager factory, typed by the decorator
+    """Redirect file descriptor 2 to /dev/null for the duration of the block.
+
+    PortAudio writes ALSA and JACK warnings straight to fd 2 from C, which
+    ``contextlib.redirect_stderr`` cannot catch (it only rebinds ``sys.stderr``).
+    Under a Rich ``Live`` those bytes land in the middle of a frame and corrupt
+    the screen, so initialising PortAudio has to happen with the descriptor
+    pointed elsewhere.
+    """
+    import contextlib
+
+    @contextlib.contextmanager
+    def _ctx():  # noqa: ANN202
+        try:
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            saved = os.dup(2)
+        except OSError:  # pragma: no cover - no fd 2 (rare, e.g. some daemons)
+            yield
+            return
+        try:
+            os.dup2(devnull, 2)
+            yield
+        finally:
+            os.dup2(saved, 2)
+            os.close(saved)
+            os.close(devnull)
+
+    return _ctx()
+
+
+def probe_voice_backend(*, force: bool = False) -> tuple[bool, str]:
+    """Strict availability check — actually opens PortAudio. Never per frame.
+
+    :func:`is_voice_available` only asks whether the modules are on the path,
+    which on Linux is not the same question: the ``sounddevice`` wheel is pure
+    Python and imports happily without the system PortAudio library, then fails
+    at the first recording. That made the app promise a feature it could not
+    deliver, with an error arriving only once the user had already tried to
+    speak.
+
+    This runs once per process, at the moment dictation is requested, where a
+    ~100 ms hitch is invisible and an honest error is worth having. The result
+    is cached and mirrored back into :func:`is_voice_available` so the render
+    path stays exactly as cheap as it was.
+    """
+    global _backend_probe
+    if _backend_probe is not None and not force:
+        return _backend_probe
+
+    available, reason = _module_check()
+    if not available:
+        _backend_probe = (available, reason)
+        return _backend_probe
+
+    try:
+        with _silence_stderr():
+            import sounddevice as sd
+
+            sd.query_devices()
+    except Exception as exc:  # noqa: BLE001 - a missing native lib surfaces as OSError here or at import
+        logger.warning("PortAudio unavailable: %s", exc)
+        hint = (
+            " — sudo apt install libportaudio2 (or your distro's equivalent)"
+            if sys.platform.startswith("linux")
+            else ""
+        )
+        _backend_probe = (False, f"Audio backend unavailable{hint}")
+        return _backend_probe
+
+    _backend_probe = (True, "")
+    return _backend_probe
+
+
+def voice_state() -> str:
+    """One vocabulary for every dictation surface: how to talk about voice here.
+
+    Returns ``"ready"``, ``"installable"``, ``"declined"`` or ``"unsupported"``.
+    The chip, the input hint, the welcome tip and the Settings row all render
+    from this rather than each deciding for itself, which is how they used to
+    end up saying different things about the same machine.
+    """
+    if is_voice_available()[0]:
+        return "ready"
+    if unsupported_blocker():
+        return "unsupported"
+
+    from yeaboi.config import is_voice_install_offer_enabled
+
+    return "installable" if is_voice_install_offer_enabled() else "declined"
+
+
+def unsupported_blocker() -> str:
+    """Why dictation cannot work here at all, or ``""`` if installing would help.
+
+    There are two ways to be beyond help, and every surface needs the same
+    sentence for both:
+
+    1. No wheel can exist for this platform, or a past install failed
+       permanently — :func:`yeaboi.voice_install.unsupported_reason`.
+    2. The packages are *already* installed and something else is broken. The
+       common one is a Linux host with no ``libportaudio2``: ``sounddevice`` is
+       a pure-Python wheel that imports happily without it, so the modules are
+       present and an install would exit 0 having changed nothing. Offering one
+       would talk the user through ~325 MB and two minutes to arrive back
+       exactly where they started — on the very platform the strict probe was
+       added for.
+
+    Cheap enough for the render path: a find_spec pair plus a memoised read. It
+    never *starts* a strict probe, it only reports one that already ran.
+    """
+    from yeaboi import voice_install
+
+    verdict = voice_install.unsupported_reason()
+    if verdict:
+        return verdict
+    if _module_check()[0]:
+        available, reason = is_voice_available()
+        if not available:
+            return reason
+    return ""
 
 
 def is_model_loaded() -> bool:

--- a/src/yeaboi/voice_install.py
+++ b/src/yeaboi/voice_install.py
@@ -1,0 +1,986 @@
+"""In-app installer for the optional dictation stack — packages, then the model.
+
+Voice input ships as the ``yeaboi[voice]`` extra (``sounddevice`` +
+``faster-whisper``) rather than as a core dependency, because ``ctranslate2``
+and ``onnxruntime`` publish **no sdist** and only build wheels for macOS
+x86_64/arm64, ``manylinux_2_28`` x86_64/aarch64 and ``win_amd64``. Making them
+required would turn ``pip install yeaboi`` into a hard failure on musl, on glibc
+older than 2.28, and on 32-bit and armv7 hosts — users who can run every other
+mode today.
+
+The cost of that choice used to land entirely on the user: quit the app,
+reinstall with the extra, come back, then sit through a silent ~145 MB model
+download on the first dictation. This module moves all of it inside the app, so
+double-tapping Space is the only step. Nothing here imports Rich or any TUI
+module — :mod:`yeaboi.ui.shared._voice_input` drives it, and ``cli.py``'s
+``--install-voice`` drives the same functions with plain prints.
+
+Design notes / architectural decisions:
+- **Additive commands only.** :func:`install_plan` never returns the command a
+  human would type (``uv sync``, ``uv tool install``): both *rebuild* the
+  environment this process is executing out of. See the table in
+  :func:`install_plan` for the per-method substitution and why each one is safe.
+- **The two packages, never the extra.** Installing ``yeaboi[voice]`` would
+  reinstall yeaboi itself — replacing the running process's own code and, in a
+  source checkout, clobbering the editable install with a PyPI build.
+- **Wheels only.** ``--only-binary=:all:`` turns an unsupported platform into a
+  four-second honest answer instead of a twenty-minute doomed C++ build behind a
+  progress bar (``av``/``tokenizers``/``numpy`` all ship sdists, so without the
+  flag pip cheerfully tries). ``VOICE_INSTALL_ALLOW_BUILD=1`` opts back in.
+- **The child never touches the terminal.** A package manager writing to the TTY
+  underneath a Rich ``Live`` shreds the display, so stdout and stderr are merged
+  into one pipe read by a daemon thread and stdin is ``DEVNULL`` — a prompting
+  pip must fail fast rather than eat the app's keystrokes.
+- **The model download runs in a child, and the parent counts bytes on disk.**
+  ``faster_whisper.utils.download_model`` hardcodes a disabled tqdm, and
+  ``snapshot_download``'s ``tqdm_class`` only wraps the outer per-*file* bar —
+  useless when one 145 MB ``model.bin`` is 95% of the payload. Polling the HF
+  cache directory (which includes the in-flight ``.incomplete`` blob) gives real
+  bytes, depends on no library internals, and makes cancel a real ``terminate``.
+- **No MCP tool, deliberately.** Installing arbitrary packages into the host
+  environment on an LLM's say-so is not a capability worth exposing; the TUI
+  offer and the CLI flag are both human-initiated.
+- **fs_policy is not involved.** That sandbox is enforced at explicit in-process
+  call sites for user-supplied paths; a child process writing to ``site-packages``
+  bypasses it entirely, so adding allow-rules for those directories would widen
+  what the agent's file tools may touch for exactly zero enforcement gain.
+
+# See docs: "Voice Input" — the installer is a helper, not an agent path. It
+# makes no LLM calls and does not go through get_llm().
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# The `voice` extra's contents. Asserted equal to pyproject.toml's extra by
+# tests/unit/test_voice_install.py, so the two cannot drift.
+VOICE_PACKAGES: tuple[str, ...] = ("sounddevice", "faster-whisper")
+
+# Rounded installed size of the wheel set (ctranslate2 + onnxruntime + av +
+# numpy + tokenizers + the rest). Used only for the "~325 MB" in the offer, so
+# approximate is fine — a wrong order of magnitude would not be.
+PACKAGES_MB = 180
+
+# One-time model download per size. The offer must not hardcode "140 MB": a user
+# with VOICE_MODEL=large-v3 is agreeing to twenty times that.
+MODEL_MB: dict[str, int] = {"tiny": 75, "base": 145, "small": 480, "medium": 1500, "large-v3": 3100}
+
+# Whitelist for the size interpolated into the child's -c program. Everything
+# else is rejected before a process is spawned.
+MODEL_SIZES: frozenset[str] = frozenset(MODEL_MB)
+
+_HF_ORG = "Systran"
+_HF_API = "https://huggingface.co/api/models/{repo}/tree/main"
+
+# Only one install per process, and only one across processes: pip is not safe
+# against concurrent writes to the same site-packages, and two open yeaboi
+# windows is an ordinary situation rather than an edge case.
+_install_lock = threading.Lock()
+
+_ALLOW_BUILD_ENV = "VOICE_INSTALL_ALLOW_BUILD"
+
+# Progress cadence for the model download. 250 ms is fast enough that the bar
+# looks live at 30 fps and slow enough that rglob() over the cache is free.
+_POLL_SECONDS = 0.25
+
+# No wall-clock timeout on the download — a 460 MB "small" on hotel wifi is
+# legitimately twenty minutes, and killing a slow success is worse than waiting.
+# A byte counter that has not moved in this long is reported as stalled instead.
+_STALL_SECONDS = 120.0
+
+
+@dataclass(frozen=True)
+class InstallPlan:
+    """How to add the dictation packages to *this* interpreter, right now."""
+
+    method: str  # "uv-project" | "uv-tool" | "pipx" | "pip" | "blocked"
+    argv: tuple[str, ...]
+    display_command: str  # what we show and log; shlex-joined argv
+    durable: bool  # survives a later `uv tool upgrade` / `pipx reinstall`
+    blocked: str  # non-empty => refuse before spawning anything
+    follow_up: str  # the command that makes a non-durable install durable
+
+
+# ---------------------------------------------------------------------------
+# Platform gate
+# ---------------------------------------------------------------------------
+
+
+def platform_support() -> tuple[bool, str]:
+    """Return ``(supported, reason)`` for hosts where no wheel *can* exist.
+
+    Gates only what is certain, because a stale allow-list that refuses a
+    platform pip would have served is worse than a failed install with a real
+    error message: 32-bit interpreters, architectures outside the four
+    ctranslate2/onnxruntime build for, and non-glibc Linux (musl reports an
+    empty name from ``platform.libc_ver``). A too-new CPython is deliberately
+    *not* gated here — that is a moving target which resolves itself when the
+    wheels land, so it surfaces through :func:`classify_failure` instead.
+    """
+    if sys.maxsize <= 2**32:
+        return False, "32-bit Python (the speech engine ships 64-bit wheels only)"
+    machine = platform.machine().lower()
+    if machine not in {"x86_64", "amd64", "arm64", "aarch64"}:
+        return False, f"{platform.machine()} CPUs have no speech-engine wheel"
+    if sys.platform.startswith("linux"):
+        libc, version = platform.libc_ver()
+        if libc and libc != "glibc":
+            return False, f"{libc} libc (the speech engine builds against glibc only)"
+        if not libc:
+            return False, "musl libc (the speech engine builds against glibc only)"
+        parts = [int(p) for p in re.findall(r"\d+", version)[:2]] or [0]
+        if tuple(parts) < (2, 17):
+            return False, f"glibc {version} is older than the 2.17 the speech engine needs"
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Sticky verdicts
+# ---------------------------------------------------------------------------
+
+
+def _verdict_key() -> str:
+    """Identify the environment a permanent verdict applies to.
+
+    Keyed on platform *and* Python version *and* interpreter path so a Python
+    upgrade, or a reinstall somewhere else, silently invalidates a "no wheel"
+    verdict instead of condemning the machine forever.
+    """
+    return f"{platform.platform()}|{sys.version_info[0]}.{sys.version_info[1]}|{sys.executable}"
+
+
+# A stored verdict stops being trusted after this long. "Permanent" here means
+# "nothing you can do in this session will change it", not "true forever": the
+# two codes we persist both have futures. NO_WHEEL covers a CPython so new that
+# no cp3XX wheel exists yet — which the platform gate deliberately does not
+# pre-empt because it "resolves itself when the wheels land" — and a corporate
+# mirror that has not synced ctranslate2 yet. EXTERNALLY_MANAGED can be resolved
+# by an OS upgrade. The key already invalidates on a Python or interpreter
+# change; this covers the case where the *world* changed and the machine did not,
+# so one bad attempt cannot condemn a host for good.
+_VERDICT_TTL_SECONDS = 30 * 24 * 3600.0
+
+
+def read_verdict() -> tuple[str, str]:
+    """Return a stored ``(code, message)`` permanent failure, or ``("", "")``.
+
+    An expired verdict reads as absent, so the next double-tap re-offers.
+    """
+    from yeaboi.paths import get_voice_install_path
+
+    try:
+        raw = json.loads(get_voice_install_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return "", ""
+    if not isinstance(raw, dict) or raw.get("key") != _verdict_key():
+        return "", ""
+    try:
+        stamped = float(raw.get("at", 0.0))
+    except (TypeError, ValueError):
+        stamped = 0.0
+    # A missing/0 stamp is a file written by an older build: treat it as fresh
+    # rather than as 1970, which would expire every one of them on read.
+    if stamped and time.time() - stamped > _VERDICT_TTL_SECONDS:
+        logger.info("Voice-install verdict expired; dictation will be offered again")
+        return "", ""
+    return str(raw.get("code", "")), str(raw.get("message", ""))
+
+
+def write_verdict(code: str, message: str) -> None:
+    """Persist a permanent failure so the offer stops appearing. Best-effort."""
+    from yeaboi.paths import get_voice_install_path
+
+    try:
+        get_voice_install_path().write_text(
+            json.dumps({"key": _verdict_key(), "code": code, "message": message, "at": time.time()}),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.warning("Could not persist voice-install verdict: %s", exc)
+        return
+    finally:
+        reset_unsupported_cache()
+    logger.info("Voice install marked unavailable for up to %d days: %s", _VERDICT_TTL_SECONDS // 86400, code)
+
+
+def clear_verdict() -> None:
+    """Forget any stored permanent failure (used by tests and a manual retry)."""
+    from yeaboi.paths import get_voice_install_path
+
+    try:
+        get_voice_install_path().unlink(missing_ok=True)
+    except OSError:  # pragma: no cover - unlink on a readable dir practically cannot fail
+        logger.warning("Could not clear voice-install verdict", exc_info=True)
+    reset_unsupported_cache()
+
+
+# Memoised because every input-box render asks for it (via voice_state) and the
+# answer involves a JSON read. Cleared by clear_verdict() and refresh_imports().
+_unsupported_cache: str | None = None
+
+
+def unsupported_reason() -> str:
+    """Return why dictation can never work here, or ``""`` if it might.
+
+    Combines the pre-flight platform gate with any stored permanent verdict, so
+    every surface asks one question instead of two.
+    """
+    global _unsupported_cache
+    if _unsupported_cache is None:
+        supported, reason = platform_support()
+        _unsupported_cache = reason if not supported else read_verdict()[1]
+    return _unsupported_cache
+
+
+def reset_unsupported_cache() -> None:
+    """Forget the memoised verdict (after writing or clearing one, and in tests)."""
+    global _unsupported_cache
+    _unsupported_cache = None
+
+
+# ---------------------------------------------------------------------------
+# The install command
+# ---------------------------------------------------------------------------
+
+
+def _is_source_checkout() -> bool:
+    """True when this package is being run from a repo checkout, not a wheel."""
+    repo_root = Path(__file__).resolve().parents[2]
+    return (repo_root / "pyproject.toml").exists() and (repo_root / "src" / "yeaboi").is_dir()
+
+
+def _pipx_venv_name() -> str:
+    """Derive the pipx venv name from the interpreter path; ``""`` if it can't.
+
+    The argument to ``pipx inject`` is the *venv* name, and the legacy install of
+    this app is registered as ``scrum-agent`` rather than ``yeaboi`` — so it must
+    be read off the path, never hardcoded.
+    """
+    try:
+        parts = Path(sys.executable).resolve().parts
+    except OSError:
+        return ""
+    if "venvs" not in parts:
+        return ""
+    name = parts[parts.index("venvs") + 1] if parts.index("venvs") + 1 < len(parts) else ""
+    return name if re.fullmatch(r"[A-Za-z0-9._-]+", name or "") else ""
+
+
+def _externally_managed() -> bool:
+    """True for a PEP 668 system Python (Homebrew, Debian) outside a venv."""
+    if sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+        return False  # inside a venv — always ours to write to
+    import sysconfig
+
+    stdlib = sysconfig.get_path("stdlib")
+    return bool(stdlib) and (Path(stdlib) / "EXTERNALLY-MANAGED").exists()
+
+
+def _binary_flags(program: str) -> tuple[str, ...]:
+    if os.getenv(_ALLOW_BUILD_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        return ()
+    return ("--no-build",) if program == "uv" else ("--only-binary=:all:",)
+
+
+def install_plan(*, ignore_verdict: bool = False) -> InstallPlan:
+    """Return the additive command that adds dictation to the running interpreter.
+
+    ``ignore_verdict`` skips a *stored* past failure but never the platform gate,
+    which is the one thing here that is genuinely certain. It is what
+    ``--install-voice`` passes: a human typing the command explicitly is asking
+    to retry, and refusing them on the strength of an old cached failure leaves
+    no way back at all.
+
+    :func:`yeaboi.voice.voice_install_command` returns what a *human* should type;
+    two of its four branches are wrong to run against a live process, so this
+    substitutes an additive equivalent:
+
+    ============  ==========================================================
+    detected      why not the printed command
+    ============  ==========================================================
+    source        ``uv sync`` is *exact*: it uninstalls anything absent from
+                  the lockfile, out from under a running process, and it
+                  resolves from ``cwd`` — which for a TUI is wherever the user
+                  happened to launch it.
+    uv tool       ``uv tool install --force`` deletes and recreates the venv
+                  this process is executing out of. ``uv pip install --python``
+                  targets the same interpreter and only adds.
+    pipx          same rebuild hazard; ``pipx inject`` is the additive form and
+                  is recorded in pipx metadata, so it survives a reinstall.
+    pip / venv    ``sys.executable -m pip``, never a bare ``pip`` — which may
+                  well belong to a different environment.
+    ============  ==========================================================
+    """
+    supported, platform_reason = platform_support()
+    if not supported:
+        return InstallPlan("blocked", (), "", False, platform_reason, "")
+    stored = "" if ignore_verdict else read_verdict()[1]
+    if stored:
+        return InstallPlan("blocked", (), "", False, stored, "")
+    if _externally_managed():
+        return InstallPlan(
+            "blocked",
+            (),
+            "",
+            False,
+            "this is a system-managed Python — reinstall yeaboi with `uv tool install yeaboi` or `pipx install yeaboi`",
+            "",
+        )
+
+    exe = sys.executable
+    uv = shutil.which("uv")
+    if _is_source_checkout() or "/uv/tools/" in exe.replace("\\", "/"):
+        method = "uv-project" if _is_source_checkout() else "uv-tool"
+        if not uv:
+            return InstallPlan("blocked", (), "", False, "`uv` is not on PATH", "")
+        argv = (uv, "pip", "install", "--python", exe, *_binary_flags("uv"), *VOICE_PACKAGES)
+        follow_up = "uv sync --extra voice" if method == "uv-project" else "uv tool install --force 'yeaboi[voice]'"
+        return InstallPlan(method, argv, shlex.join(argv), False, "", follow_up)
+
+    venv_name = _pipx_venv_name()
+    pipx = shutil.which("pipx")
+    if venv_name and pipx:
+        argv = (pipx, "inject", venv_name, *VOICE_PACKAGES)
+        return InstallPlan("pipx", argv, shlex.join(argv), True, "", "")
+
+    argv = (
+        exe,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-input",
+        *_binary_flags("pip"),
+        *VOICE_PACKAGES,
+    )
+    return InstallPlan("pip", argv, shlex.join(argv), True, "", "")
+
+
+def size_estimate_mb() -> int:
+    """Rounded MB the offer is asking the user to agree to, model included."""
+    from yeaboi.config import get_voice_model
+
+    size = get_voice_model()
+    model = 0 if model_is_cached(size) else MODEL_MB.get(size, MODEL_MB["base"])
+    return PACKAGES_MB + model
+
+
+# ---------------------------------------------------------------------------
+# Running the installer
+# ---------------------------------------------------------------------------
+
+
+def _child_env() -> dict[str, str]:
+    """Environment that stops the child drawing anything a pipe can't carry.
+
+    Without the progress-bar kills, pip and uv emit carriage-return bars that
+    arrive as one enormous line and defeat :func:`narrate` entirely; without
+    ``COLUMNS`` they hard-wrap a package name across two lines and defeat it
+    again. ``TERM=dumb`` and ``NO_COLOR`` strip the ANSI escapes that would
+    otherwise be rendered literally inside a status line.
+    """
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONUNBUFFERED": "1",
+            "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+            "PIP_NO_INPUT": "1",
+            "PIP_PROGRESS_BAR": "off",
+            "UV_NO_PROGRESS": "1",
+            "NO_COLOR": "1",
+            "CLICOLOR": "0",
+            "TERM": "dumb",
+            "COLUMNS": "200",
+        }
+    )
+    return env
+
+
+_NARRATIONS: tuple[tuple[re.Pattern[str], Callable[[re.Match[str]], str]], ...] = (
+    (
+        re.compile(r"^\s*Downloading\s+([A-Za-z0-9._-]+?)-[\d.]+.*?\(([\d.]+\s*[kKMG]B)\)"),
+        lambda m: f"downloading {m[1]} ({m[2]})",
+    ),
+    (re.compile(r"^\s*Downloading\s+([A-Za-z0-9._-]+?)-[\d.]"), lambda m: f"downloading {m[1]}"),
+    (re.compile(r"^\s*Using cached\s+([A-Za-z0-9._-]+?)-[\d.]"), lambda m: f"using cached {m[1]}"),
+    (re.compile(r"^\s*Collecting\s+([A-Za-z0-9._\[\]-]+)"), lambda m: f"resolving {m[1]}"),
+    (re.compile(r"^\s*Building wheel for\s+([A-Za-z0-9._-]+)"), lambda m: f"building {m[1]}"),
+    (re.compile(r"^\s*Installing collected packages"), lambda _m: "installing packages"),
+    (re.compile(r"^\s*Resolved\s+(\d+)\s+packages?"), lambda m: f"resolved {m[1]} packages"),
+    (re.compile(r"^\s*Prepared\s+(\d+)\s+packages?"), lambda m: f"downloaded {m[1]} packages"),
+    (re.compile(r"^\s*Installed\s+(\d+)\s+packages?"), lambda m: f"installed {m[1]} packages"),
+    (re.compile(r"^\s*Successfully installed"), lambda _m: "installed packages"),
+)
+
+
+def narrate(line: str) -> str:
+    """Turn one installer output line into a short phrase, or ``""`` to ignore it.
+
+    Callers keep the *previous* phrase when this returns empty, so raw resolver
+    noise never reaches a one-line status. The status line has room for a few
+    words, not for pip.
+    """
+    for pattern, render in _NARRATIONS:
+        match = pattern.search(line)
+        if match is not None:
+            return render(match)
+    return ""
+
+
+_FAILURES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "NO_WHEEL",
+        re.compile(
+            r"no matching distribution|could not find a version|"
+            r"has no (?:source distribution or )?wheels?|"
+            r"does(?:n't| not) have a (?:source distribution or )?wheel|"
+            r"requires a different python",
+            re.I,
+        ),
+    ),
+    ("EXTERNALLY_MANAGED", re.compile(r"externally-managed-environment", re.I)),
+    (
+        "NO_NETWORK",
+        re.compile(
+            r"temporary failure in name resolution|getaddrinfo|failed to establish a new connection|"
+            r"error sending request|certificate verify failed|network is unreachable|proxyerror",
+            re.I,
+        ),
+    ),
+    ("DISK_FULL", re.compile(r"no space left on device|errno 28|disk quota exceeded", re.I)),
+    ("PERMISSION", re.compile(r"permission denied|errno 13|consider using the `--user` option", re.I)),
+)
+
+_FAILURE_MESSAGES: dict[str, str] = {
+    "EXTERNALLY_MANAGED": (
+        "This is a system-managed Python — installing here would need sudo and could break OS packages. "
+        "Reinstall yeaboi with `uv tool install yeaboi` or `pipx install yeaboi`."
+    ),
+    "NO_NETWORK": "Can't reach the package index. Try again when you're online.",
+    "DISK_FULL": "Out of disk — dictation needs roughly 400 MB of packages plus the speech model.",
+    "PERMISSION": "Permission denied writing to this environment. yeaboi will not re-run itself with sudo.",
+    "MANAGER_MISSING": "The package manager that installed yeaboi isn't on PATH any more.",
+    "CANCELLED": "Install cancelled — nothing was changed.",
+    "TIMEOUT": "The install took too long and was stopped.",
+}
+
+# Codes we refuse to retry: nothing about this machine will change by trying again.
+PERMANENT_CODES: frozenset[str] = frozenset({"NO_WHEEL", "EXTERNALLY_MANAGED"})
+
+
+def _host_description() -> str:
+    """Name the host precisely enough that "no wheel" is actionable.
+
+    The Python version matters as much as the platform here: a brand-new CPython
+    with no cp3XX wheels yet looks identical to an unsupported OS unless we say
+    which one it was.
+    """
+    parts = [f"{platform.system().lower()}/{platform.machine()}"]
+    if sys.platform.startswith("linux"):
+        libc, libc_version = platform.libc_ver()
+        parts.append("(" + " ".join(filter(None, (libc or "musl", libc_version))) + ")")
+    parts.append(f"on CPython {sys.version_info[0]}.{sys.version_info[1]}")
+    return " ".join(parts)
+
+
+def classify_failure(returncode: int, output: str) -> tuple[str, str]:
+    """Map an installer exit into ``(code, human message)``.
+
+    Pure over its inputs so the whole taxonomy is table-testable without ever
+    running a package manager.
+    """
+    for code, pattern in _FAILURES:
+        if pattern.search(output):
+            if code == "NO_WHEEL":
+                return code, (
+                    "No prebuilt speech-engine wheel exists for "
+                    f"{_host_description()} — dictation can't run on this machine yet."
+                )
+            return code, _FAILURE_MESSAGES[code]
+    tail = " / ".join(line.strip() for line in output.strip().splitlines()[-3:] if line.strip())
+    return "UNKNOWN", (
+        f"Install failed (exit {returncode}). {tail}" if tail else f"Install failed (exit {returncode})."
+    )
+
+
+# How long a lock may sit untouched before another window may break it. Only
+# consulted where a liveness probe is unavailable (Windows, see _pid_alive): the
+# alternative there is a machine that can never install dictation again because
+# one crashed run left its lock behind.
+_LOCK_STALE_SECONDS = 3600.0
+
+
+def _pid_alive(pid: int) -> bool | None:
+    """Return whether *pid* is running, or ``None`` when that cannot be asked.
+
+    ``os.kill(pid, 0)`` is a liveness probe on POSIX only. On Windows CPython it
+    calls ``TerminateProcess(handle, sig)`` for every signal except
+    ``CTRL_C_EVENT``/``CTRL_BREAK_EVENT`` — so using it as a probe would *kill*
+    the other yeaboi window, mid-session, with exit code 0. Windows is a
+    supported dictation platform (``win_amd64`` is one of the four wheel targets
+    this module exists to work around) and two open windows is ordinary here, so
+    that path answers ``None`` and the caller falls back to the lock's age.
+    """
+    if sys.platform == "win32":
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True  # alive, owned by another user
+    return True
+
+
+class _Lockfile:
+    """Cross-process "one installer at a time" guard, with stale-pid recovery."""
+
+    def __init__(self) -> None:
+        from yeaboi.paths import get_bin_dir
+
+        self.path = get_bin_dir() / "voice-install.lock"
+        self.acquired = False
+
+    def __enter__(self) -> _Lockfile:
+        for _attempt in range(2):
+            try:
+                fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            except FileExistsError:
+                if self._stale():
+                    continue
+                return self
+            except OSError:  # pragma: no cover - unwritable bin dir: proceed rather than block
+                self.acquired = True
+                return self
+            with os.fdopen(fd, "w") as handle:
+                handle.write(str(os.getpid()))
+            self.acquired = True
+            return self
+        return self
+
+    def _stale(self) -> bool:
+        try:
+            pid = int(self.path.read_text(encoding="utf-8").strip() or "0")
+        except (OSError, ValueError):
+            pid = 0
+        if pid and pid != os.getpid():
+            alive = _pid_alive(pid)
+            if alive:
+                return False
+            if alive is None and not self._expired():
+                # Windows: no safe probe, so age is the only evidence we have.
+                return False
+        try:
+            self.path.unlink(missing_ok=True)
+        except OSError:  # pragma: no cover
+            return False
+        return True
+
+    def _expired(self) -> bool:
+        """True when the lock is old enough to break without a liveness probe."""
+        try:
+            age = time.time() - self.path.stat().st_mtime
+        except OSError:  # pragma: no cover - the file we just failed to create
+            return True
+        return age > _LOCK_STALE_SECONDS
+
+    def __exit__(self, *_exc: object) -> None:
+        if self.acquired:
+            try:
+                self.path.unlink(missing_ok=True)
+            except OSError:  # pragma: no cover
+                logger.debug("Could not remove voice-install lock", exc_info=True)
+
+
+def install_packages(
+    on_line: Callable[[str], None],
+    cancel_event: threading.Event | None = None,
+    *,
+    plan: InstallPlan | None = None,
+    timeout: float = 900.0,
+) -> tuple[bool, str]:
+    """Install the dictation packages into this interpreter. Never raises.
+
+    ``on_line`` receives a short narrated phrase per interesting output line (see
+    :func:`narrate`); the raw stream goes to the log. Returns ``(ok, message)``,
+    where a failure message is already human-readable.
+    """
+    plan = plan or install_plan()
+    if plan.blocked:
+        logger.info("Voice install refused before spawning: %s", plan.blocked)
+        return False, plan.blocked
+    if not _install_lock.acquire(blocking=False):
+        return False, "An install is already running in this window."
+
+    try:
+        with _Lockfile() as lock:
+            if not lock.acquired:
+                return False, "Another yeaboi window is installing dictation right now."
+            return _run_installer(plan, on_line, cancel_event, timeout)
+    finally:
+        _install_lock.release()
+
+
+def _log_index_host() -> None:
+    """Record which index the child will use, so a hijacked mirror is visible."""
+    for var in ("UV_INDEX_URL", "UV_DEFAULT_INDEX", "PIP_INDEX_URL"):
+        raw = os.getenv(var, "").strip()
+        if raw:
+            from urllib.parse import urlsplit
+
+            logger.info("Voice install using %s host %s", var, urlsplit(raw).hostname or "?")
+
+
+def _run_installer(
+    plan: InstallPlan,
+    on_line: Callable[[str], None],
+    cancel_event: threading.Event | None,
+    timeout: float,
+) -> tuple[bool, str]:
+    logger.info("Voice install starting: %s", plan.display_command)
+    _log_index_host()
+    from yeaboi.paths import get_bin_dir
+
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - argv is built from module constants and sys.executable
+            list(plan.argv),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(get_bin_dir()),
+            env=_child_env(),
+            start_new_session=True,
+        )
+    except OSError as exc:
+        logger.warning("Voice install could not start: %s", exc)
+        return False, f"Could not run the installer: {exc}"
+
+    tail: deque[str] = deque(maxlen=200)
+
+    def _pump() -> None:
+        assert proc.stdout is not None
+        for raw in proc.stdout:
+            line = raw.rstrip()
+            if not line:
+                continue
+            tail.append(line)
+            logger.debug("voice-install: %s", line)
+            phrase = narrate(line)
+            if phrase:
+                on_line(phrase)
+
+    reader = threading.Thread(target=_pump, name="voice-install-read", daemon=True)
+    reader.start()
+
+    deadline = time.monotonic() + timeout
+    while proc.poll() is None:
+        if cancel_event is not None and cancel_event.is_set():
+            _terminate(proc)
+            logger.info("Voice install cancelled by the user")
+            return False, _FAILURE_MESSAGES["CANCELLED"]
+        if time.monotonic() > deadline:
+            _terminate(proc)
+            logger.warning("Voice install timed out after %.0fs", timeout)
+            return False, f"{_FAILURE_MESSAGES['TIMEOUT']} Run it yourself: {plan.display_command}"
+        time.sleep(_POLL_SECONDS)
+    reader.join(timeout=2.0)
+
+    if proc.returncode == 0:
+        refresh_imports()
+        ok, reason = verify_installed()
+        if ok:
+            logger.info("Voice install succeeded via %s", plan.method)
+            return True, ""
+        logger.warning("Voice install exited 0 but the packages are not importable: %s", reason)
+        return False, "Installed, but this Python can't see the packages yet — restart yeaboi."
+
+    code, message = classify_failure(proc.returncode, "\n".join(tail))
+    logger.warning("Voice install failed (%s): exit %s", code, proc.returncode)
+    if code in PERMANENT_CODES:
+        write_verdict(code, message)
+    return False, message
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    """Stop a child politely, then not politely."""
+    proc.terminate()
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:  # pragma: no cover - unkillable child
+            logger.warning("Voice install child would not die")
+
+
+# ---------------------------------------------------------------------------
+# Making the new packages visible to this process
+# ---------------------------------------------------------------------------
+
+
+def refresh_imports() -> None:
+    """Make a just-installed package importable, and un-stick everything memoised.
+
+    Four caches in this app answer "is voice installed?" — the sticky-verdict
+    memo here, the strict backend probe, the input-box chip and the welcome
+    tips — and all four were written when the answer could not change
+    mid-process. They can now, so each one has to be dropped here or the app
+    keeps rendering "off" for the rest of the run. Anything memoising that
+    question in future belongs in this function too.
+    """
+    import importlib
+
+    importlib.invalidate_caches()
+    reset_unsupported_cache()
+
+    from yeaboi import voice
+
+    voice.reset_probe()
+
+    try:
+        from yeaboi.ui.shared._tips import get_tips
+        from yeaboi.ui.shared._voice_input import reset_voice_chip
+    except ImportError:  # pragma: no cover - headless callers (CLI) have no UI package need
+        return
+    reset_voice_chip()
+    get_tips.cache_clear()
+
+
+def verify_installed() -> tuple[bool, str]:
+    """Confirm both packages are really importable, not merely path-shaped.
+
+    ``find_spec`` also succeeds for a *namespace* package, so a half-written
+    install can pass the cheap probe. Requiring an ``origin`` means a real
+    module file exists behind the name.
+    """
+    import importlib.util
+
+    for module in ("sounddevice", "faster_whisper"):
+        try:
+            spec = importlib.util.find_spec(module)
+        except (ImportError, ValueError):
+            spec = None
+        if spec is None or spec.origin is None:
+            return False, f"{module} is not importable"
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# The speech model
+# ---------------------------------------------------------------------------
+
+
+def model_repo_id(size: str) -> str:
+    """Hugging Face repo holding the CTranslate2 build of a Whisper size."""
+    return f"{_HF_ORG}/faster-whisper-{size}"
+
+
+def model_cache_dir() -> Path:
+    """Resolve the Hugging Face cache this machine will download into.
+
+    Deliberately *not* relocated under ``~/.yeaboi``: a user who already has
+    ``faster-whisper-base`` from another tool would otherwise pay 145 MB again.
+    The trade is that the bytes land somewhere yeaboi does not own, so every
+    surface that mentions the download also prints this path.
+    """
+    override = os.getenv("HF_HUB_CACHE") or os.getenv("HUGGINGFACE_HUB_CACHE")
+    if override:
+        return Path(override).expanduser()
+    home = os.getenv("HF_HOME")
+    if home:
+        return Path(home).expanduser() / "hub"
+    return Path.home() / ".cache" / "huggingface" / "hub"
+
+
+def _repo_dir(size: str) -> Path:
+    return model_cache_dir() / f"models--{_HF_ORG}--faster-whisper-{size}"
+
+
+def model_bytes_on_disk(size: str) -> int:
+    """Bytes already fetched for ``size`` — completed blobs and in-flight ones.
+
+    Counting ``blobs/<etag>.incomplete`` is what makes the progress bar move
+    smoothly through a single 145 MB file instead of jumping when it lands.
+    """
+    repo = _repo_dir(size)
+    if not repo.is_dir():
+        return 0
+    total = 0
+    for path in repo.rglob("*"):
+        try:
+            if path.is_file() and not path.is_symlink():
+                total += path.stat().st_size
+        except OSError:  # pragma: no cover - file vanished mid-scan
+            continue
+    return total
+
+
+def model_is_cached(size: str) -> bool:
+    """True when a usable snapshot of ``size`` is already on disk."""
+    snapshots = _repo_dir(size) / "snapshots"
+    if not snapshots.is_dir():
+        return False
+    return any((snapshot / "model.bin").exists() for snapshot in snapshots.iterdir())
+
+
+def model_total_bytes(size: str, timeout: float = 8.0) -> int:
+    """Total download size from the HF tree API; ``0`` when it can't be known.
+
+    A zero total is not an error — the caller renders an indeterminate spinner
+    rather than inventing a percentage.
+    """
+    url = _HF_API.format(repo=model_repo_id(size))
+    try:
+        request = urllib.request.Request(url, headers={"Accept": "application/json"})  # noqa: S310 - fixed https constant
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            entries = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001 - offline is an ordinary outcome here
+        logger.info("Could not size the speech model: %s", exc)
+        return 0
+    if not isinstance(entries, list):
+        return 0
+    return sum(int(entry.get("size", 0)) for entry in entries if isinstance(entry, dict))
+
+
+def download_model(
+    size: str,
+    on_progress: Callable[[str, float | None], None],
+    cancel_event: threading.Event | None = None,
+) -> tuple[bool, str]:
+    """Fetch the Whisper model, reporting a real byte fraction. Never raises.
+
+    The download runs in a child process and the fraction is computed by the
+    parent from the cache directory's size. That buys three things a thread
+    could not: a genuine cancel (``terminate``), byte-level progress without
+    touching any huggingface_hub internal, and containment for the first
+    ``ctranslate2``/``onnxruntime`` import — which can ``SIGILL`` on a CPU
+    without AVX, and would take the whole TUI with it in-process.
+
+    Returns ``(ok, message)``. A failure here is a *warning*, not a broken
+    feature: the packages are installed, so the model simply downloads lazily on
+    the first dictation exactly as it always did.
+    """
+    if size not in MODEL_SIZES:
+        return False, f"Unknown speech model size {size!r}"
+    if model_is_cached(size):
+        return True, ""
+
+    total = model_total_bytes(size)
+    env = _child_env()
+    env["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
+    env["HF_HUB_DISABLE_TELEMETRY"] = "1"
+    # Load-bearing, and invisible if you do not know to look for it: huggingface_hub
+    # ships `hf_xet` transitively, and the Xet path stages content in a *separate*
+    # cache and materialises the file only at the end — so the repo directory sits
+    # at a couple of megabytes for the whole download and then jumps to 100%.
+    # Measured here: 3% … 3% … 3% … 100%. The classic downloader streams into
+    # blobs/<etag>.incomplete inside the repo, which is what _bytes_on_disk counts,
+    # and gives a bar that actually moves (874 B → 2.6 MB → 13 MB → 23 MB → …).
+    # A once-per-install download is worth more as honest progress than as a
+    # marginally faster opaque one.
+    env["HF_HUB_DISABLE_XET"] = "1"
+    program = f"from faster_whisper.utils import download_model; download_model({size!r})"
+
+    logger.info("Speech model download starting: %s (%d bytes expected)", size, total)
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - size is whitelist-checked against MODEL_SIZES above
+            [sys.executable, "-c", program],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        logger.warning("Speech model download could not start: %s", exc)
+        return False, f"Could not start the model download: {exc}"
+
+    tail: deque[str] = deque(maxlen=100)
+
+    def _pump() -> None:
+        assert proc.stdout is not None
+        for raw in proc.stdout:
+            line = raw.rstrip()
+            if line:
+                tail.append(line)
+                logger.debug("voice-model: %s", line)
+
+    reader = threading.Thread(target=_pump, name="voice-model-read", daemon=True)
+    reader.start()
+
+    seen = 0
+    moved_at = time.monotonic()
+    while proc.poll() is None:
+        if cancel_event is not None and cancel_event.is_set():
+            _terminate(proc)
+            logger.info("Speech model download cancelled by the user")
+            return False, "Download stopped — it resumes where it left off."
+        now = model_bytes_on_disk(size)
+        if now > seen:
+            seen, moved_at = now, time.monotonic()
+        stalled = time.monotonic() - moved_at > _STALL_SECONDS
+        # The engine knows the bytes, so it spells them: the UI would otherwise
+        # have to re-fetch the total just to render "76/145 MB".
+        detail = f"{seen // 1_000_000}/{total // 1_000_000} MB" if total else ""
+        on_progress(
+            "stalled — no data for a while" if stalled else detail,
+            (min(seen / total, 0.999) if total else None),
+        )
+        time.sleep(_POLL_SECONDS)
+    reader.join(timeout=2.0)
+
+    if proc.returncode == 0:
+        on_progress("", 1.0)
+        logger.info("Speech model %s downloaded to %s", size, model_cache_dir())
+        return True, ""
+
+    output = "\n".join(tail)
+    code, message = classify_failure(proc.returncode, output)
+    logger.warning("Speech model download failed (%s): exit %s", code, proc.returncode)
+    if code == "NO_NETWORK":
+        return False, "Can't reach huggingface.co — the model will download on your first dictation instead."
+    return False, message
+
+
+def warm_model(size: str) -> tuple[bool, str]:
+    """Load the model into :data:`yeaboi.voice._MODEL_CACHE`. Never raises.
+
+    Without this the bar hits 100% and the user then waits another few seconds
+    staring at "transcribing" while CTranslate2 reads the weights — which reads
+    as a hang immediately after a progress bar promised completion.
+    """
+    from yeaboi import voice
+
+    try:
+        voice._get_model()
+    except Exception as exc:  # noqa: BLE001 - a cold first transcription is the fallback
+        logger.warning("Could not preload the speech model: %s", exc)
+        return False, str(exc)
+    logger.info("Speech model %s preloaded", size)
+    return True, ""

--- a/src/yeaboi/voice_install.py
+++ b/src/yeaboi/voice_install.py
@@ -70,6 +70,14 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# The single spawn seam for this module. Both children — the package manager and
+# the model fetcher — go through this name and nothing else does, which is what
+# lets `tests/conftest.py` block *this* module's spawns without touching the
+# shared ``subprocess`` module every other test relies on. It is the only thing
+# standing between a test that forgets a patch and a real 325 MB install: one
+# did, and it ran `uv pip install` on a CI runner until the runner was killed.
+_popen = subprocess.Popen
+
 # The `voice` extra's contents. Asserted equal to pyproject.toml's extra by
 # tests/unit/test_voice_install.py, so the two cannot drift.
 VOICE_PACKAGES: tuple[str, ...] = ("sounddevice", "faster-whisper")
@@ -660,7 +668,7 @@ def _run_installer(
     from yeaboi.paths import get_bin_dir
 
     try:
-        proc = subprocess.Popen(  # noqa: S603 - argv is built from module constants and sys.executable
+        proc = _popen(  # noqa: S603 - argv is built from module constants and sys.executable
             list(plan.argv),
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -906,7 +914,7 @@ def download_model(
 
     logger.info("Speech model download starting: %s (%d bytes expected)", size, total)
     try:
-        proc = subprocess.Popen(  # noqa: S603 - size is whitelist-checked against MODEL_SIZES above
+        proc = _popen(  # noqa: S603 - size is whitelist-checked against MODEL_SIZES above
             [sys.executable, "-c", program],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,3 +156,40 @@ def vcr_config():
         # the response shape, not the exact query params sent.
         "match_on": ["method", "scheme", "host", "port", "path"],
     }
+
+
+class RealPackageInstallBlocked(BaseException):
+    """Raised when a test reaches a real dictation-install or model-download spawn.
+
+    A ``BaseException`` for the same reason as :class:`RealBrowserBlocked`:
+    ``install_packages`` and ``download_model`` both wrap their spawn in
+    ``except OSError`` and degrade to a "could not start" message, and the
+    ``_run_install`` worker now catches ``Exception`` — so a plain exception here
+    would be swallowed and the guard would quietly report a failed install
+    instead of failing the test.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _no_real_package_install(monkeypatch):
+    """No test may spawn a real package manager or model download.
+
+    This is not hypothetical. ``TestDoubleTapInDescriptionLoop`` patched
+    ``is_voice_available`` but not the strict ``probe_voice_backend``, so on a
+    machine *without* the voice extra — which is every CI runner — the double-tap
+    fell through to the install offer, its leftover ``"enter"`` keystroke accepted
+    it, and the job ran a real ``uv pip install`` plus a 145 MB model fetch until
+    the runner was killed. It passed locally, where the extra is installed and the
+    offer never appears.
+
+    Blocks ``voice_install._popen``, the module's single spawn seam, rather than
+    ``subprocess.Popen`` — patching the latter would patch the shared module for
+    every other test in the suite. Tests that legitimately drive the installer
+    patch the same name and share this MonkeyPatch instance, so their setattr
+    lands after ours and wins.
+    """
+
+    def _blocked(argv, *args, **kwargs):
+        raise RealPackageInstallBlocked(f"test tried to spawn a real installer: {argv}")
+
+    monkeypatch.setattr("yeaboi.voice_install._popen", _blocked)

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -70,6 +70,11 @@ class TestParsing:
         assert args.list_audio_devices is True
         assert build_parser().parse_args([]).list_audio_devices is False
 
+    def test_install_voice_parses(self):
+        args = build_parser().parse_args(["--install-voice"])
+        assert args.install_voice is True
+        assert build_parser().parse_args([]).install_voice is False
+
     def test_report_parses(self):
         args = build_parser().parse_args(["report", "--period", "quarter", "--format", "json"])
         assert args.command == "report"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,9 +1,11 @@
 """Tests for configuration and environment variable handling."""
 
 import os
+from pathlib import Path
 
 import pytest
 
+from yeaboi import config
 from yeaboi.config import (
     BETA_ACK_KEY,
     FORCE_BETA_NOTICE_ENV,
@@ -895,3 +897,57 @@ class TestStorageAndExportConfig:
         cfg.set_data_dir("  ")
         assert os.environ["YEABOI_HOME"] == ""
         assert get_data_dir() == ""
+
+
+class TestVoiceInstallOffer:
+    """The permanent "never ask again" tier of the dictation install offer."""
+
+    def test_defaults_on(self, monkeypatch):
+        monkeypatch.delenv("VOICE_INSTALL_OFFER", raising=False)
+        monkeypatch.delenv("YEABOI_FORCE_VOICE_OFFER", raising=False)
+        assert config.is_voice_install_offer_enabled() is True
+
+    @pytest.mark.parametrize("value", ["off", "false", "0", "no", "OFF"])
+    def test_disabling_values(self, monkeypatch, value):
+        monkeypatch.delenv("YEABOI_FORCE_VOICE_OFFER", raising=False)
+        monkeypatch.setenv("VOICE_INSTALL_OFFER", value)
+        assert config.is_voice_install_offer_enabled() is False
+
+    def test_the_force_env_reopens_a_permanent_decline(self, monkeypatch):
+        """A once-ever gate is otherwise impossible to demo or review."""
+        monkeypatch.setenv("VOICE_INSTALL_OFFER", "off")
+        monkeypatch.setenv("YEABOI_FORCE_VOICE_OFFER", "1")
+        assert config.is_voice_install_offer_enabled() is True
+
+    def test_setter_writes_env_and_disk(self, monkeypatch):
+        written: list[tuple[str, str]] = []
+        monkeypatch.setattr(config, "set_config_value", lambda k, v: written.append((k, v)) or Path("/tmp/.env"))
+        monkeypatch.delenv("YEABOI_FORCE_VOICE_OFFER", raising=False)
+        # The setter writes os.environ itself, so register the key for teardown.
+        monkeypatch.delenv("VOICE_INSTALL_OFFER", raising=False)
+        config.set_voice_install_offer(False)
+        assert os.environ["VOICE_INSTALL_OFFER"] == "off"
+        assert written == [("VOICE_INSTALL_OFFER", "off")]
+        assert config.is_voice_install_offer_enabled() is False
+
+    def test_a_failed_disk_write_still_honours_the_decline_this_session(self, monkeypatch):
+        """Re-asking on the next launch is the lesser failure; re-asking on the
+        next keystroke is not."""
+
+        def _boom(_k, _v):
+            raise OSError("read-only home")
+
+        monkeypatch.setattr(config, "set_config_value", _boom)
+        monkeypatch.delenv("YEABOI_FORCE_VOICE_OFFER", raising=False)
+        monkeypatch.delenv("VOICE_INSTALL_OFFER", raising=False)
+        config.set_voice_install_offer(False)
+        assert config.is_voice_install_offer_enabled() is False
+
+
+class TestVoiceExtraMarker:
+    def test_round_trip(self, monkeypatch):
+        monkeypatch.delenv("VOICE_EXTRA_INSTALLED", raising=False)
+        monkeypatch.setattr(config, "set_config_value", lambda _k, _v: Path("/tmp/.env"))
+        assert config.voice_extra_was_installed() is False
+        config.mark_voice_extra_installed()
+        assert config.voice_extra_was_installed() is True

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -97,3 +97,32 @@ class TestRedactingFormatter:
         record = self._record("token ghp_abcdefghijklmnopqrstuvwx")
         self._format(record)
         assert "ghp_" in record.getMessage()  # other handlers see the original
+
+
+class TestUrlCredentials:
+    """pip and uv echo the package-index URL, and a corporate mirror routinely
+    carries a token in it — which the voice installer then logs."""
+
+    def test_index_credentials_are_stripped_but_the_host_survives(self):
+        from yeaboi.redaction import redact
+
+        out = redact("Looking in indexes: https://svc:AKCp8xyzSECRETVALUE@nexus.corp/repository/pypi/simple")
+        assert "AKCp8xyzSECRETVALUE" not in out
+        assert "svc:" not in out
+        assert "nexus.corp/repository/pypi/simple" in out
+
+    def test_a_credential_free_url_is_untouched(self):
+        from yeaboi.redaction import redact
+
+        assert redact("https://pypi.org/simple") == "https://pypi.org/simple"
+
+    def test_a_bare_port_is_not_mistaken_for_a_password(self):
+        from yeaboi.redaction import redact
+
+        assert redact("connecting to https://nexus.corp:8443/simple") == "connecting to https://nexus.corp:8443/simple"
+
+    def test_it_is_idempotent(self):
+        from yeaboi.redaction import redact
+
+        once = redact("https://u:pa55word@host/x")
+        assert redact(once) == once

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -423,3 +423,78 @@ class TestProviderSelect:
         console = _make_console()
         result = select_provider(console, _read_key_fn=_safe_key_fn("left", "esc"))
         assert result is None
+
+
+class TestVoiceTipTruthiness:
+    """is_voice_available returns (available, reason). A bare truthiness test on
+    that tuple is always True, so the wizard used to tell every user dictation
+    was ready — installed or not."""
+
+    def test_the_tip_reflects_a_missing_extra(self, monkeypatch, capsys):
+        """Installable: point at the gesture, not at a shell command. The
+        double-tap does the install, and sending the user to another terminal
+        for it is the friction this whole feature removed."""
+        from rich.console import Console
+
+        import yeaboi.setup_wizard as wizard
+
+        monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
+        monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "installable")
+        monkeypatch.setattr("yeaboi.voice.voice_install_command", lambda: "uv sync --extra voice")
+        console = Console(force_terminal=False, color_system=None)
+        wizard._print_voice_tip(console)
+        out = capsys.readouterr().out
+        assert "double-tap Space" in out
+        assert "uv sync --extra voice" not in out
+        assert "is ready" not in out
+
+    def test_the_tip_falls_back_to_a_command_once_declined(self, monkeypatch, capsys):
+        """ "Never" was the answer to the offer, not to dictation — so this is
+        the one state where naming the manual command is the right move."""
+        from rich.console import Console
+
+        import yeaboi.setup_wizard as wizard
+
+        monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
+        monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "declined")
+        monkeypatch.setattr("yeaboi.voice.voice_install_command", lambda: "uv sync --extra voice")
+        console = Console(force_terminal=False, color_system=None)
+        wizard._print_voice_tip(console)
+        assert "uv sync --extra voice" in capsys.readouterr().out
+
+    def test_the_tip_never_prints_a_doomed_command(self, monkeypatch, capsys):
+        """The wizard is the first surface a user meets, so it is the worst one
+        to print an install command that physically cannot succeed."""
+        from rich.console import Console
+
+        import yeaboi.setup_wizard as wizard
+
+        monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
+        monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "unsupported")
+        monkeypatch.setattr("yeaboi.voice.unsupported_blocker", lambda: "musl libc has no speech-engine wheel")
+        monkeypatch.setattr("yeaboi.voice.voice_install_command", lambda: "uv sync --extra voice")
+        console = Console(force_terminal=False, color_system=None)
+        wizard._print_voice_tip(console)
+        out = capsys.readouterr().out
+        assert "musl libc" in out
+        assert "uv sync --extra voice" not in out
+
+    def test_the_tip_says_ready_only_when_it_is(self, monkeypatch, capsys):
+        from rich.console import Console
+
+        import yeaboi.setup_wizard as wizard
+
+        monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
+        monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+        console = Console(force_terminal=False, color_system=None)
+        wizard._print_voice_tip(console)
+        assert "ready" in capsys.readouterr().out
+
+    def test_tips_off_prints_nothing(self, monkeypatch, capsys):
+        from rich.console import Console
+
+        import yeaboi.setup_wizard as wizard
+
+        monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: False)
+        wizard._print_voice_tip(Console(force_terminal=False, color_system=None))
+        assert capsys.readouterr().out.strip() == ""

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -245,7 +245,7 @@ CAPABILITIES: dict[str, dict] = {
         "engines": Exempt("TUI utility page — writes ~/.yeaboi/.env via config"),
         "mcp_tools": Exempt("TUI utility page; MCP servers must not rewrite host credentials"),
         "tui_mode": "settings",
-        "cli": {"--setup", "--theme", "--allow-path", "--list-audio-devices"},
+        "cli": {"--setup", "--theme", "--allow-path", "--list-audio-devices", "--install-voice"},
         "skill": Exempt("TUI utility page"),
     },
 }

--- a/tests/unit/test_tips.py
+++ b/tests/unit/test_tips.py
@@ -22,7 +22,7 @@ def _clear_cache():
 
 def test_get_tips_non_empty(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     tips = get_tips()
     assert len(tips) > 1
     assert all(isinstance(t, FeatureTip) and t.text for t in tips)
@@ -31,26 +31,61 @@ def test_get_tips_non_empty(monkeypatch):
 
 def test_voice_tip_when_available(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     voice_tip = get_tips()[0]
     assert voice_tip.key == "voice"
     assert "double-tap Space" in voice_tip.text
     _clear_cache()
 
 
-def test_voice_tip_when_unavailable(monkeypatch):
+def test_voice_tip_when_installable(monkeypatch):
+    """The gesture *is* the install now, so the tip points at it, not at a shell."""
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (False, "reason"))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "installable")
     voice_tip = get_tips()[0]
-    # Tip shows the install-method-aware command (not a hardcoded `uv sync`).
+    assert "double-tap Space" in voice_tip.text
+    assert "one keystroke" in voice_tip.text
+    assert voice_install_command() not in voice_tip.text
+    _clear_cache()
+
+
+def test_voice_tip_when_declined_falls_back_to_the_manual_command(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "declined")
+    voice_tip = get_tips()[0]
+    # The install-method-aware command, not a hardcoded `uv sync`.
     assert "enable dictation" in voice_tip.text
     assert voice_install_command() in voice_tip.text
     _clear_cache()
 
 
+def test_voice_tip_when_unsupported_never_invites_a_doomed_install(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "unsupported")
+    monkeypatch.setattr("yeaboi.voice.unsupported_blocker", lambda: "musl libc has no wheel")
+    voice_tip = get_tips()[0]
+    assert "musl libc has no wheel" in voice_tip.text
+    assert voice_install_command() not in voice_tip.text
+    _clear_cache()
+
+
+def test_voice_tip_when_unsupported_names_the_actual_blocker(monkeypatch):
+    """A Linux host missing libportaudio2 is 'unsupported' too, and the tip has
+    to carry the apt command rather than a sentence about the wheel matrix —
+    restating the platform gate there would be actively misleading."""
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "unsupported")
+    monkeypatch.setattr(
+        "yeaboi.voice.unsupported_blocker",
+        lambda: "Audio backend unavailable — sudo apt install libportaudio2",
+    )
+    assert "libportaudio2" in get_tips()[0].text
+    _clear_cache()
+
+
 def test_music_tip_when_available(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     monkeypatch.setattr("yeaboi.music.is_music_available", lambda: (True, ""))
     assert any("Ctrl+P" in t.text for t in get_tips())
     _clear_cache()
@@ -58,7 +93,7 @@ def test_music_tip_when_available(monkeypatch):
 
 def test_music_tip_when_unavailable(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     monkeypatch.setattr("yeaboi.music.is_music_available", lambda: (False, "no ffplay"))
     assert any("brew install" in t.text and "ffmpeg" in t.text for t in get_tips())
     _clear_cache()
@@ -66,7 +101,7 @@ def test_music_tip_when_unavailable(monkeypatch):
 
 def test_current_tip_advances_with_tick(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     idx0, _ = current_tip(0.0)
     idx1, _ = current_tip(TIP_ROTATE_SECONDS + 0.1)
     assert idx0 == 0
@@ -76,7 +111,7 @@ def test_current_tip_advances_with_tick(monkeypatch):
 
 def test_current_tip_stable_within_window(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     idx_a, tip_a = current_tip(0.0)
     idx_b, tip_b = current_tip(TIP_ROTATE_SECONDS - 0.01)
     assert idx_a == idx_b
@@ -86,7 +121,7 @@ def test_current_tip_stable_within_window(monkeypatch):
 
 def test_current_tip_wraps_around(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     n = len(get_tips())
     # After a full cycle we return to the first tip.
     idx_first, _ = current_tip(0.0)
@@ -97,7 +132,7 @@ def test_current_tip_wraps_around(monkeypatch):
 
 def test_current_tip_handles_negative_tick(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     idx, tip = current_tip(-5.0)
     assert idx == 0
     assert tip.text
@@ -106,7 +141,7 @@ def test_current_tip_handles_negative_tick(monkeypatch):
 
 def test_rotate_seconds_override(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     # With a 1s window, tick=1.5 lands on the second tip.
     idx, _ = current_tip(1.5, rotate_seconds=1.0)
     assert idx == 1
@@ -115,7 +150,7 @@ def test_rotate_seconds_override(monkeypatch):
 
 def test_resolve_index_applies_browse_offset(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     n = tip_count()
     # The offset shifts the auto index; auto-rotation still advances with tick.
     assert resolve_index(0.0, 0) == 0
@@ -130,7 +165,7 @@ def test_resolve_index_applies_browse_offset(monkeypatch):
 
 def test_build_tips_text_lists_every_tip(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     text = build_tips_text()
     assert text.startswith("# yeaboi — Tips")
     # Every tip's text appears as a bullet.
@@ -142,7 +177,7 @@ def test_build_tips_text_lists_every_tip(monkeypatch):
 
 def test_build_tips_text_marks_new_and_opens(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     text = build_tips_text()
     # The flagged feature is marked NEW and notes the mode it opens.
     assert "(NEW)" in text
@@ -156,7 +191,7 @@ def test_build_tips_text_marks_new_and_opens(monkeypatch):
 
 def test_tip_at_wraps(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     assert tip_at(0) == get_tips()[0]
     assert tip_at(tip_count()) == get_tips()[0]  # wraps around
     _clear_cache()
@@ -164,7 +199,7 @@ def test_tip_at_wraps(monkeypatch):
 
 def test_at_least_one_new_feature_tip(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     # The NEW badge only renders when some tip is flagged fresh.
     assert any(t.is_new for t in _tips._FEATURE_TIPS)
     _clear_cache()
@@ -172,7 +207,7 @@ def test_at_least_one_new_feature_tip(monkeypatch):
 
 def test_at_least_one_beta_feature_tip(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     # The BETA badge branch would otherwise go dead without anything noticing.
     assert any(t.is_beta for t in _tips._FEATURE_TIPS)
     _clear_cache()
@@ -180,7 +215,7 @@ def test_at_least_one_beta_feature_tip(monkeypatch):
 
 def test_performance_tip_is_beta_not_new(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     perf = next(t for t in _tips._FEATURE_TIPS if t.key == "performance")
     # Unverified, not recent — the two badges make different promises.
     assert perf.is_beta is True
@@ -190,7 +225,7 @@ def test_performance_tip_is_beta_not_new(monkeypatch):
 
 def test_build_tips_text_marks_beta(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     lines = _tips.build_tips_text().splitlines()
     perf_line = next(line for line in lines if "Performance preps 1:1s" in line)
     planning_line = next(line for line in lines if "Planning starts as a chat" in line)
@@ -201,7 +236,7 @@ def test_build_tips_text_marks_beta(monkeypatch):
 
 def test_carded_tips_have_mode_keys(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     # A representative feature tip carries a jump target; ambient tips do not.
     planning = next(t for t in _tips._FEATURE_TIPS if t.key == "planning")
     assert planning.mode_key == "project-planning"
@@ -216,7 +251,7 @@ def test_module_constant_present():
 
 def test_tip_count_matches_get_tips(monkeypatch):
     _clear_cache()
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     assert tip_count() == len(get_tips())
     _clear_cache()
 

--- a/tests/unit/test_tips_ui.py
+++ b/tests/unit/test_tips_ui.py
@@ -74,13 +74,28 @@ def test_voice_hint_is_empty_when_voice_is_installed(monkeypatch):
     assert _voice_hint() == ""
 
 
-def test_voice_hint_shows_install_when_unavailable(monkeypatch):
+def test_voice_hint_is_silent_when_installable(monkeypatch):
+    """The input-box chip carries the gesture, and the gesture installs — there
+    is no command left for the user to copy out of this line."""
     monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
-    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (False, "x"))
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "installable")
+    assert _voice_hint() == ""
+
+
+def test_voice_hint_shows_the_command_after_a_permanent_decline(monkeypatch):
+    monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "declined")
     hint = _voice_hint()
-    # Hint shows the install-method-aware command (not a hardcoded `uv sync`).
-    assert "dictate:" in hint
+    assert "dictate" in hint
     assert voice_install_command() in hint
+
+
+def test_voice_hint_names_the_platform_when_dictation_cannot_run(monkeypatch):
+    monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "unsupported")
+    hint = _voice_hint()
+    assert "64-bit" in hint
+    assert voice_install_command() not in hint
 
 
 def test_mode_screen_renders_with_tips_on(monkeypatch):

--- a/tests/unit/test_update_check.py
+++ b/tests/unit/test_update_check.py
@@ -67,6 +67,25 @@ class TestIsNewer:
 class TestDetectUpgradeCommand:
     def test_uv_tool_install(self, monkeypatch):
         monkeypatch.setattr(update_check.sys, "executable", "/Users/x/.local/share/uv/tools/yeaboi/bin/python")
+        monkeypatch.setattr(update_check, "_voice_is_live", lambda: False)
+        assert update_check.detect_upgrade_command() == "uv tool upgrade yeaboi"
+
+    def test_uv_tool_install_carries_dictation_across_the_upgrade(self, monkeypatch):
+        """An in-app `uv pip install` is not in uv's tool receipt, so a plain
+        `uv tool upgrade` rebuilds the venv and silently drops dictation."""
+        monkeypatch.setattr(update_check.sys, "executable", "/Users/x/.local/share/uv/tools/yeaboi/bin/python")
+        monkeypatch.setattr(update_check, "_voice_is_live", lambda: True)
+        assert update_check.detect_upgrade_command() == "uv tool install --force 'yeaboi[voice]'"
+
+    def test_pipx_needs_no_such_workaround(self, monkeypatch):
+        """`pipx inject` is recorded in pipx metadata and survives a reinstall."""
+        monkeypatch.setattr(update_check.sys, "executable", "/Users/x/.local/pipx/venvs/yeaboi/bin/python")
+        monkeypatch.setattr(update_check, "_voice_is_live", lambda: True)
+        assert update_check.detect_upgrade_command() == "pipx upgrade yeaboi"
+
+    def test_a_broken_voice_probe_never_breaks_the_upgrade_hint(self, monkeypatch):
+        monkeypatch.setattr(update_check.sys, "executable", "/Users/x/.local/share/uv/tools/yeaboi/bin/python")
+        monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
         assert update_check.detect_upgrade_command() == "uv tool upgrade yeaboi"
 
     def test_pipx_install(self, monkeypatch):
@@ -75,6 +94,7 @@ class TestDetectUpgradeCommand:
 
     def test_unknown_falls_back_to_uv(self, monkeypatch):
         monkeypatch.setattr(update_check.sys, "executable", "/usr/bin/python3")
+        monkeypatch.setattr(update_check, "_voice_is_live", lambda: False)
         assert update_check.detect_upgrade_command() == "uv tool upgrade yeaboi"
 
 

--- a/tests/unit/test_voice.py
+++ b/tests/unit/test_voice.py
@@ -1409,6 +1409,21 @@ class TestVoiceIndicator:
 
 
 class TestRecordVoiceInput:
+    @pytest.fixture(autouse=True)
+    def _strict_probe_follows_the_cheap_one(self, monkeypatch):
+        """Keep the two availability probes telling the same story here.
+
+        ``record_voice_input`` gates on the *strict* ``probe_voice_backend``,
+        but most tests in this class only fake ``is_voice_available``. On a
+        machine that has the voice extra the real strict probe succeeds anyway
+        and the gap is invisible; on one that does not — every CI runner — the
+        test falls straight into the install offer, records nothing, and asserts
+        against an empty list. Delegating keeps them in step no matter which one
+        a given test patches, and a test that patches the strict probe itself
+        still wins by sharing this ``monkeypatch``.
+        """
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: voice.is_voice_available())
+
     def _patch_voice(self, monkeypatch, *, available=(True, ""), transcript="hello", frames_have_audio=True):
         from yeaboi.ui.shared import _voice_input
 

--- a/tests/unit/test_voice.py
+++ b/tests/unit/test_voice.py
@@ -830,6 +830,11 @@ class TestDoubleTapInDescriptionLoop:
         from yeaboi.ui.session.phases import _phases_intake
 
         monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        # The strict probe too, not just the cheap one: record_voice_input gates
+        # on probe_voice_backend, so on a machine without the voice extra — every
+        # CI runner — this test would otherwise fall into the install offer and
+        # its leftover "enter" would accept a real 325 MB install.
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (True, ""))
 
         class _Rec:
             def __init__(self, **kwargs):

--- a/tests/unit/test_voice.py
+++ b/tests/unit/test_voice.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib.machinery
 import io
 import sys
+import time
 import types
 import wave
 
@@ -872,16 +873,39 @@ class TestInputBoxTitle:
     def test_advertises_the_gesture_when_installed(self, monkeypatch):
         from yeaboi.ui.shared._voice_input import input_box_title
 
-        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        monkeypatch.setattr(voice, "voice_state", lambda: "ready")
         assert "Space Space" in input_box_title("Message", 60).plain
 
-    def test_says_off_when_not_installed(self, monkeypatch):
+    def test_keeps_the_gesture_when_voice_is_merely_installable(self, monkeypatch):
+        """The chip must not deny a feature that is one keystroke away: the
+        double-tap works, it just opens the install offer first."""
+        from yeaboi.ui.shared._voice_input import input_box_title, voice_chip
+
+        monkeypatch.setattr(voice, "voice_state", lambda: "installable")
+        assert "Space Space" in input_box_title("Message", 60).plain
+        assert voice_chip()[1] == "rgb(80,80,92)"  # dimmed: live, not yet set up
+
+    @pytest.mark.parametrize("state", ["declined", "unsupported"])
+    def test_says_off_only_when_dictation_really_is_off(self, monkeypatch, state):
         from yeaboi.ui.shared._voice_input import input_box_title
 
-        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "install it"))
+        monkeypatch.setattr(voice, "voice_state", lambda: state)
         title = input_box_title("Message", 60).plain
         assert "off" in title
         assert "Space Space" not in title
+
+    def test_the_two_live_states_are_the_same_width(self, monkeypatch):
+        """input_box_title and the standup box-top both measure this chip; a
+        width change between the states would move a border."""
+        from rich.cells import cell_len
+
+        from yeaboi.ui.shared._voice_input import reset_voice_chip, voice_chip
+
+        monkeypatch.setattr(voice, "voice_state", lambda: "ready")
+        ready = cell_len(voice_chip()[0])
+        reset_voice_chip()
+        monkeypatch.setattr(voice, "voice_state", lambda: "installable")
+        assert cell_len(voice_chip()[0]) == ready
 
     def test_ignores_the_tips_setting(self, monkeypatch):
         """An affordance is UI, not a tip — tips-off users must still see it."""
@@ -954,6 +978,15 @@ class TestStandupBoxChip:
 
         reason = "" if available else "not installed"
         monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (available, reason))
+        # The module check has to agree with is_voice_available, or the fake is
+        # incoherent: "modules present but unavailable" is how a dead PortAudio
+        # presents, and unsupported_blocker() reads it as beyond help rather
+        # than as installable.
+        monkeypatch.setattr("yeaboi.voice._module_check", lambda: (available, reason))
+        # Pin the offer setting too: voice_state() reads it, and the chip must
+        # not depend on whatever the ambient config happens to say.
+        monkeypatch.setattr("yeaboi.config.is_voice_install_offer_enabled", lambda: True)
+        monkeypatch.setattr("yeaboi.voice_install.unsupported_reason", lambda: "")
         return _render(
             _build_standup_input_screen("What did you do yesterday?", "", box_rows=box_rows, width=width, height=30),
             width=width,
@@ -975,9 +1008,12 @@ class TestStandupBoxChip:
         chip_line = next(line for line in out.splitlines() if "Space Space" in line)
         assert "╭" in chip_line
 
-    def test_says_off_when_voice_is_not_installed(self, monkeypatch):
-        out = self._screen(monkeypatch, width=100, available=False)
-        assert "🎤 off" in out
+    def test_keeps_the_gesture_when_voice_is_installable(self, monkeypatch):
+        assert "Space Space" in self._screen(monkeypatch, width=100, available=False)
+
+    def test_says_off_once_dictation_is_really_unavailable(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "unsupported")
+        assert "🎤 off" in self._screen(monkeypatch, width=100, available=False)
 
     def test_the_inlaid_border_keeps_the_box_square(self, monkeypatch):
         """The chip eats border dashes, so a mis-counted width (the emoji is two
@@ -1372,6 +1408,8 @@ class TestRecordVoiceInput:
         from yeaboi.ui.shared import _voice_input
 
         monkeypatch.setattr(voice, "is_voice_available", lambda: available)
+        # record_voice_input asks the strict probe, not the per-frame one.
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: available)
 
         class _Rec:
             def __init__(self, **kwargs):
@@ -1398,9 +1436,10 @@ class TestRecordVoiceInput:
         mod = self._patch_voice(monkeypatch, transcript="ignored")
         assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["esc"])) is None
 
-    def test_unavailable_returns_none(self, monkeypatch):
+    def test_unavailable_offers_to_install_and_returns_none_on_decline(self, monkeypatch):
         mod = self._patch_voice(monkeypatch, available=(False, "Install voice extra: uv sync --extra voice"))
-        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["x"])) is None
+        mod.reset_voice_chip()  # also clears the session decline
+        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["esc"])) is None
 
     def test_no_audio_returns_none(self, monkeypatch):
         mod = self._patch_voice(monkeypatch, frames_have_audio=False)
@@ -1585,3 +1624,699 @@ class TestRecordVoiceInput:
         monkeypatch.setattr(voice, "Recorder", _boom)
         _voice_input.record_voice_input(_FakeLive(), _console(), _KeySequence(["x"]))
         assert events == ["pause", "resume"]  # music restored even on mic failure
+
+
+class TestProbeVoiceBackend:
+    """The cheap probe answers "are the modules there?"; the strict one answers
+    "will recording actually work?" — which on Linux is a different question."""
+
+    def setup_method(self):
+        voice.reset_probe()
+
+    def teardown_method(self):
+        voice.reset_probe()
+
+    def test_a_present_but_unusable_portaudio_is_caught(self, monkeypatch, _inject):
+        sd = _inject(faster_whisper_captured={})
+
+        def boom():
+            raise OSError("PortAudio library not found")
+
+        monkeypatch.setattr(sd, "query_devices", boom)
+        assert voice.probe_voice_backend()[0] is False
+
+    def test_the_cheap_probe_stays_cheap_and_never_opens_portaudio(self, monkeypatch, _inject):
+        sd = _inject(faster_whisper_captured={})
+        calls = []
+        monkeypatch.setattr(sd, "query_devices", lambda *a, **k: calls.append(1) or [])
+        assert voice.is_voice_available() == (True, "")
+        assert calls == []
+
+    def test_the_cheap_probe_reports_a_strict_failure_once_it_is_known(self, monkeypatch, _inject):
+        sd = _inject(faster_whisper_captured={})
+        monkeypatch.setattr(sd, "query_devices", lambda *a, **k: (_ for _ in ()).throw(OSError("no lib")))
+        assert voice.is_voice_available()[0] is True  # modules are on the path
+        voice.probe_voice_backend()
+        assert voice.is_voice_available()[0] is False  # ...but the backend is dead
+
+    def test_the_strict_probe_runs_once_per_process(self, monkeypatch, _inject):
+        sd = _inject(faster_whisper_captured={})
+        calls = []
+        monkeypatch.setattr(sd, "query_devices", lambda *a, **k: calls.append(1) or [])
+        voice.probe_voice_backend()
+        voice.probe_voice_backend()
+        assert len(calls) == 1
+        voice.probe_voice_backend(force=True)
+        assert len(calls) == 2
+
+    def test_reset_probe_clears_the_cache(self, monkeypatch, _inject):
+        sd = _inject(faster_whisper_captured={})
+        calls = []
+        monkeypatch.setattr(sd, "query_devices", lambda *a, **k: calls.append(1) or [])
+        voice.probe_voice_backend()
+        voice.reset_probe()
+        voice.probe_voice_backend()
+        assert len(calls) == 2
+
+    def test_missing_modules_short_circuit_before_any_import(self, _inject):
+        _inject(sounddevice=False)
+        assert voice.probe_voice_backend()[0] is False
+
+    def test_render_paths_never_call_the_strict_probe(self, monkeypatch):
+        """A regression guard: this probe costs ~100 ms and opens PortAudio, and
+        the chip and tips are rebuilt on every frame."""
+        from yeaboi.ui.shared import _tips, _voice_input
+
+        def forbidden(**_kw):
+            raise AssertionError("probe_voice_backend must never run on a render path")
+
+        monkeypatch.setattr(voice, "probe_voice_backend", forbidden)
+        _voice_input.reset_voice_chip()
+        _tips.get_tips.cache_clear()
+        _voice_input.voice_chip()
+        _tips.get_tips()
+        _tips.get_tips.cache_clear()
+
+
+class TestVoiceState:
+    def _state(self, monkeypatch, *, available, unsupported="", offer=True):
+        from yeaboi import voice_install
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (available, ""))
+        monkeypatch.setattr(voice_install, "unsupported_reason", lambda: unsupported)
+        monkeypatch.setattr("yeaboi.config.is_voice_install_offer_enabled", lambda: offer)
+        return voice.voice_state()
+
+    def test_ready(self, monkeypatch):
+        assert self._state(monkeypatch, available=True) == "ready"
+
+    def test_installable(self, monkeypatch):
+        assert self._state(monkeypatch, available=False) == "installable"
+
+    def test_declined(self, monkeypatch):
+        assert self._state(monkeypatch, available=False, offer=False) == "declined"
+
+    def test_unsupported_beats_declined(self, monkeypatch):
+        assert self._state(monkeypatch, available=False, unsupported="musl libc", offer=False) == "unsupported"
+
+    def test_an_installed_machine_is_ready_even_if_the_offer_is_off(self, monkeypatch):
+        assert self._state(monkeypatch, available=True, offer=False) == "ready"
+
+
+class TestInstallStatusLine:
+    """Render tests for the setup frames. No new _build_*_screen is introduced —
+    these lines travel through the callers' existing status row, so what has to
+    be proven is that they survive _fit at every width the app supports."""
+
+    from yeaboi.ui.shared import _voice_input as _mod
+
+    STAGES = (
+        ("install", {"detail": "downloading ctranslate2 (37 MB)", "elapsed": 7.0}),
+        ("download", {"fraction": 0.52, "size": "76/145 MB"}),
+        ("download", {"fraction": None}),
+        ("load", {}),
+        ("ready", {}),
+    )
+
+    def test_every_stage_returns_a_colour_and_a_line(self):
+        from yeaboi.ui.shared._voice_input import install_status_line
+
+        for stage, kwargs in self.STAGES:
+            border, line = install_status_line(stage, tick=1.0, width=100, **kwargs)
+            assert border.startswith("rgb("), stage
+            assert line.strip(), stage
+
+    @pytest.mark.parametrize("width", [100, 68, 40, 28, 20])
+    def test_lines_fit_the_width_they_are_given(self, width):
+        from rich.cells import cell_len
+
+        from yeaboi.ui.shared._voice_input import install_offer_line, install_status_line
+
+        assert cell_len(install_offer_line(size_mb=325, width=width)) <= width
+        for stage, kwargs in self.STAGES:
+            _border, line = install_status_line(stage, tick=1.0, width=width, **kwargs)
+            assert cell_len(line) <= width, (stage, width, line)
+
+    @pytest.mark.parametrize("width", [100, 68, 40, 28, 20])
+    def test_the_offer_never_loses_its_two_answers(self, width):
+        """Whatever else drops, the accept key and the way out survive."""
+        from yeaboi.ui.shared._voice_input import install_offer_line
+
+        line = install_offer_line(size_mb=325, width=width)
+        assert "Enter" in line and "Esc" in line
+
+    @pytest.mark.parametrize("width", [100, 68, 40])
+    def test_cancellable_stages_keep_saying_so(self, width):
+        from yeaboi.ui.shared._voice_input import install_status_line
+
+        for stage, kwargs in self.STAGES:
+            if stage == "ready":
+                continue
+            _border, line = install_status_line(stage, tick=1.0, width=width, can_cancel=True, **kwargs)
+            assert "Esc" in line, (stage, width)
+
+    def test_a_blocking_key_reader_never_promises_an_esc(self):
+        """Advertising a key that physically cannot fire is worse than silence."""
+        from yeaboi.ui.shared._voice_input import install_status_line
+
+        for stage, kwargs in self.STAGES:
+            _border, line = install_status_line(stage, tick=1.0, width=200, can_cancel=False, **kwargs)
+            assert "Esc" not in line, stage
+
+    def test_the_offer_size_is_computed_not_hardcoded(self):
+        from yeaboi.ui.shared._voice_input import install_offer_line
+
+        assert "~3280 MB" in install_offer_line(size_mb=3280, width=200)
+
+    def test_the_reinstall_wording_explains_the_regression(self):
+        from yeaboi.ui.shared._voice_input import install_offer_line
+
+        assert "upgrade removed" in install_offer_line(size_mb=180, reinstall=True, width=200)
+
+    @pytest.mark.parametrize(
+        ("fraction", "expected"),
+        [(0.0, "▱" * 10), (0.52, "▰" * 5 + "▱" * 5), (1.0, "▰" * 10), (-1.0, "▱" * 10), (2.0, "▰" * 10)],
+    )
+    def test_bar_clamps(self, fraction, expected):
+        from yeaboi.ui.shared._voice_input import _bar
+
+        assert _bar(fraction) == expected
+
+    def test_the_popup_fallback_does_not_wrap_at_eighty_columns(self):
+        """_center's vertical centring assumes a five-row popup; a wrapped line
+        breaks it."""
+        from yeaboi.ui.shared._voice_input import _REC_BORDER, _center, install_offer_line
+
+        console = Console(file=io.StringIO(), width=80)
+        line = install_offer_line(size_mb=325, width=_status_width_for(console))
+        rendered = _render(_center(console, line, _REC_BORDER), width=80)
+        body = [row for row in rendered.splitlines() if "Set up dictation" in row]
+        assert len(body) == 1  # one row, not a wrapped two
+        assert "n never" in body[0]  # ...and not truncated either
+
+
+def _status_width_for(console):
+    from yeaboi.ui.shared._voice_input import _status_width
+
+    return _status_width(console)
+
+
+class TestVoiceInstallOffer:
+    """The double-tap-Space path when the packages are missing."""
+
+    def _setup(self, monkeypatch, *, state="installable", plan_blocked="", install=(True, ""), model=(True, "")):
+        from yeaboi import voice_install
+        from yeaboi.ui.shared import _voice_input
+
+        _voice_input.reset_voice_chip()  # clears the session decline too
+        monkeypatch.setattr(voice, "voice_state", lambda: state)
+        monkeypatch.setattr(voice_install, "unsupported_reason", lambda: "musl libc" if state == "unsupported" else "")
+        monkeypatch.setattr(voice_install, "size_estimate_mb", lambda: 325)
+        monkeypatch.setattr(
+            voice_install,
+            "install_plan",
+            lambda: voice_install.InstallPlan("pip", ("x",), "pip install x", True, plan_blocked, ""),
+        )
+        monkeypatch.setattr(voice_install, "install_packages", lambda *a, **k: install)
+        monkeypatch.setattr(voice_install, "download_model", lambda *a, **k: model)
+        monkeypatch.setattr(voice_install, "warm_model", lambda _s: (True, ""))
+        monkeypatch.setattr("yeaboi.config.mark_voice_extra_installed", lambda: None)
+        monkeypatch.setattr("yeaboi.config.voice_extra_was_installed", lambda: False)
+        return _voice_input
+
+    def _run(self, mod, keys, *, available_after=True, transcript="hello"):
+        """Drive record_voice_input from unavailable through the offer."""
+        states = iter([(False, "Install voice extra: pip install x")])
+
+        def _probe(**_kw):
+            return next(states, (available_after, "" if available_after else "still missing"))
+
+        return _probe, mod.record_voice_input(_FakeLive(), _console(), _KeySequence(keys))
+
+    def test_the_offer_is_shown_when_installable(self, monkeypatch):
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        seen: list[str] = []
+        mod.record_voice_input(
+            _FakeLive(),
+            Console(file=io.StringIO(), width=140),
+            _KeySequence(["esc"]),
+            render_status=lambda _b, line: seen.append(line) or "frame",
+        )
+        assert any("Set up dictation" in line and "Enter installs" in line for line in seen)
+
+    def test_enter_installs_and_falls_through_to_recording(self, monkeypatch):
+        mod = self._setup(monkeypatch)
+        probes = iter([(False, "nope")])
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: next(probes, (True, "")))
+
+        class _Rec:
+            device_name = "Fake Mic"
+
+            def __init__(self, **_kw):
+                pass
+
+            def level(self):
+                return 0.4
+
+            def stop(self):
+                return b"AUDIO"
+
+        monkeypatch.setattr(voice, "Recorder", _Rec)
+        monkeypatch.setattr(voice, "transcribe", lambda _wav: "spoken words")
+        seen: list[str] = []
+        result = mod.record_voice_input(
+            _FakeLive(),
+            Console(file=io.StringIO(), width=140),
+            _KeySequence(["enter", "", "enter"]),
+            render_status=lambda _b, line: seen.append(line) or "frame",
+        )
+        assert result == "spoken words"
+        assert any("Dictation is ready" in line for line in seen)
+        assert any("REC" in line for line in seen)
+
+    def test_esc_declines_for_this_session_only(self, monkeypatch):
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        written: list[tuple] = []
+        monkeypatch.setattr("yeaboi.config.set_config_value", lambda k, v: written.append((k, v)))
+
+        first: list[str] = []
+        mod.record_voice_input(
+            _FakeLive(), _console(), _KeySequence(["esc"]), render_status=lambda _b, li: first.append(li) or "f"
+        )
+        second: list[str] = []
+        mod.record_voice_input(
+            _FakeLive(), _console(), _KeySequence(["x"]), render_status=lambda _b, li: second.append(li) or "f"
+        )
+        assert any("Set up dictation" in line for line in first)
+        assert not any("Set up dictation" in line for line in second)
+        assert written == []  # a session decline is never persisted
+
+    def test_n_declines_permanently(self, monkeypatch):
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        recorded: list[bool] = []
+        monkeypatch.setattr("yeaboi.config.set_voice_install_offer", lambda enabled: recorded.append(enabled))
+        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["n"])) is None
+        assert recorded == [False]
+
+    def test_space_tab_and_clicks_do_not_authorise_an_install(self, monkeypatch):
+        """Key repeat on the double-tap must not agree to a 300 MB download."""
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        from yeaboi import voice_install
+
+        started: list[int] = []
+        monkeypatch.setattr(voice_install, "install_packages", lambda *a, **k: started.append(1) or (True, ""))
+        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence([" ", "tab", "click:4:9", "esc"])) is None
+        assert started == []
+
+    def test_an_unknown_key_keeps_the_offer_up(self, monkeypatch):
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        from yeaboi import voice_install
+
+        started: list[int] = []
+        monkeypatch.setattr(voice_install, "install_packages", lambda *a, **k: started.append(1) or (True, ""))
+        seen: list[str] = []
+        mod.record_voice_input(
+            _FakeLive(),
+            Console(file=io.StringIO(), width=140),
+            _KeySequence(["q", "enter"]),
+            render_status=lambda _b, li: seen.append(li) or "f",
+        )
+        assert started == [1]  # the typo did not dismiss the offer
+
+    def test_install_failure_shows_the_manual_command(self, monkeypatch):
+        mod = self._setup(monkeypatch, install=(False, "Install failed — run pip install x yourself"))
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        live = _FakeLive()
+        assert mod.record_voice_input(live, _console(), _KeySequence(["enter", "x"])) is None
+        assert any("pip install x" in _render(frame) for frame in live.frames)
+
+    def test_an_unsupported_platform_is_never_offered_an_install(self, monkeypatch):
+        mod = self._setup(monkeypatch, state="unsupported")
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        live = _FakeLive()
+        assert mod.record_voice_input(live, _console(), _KeySequence(["x"])) is None
+        rendered = " ".join(_render(frame) for frame in live.frames)
+        assert "musl libc" in rendered
+        assert "Set up dictation" not in rendered
+
+    def test_a_blocked_plan_says_why_instead_of_offering(self, monkeypatch):
+        mod = self._setup(monkeypatch, plan_blocked="`uv` is not on PATH")
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        live = _FakeLive()
+        assert mod.record_voice_input(live, _console(), _KeySequence(["x"])) is None
+        assert "not on PATH" in " ".join(_render(frame) for frame in live.frames)
+
+    def test_a_permanent_decline_still_shows_the_manual_command(self, monkeypatch):
+        mod = self._setup(monkeypatch, state="declined")
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "run: pip install yeaboi[voice]"))
+        live = _FakeLive()
+        assert mod.record_voice_input(live, _console(), _KeySequence(["x"])) is None
+        assert "pip install" in " ".join(_render(frame) for frame in live.frames)
+
+    def test_a_failed_model_download_still_leaves_dictation_working(self, monkeypatch):
+        """The packages are in; the model just downloads lazily as it always did."""
+        mod = self._setup(monkeypatch, model=(False, "Can't reach huggingface.co"))
+        probes = iter([(False, "nope")])
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: next(probes, (True, "")))
+
+        class _Rec:
+            device_name = "Fake Mic"
+
+            def __init__(self, **_kw):
+                pass
+
+            def level(self):
+                return 0.4
+
+            def stop(self):
+                return b"AUDIO"
+
+        monkeypatch.setattr(voice, "Recorder", _Rec)
+        monkeypatch.setattr(voice, "transcribe", lambda _wav: "still works")
+        assert mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["enter", "", "enter"])) == "still works"
+
+    def test_installed_but_still_invisible_asks_for_a_restart(self, monkeypatch):
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "Audio backend unavailable"))
+        live = _FakeLive()
+        assert mod.record_voice_input(live, _console(), _KeySequence(["enter", "x"])) is None
+        assert "Audio backend unavailable" in " ".join(_render(frame) for frame in live.frames)
+
+    def test_setting_up_dictation_never_touches_the_music(self, monkeypatch):
+        """No microphone is open yet, and suspending someone's focus music for a
+        multi-minute wait is backwards."""
+        from yeaboi import music
+
+        events: list[str] = []
+        monkeypatch.setattr(music, "pause_for_voice", lambda: events.append("pause"))
+        monkeypatch.setattr(music, "resume_after_voice", lambda: events.append("resume"))
+        mod = self._setup(monkeypatch, install=(False, "nope"))
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        for keys in (["esc"], ["n"], ["enter", "x"]):
+            mod.reset_voice_chip()
+            mod.record_voice_input(_FakeLive(), _console(), _KeySequence(keys))
+        assert events == []
+
+    def test_the_frame_loop_is_throttled_even_by_a_non_blocking_reader(self, monkeypatch):
+        """A reader that returns early must not spin the loop flat out for the
+        whole install — measured at 2.1M frames in 44s before the floor."""
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        from yeaboi import voice_install
+
+        def _slow_install(_on_line, _cancel=None, **_kw):
+            time.sleep(0.35)
+            return True, ""
+
+        monkeypatch.setattr(voice_install, "install_packages", _slow_install)
+        painted: list[str] = []
+
+        class _EagerKey:
+            """Accepts a timeout and ignores it — the failure mode being guarded.
+
+            Answers the offer at once, then returns "no key" instantly forever,
+            which is what the install loop has to survive.
+            """
+
+            def __init__(self):
+                self._first = True
+
+            def __call__(self, timeout=None):
+                if self._first:
+                    self._first = False
+                    return "enter"
+                return ""
+
+        mod.record_voice_input(
+            _FakeLive(),
+            _console(),
+            _EagerKey(),
+            render_status=lambda _b, line: painted.append(line) or "f",
+        )
+        # ~0.35s at 30fps is a handful of frames, not thousands.
+        assert len(painted) < 100, len(painted)
+
+    def test_the_offer_stays_above_the_music_pause(self):
+        """The music invariant is structural: every early return from the offer
+        sits above pause_for_voice, so there is nothing to resume."""
+        from pathlib import Path
+
+        source = Path(mod_source()).read_text(encoding="utf-8")
+        assert source.index("_offer_install(live, console") < source.index("music.pause_for_voice()")
+
+    def test_the_poker_duel_never_reaches_the_installer(self):
+        """It runs headless on a server thread, with no screen to offer on."""
+        from pathlib import Path
+
+        import yeaboi.poker.server as poker_server
+
+        assert "voice_install" not in Path(poker_server.__file__).read_text(encoding="utf-8")
+
+
+def mod_source() -> str:
+    from yeaboi.ui.shared import _voice_input
+
+    return _voice_input.__file__
+
+
+class TestInstallVoiceCommand:
+    """`yeaboi --install-voice` — the headless twin of the in-app offer.
+
+    This is the surface CI, dev containers and dumb terminals get, so its exit
+    code is the whole contract: 0 means dictation actually runs here.
+    """
+
+    @pytest.fixture
+    def _plan(self):
+        from yeaboi import voice_install
+
+        return voice_install.InstallPlan(
+            method="pip",
+            argv=("python", "-m", "pip", "install", "sounddevice"),
+            display_command="python -m pip install sounddevice",
+            durable=True,
+            blocked="",
+            follow_up="",
+        )
+
+    def test_reports_and_exits_1_when_the_platform_is_blocked(self, monkeypatch, capsys):
+        from yeaboi import cli, voice_install
+
+        blocked = voice_install.InstallPlan("blocked", (), "", False, "musl libc", "")
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "not installed"))
+        monkeypatch.setattr(voice_install, "install_plan", lambda **_kw: blocked)
+        assert cli._install_voice() == 1
+        assert "musl libc" in capsys.readouterr().out
+
+    def test_ignores_a_stored_verdict(self, monkeypatch):
+        """Typing the command *is* the retry. A month-old cached failure — a
+        wheel that had not landed, a mirror that had not synced — must not be
+        the reason the explicit escape hatch refuses."""
+        from yeaboi import cli, voice_install
+
+        seen: dict = {}
+
+        def _plan_spy(**kwargs):
+            seen.update(kwargs)
+            return voice_install.InstallPlan("blocked", (), "", False, "nope", "")
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "not installed"))
+        monkeypatch.setattr(voice_install, "install_plan", _plan_spy)
+        cli._install_voice()
+        assert seen == {"ignore_verdict": True}
+
+    def test_exits_1_when_the_install_fails(self, monkeypatch, capsys, _plan):
+        from yeaboi import cli, voice_install
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "not installed"))
+        monkeypatch.setattr(voice_install, "install_plan", lambda **_kw: _plan)
+        monkeypatch.setattr(voice_install, "install_packages", lambda *_a, **_k: (False, "no wheel"))
+        assert cli._install_voice() == 1
+        assert "no wheel" in capsys.readouterr().out
+
+    def test_happy_path_exits_0(self, monkeypatch, capsys, _plan):
+        from yeaboi import cli, voice_install
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "not installed"))
+        monkeypatch.setattr(voice_install, "install_plan", lambda **_kw: _plan)
+        monkeypatch.setattr(voice_install, "install_packages", lambda *_a, **_k: (True, ""))
+        monkeypatch.setattr("yeaboi.config.mark_voice_extra_installed", lambda: None)
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setattr(voice_install, "download_model", lambda *_a, **_k: (True, ""))
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_k: (True, ""))
+        assert cli._install_voice() == 0
+        out = capsys.readouterr().out
+        assert "Packages installed." in out
+        assert "ready" in out
+
+    def test_a_failed_model_download_still_probes(self, monkeypatch, capsys, _plan):
+        """A missing model is a warning — it downloads lazily on first use. But
+        returning 0 without probing would report success on a host where the
+        packages landed and PortAudio is missing."""
+        from yeaboi import cli, voice_install
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "not installed"))
+        monkeypatch.setattr(voice_install, "install_plan", lambda **_kw: _plan)
+        monkeypatch.setattr(voice_install, "install_packages", lambda *_a, **_k: (True, ""))
+        monkeypatch.setattr("yeaboi.config.mark_voice_extra_installed", lambda: None)
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setattr(voice_install, "download_model", lambda *_a, **_k: (False, "offline"))
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_k: (False, "Audio backend unavailable"))
+        assert cli._install_voice() == 1
+        out = capsys.readouterr().out
+        assert "offline" in out
+        assert "Audio backend unavailable" in out
+
+    def test_skips_the_install_when_already_present(self, monkeypatch, capsys):
+        from yeaboi import cli, voice_install
+
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        monkeypatch.setattr(voice_install, "install_plan", _fail_if_called)
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: True)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_k: (True, ""))
+        assert cli._install_voice() == 0
+        assert "already installed" in capsys.readouterr().out
+
+
+def _fail_if_called(*_args, **_kwargs):
+    raise AssertionError("install_plan must not be consulted when voice is already available")
+
+
+class TestInstallVoiceEcho:
+    """The two plain-print helpers. No Rich here by design: the output has to
+    survive a pipe, a CI log and a terminal with no cursor control."""
+
+    def test_echo_once_drops_consecutive_repeats(self, capsys):
+        from yeaboi import cli
+
+        echoed: list[str] = []
+        for phrase in ("Resolving", "Resolving", "Downloading", "Downloading", "Resolving"):
+            cli._echo_once(echoed, phrase)
+        assert capsys.readouterr().out.count("Resolving") == 2  # repeat collapsed, later recurrence kept
+        assert echoed == ["Resolving", "Downloading", "Resolving"]
+
+    def test_echo_once_ignores_the_empty_phrase(self, capsys):
+        from yeaboi import cli
+
+        echoed: list[str] = []
+        cli._echo_once(echoed, "")
+        assert capsys.readouterr().out == ""
+        assert echoed == []
+
+    def test_echo_progress_prints_a_percentage(self, capsys):
+        from yeaboi import cli
+
+        cli._echo_progress("120 MB / 145 MB", 0.83)
+        assert "83%" in capsys.readouterr().out
+
+    def test_echo_progress_stays_silent_without_a_fraction(self, capsys):
+        """An unknown total is common early in a download; a bar with no number
+        in it is worse than no line at all on a non-cursor terminal."""
+        from yeaboi import cli
+
+        cli._echo_progress("starting", None)
+        assert capsys.readouterr().out == ""
+
+
+class TestUnsupportedBlocker:
+    """ "Installable" must mean an install would actually help.
+
+    ``sounddevice`` is a pure-Python wheel that imports happily without the
+    system PortAudio library, so on a Linux host missing ``libportaudio2`` the
+    modules are present and an install exits 0 having changed nothing. Offering
+    one would walk the user through ~325 MB and two minutes to arrive back
+    exactly where they started — on the very platform the strict probe exists
+    for.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_stored_verdict(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.voice_install.unsupported_reason", lambda: "")
+
+    def test_missing_modules_stay_installable(self, monkeypatch):
+        monkeypatch.setattr(voice, "_module_check", lambda: (False, "not installed"))
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (False, "not installed"))
+        monkeypatch.setattr("yeaboi.config.is_voice_install_offer_enabled", lambda: True)
+        assert voice.unsupported_blocker() == ""
+        assert voice.voice_state() == "installable"
+
+    def test_a_dead_backend_is_unsupported_not_installable(self, monkeypatch):
+        monkeypatch.setattr(voice, "_module_check", lambda: (True, ""))
+        monkeypatch.setattr(
+            voice,
+            "is_voice_available",
+            lambda: (False, "Audio backend unavailable — sudo apt install libportaudio2"),
+        )
+        monkeypatch.setattr("yeaboi.config.is_voice_install_offer_enabled", lambda: True)
+        assert "libportaudio2" in voice.unsupported_blocker()
+        assert voice.voice_state() == "unsupported"
+
+    def test_a_stored_verdict_wins(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.voice_install.unsupported_reason", lambda: "musl libc")
+        monkeypatch.setattr(voice, "_module_check", lambda: (False, "not installed"))
+        assert voice.unsupported_blocker() == "musl libc"
+
+    def test_a_working_setup_has_no_blocker(self, monkeypatch):
+        monkeypatch.setattr(voice, "_module_check", lambda: (True, ""))
+        monkeypatch.setattr(voice, "is_voice_available", lambda: (True, ""))
+        assert voice.unsupported_blocker() == ""
+        assert voice.voice_state() == "ready"
+
+
+class TestVoiceInstallModelStage:
+    """What happens after the packages land — the half that runs in-process.
+
+    Reuses the offer harness without inheriting its tests.
+    """
+
+    _setup = TestVoiceInstallOffer._setup
+
+    def test_a_failed_download_never_warms_the_model(self, monkeypatch):
+        """warm_model loads in-process, and WhisperModel downloads the weights
+        itself when they are missing — with no progress, no byte count and no
+        cancel. It would also defeat the reason the fetch runs in a child at
+        all: on an AVX-less host that child dies of SIGILL, and importing
+        ctranslate2 here would take the TUI down with the same instruction."""
+        from yeaboi import voice_install
+
+        mod = self._setup(monkeypatch, model=(False, "offline"))
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        monkeypatch.setattr(
+            voice_install,
+            "warm_model",
+            lambda _s: pytest.fail("warm_model would download the weights in-process"),
+        )
+        mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["enter", "x"]))
+
+    def test_a_successful_download_does_warm_the_model(self, monkeypatch):
+        """The whole point of the extra stage: first dictation is instant."""
+        from yeaboi import voice_install
+
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+        warmed: list[str] = []
+        monkeypatch.setattr(voice_install, "warm_model", lambda s: warmed.append(s) or (True, ""))
+        mod.record_voice_input(_FakeLive(), _console(), _KeySequence(["enter", "x"]))
+        assert len(warmed) == 1
+
+    def test_an_unexpected_worker_error_is_caught_and_named(self, monkeypatch):
+        """duck_working_thread does not catch, so without a guard the traceback
+        prints straight through the Rich Live and the outcome stays at its
+        default — "see the log", with nothing in the log."""
+        from yeaboi import voice_install
+
+        mod = self._setup(monkeypatch)
+        monkeypatch.setattr(voice, "probe_voice_backend", lambda **_kw: (False, "nope"))
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(voice_install, "install_packages", _boom)
+        live = _FakeLive()
+        assert mod.record_voice_input(live, _console(), _KeySequence(["enter", "x"])) is None
+        assert any("unexpected error" in _render(frame) for frame in live.frames)

--- a/tests/unit/test_voice_install.py
+++ b/tests/unit/test_voice_install.py
@@ -388,7 +388,7 @@ def fake_popen(monkeypatch):
 
     def make(lines, exit_code=0, stay_alive=0):
         cls = type("_Scripted", (_FakePopen,), {"lines": lines, "exit_code": exit_code, "stay_alive": stay_alive})
-        monkeypatch.setattr(voice_install.subprocess, "Popen", cls)
+        monkeypatch.setattr(voice_install, "_popen", cls)
         return cls
 
     return make
@@ -453,7 +453,7 @@ class TestInstallPackages:
 
     def test_a_blocked_plan_never_spawns_anything(self, monkeypatch):
         sentinel = lambda *_a, **_k: pytest.fail("Popen must not be called for a blocked plan")  # noqa: E731
-        monkeypatch.setattr(voice_install.subprocess, "Popen", sentinel)
+        monkeypatch.setattr(voice_install, "_popen", sentinel)
         plan = voice_install.InstallPlan("blocked", (), "", False, "musl libc", "")
         ok, message = voice_install.install_packages(lambda _line: None, plan=plan)
         assert not ok
@@ -463,6 +463,17 @@ class TestInstallPackages:
 class TestInstallPackagesRealChild:
     """The one place a real process runs — a fake Popen cannot prove the reader
     thread, the merged stderr and the non-blocking wait work together."""
+
+    @pytest.fixture(autouse=True)
+    def _allow_real_spawn(self, monkeypatch):
+        """Opt out of the conftest spawn guard, deliberately and in one place.
+
+        Every argv used in this class is a ``sys.executable -c <literal>``, never
+        a package manager, so nothing here can install anything. Sharing the
+        ``monkeypatch`` instance means this setattr lands after the guard's and
+        wins.
+        """
+        monkeypatch.setattr(voice_install, "_popen", subprocess.Popen)
 
     def test_streams_both_stdout_and_stderr_from_a_live_process(self, monkeypatch):
         program = (
@@ -608,15 +619,17 @@ class TestModelPaths:
 def child_program(monkeypatch):
     """Run a stand-in child instead of the real download, keeping a real Popen.
 
-    Patching ``voice_install.subprocess.Popen`` patches the shared module, so the
-    replacement has to close over the original or it calls itself.
+    Closes over ``subprocess.Popen`` rather than reading ``voice_install._popen``:
+    that name is the conftest guard by the time this runs, so calling it would
+    raise instead of spawning. Patching the module's own seam (not the shared
+    ``subprocess`` module) keeps the replacement scoped to this module.
     """
     real_popen = subprocess.Popen
 
     def substitute(program: str):
         monkeypatch.setattr(
-            voice_install.subprocess,
-            "Popen",
+            voice_install,
+            "_popen",
             lambda _argv, **kw: real_popen([sys.executable, "-c", program], **kw),
         )
 
@@ -626,7 +639,7 @@ def child_program(monkeypatch):
 class TestDownloadModel:
     def test_an_unknown_size_never_reaches_a_subprocess(self, monkeypatch):
         monkeypatch.setattr(
-            voice_install.subprocess, "Popen", lambda *_a, **_k: pytest.fail("must not spawn for an unknown size")
+            voice_install, "_popen", lambda *_a, **_k: pytest.fail("must not spawn for an unknown size")
         )
         ok, message = voice_install.download_model("'; rm -rf /", lambda *_a: None)
         assert not ok
@@ -635,7 +648,7 @@ class TestDownloadModel:
     def test_an_already_cached_model_is_a_no_op(self, monkeypatch):
         monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: True)
         monkeypatch.setattr(
-            voice_install.subprocess, "Popen", lambda *_a, **_k: pytest.fail("must not re-download a cached model")
+            voice_install, "_popen", lambda *_a, **_k: pytest.fail("must not re-download a cached model")
         )
         assert voice_install.download_model("base", lambda *_a: None) == (True, "")
 
@@ -703,7 +716,7 @@ class TestModelChildEnv:
             seen.update(kw.get("env") or {})
             return real_popen([sys.executable, "-c", "pass"], **kw)
 
-        monkeypatch.setattr(voice_install.subprocess, "Popen", capture)
+        monkeypatch.setattr(voice_install, "_popen", capture)
         voice_install.download_model("base", lambda *_a: None)
         assert seen["HF_HUB_DISABLE_XET"] == "1"
         assert seen["HF_HUB_DISABLE_PROGRESS_BARS"] == "1"  # no tqdm into the Live
@@ -720,7 +733,7 @@ class TestModelChildEnv:
         monkeypatch.setattr(voice_install, "model_total_bytes", lambda _s, **_k: 0)
         monkeypatch.setattr(voice_install, "model_bytes_on_disk", lambda _s: 0)
         monkeypatch.setattr(voice_install, "_POLL_SECONDS", 0.01)
-        monkeypatch.setattr(voice_install.subprocess, "Popen", capture)
+        monkeypatch.setattr(voice_install, "_popen", capture)
         voice_install.download_model("large-v3", lambda *_a: None)
         assert "'large-v3'" in captured[0][2]
 
@@ -851,3 +864,23 @@ class TestRefreshImportsDropsTheVerdictMemo:
         monkeypatch.setattr(voice_install, "_unsupported_cache", "stale answer")
         voice_install.refresh_imports()
         assert voice_install.unsupported_reason() == ""
+
+
+class TestSpawnGuard:
+    """The conftest guard must actually be wired to this module's seam.
+
+    Without it, one test that forgets to patch the probe runs a real
+    ``uv pip install`` plus a 145 MB model fetch on a CI runner — which is
+    exactly how this guard came to exist. If the seam is ever renamed or the
+    call sites go back to ``subprocess.Popen`` directly, this fails loudly here
+    instead of silently on a runner eight minutes later.
+    """
+
+    def test_a_real_spawn_is_blocked(self):
+        with pytest.raises(BaseException, match="real installer"):
+            voice_install._popen([sys.executable, "-c", "pass"])
+
+    def test_both_call_sites_go_through_the_seam(self):
+        source = (REPO_ROOT / "src" / "yeaboi" / "voice_install.py").read_text(encoding="utf-8")
+        assert "proc = _popen(" in source
+        assert "proc = subprocess.Popen(" not in source

--- a/tests/unit/test_voice_install.py
+++ b/tests/unit/test_voice_install.py
@@ -1,0 +1,853 @@
+"""Unit tests for the in-app dictation installer.
+
+Nothing here installs anything or reaches the network. Two layers are used
+deliberately for the subprocess paths: a fake ``Popen`` for the progress and
+failure sequences (fast, exhaustive), plus a handful of *real* short-lived child
+processes, because only a real process proves the reader thread, the merged
+stderr and the non-blocking wait actually work together.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from yeaboi import voice_install
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    """Point every persisted path at a tmp dir and clear the memoised verdict."""
+    monkeypatch.setattr(voice_install, "_unsupported_cache", None)
+    monkeypatch.setattr("yeaboi.paths.get_voice_install_path", lambda: tmp_path / "voice_install.json")
+    monkeypatch.setattr("yeaboi.paths.get_bin_dir", lambda: tmp_path)
+    yield
+    voice_install.reset_unsupported_cache()
+
+
+def _no_source_checkout(monkeypatch):
+    """Make _is_source_checkout() False so the PyPI branches can be exercised."""
+    monkeypatch.setattr(voice_install, "_is_source_checkout", lambda: False)
+
+
+# ---------------------------------------------------------------------------
+# Requirements must not drift from pyproject
+# ---------------------------------------------------------------------------
+
+
+class TestRequirementsMatchExtra:
+    def test_voice_packages_equal_the_pyproject_extra(self):
+        data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        extra = data["project"]["optional-dependencies"]["voice"]
+        assert set(voice_install.VOICE_PACKAGES) == set(extra)
+
+    def test_every_model_size_has_a_download_estimate(self):
+        assert voice_install.MODEL_SIZES == frozenset(voice_install.MODEL_MB)
+
+
+# ---------------------------------------------------------------------------
+# Platform gate
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformSupport:
+    def test_64bit_mac_arm_is_supported(self, monkeypatch):
+        monkeypatch.setattr(sys, "maxsize", 2**63 - 1)
+        monkeypatch.setattr("platform.machine", lambda: "arm64")
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert voice_install.platform_support() == (True, "")
+
+    def test_32bit_python_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(sys, "maxsize", 2**31 - 1)
+        supported, reason = voice_install.platform_support()
+        assert not supported
+        assert "32-bit" in reason
+
+    def test_unknown_architecture_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(sys, "maxsize", 2**63 - 1)
+        monkeypatch.setattr("platform.machine", lambda: "armv7l")
+        supported, reason = voice_install.platform_support()
+        assert not supported
+        assert "armv7l" in reason
+
+    def test_musl_linux_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(sys, "maxsize", 2**63 - 1)
+        monkeypatch.setattr("platform.machine", lambda: "x86_64")
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr("platform.libc_ver", lambda: ("", ""))
+        supported, reason = voice_install.platform_support()
+        assert not supported
+        assert "musl" in reason
+
+    def test_ancient_glibc_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(sys, "maxsize", 2**63 - 1)
+        monkeypatch.setattr("platform.machine", lambda: "x86_64")
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr("platform.libc_ver", lambda: ("glibc", "2.12"))
+        supported, reason = voice_install.platform_support()
+        assert not supported
+        assert "2.12" in reason
+
+    def test_modern_glibc_is_supported(self, monkeypatch):
+        monkeypatch.setattr(sys, "maxsize", 2**63 - 1)
+        monkeypatch.setattr("platform.machine", lambda: "x86_64")
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr("platform.libc_ver", lambda: ("glibc", "2.35"))
+        assert voice_install.platform_support()[0]
+
+    def test_a_new_cpython_is_not_pre_gated(self, monkeypatch):
+        """A missing cp3XX wheel resolves itself when the wheel lands, so it is
+        classified after a real attempt rather than refused up front."""
+        monkeypatch.setattr(sys, "maxsize", 2**63 - 1)
+        monkeypatch.setattr("platform.machine", lambda: "arm64")
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(sys, "version_info", (3, 99, 0, "final", 0))
+        assert voice_install.platform_support()[0]
+
+
+# ---------------------------------------------------------------------------
+# Sticky verdicts
+# ---------------------------------------------------------------------------
+
+
+class TestVerdicts:
+    def test_round_trip(self):
+        voice_install.write_verdict("NO_WHEEL", "nope")
+        assert voice_install.read_verdict() == ("NO_WHEEL", "nope")
+        assert voice_install.unsupported_reason() == "nope"
+
+    def test_a_different_environment_ignores_the_verdict(self, monkeypatch):
+        voice_install.write_verdict("NO_WHEEL", "nope")
+        monkeypatch.setattr(voice_install, "_verdict_key", lambda: "some other machine")
+        assert voice_install.read_verdict() == ("", "")
+
+    def test_clear_removes_it(self):
+        voice_install.write_verdict("NO_WHEEL", "nope")
+        voice_install.clear_verdict()
+        assert voice_install.read_verdict() == ("", "")
+        assert voice_install.unsupported_reason() == ""
+
+    def test_unsupported_reason_is_memoised(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(voice_install, "read_verdict", lambda: (calls.append(1), ("", ""))[1])
+        voice_install.unsupported_reason()
+        voice_install.unsupported_reason()
+        assert len(calls) == 1
+
+    def test_platform_gate_wins_over_a_stored_verdict(self, monkeypatch):
+        monkeypatch.setattr(voice_install, "platform_support", lambda: (False, "32-bit Python"))
+        assert voice_install.unsupported_reason() == "32-bit Python"
+
+
+# ---------------------------------------------------------------------------
+# The install command
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPlan:
+    def test_source_checkout_uses_additive_uv_pip(self, monkeypatch):
+        monkeypatch.setattr(voice_install, "_is_source_checkout", lambda: True)
+        monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+        plan = voice_install.install_plan()
+        assert plan.method == "uv-project"
+        assert plan.argv[:3] == ("/usr/bin/uv", "pip", "install")
+        assert "--python" in plan.argv and sys.executable in plan.argv
+        assert plan.follow_up == "uv sync --extra voice"
+
+    def test_source_checkout_never_runs_uv_sync(self, monkeypatch):
+        """`uv sync` is exact: it uninstalls whatever the lockfile omits, out
+        from under the running process."""
+        monkeypatch.setattr(voice_install, "_is_source_checkout", lambda: True)
+        monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+        assert "sync" not in voice_install.install_plan().argv
+
+    def test_uv_tool_never_rebuilds_its_own_venv(self, monkeypatch):
+        """`uv tool install --force` deletes the venv this process runs from."""
+        _no_source_checkout(monkeypatch)
+        monkeypatch.setattr(sys, "executable", "/home/u/.local/share/uv/tools/yeaboi/bin/python")
+        monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+        plan = voice_install.install_plan()
+        assert plan.method == "uv-tool"
+        assert "tool" not in plan.argv
+        assert plan.follow_up == "uv tool install --force 'yeaboi[voice]'"
+        assert plan.durable is False
+
+    def test_uv_tool_without_uv_on_path_is_blocked(self, monkeypatch):
+        _no_source_checkout(monkeypatch)
+        monkeypatch.setattr(sys, "executable", "/home/u/.local/share/uv/tools/yeaboi/bin/python")
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        plan = voice_install.install_plan()
+        assert plan.method == "blocked"
+        assert "uv" in plan.blocked
+
+    def test_pipx_injects_by_venv_name(self, monkeypatch):
+        _no_source_checkout(monkeypatch)
+        monkeypatch.setattr(sys, "executable", "/home/u/.local/pipx/venvs/scrum-agent/bin/python")
+        monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}" if name == "pipx" else None)
+        monkeypatch.setattr(Path, "resolve", lambda self, **_kw: self)
+        plan = voice_install.install_plan()
+        assert plan.method == "pipx"
+        assert plan.argv[:3] == ("/usr/bin/pipx", "inject", "scrum-agent")
+        assert plan.durable is True
+
+    def test_plain_pip_targets_this_interpreter(self, monkeypatch):
+        _no_source_checkout(monkeypatch)
+        monkeypatch.setattr(sys, "executable", "/usr/local/venv/bin/python")
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        plan = voice_install.install_plan()
+        assert plan.method == "pip"
+        assert plan.argv[:4] == ("/usr/local/venv/bin/python", "-m", "pip", "install")
+        assert "--only-binary=:all:" in plan.argv
+
+    def test_wheels_only_by_default_and_opt_out_via_env(self, monkeypatch):
+        _no_source_checkout(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        assert "--only-binary=:all:" in voice_install.install_plan().argv
+        monkeypatch.setenv(voice_install._ALLOW_BUILD_ENV, "1")
+        assert "--only-binary=:all:" not in voice_install.install_plan().argv
+
+    def test_externally_managed_python_is_blocked_before_spawning(self, monkeypatch):
+        monkeypatch.setattr(voice_install, "_externally_managed", lambda: True)
+        plan = voice_install.install_plan()
+        assert plan.method == "blocked"
+        assert plan.argv == ()
+        assert "system-managed" in plan.blocked
+
+    def test_unsupported_platform_is_blocked(self, monkeypatch):
+        monkeypatch.setattr(voice_install, "platform_support", lambda: (False, "musl libc"))
+        assert voice_install.install_plan().blocked == "musl libc"
+
+    def test_nothing_from_the_environment_reaches_argv(self, monkeypatch):
+        """argv is built from module constants and sys.executable only."""
+        _no_source_checkout(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        monkeypatch.setenv("EVIL", "; rm -rf /")
+        argv = voice_install.install_plan().argv
+        assert "; rm -rf /" not in " ".join(argv)
+        assert set(argv) & set(os.environ.values()) <= {sys.executable}
+
+    def test_the_extra_is_never_installed_over_the_running_app(self, monkeypatch):
+        """`yeaboi[voice]` would reinstall yeaboi itself, mid-run."""
+        _no_source_checkout(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        joined = " ".join(voice_install.install_plan().argv)
+        assert "yeaboi" not in joined.replace(sys.executable, "")
+
+
+class TestPipxVenvName:
+    def test_legacy_distribution_name_is_read_off_the_path(self, monkeypatch):
+        monkeypatch.setattr(sys, "executable", "/home/u/.local/pipx/venvs/scrum-agent/bin/python")
+        monkeypatch.setattr(Path, "resolve", lambda self, **_kw: self)
+        assert voice_install._pipx_venv_name() == "scrum-agent"
+
+    def test_a_non_pipx_path_yields_nothing(self, monkeypatch):
+        monkeypatch.setattr(sys, "executable", "/usr/bin/python3")
+        monkeypatch.setattr(Path, "resolve", lambda self, **_kw: self)
+        assert voice_install._pipx_venv_name() == ""
+
+    def test_a_hostile_venv_name_is_refused(self, monkeypatch):
+        monkeypatch.setattr(sys, "executable", "/home/u/.local/pipx/venvs/a b;rm -rf/bin/python")
+        monkeypatch.setattr(Path, "resolve", lambda self, **_kw: self)
+        assert voice_install._pipx_venv_name() == ""
+
+
+# ---------------------------------------------------------------------------
+# Narration and failure classification
+# ---------------------------------------------------------------------------
+
+
+class TestNarrate:
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            ("Collecting faster-whisper", "resolving faster-whisper"),
+            (
+                "  Downloading ctranslate2-4.8.1-cp313-macosx_11_0_arm64.whl (37.3 MB)",
+                "downloading ctranslate2 (37.3 MB)",
+            ),
+            ("  Downloading numpy-2.4.3-cp313.whl", "downloading numpy"),
+            ("  Using cached tokenizers-0.23.1-cp310-abi3.whl", "using cached tokenizers"),
+            ("Installing collected packages: numpy, av", "installing packages"),
+            ("Resolved 14 packages in 431ms", "resolved 14 packages"),
+            ("Prepared 9 packages in 12.30s", "downloaded 9 packages"),
+            ("Installed 9 packages in 88ms", "installed 9 packages"),
+            ("  Building wheel for av (pyproject.toml)", "building av"),
+        ],
+    )
+    def test_known_shapes(self, line, expected):
+        assert voice_install.narrate(line) == expected
+
+    def test_unrecognised_noise_is_dropped_so_the_previous_phrase_survives(self):
+        assert voice_install.narrate("  WARNING: something about a cache directory") == ""
+        assert voice_install.narrate("") == ""
+
+
+class TestClassifyFailure:
+    @pytest.mark.parametrize(
+        ("output", "code"),
+        [
+            ("ERROR: No matching distribution found for onnxruntime", "NO_WHEEL"),
+            ("Could not find a version that satisfies the requirement ctranslate2", "NO_WHEEL"),
+            ("ctranslate2 does not have a wheel for the current platform", "NO_WHEEL"),
+            ("faster-whisper requires a different Python: 3.99 not in <3.13", "NO_WHEEL"),
+            ("error: externally-managed-environment", "EXTERNALLY_MANAGED"),
+            ("Temporary failure in name resolution", "NO_NETWORK"),
+            ("SSLError: certificate verify failed", "NO_NETWORK"),
+            ("OSError: [Errno 28] No space left on device", "DISK_FULL"),
+            ("PermissionError: [Errno 13] Permission denied: '/usr/lib'", "PERMISSION"),
+        ],
+    )
+    def test_table(self, output, code):
+        assert voice_install.classify_failure(1, output)[0] == code
+
+    def test_no_wheel_names_the_python_version_not_just_the_platform(self):
+        _code, message = voice_install.classify_failure(1, "No matching distribution found")
+        assert f"CPython {sys.version_info[0]}.{sys.version_info[1]}" in message
+
+    def test_unknown_keeps_the_tail_for_the_log_pointer(self):
+        code, message = voice_install.classify_failure(2, "line one\nline two\nsomething odd")
+        assert code == "UNKNOWN"
+        assert "something odd" in message
+
+    def test_only_hopeless_codes_are_permanent(self):
+        assert voice_install.PERMANENT_CODES == {"NO_WHEEL", "EXTERNALLY_MANAGED"}
+
+
+# ---------------------------------------------------------------------------
+# Child environment
+# ---------------------------------------------------------------------------
+
+
+class TestChildEnv:
+    def test_every_progress_bar_and_colour_source_is_disabled(self):
+        env = voice_install._child_env()
+        assert env["PIP_PROGRESS_BAR"] == "off"
+        assert env["UV_NO_PROGRESS"] == "1"
+        assert env["NO_COLOR"] == "1"
+        assert env["TERM"] == "dumb"
+        assert env["PIP_NO_INPUT"] == "1"
+        # A wrapped package name would defeat narrate() as surely as a colour code.
+        assert env["COLUMNS"] == "200"
+
+
+# ---------------------------------------------------------------------------
+# Running the installer — fake Popen
+# ---------------------------------------------------------------------------
+
+
+class _FakePopen:
+    """Scripted stand-in for a package manager."""
+
+    instances: list[_FakePopen] = []
+
+    def __init__(self, argv, **kwargs):
+        self.argv = argv
+        self.kwargs = kwargs
+        self.stdout = iter(self.lines)
+        self.terminated = False
+        self.killed = False
+        self._polls = 0
+        _FakePopen.instances.append(self)
+
+    lines: list[str] = []
+    exit_code = 0
+    stay_alive = 0
+
+    def poll(self):
+        self._polls += 1
+        if self._polls <= self.stay_alive:
+            return None
+        self.returncode = self.exit_code
+        return self.exit_code
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):  # pragma: no cover - only when wait() times out
+        self.killed = True
+
+    def wait(self, timeout=None):
+        self.returncode = getattr(self, "returncode", self.exit_code)
+        return self.returncode
+
+
+@pytest.fixture
+def fake_popen(monkeypatch):
+    _FakePopen.instances = []
+
+    def make(lines, exit_code=0, stay_alive=0):
+        cls = type("_Scripted", (_FakePopen,), {"lines": lines, "exit_code": exit_code, "stay_alive": stay_alive})
+        monkeypatch.setattr(voice_install.subprocess, "Popen", cls)
+        return cls
+
+    return make
+
+
+_PIP_TRANSCRIPT = [
+    "Collecting sounddevice\n",
+    "  Downloading sounddevice-0.5.5-py3-none-any.whl (32 kB)\n",
+    "Collecting faster-whisper\n",
+    "  Downloading ctranslate2-4.8.1-cp313.whl (37.3 MB)\n",
+    "Installing collected packages: sounddevice, ctranslate2\n",
+    "Successfully installed sounddevice-0.5.5 ctranslate2-4.8.1\n",
+]
+
+
+class TestInstallPackages:
+    def _plan(self):
+        return voice_install.InstallPlan("pip", ("/bin/true",), "/bin/true", True, "", "")
+
+    def test_narrated_progress_in_order(self, fake_popen, monkeypatch):
+        fake_popen(_PIP_TRANSCRIPT)
+        monkeypatch.setattr(voice_install, "refresh_imports", lambda: None)
+        monkeypatch.setattr(voice_install, "verify_installed", lambda: (True, ""))
+        seen: list[str] = []
+        ok, message = voice_install.install_packages(seen.append, plan=self._plan())
+        assert ok and message == ""
+        assert seen[0] == "resolving sounddevice"
+        assert "downloading ctranslate2 (37.3 MB)" in seen
+        assert seen[-1] == "installed packages"
+
+    def test_pipes_are_never_inherited(self, fake_popen, monkeypatch):
+        """A child writing to the TTY under a Rich Live corrupts the display."""
+        fake_popen(_PIP_TRANSCRIPT)
+        monkeypatch.setattr(voice_install, "refresh_imports", lambda: None)
+        monkeypatch.setattr(voice_install, "verify_installed", lambda: (True, ""))
+        voice_install.install_packages(lambda _line: None, plan=self._plan())
+        kwargs = _FakePopen.instances[-1].kwargs
+        assert kwargs["stdin"] is subprocess.DEVNULL
+        assert kwargs["stdout"] is subprocess.PIPE
+        assert kwargs["stderr"] is subprocess.STDOUT
+
+    def test_exit_zero_but_not_importable_asks_for_a_restart(self, fake_popen, monkeypatch):
+        fake_popen(_PIP_TRANSCRIPT)
+        monkeypatch.setattr(voice_install, "refresh_imports", lambda: None)
+        monkeypatch.setattr(voice_install, "verify_installed", lambda: (False, "sounddevice is not importable"))
+        ok, message = voice_install.install_packages(lambda _line: None, plan=self._plan())
+        assert not ok
+        assert "restart" in message.lower()
+
+    def test_no_wheel_failure_is_recorded_as_permanent(self, fake_popen):
+        fake_popen(["ERROR: No matching distribution found for onnxruntime\n"], exit_code=1)
+        ok, message = voice_install.install_packages(lambda _line: None, plan=self._plan())
+        assert not ok
+        assert "No prebuilt speech-engine wheel" in message
+        assert voice_install.read_verdict()[0] == "NO_WHEEL"
+
+    def test_a_retryable_failure_is_not_recorded(self, fake_popen):
+        fake_popen(["Temporary failure in name resolution\n"], exit_code=1)
+        ok, _message = voice_install.install_packages(lambda _line: None, plan=self._plan())
+        assert not ok
+        assert voice_install.read_verdict() == ("", "")
+
+    def test_a_blocked_plan_never_spawns_anything(self, monkeypatch):
+        sentinel = lambda *_a, **_k: pytest.fail("Popen must not be called for a blocked plan")  # noqa: E731
+        monkeypatch.setattr(voice_install.subprocess, "Popen", sentinel)
+        plan = voice_install.InstallPlan("blocked", (), "", False, "musl libc", "")
+        ok, message = voice_install.install_packages(lambda _line: None, plan=plan)
+        assert not ok
+        assert message == "musl libc"
+
+
+class TestInstallPackagesRealChild:
+    """The one place a real process runs — a fake Popen cannot prove the reader
+    thread, the merged stderr and the non-blocking wait work together."""
+
+    def test_streams_both_stdout_and_stderr_from_a_live_process(self, monkeypatch):
+        program = (
+            "import sys;"
+            "print('Collecting sounddevice');"
+            "print('  Downloading ctranslate2-4.8.1-cp313.whl (37.3 MB)', file=sys.stderr);"
+            "print('Successfully installed sounddevice-0.5.5')"
+        )
+        plan = voice_install.InstallPlan("pip", (sys.executable, "-c", program), "python -c ...", True, "", "")
+        monkeypatch.setattr(voice_install, "refresh_imports", lambda: None)
+        monkeypatch.setattr(voice_install, "verify_installed", lambda: (True, ""))
+        seen: list[str] = []
+        ok, _message = voice_install.install_packages(seen.append, plan=plan)
+        assert ok
+        assert "resolving sounddevice" in seen
+        assert "downloading ctranslate2 (37.3 MB)" in seen  # arrived via stderr
+
+    def test_a_nonzero_exit_is_classified_from_the_tail(self):
+        program = "import sys; print('ERROR: No matching distribution found for onnxruntime'); sys.exit(1)"
+        plan = voice_install.InstallPlan("pip", (sys.executable, "-c", program), "python -c ...", True, "", "")
+        ok, message = voice_install.install_packages(lambda _line: None, plan=plan)
+        assert not ok
+        assert "No prebuilt speech-engine wheel" in message
+
+    def test_cancel_terminates_a_running_child(self):
+        plan = voice_install.InstallPlan(
+            "pip", (sys.executable, "-c", "import time; time.sleep(30)"), "sleep", True, "", ""
+        )
+        cancel = threading.Event()
+        threading.Timer(0.3, cancel.set).start()
+        started = time.monotonic()
+        ok, message = voice_install.install_packages(lambda _line: None, cancel, plan=plan)
+        assert not ok
+        assert "cancelled" in message.lower()
+        assert time.monotonic() - started < 10
+
+    def test_a_timeout_points_at_the_manual_command(self):
+        plan = voice_install.InstallPlan(
+            "pip", (sys.executable, "-c", "import time; time.sleep(30)"), "pip install x", True, "", ""
+        )
+        ok, message = voice_install.install_packages(lambda _line: None, timeout=0.5, plan=plan)
+        assert not ok
+        assert "pip install x" in message
+
+
+# ---------------------------------------------------------------------------
+# Making the install visible in-process
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshImports:
+    def test_every_memo_that_answers_is_voice_installed_is_dropped(self, monkeypatch):
+        """All three caches were written when the answer could not change
+        mid-process. It can now."""
+        from yeaboi import voice
+        from yeaboi.ui.shared import _tips, _voice_input
+
+        calls: list[str] = []
+        monkeypatch.setattr("importlib.invalidate_caches", lambda: calls.append("importlib"))
+        monkeypatch.setattr(voice, "reset_probe", lambda: calls.append("probe"))
+        monkeypatch.setattr(_voice_input, "reset_voice_chip", lambda: calls.append("chip"))
+        monkeypatch.setattr(_tips.get_tips, "cache_clear", lambda: calls.append("tips"))
+        voice_install.refresh_imports()
+        assert set(calls) == {"importlib", "probe", "chip", "tips"}
+
+    def test_a_stale_chip_survives_until_refresh(self, monkeypatch):
+        """The chip memo assumed availability could not change mid-process. It
+        can now, so refresh_imports has to be the thing that drops it."""
+        from yeaboi import voice
+        from yeaboi.ui.shared import _voice_input
+
+        _voice_input.reset_voice_chip()
+        monkeypatch.setattr(voice, "voice_state", lambda: "unsupported")
+        assert _voice_input.voice_chip()[0] == _voice_input._CHIP_OFF
+        monkeypatch.setattr(voice, "voice_state", lambda: "ready")
+        assert _voice_input.voice_chip()[0] == _voice_input._CHIP_OFF  # still memoised
+        voice_install.refresh_imports()
+        assert _voice_input.voice_chip() == (_voice_input._CHIP_ON, _voice_input._CHIP_ON_STYLE)
+
+
+class TestVerifyInstalled:
+    def test_a_namespace_package_does_not_count_as_installed(self, monkeypatch):
+        import importlib.machinery
+
+        spec = importlib.machinery.ModuleSpec("sounddevice", loader=None)  # origin stays None
+        monkeypatch.setattr("importlib.util.find_spec", lambda _name: spec)
+        ok, reason = voice_install.verify_installed()
+        assert not ok
+        assert "sounddevice" in reason
+
+    def test_a_real_module_counts(self, monkeypatch):
+        import importlib.machinery
+
+        spec = importlib.machinery.ModuleSpec("x", loader=None, origin="/tmp/x.py")
+        monkeypatch.setattr("importlib.util.find_spec", lambda _name: spec)
+        assert voice_install.verify_installed() == (True, "")
+
+
+# ---------------------------------------------------------------------------
+# The speech model
+# ---------------------------------------------------------------------------
+
+
+class TestModelPaths:
+    def test_repo_id(self):
+        assert voice_install.model_repo_id("base") == "Systran/faster-whisper-base"
+
+    def test_hf_hub_cache_wins(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "hub"))
+        assert voice_install.model_cache_dir() == tmp_path / "hub"
+
+    def test_hf_home_is_honoured(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+        monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        assert voice_install.model_cache_dir() == tmp_path / "hub"
+
+    def test_bytes_on_disk_counts_the_incomplete_blob(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        blobs = tmp_path / "models--Systran--faster-whisper-base" / "blobs"
+        blobs.mkdir(parents=True)
+        (blobs / "abc").write_bytes(b"x" * 100)
+        (blobs / "def.incomplete").write_bytes(b"y" * 50)
+        assert voice_install.model_bytes_on_disk("base") == 150
+
+    def test_not_cached_without_a_model_bin(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        snap = tmp_path / "models--Systran--faster-whisper-base" / "snapshots" / "abc"
+        snap.mkdir(parents=True)
+        assert voice_install.model_is_cached("base") is False
+        (snap / "model.bin").write_bytes(b"weights")
+        assert voice_install.model_is_cached("base") is True
+
+    def test_total_bytes_is_zero_when_offline(self, monkeypatch):
+        def boom(*_a, **_k):
+            raise OSError("offline")
+
+        monkeypatch.setattr(voice_install.urllib.request, "urlopen", boom)
+        assert voice_install.model_total_bytes("base") == 0
+
+
+@pytest.fixture
+def child_program(monkeypatch):
+    """Run a stand-in child instead of the real download, keeping a real Popen.
+
+    Patching ``voice_install.subprocess.Popen`` patches the shared module, so the
+    replacement has to close over the original or it calls itself.
+    """
+    real_popen = subprocess.Popen
+
+    def substitute(program: str):
+        monkeypatch.setattr(
+            voice_install.subprocess,
+            "Popen",
+            lambda _argv, **kw: real_popen([sys.executable, "-c", program], **kw),
+        )
+
+    return substitute
+
+
+class TestDownloadModel:
+    def test_an_unknown_size_never_reaches_a_subprocess(self, monkeypatch):
+        monkeypatch.setattr(
+            voice_install.subprocess, "Popen", lambda *_a, **_k: pytest.fail("must not spawn for an unknown size")
+        )
+        ok, message = voice_install.download_model("'; rm -rf /", lambda *_a: None)
+        assert not ok
+        assert "Unknown speech model size" in message
+
+    def test_an_already_cached_model_is_a_no_op(self, monkeypatch):
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: True)
+        monkeypatch.setattr(
+            voice_install.subprocess, "Popen", lambda *_a, **_k: pytest.fail("must not re-download a cached model")
+        )
+        assert voice_install.download_model("base", lambda *_a: None) == (True, "")
+
+    def test_fraction_tracks_bytes_on_disk_and_ends_at_one(self, monkeypatch, child_program):
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setattr(voice_install, "model_total_bytes", lambda _s, **_k: 1000)
+        monkeypatch.setattr(voice_install, "_POLL_SECONDS", 0.01)
+        grown = iter([0, 250, 500, 1000, 1000, 1000])
+        monkeypatch.setattr(voice_install, "model_bytes_on_disk", lambda _s: next(grown, 1000))
+        seen: list[float | None] = []
+        child_program("import time; time.sleep(0.15)")
+        ok, _message = voice_install.download_model("base", lambda _s, f: seen.append(f))
+        assert ok
+        assert seen[-1] == 1.0
+        fractions = [f for f in seen if f is not None]
+        assert fractions == sorted(fractions)
+        assert all(f <= 1.0 for f in fractions)
+
+    def test_an_unknown_total_reports_an_indeterminate_fraction(self, monkeypatch, child_program):
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setattr(voice_install, "model_total_bytes", lambda _s, **_k: 0)
+        monkeypatch.setattr(voice_install, "model_bytes_on_disk", lambda _s: 10)
+        monkeypatch.setattr(voice_install, "_POLL_SECONDS", 0.01)
+        seen: list[float | None] = []
+        child_program("import time; time.sleep(0.1)")
+        voice_install.download_model("base", lambda _s, f: seen.append(f))
+        assert any(f is None for f in seen)
+        assert all(f in (None, 1.0) for f in seen)
+
+    def test_offline_is_a_warning_not_a_broken_feature(self, monkeypatch, child_program):
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setattr(voice_install, "model_total_bytes", lambda _s, **_k: 0)
+        monkeypatch.setattr(voice_install, "model_bytes_on_disk", lambda _s: 0)
+        monkeypatch.setattr(voice_install, "_POLL_SECONDS", 0.01)
+        child_program("import sys; print('Temporary failure in name resolution'); sys.exit(1)")
+        ok, message = voice_install.download_model("base", lambda *_a: None)
+        assert not ok
+        assert "first dictation" in message
+
+    def test_cancel_promises_a_resume(self, monkeypatch, child_program):
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setattr(voice_install, "model_total_bytes", lambda _s, **_k: 100)
+        monkeypatch.setattr(voice_install, "model_bytes_on_disk", lambda _s: 10)
+        monkeypatch.setattr(voice_install, "_POLL_SECONDS", 0.01)
+        child_program("import time; time.sleep(30)")
+        cancel = threading.Event()
+        threading.Timer(0.2, cancel.set).start()
+        ok, message = voice_install.download_model("base", lambda *_a: None, cancel)
+        assert not ok
+        assert "resumes" in message
+
+
+class TestModelChildEnv:
+    def test_xet_is_disabled_so_the_progress_bar_can_move(self, monkeypatch, child_program):
+        """With Xet on, bytes stage in a separate cache and the repo dir jumps
+        from ~3% to 100% at the very end — the bar would be a lie."""
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setattr(voice_install, "model_total_bytes", lambda _s, **_k: 0)
+        monkeypatch.setattr(voice_install, "model_bytes_on_disk", lambda _s: 0)
+        monkeypatch.setattr(voice_install, "_POLL_SECONDS", 0.01)
+        seen: dict = {}
+        real_popen = subprocess.Popen
+
+        def capture(_argv, **kw):
+            seen.update(kw.get("env") or {})
+            return real_popen([sys.executable, "-c", "pass"], **kw)
+
+        monkeypatch.setattr(voice_install.subprocess, "Popen", capture)
+        voice_install.download_model("base", lambda *_a: None)
+        assert seen["HF_HUB_DISABLE_XET"] == "1"
+        assert seen["HF_HUB_DISABLE_PROGRESS_BARS"] == "1"  # no tqdm into the Live
+
+    def test_the_size_is_whitelisted_before_it_reaches_the_child_program(self, monkeypatch):
+        captured: list = []
+        real_popen = subprocess.Popen
+
+        def capture(argv, **kw):
+            captured.append(argv)
+            return real_popen([sys.executable, "-c", "pass"], **kw)
+
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setattr(voice_install, "model_total_bytes", lambda _s, **_k: 0)
+        monkeypatch.setattr(voice_install, "model_bytes_on_disk", lambda _s: 0)
+        monkeypatch.setattr(voice_install, "_POLL_SECONDS", 0.01)
+        monkeypatch.setattr(voice_install.subprocess, "Popen", capture)
+        voice_install.download_model("large-v3", lambda *_a: None)
+        assert "'large-v3'" in captured[0][2]
+
+
+class TestSizeEstimate:
+    def test_the_model_is_dropped_from_the_total_once_cached(self, monkeypatch):
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: True)
+        assert voice_install.size_estimate_mb() == voice_install.PACKAGES_MB
+
+    def test_a_bigger_model_makes_a_bigger_promise(self, monkeypatch):
+        monkeypatch.setattr(voice_install, "model_is_cached", lambda _s: False)
+        monkeypatch.setenv("VOICE_MODEL", "large-v3")
+        assert voice_install.size_estimate_mb() == voice_install.PACKAGES_MB + 3100
+
+
+class TestLockLiveness:
+    """The stale-lock probe must never be a kill.
+
+    ``os.kill(pid, 0)`` is a liveness probe on POSIX only. On Windows CPython it
+    calls ``TerminateProcess`` for every signal but the two console events, so
+    using it here would terminate the other yeaboi window mid-session — on a
+    platform that is one of the four the speech-engine wheels target, where two
+    open windows is an ordinary situation rather than an edge case.
+    """
+
+    def test_never_signals_on_windows(self, monkeypatch):
+        monkeypatch.setattr(voice_install.sys, "platform", "win32")
+        monkeypatch.setattr(
+            voice_install.os,
+            "kill",
+            lambda *_a: pytest.fail("os.kill on Windows terminates the target"),
+        )
+        assert voice_install._pid_alive(4321) is None
+
+    def test_probes_on_posix(self, monkeypatch):
+        monkeypatch.setattr(voice_install.sys, "platform", "linux")
+        assert voice_install._pid_alive(os.getpid()) is True
+
+    def test_a_dead_pid_reads_as_dead_on_posix(self, monkeypatch):
+        monkeypatch.setattr(voice_install.sys, "platform", "linux")
+
+        def _boom(*_a):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(voice_install.os, "kill", _boom)
+        assert voice_install._pid_alive(4321) is False
+
+    def test_windows_keeps_a_fresh_lock(self, monkeypatch, tmp_path):
+        """With no probe available, age is the only evidence — and a lock
+        written seconds ago belongs to a live install."""
+        monkeypatch.setattr(voice_install.sys, "platform", "win32")
+        lock = voice_install._Lockfile()
+        lock.path.write_text("4321", encoding="utf-8")
+        assert lock._stale() is False
+        assert lock.path.exists()
+
+    def test_windows_breaks_an_ancient_lock(self, monkeypatch):
+        """Otherwise one crashed run leaves a machine that can never install."""
+        monkeypatch.setattr(voice_install.sys, "platform", "win32")
+        lock = voice_install._Lockfile()
+        lock.path.write_text("4321", encoding="utf-8")
+        old = time.time() - voice_install._LOCK_STALE_SECONDS - 60
+        os.utime(lock.path, (old, old))
+        assert lock._stale() is True
+        assert not lock.path.exists()
+
+
+class TestVerdictExpiry:
+    """ "Permanent" means "nothing you can do right now", not "true forever"."""
+
+    def test_a_fresh_verdict_is_honoured(self):
+        voice_install.write_verdict("NO_WHEEL", "no wheel yet")
+        assert voice_install.read_verdict() == ("NO_WHEEL", "no wheel yet")
+
+    def test_an_expired_verdict_reads_as_absent(self, monkeypatch):
+        """A too-new CPython is deliberately not pre-gated because it "resolves
+        itself when the wheels land" — but the verdict it produces is keyed on
+        platform, Python version and interpreter path, none of which change when
+        the cp3XX wheel is finally published. Without expiry, one attempt during
+        that window condemns the machine for good."""
+        voice_install.write_verdict("NO_WHEEL", "no wheel yet")
+        later = time.time() + voice_install._VERDICT_TTL_SECONDS + 60
+        monkeypatch.setattr(voice_install.time, "time", lambda: later)
+        voice_install.reset_unsupported_cache()
+        assert voice_install.read_verdict() == ("", "")
+        assert voice_install.unsupported_reason() == ""
+
+    def test_a_stampless_verdict_is_treated_as_fresh(self, monkeypatch, tmp_path):
+        """Files written by an earlier build carry no timestamp. Reading a
+        missing stamp as 1970 would expire every one of them on sight."""
+        path = tmp_path / "voice_install.json"
+        path.write_text(
+            json.dumps({"key": voice_install._verdict_key(), "code": "NO_WHEEL", "message": "old file"}),
+            encoding="utf-8",
+        )
+        assert voice_install.read_verdict() == ("NO_WHEEL", "old file")
+
+
+class TestInstallPlanVerdictBypass:
+    def test_a_stored_verdict_blocks_the_plan(self):
+        voice_install.write_verdict("NO_WHEEL", "no wheel for this host")
+        assert voice_install.install_plan().blocked == "no wheel for this host"
+
+    def test_ignore_verdict_gets_a_real_plan(self, monkeypatch):
+        """--install-voice is the explicit retry, and refusing it on the
+        strength of a cached failure leaves no way back at all."""
+        _no_source_checkout(monkeypatch)
+        monkeypatch.setattr(voice_install, "_externally_managed", lambda: False)
+        monkeypatch.setattr(voice_install, "_pipx_venv_name", lambda: "")
+        voice_install.write_verdict("NO_WHEEL", "no wheel for this host")
+        plan = voice_install.install_plan(ignore_verdict=True)
+        assert plan.blocked == ""
+        assert plan.method == "pip"
+
+    def test_ignore_verdict_still_honours_the_platform_gate(self, monkeypatch):
+        """The one thing here that is genuinely certain, not cached."""
+        monkeypatch.setattr(voice_install, "platform_support", lambda: (False, "32-bit Python"))
+        assert voice_install.install_plan(ignore_verdict=True).blocked == "32-bit Python"
+
+
+class TestRefreshImportsDropsTheVerdictMemo:
+    def test_the_memoised_verdict_is_cleared(self, monkeypatch):
+        """Four caches answer "is voice installed?" and refresh_imports has to
+        drop all of them, or the app renders "off" for the rest of the run."""
+        voice_install.write_verdict("NO_WHEEL", "stale answer")
+        assert voice_install.unsupported_reason() == "stale answer"
+        voice_install.clear_verdict()
+        monkeypatch.setattr(voice_install, "_unsupported_cache", "stale answer")
+        voice_install.refresh_imports()
+        assert voice_install.unsupported_reason() == ""

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "2.57.0"
+version = "2.58.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

Dictation was a separate manual install step: a user had to know to reinstall
yeaboi with the `voice` extra before double-tapping Space did anything, then sit
through a silent ~145 MB model download on the first attempt. In practice
dictation stayed off.

Now the gesture *is* the install. Double-tapping Space in any text field with the
speech packages missing opens an in-app offer — **Enter** installs, **Esc** is
"not now" for this session, **`n`** is "never" (persisted). Accepting installs
into the running interpreter, downloads the Whisper model with a real
byte-percentage bar, and drops straight into recording. No restart, no second
terminal.

- **`src/yeaboi/voice_install.py`** — the headless engine: install plan, package
  install, model download, cache probing, sticky verdicts.
- **`yeaboi --install-voice`** — the non-TUI twin, for CI, dev containers and
  terminals the full-screen UI cannot drive. Plain prints, no Rich `Live`, so the
  output survives a pipe and a CI log.
- **One vocabulary.** Every surface renders from `voice.voice_state()` —
  `ready` / `installable` / `declined` / `unsupported` — so the input-box chip,
  the welcome tip, the Settings row and the setup wizard cannot disagree about
  the same machine.

**Why the packages stay optional.** `ctranslate2` and `onnxruntime` publish no
sdist and only build wheels for 64-bit macOS, `manylinux_2_28` and `win_amd64`.
As hard dependencies they would turn `pip install yeaboi` into a hard failure on
musl/Alpine, glibc < 2.28, 32-bit and armv7 — hosts that run every other mode
fine. So the extra stays an extra, and this feature removes the cost of that
choice from the user rather than from the platform matrix.

**Two hazards the installer is built around**, both pinned by tests:
`uv sync` is *exact* and would uninstall anything absent from the lockfile out
from under the running process, and `uv tool install --force` deletes the venv
this process is executing out of. Every in-app path uses the additive
`uv pip install --python <sys.executable>` / `pipx inject` instead.

## Review findings addressed

An independent `code-reviewer` pass raised one blocker and five should-fix
findings before this was opened. All eleven (including the nits) are fixed:

1. **blocker — `os.kill(pid, 0)` is a kill on Windows.** CPython maps it to
   `TerminateProcess` for every signal but the two console events, so the
   stale-lock "probe" would have terminated the other yeaboi window mid-session
   — on one of the four platforms the wheels target. Now `_pid_alive()` returns
   `None` there and staleness falls back to the lock's age.
2. **Verdicts now expire.** `NO_WHEEL` covers a CPython so new no `cp3XX` wheel
   exists yet — the platform gate deliberately does not pre-empt that because it
   "resolves itself when the wheels land" — but the verdict key changes on none
   of it. Verdicts carry a timestamp and a 30-day TTL, and
   `install_plan(ignore_verdict=True)` lets `--install-voice` retry explicitly.
3. **A failed model download no longer calls `warm_model()`**, which would have
   done in-process, uncancellably and with no byte count, exactly the download
   the child process exists to contain — and on an AVX-less host would have
   taken the TUI down with the SIGILL the child had just absorbed.
4. **A dead PortAudio is `unsupported`, not `installable`.** `sounddevice`
   imports fine without `libportaudio2`, so the old path offered a ~325 MB
   install that would exit 0 having changed nothing. `voice.unsupported_blocker()`
   distinguishes the two and surfaces the apt hint instead.
5. **`--install-voice` configures logging first**, so the installer's raw child
   output reaches the log file on the one surface where the log is the only
   diagnostic.
6. **Tests for the CLI half** — `_install_voice`, `_echo_once`, `_echo_progress`,
   covering all four exit-code branches.
7. A failed model download falls through to the readiness probe instead of
   returning 0 blind. 8. The offer loop floors every non-exiting frame, not just
   the empty-key one. 9. The setup wizard renders from `voice_state()` like
   everything else. 10. The `refresh_imports()` docstring now matches what it
   drops (and drops the fourth memo it claimed to). 11. The install worker is
   exception-guarded, so an unexpected error is logged rather than printed
   through the Rich `Live`.

## Test plan

- `make test` — 10265 passed, 47 skipped
- `make lint` — clean
- `make security` — ruff SAST clean, `pip-audit` reports no known vulnerabilities
- `make cowork-check` — clean
- New: `tests/unit/test_voice_install.py` (93 tests) plus `TestInstallVoiceCommand`,
  `TestInstallVoiceEcho`, `TestUnsupportedBlocker`, `TestVoiceInstallModelStage`,
  `TestLockLiveness`, `TestVerdictExpiry`, `TestInstallPlanVerdictBypass` in the
  voice suites.

## Definition of Done

- Item 5 (surface parity): `--install-voice` registered on the `settings`
  capability's CLI set; the `voice` `FeatureTip` renders from `voice_state()`.
  No MCP tool, deliberately — installing arbitrary packages into the host
  environment on an LLM's say-so is not a capability worth shipping, and both
  entry points are human-initiated.
- Item 7 (web bundles): does not apply — nothing under `frontend/` changed.
- Items 8–9 (Notion, Slack): fire on merge via `pr-merged-close-loop`.
- Item 10 (review feedback): outstanding — `claude-review.yml` has not run yet.

Closes YEA-61

🤖 Generated with [Claude Code](https://claude.com/claude-code)