### PR TITLE
make the cowork day-ahead slack post readable

### DIFF
--- a/.claude/agents/cowork-scribe.md
+++ b/.claude/agents/cowork-scribe.md
@@ -98,14 +98,17 @@ reference definition. Escaping means never having to work out which case today's
 `[type][workstream]` tag sits *outside* the link for the same reason — outside, it is not link text
 at all and needs no escaping.
 
-Emoji are anchors, not decoration. The daily digest's section headings — one per proposal type, plus
-`feature-candidate`, marketing, the two health sections and the Monday calibration section — are
-**one fixed emoji plus bold text**
-(`🐛 **Bugs**`), the emoji constant per section so a returning reader finds a section by shape
-before they read a word; `cron/digest.md` owns the table. Everywhere else, and in prose anywhere,
-no emoji: a ship note is one line and a decorated one line is just a decorated one line. Never spend
-✅ or ❌ decoratively in any message — those two are the approval verbs, and a reader who sees them
-in a heading has to work out whether they mean something.
+Emoji are anchors, not decoration. Two messages have sections, and both mark them the same way:
+**one fixed emoji plus bold text** (`🐛 **Bugs**`), the emoji constant per section so a returning
+reader finds a section by shape before they read a word. The daily digest's headings — one per
+proposal type, plus `feature-candidate`, marketing, the two health sections and the Monday
+calibration section — are owned by the table in `cron/digest.md`. The day-ahead post's four are
+owned by `SECTION_EMOJI` in `scripts/cowork_setup.py`, because that message is rendered rather than
+composed; they do not overlap the digest's, so the two daily posts are never confusable at a glance.
+Everywhere else, and in prose anywhere, no emoji: a ship note is one line and a decorated one line
+is just a decorated one line. Never spend ✅ or ❌ decoratively in any message — those two are the
+approval verbs, and a reader who sees them in a heading has to work out whether they mean
+something.
 
 `cron/day-ahead.md` is the one message you do not compose. It arrives as a rendered `lines` array
 out of `scripts/cowork_setup.py --agenda`: post the lines joined by newlines, as one channel-level
@@ -113,6 +116,11 @@ message, and change nothing — not a time, not a summary, not the order. Every 
 already made in tested Python, so "improving" a line here is the one edit that could tell somebody
 the wrong morning while looking like a tidy-up. If a line reads wrong, say so in the run log; the
 fix is a PR against the script.
+
+That includes the formatting. The lines arrive as finished Markdown, with the bold, the backticked
+times and the four section anchors already in them — **post them byte for byte**. Do not re-wrap
+them, do not escape anything, and in particular do not strip the emoji to satisfy the paragraph
+above: those four are anchors under that rule, not the decoration it forbids.
 
 The daily digest is the one event with a thread: after its single channel message, post one reply
 per listed item **into that message's thread**, shaped `#<issue-number> — <verbatim title> —

--- a/.claude/commands/cowork.md
+++ b/.claude/commands/cowork.md
@@ -128,6 +128,10 @@ Print exactly what it prints. This is the same text `cron/day-ahead.md` posts to
 UTC each morning, which is the point: the local answer and the posted one come from one renderer,
 so they cannot disagree.
 
+That is why the terminal shows Markdown source — `**cd-deploy**`, backticked times — rather than a
+terminal's own idea of bold. Rendering it here would mean a second renderer, and a second renderer
+is a second thing that can be wrong about a Tuesday.
+
 `--date YYYY-MM-DD` answers "what is on next Monday?". Nothing here touches the account — the
 schedule lives in `cowork/README.md`, not in the routines API, so this verb skips the
 `RemoteTrigger list` every other verb starts with. What it *cannot* tell you is whether the fleet

--- a/cowork/routines/cron/day-ahead.md
+++ b/cowork/routines/cron/day-ahead.md
@@ -44,10 +44,15 @@ So:
   looks like. The digest owns all of that and posts three hours later.
 - **Never edit a file, open an issue, or touch Linear.** It has no `Write` or `Edit` grant, and
   the one thing it may spawn is the scribe.
+- **Never reformat it either.** The lines are finished Markdown — bold headings, four fixed section
+  anchors, backticked times — in the dialect the connector actually reads, which is not Slack's
+  mrkdwn. `agenda_lines()` owns that, and `tests/unit/test_cowork_setup.py` fails if it drifts back.
+  Escaping a character or dropping an emoji on the way out is the same edit as re-timing a line: it
+  changes what was tested into something that was not.
 
 ## Post every day
 
-Including Sundays, when no sweep fires at all and the message is four lines. This is the one
+Including Sundays, when no sweep fires at all and the message is a short one. This is the one
 routine in the fleet exempt from "nothing to do is a valid outcome, exit quietly", and
 deliberately so: silence from a *findings* routine means it found nothing, which is
 information. Silence from a *schedule* routine is ambiguous — nothing scheduled, or the

--- a/scripts/cowork_setup.py
+++ b/scripts/cowork_setup.py
@@ -707,6 +707,18 @@ BACKGROUND_AFTER = 3
 # genuinely part of it; `/cowork status` is what audits whether it is registered.
 MESSENGER = "day-ahead"
 
+# One fixed emoji per section, which is `cron/digest.md`'s convention and the only
+# decoration `.claude/agents/cowork-scribe.md` permits: constant per section, so a
+# reader who gets this every morning finds the part they want by shape before they
+# read a word. Four rules held them to these four codepoints. None is a variation
+# sequence — a trailing U+FE0F that one client needs and another drops is a heading
+# that renders two ways, which `TestAgenda` pins by length rather than by trusting
+# this comment. None is `✅` or `❌`, which `cron/slack-relay.md` parses as
+# the approval verbs. None collides with the digest's eleven, so the two daily posts
+# are never confusable at a glance. And all four sit inside one Unicode block, which
+# is what keeps them legible beside each other at Slack's heading size.
+SECTION_EMOJI = {"today": "📅", "background": "🔁", "events": "🔔", "ahead": "📆"}
+
 # How far the tail looks. A week is what makes the fortnightly and monthly sweeps
 # visible: `30 7 11,25 * *` is unreadable, "Tue 11  poker-sweep" is not.
 HORIZON_DAYS = 7
@@ -930,18 +942,47 @@ def agenda(day: date, horizon: int = HORIZON_DAYS) -> dict:
     return payload
 
 
+def _joined(stamps: Sequence[str]) -> str:
+    """``a``, ``a and b``, ``a, b and c`` — the quiet days named in one clause.
+
+    ``stamps`` must be non-empty. Returning ``""`` for an empty one would render
+    " is clear." out of a caller that had nothing to say, so the caller checks.
+    """
+    if len(stamps) == 1:
+        return stamps[0]
+    return ", ".join(stamps[:-1]) + " and " + stamps[-1]
+
+
 def agenda_lines(payload: dict) -> list[str]:
     """The finished Slack message, one string per line.
 
-    Bold headings, no emoji, no bare URLs — ``.claude/agents/cowork-scribe.md``'s
-    format contract, met here so the routine has nothing left to compose and
-    nothing left to get wrong.
+    **Standard Markdown, not Slack mrkdwn.** The connector takes ``**bold**``,
+    ``_italic_`` and ``` `code` ```. Slack's own ``*bold*`` is Markdown's *italic*,
+    so the two do not fail against each other — they quietly render the wrong
+    thing, which is how the daily digest shipped italic headings for weeks
+    (``.claude/agents/cowork-scribe.md`` keeps that account). This renderer made
+    the identical mistake and outlived the digest's fix, because it is the one
+    message composed in Python: the fix went to a routine file, and the test here
+    pinned ``*Today*`` as though it were correct.
+
+    Each section heading carries one fixed emoji from ``SECTION_EMOJI`` — the
+    digest's anchor convention, and the only decoration the scribe permits. Still
+    no bare URLs: the schedule links to nothing.
     """
     day = date.fromisoformat(payload["date"])
     zone = payload["display_timezone"] or "UTC"
-    lines = [f"*Today* — {day:%a} {day.day} {day:%b} ({zone})"]
+    lines = [f"{SECTION_EMOJI['today']} **Today** — {day:%a} {day.day} {day:%b} ({zone})"]
     if payload["note"]:
+        # Above the blank line, so it reads as a qualification of the heading it
+        # follows rather than as the first entry of the list it precedes.
+        #
+        # Deliberately unemphasised. The note embeds DISPLAY_TZ, and a zone name
+        # carries underscores (`America/Los_Angeles`) — wrapping it in `_…_` is
+        # how you leak a stray underscore mid-line, which is the *other* half of
+        # the dialect bug the scribe file records. A caveat nobody ever sees is
+        # not worth that.
         lines.append(payload["note"])
+    lines.append("")
 
     listed = [entry for entry in payload["today"] if entry["name"] != MESSENGER]
     if listed:
@@ -953,30 +994,90 @@ def agenda_lines(payload: dict) -> list[str]:
             # sits beside is noise. The heading already names the zone, so the
             # bracket only appears when it has something to say.
             gloss = "" if local == utc else f" ({utc} UTC)"
-            lines.append(f"{local}  {entry['name']}{summary}{gloss}")
+            # Code style on the time and bold on the name. Slack renders in a
+            # proportional font, where the two spaces that used to align this
+            # column do not; monospace is the only alignment this dialect offers.
+            # The name is bold because it is what somebody scanning for one
+            # routine is looking for — the summary beside it is the answer to a
+            # question they only ask once.
+            lines.append(f"`{local}`  **{entry['name']}**{summary}{gloss}")
     else:
-        lines.append("No routines fire today.")
+        lines.append("_No routines fire today._")
 
-    for entry in payload["background"]:
-        gloss = "" if entry["window_local"] == entry["window_utc"] else f" ({entry['window_utc']} UTC)"
-        lines.append(f"Background: {entry['name']}, {entry['firings']} runs {entry['window_local']}{gloss}")
+    standing = []
+    if payload["background"]:
+        # One anchor for the section, never one per entry: an emoji that repeats
+        # down a column has stopped being a heading and become a bullet, which is
+        # the opposite of the rule `.claude/agents/cowork-scribe.md` states. The
+        # fleet has exactly one background routine today, and `BACKGROUND_AFTER`
+        # is a threshold rather than a name check precisely so the second one
+        # needs no edit here — so the single case keeps its one-line form and the
+        # plural case grows a heading rather than a second anchor.
+        spans = []
+        for entry in payload["background"]:
+            gloss = "" if entry["window_local"] == entry["window_utc"] else f" ({entry['window_utc']} UTC)"
+            spans.append((entry["name"], f"{entry['firings']} runs `{entry['window_local']}`{gloss}"))
+        head = f"{SECTION_EMOJI['background']} **Background**"
+        if len(spans) == 1:
+            name, body = spans[0]
+            standing.append(f"{head} — {name}, {body}")
+        else:
+            standing.append(head)
+            standing.extend(f"**{name}** — {body}" for name, body in spans)
     if payload["events"]:
-        lines.append("On GitHub events: " + ", ".join(entry["name"] for entry in payload["events"]))
+        standing.append(
+            f"{SECTION_EMOJI['events']} **On GitHub events** — "
+            + ", ".join(entry["name"] for entry in payload["events"])
+        )
+    if standing:
+        # Split off by a blank line: these two are not entries in today's list,
+        # they are the things that are true all day, and run together with the
+        # timed lines they read as two more of them.
+        lines.append("")
+        lines.extend(standing)
 
-    lines.append("")
-    lines.append(f"*Next {len(payload['ahead'])} days*")
-    month = day.month
+    upcoming_lines: list[str] = []
+    quiet: list[str] = []
+    # The month of the last day actually *rendered* into the sequence, which is not
+    # the same as the last day walked. Advancing this on a quiet day spends the
+    # month marker on a line that gets collapsed into the closing sentence, and the
+    # next rendered day inherits a month it never named: `**Sat 31**` followed by
+    # `**Mon 2**`, with November announced only in an aside underneath. That is the
+    # ambiguity the marker exists to prevent, and it fires every month whose 1st
+    # falls on a Sunday. A quiet day still gets its own month when it changes —
+    # it is read in the closing sentence, where there is no sequence to infer from.
+    shown = day.month
     for entry in payload["ahead"]:
-        upcoming = [name for name in entry["names"] if name != MESSENGER]
-        names = ", ".join(upcoming) if upcoming else "nothing"
         future = date.fromisoformat(entry["date"])
         # Only when it changes: "Tue 1" a week out is ambiguous, "Tue 1 Sep" is not.
-        stamp = f"{entry['weekday']} {future.day}" + (f" {future:%b}" if future.month != month else "")
-        month = future.month
-        lines.append(f"{stamp}  {names}")
+        stamp = f"{entry['weekday']} {future.day}" + (f" {future:%b}" if future.month != shown else "")
+        names = [name for name in entry["names"] if name != MESSENGER]
+        if names:
+            upcoming_lines.append(f"**{stamp}** — " + ", ".join(names))
+            shown = future.month
+        else:
+            quiet.append(stamp)
+
+    lines.append("")
+    lines.append(f"{SECTION_EMOJI['ahead']} **Next {len(payload['ahead'])} days**")
+    if upcoming_lines:
+        lines.append("")
+        lines.extend(upcoming_lines)
+
+    # An empty day written as its own line reads as a routine called "nothing", and
+    # spends a line of a fifteen-line post saying so. Folded into one closing
+    # sentence with the dailies instead — same two facts, both of them asides.
+    # Safe to italicise where the note above was not: every name here matches
+    # `[a-z0-9-]+` (see `_ROUTINE_ROW`), so none can carry an underscore.
+    closing = []
+    if quiet:
+        closing.append(f"{_joined(quiet)} {'is' if len(quiet) == 1 else 'are'} clear.")
     daily = [name for name in payload["daily"] if name != MESSENGER]
     if daily:
-        lines.append("Every day: " + ", ".join(daily) + ".")
+        closing.append("Every day: " + ", ".join(daily) + ".")
+    if closing:
+        lines.append("")
+        lines.append("_" + " ".join(closing) + "_")
     return lines
 
 

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -26,6 +26,7 @@ import re
 import shutil
 import subprocess
 import sys
+import unicodedata
 from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
 
@@ -414,12 +415,53 @@ class TestAgenda:
         assert json.loads(json.dumps(setup.agenda(date(2026, 8, 13))))
 
     def test_the_lines_meet_the_scribes_format_contract(self):
-        """`.claude/agents/cowork-scribe.md`: no emoji headers, no bare URLs."""
+        """`.claude/agents/cowork-scribe.md`: standard Markdown, fixed section
+        anchors, no bare URLs."""
         lines = setup.agenda(date(2026, 8, 13))["lines"]
         blob = "\n".join(lines)
         assert "http" not in blob, "the schedule links to nothing; a bare URL would be the scribe's rule broken"
-        assert not re.search(r"[\U0001F300-\U0001FAFF✀-➿☀-⛿]", blob), "no emoji"
-        assert lines[0].startswith("*Today* —"), lines[0]
+        assert lines[0].startswith(f"{setup.SECTION_EMOJI['today']} **Today** —"), lines[0]
+
+    def test_no_line_carries_slack_mrkdwn_emphasis(self):
+        """The bug this format replaced, written down as a check.
+
+        The connector reads standard Markdown, where `*x*` is *italic* and bold
+        is `**x**`. Slack's own mrkdwn has it the other way, so a heading in the
+        wrong dialect does not fail — it renders the wrong weight, in a message
+        nobody diffs. `.claude/agents/cowork-scribe.md` had recorded that for
+        weeks and the digest had been fixed; this renderer had not, because the
+        only test looking at it asserted `*Today*` as though that were correct.
+        """
+        for line in setup.agenda(date(2026, 8, 13))["lines"]:
+            assert not re.search(r"(?<!\*)\*(?!\*)", line), line
+
+    def test_the_only_emoji_are_the_section_anchors_at_a_line_start(self):
+        """An allowlist rather than a codepoint range.
+
+        The range this replaced — `\U0001f300-\U0001faff`, `✀-➿`, `☀-⛿` — has a
+        hole over U+2300-U+23FF, so ⏱ and ⏳ would have walked through the guard
+        that existed to stop exactly them.
+        """
+        anchors = set(setup.SECTION_EMOJI.values())
+        for line in setup.agenda(date(2026, 8, 13))["lines"]:
+            symbols = [char for char in line if unicodedata.category(char) == "So"]
+            assert set(symbols) <= anchors, line
+            if symbols:
+                assert symbols == [line[0]], f"an anchor belongs at the start of its heading, once: {line}"
+
+    def test_the_approval_verbs_are_never_spent_decoratively(self):
+        """`cron/slack-relay.md` maps a ✅/❌ reaction onto an issue, so a reader
+        who meets either in a heading has to work out whether it meant something."""
+        blob = "\n".join(setup.agenda(date(2026, 8, 13))["lines"])
+        assert "✅" not in blob and "❌" not in blob
+
+    def test_the_sections_are_separated_by_blank_lines(self):
+        """One undifferentiated paragraph of thirteen lines is what this replaced."""
+        lines = setup.agenda(date(2026, 8, 13))["lines"]
+        ahead = next(i for i, line in enumerate(lines) if line.startswith(setup.SECTION_EMOJI["ahead"]))
+        assert lines[1] == "", "today's heading stands apart from the times under it"
+        assert lines[ahead - 1] == "", "the tail does not run on from today's block"
+        assert lines[ahead + 1] == "", "the tail's heading stands apart from its days"
 
     def test_every_listed_routine_reaches_the_rendered_lines(self):
         """A payload entry the renderer drops is a routine that runs unannounced."""
@@ -443,7 +485,184 @@ class TestAgenda:
 
     def test_the_tail_names_the_month_again_when_it_changes(self):
         lines = setup.agenda(date(2026, 8, 27))["lines"]
-        assert any(line.startswith("Tue 1 Sep") for line in lines), lines
+        assert any(line.startswith("**Tue 1 Sep** —") for line in lines), lines
+
+    def test_a_quiet_day_folds_into_the_closing_sentence(self):
+        """A day with nothing on it, written as its own line, reads as a routine
+        called "nothing" — and spends a line of the post saying so."""
+        payload = setup.agenda(date(2026, 8, 16))
+        quiet = [
+            entry for entry in payload["ahead"] if not [name for name in entry["names"] if name != setup.MESSENGER]
+        ]
+        assert quiet, "16 Aug 2026 is chosen for having a quiet day in its tail"
+        for entry in quiet:
+            future = date.fromisoformat(entry["date"])
+            stamp = f"{entry['weekday']} {future.day}"
+            assert not any(line.startswith(f"**{stamp}**") for line in payload["lines"]), stamp
+            assert any(stamp in line and "clear" in line for line in payload["lines"]), stamp
+
+    def test_a_quiet_day_does_not_spend_the_month_marker(self):
+        """The marker belongs to the day that shows it, not to the day that has it.
+
+        1 Nov 2026 is a Sunday and the fleet is quiet on Sundays, so the day that
+        changes month is the one folded away — and advancing on every day walked
+        rather than on every day rendered leaves `**Sat 31**` followed by a bare
+        `**Mon 2**`, with November announced only in an aside below it. That is
+        the ambiguity the marker exists to prevent, and it recurs every month
+        whose 1st falls on a Sunday.
+        """
+        lines = setup.agenda(date(2026, 10, 26))["lines"]
+        assert any(line.startswith("**Mon 2 Nov** —") for line in lines), lines
+        assert not any(line.startswith("**Sun 1") for line in lines), lines
+        assert any("Sun 1 Nov is clear" in line for line in lines), lines
+
+    def test_a_collapsed_quiet_day_does_not_take_a_rendered_month_with_it(self):
+        """The other half: Sun 30 Aug is folded away and Tue 1 Sep still says Sep."""
+        lines = setup.agenda(date(2026, 8, 29))["lines"]
+        assert any(line.startswith("**Tue 1 Sep** —") for line in lines), lines
+        assert not any(line.startswith("**Sun 30**") for line in lines), lines
+
+    def test_every_anchor_is_a_single_codepoint(self):
+        """No variation sequences. A trailing U+FE0F that one client needs and
+        another drops is a heading that renders two ways, and U+FE0F is category
+        `Mn` — the allowlist test above would not see it."""
+        for section, emoji in setup.SECTION_EMOJI.items():
+            assert len(emoji) == 1, f"{section}: {emoji!r}"
+
+
+def _message_payload(**overrides) -> dict:
+    """An empty agenda payload, for rendering one section at a time.
+
+    Built by hand rather than taken from ``agenda()`` because several of the
+    renderer's branches do not occur in any one week of the real schedule — the
+    fleet is quiet on Sundays and never quiet for seven days running, and it has
+    exactly one background routine — so they would go unexercised until the day
+    they were wrong.
+    """
+    base = {
+        "date": "2026-08-13",
+        "weekday": "Thu",
+        "display_timezone": "Europe/London",
+        "note": None,
+        "today": [],
+        "background": [],
+        "events": [],
+        "daily": [],
+        "ahead": [],
+    }
+    return base | overrides
+
+
+def _tail_payload(ahead: list[tuple[str, list[str]]], daily: list[str], day: str = "2026-08-13") -> dict:
+    """``_message_payload`` with just the seven-day tail filled in."""
+    return _message_payload(
+        date=day,
+        daily=daily,
+        ahead=[{"date": iso, "weekday": f"{date.fromisoformat(iso):%a}", "names": names} for iso, names in ahead],
+    )
+
+
+def _background(name: str, firings: int, window: str) -> dict:
+    """One ``day_plan`` background entry, with local and UTC windows agreeing."""
+    return {
+        "name": name,
+        "workstream": None,
+        "summary": "",
+        "firings": firings,
+        "window_utc": window,
+        "window_local": window,
+    }
+
+
+class TestStandingSections:
+    """Background and event routines — true all day rather than at a time."""
+
+    def test_one_background_routine_stays_on_the_heading_line(self):
+        lines = setup.agenda_lines(_message_payload(background=[_background("slack-relay", 17, "07:00-23:00")]))
+        assert f"{setup.SECTION_EMOJI['background']} **Background** — slack-relay, 17 runs `07:00-23:00`" in lines
+
+    def test_a_second_background_routine_does_not_get_a_second_anchor(self):
+        """An emoji repeating down a column has stopped being a heading.
+
+        `BACKGROUND_AFTER` is a threshold rather than a name check so that the
+        next hourly routine needs no edit here — which means the plural case is
+        reachable without one, and has to already be right.
+        """
+        lines = setup.agenda_lines(
+            _message_payload(
+                background=[_background("slack-relay", 17, "07:00-23:00"), _background("watcher", 5, "09:00-13:00")]
+            )
+        )
+        anchored = [line for line in lines if line.startswith(setup.SECTION_EMOJI["background"])]
+        assert anchored == [f"{setup.SECTION_EMOJI['background']} **Background**"]
+        assert "**slack-relay** — 17 runs `07:00-23:00`" in lines
+        assert "**watcher** — 5 runs `09:00-13:00`" in lines
+
+    def test_the_degraded_timezone_note_sits_with_the_heading_and_unemphasised(self):
+        """It qualifies the heading above it, not the first entry below it — and it
+        goes out verbatim, because a zone name carries underscores and `_…_` around
+        one leaks a stray delimiter mid-line."""
+        note = "times in UTC — no tz database for America/Los_Angeles (`uv add --dev tzdata` fixes it)"
+        lines = setup.agenda_lines(_message_payload(note=note, display_timezone=None))
+        assert lines[1] == note
+        assert lines[2] == ""
+
+    def test_the_month_marker_is_not_spent_on_a_collapsed_day(self):
+        """The synthetic twin of the live-schedule test, immune to a cadence change."""
+        lines = setup.agenda_lines(
+            _tail_payload(
+                [("2026-10-31", ["marketing-weekly"]), ("2026-11-01", []), ("2026-11-02", ["security-sweep"])],
+                [],
+                day="2026-10-30",
+            )
+        )
+        assert "**Mon 2 Nov** — security-sweep" in lines
+        assert "_Sun 1 Nov is clear._" in lines
+
+
+class TestClosingSentence:
+    """The one line carrying both of the tail's asides — quiet days and dailies."""
+
+    BUSY = ("2026-08-14", ["platform-sweep"])
+    QUIET = ("2026-08-15", [])
+    ALSO_QUIET = ("2026-08-16", [])
+    THIRD_QUIET = ("2026-08-17", [])
+
+    def _closing(self, ahead, daily) -> str | None:
+        lines = setup.agenda_lines(_tail_payload(ahead, daily))
+        return lines[-1] if lines[-1].startswith("_") else None
+
+    def test_it_carries_both_clauses_when_there_are_both(self):
+        assert self._closing([self.BUSY, self.QUIET], ["digest"]) == "_Sat 15 is clear. Every day: digest._"
+
+    def test_a_week_with_no_quiet_day_says_nothing_about_one(self):
+        assert self._closing([self.BUSY], ["digest"]) == "_Every day: digest._"
+
+    def test_no_daily_routine_drops_that_clause(self):
+        assert self._closing([self.BUSY, self.QUIET], []) == "_Sat 15 is clear._"
+
+    def test_neither_means_no_closing_line_at_all(self):
+        """And no stray blank line left behind where it would have been."""
+        lines = setup.agenda_lines(_tail_payload([self.BUSY], []))
+        assert self._closing([self.BUSY], []) is None
+        assert lines[-1] != "", lines
+
+    def test_quiet_days_are_counted_before_they_are_conjugated(self):
+        """`Sat 15 and Sun 16 is clear` is the kind of thing nobody reports."""
+        two = self._closing([self.BUSY, self.QUIET, self.ALSO_QUIET], [])
+        assert two == "_Sat 15 and Sun 16 are clear._"
+
+    def test_three_or_more_quiet_days_take_a_comma_and_a_final_and(self):
+        three = self._closing([self.BUSY, self.QUIET, self.ALSO_QUIET, self.THIRD_QUIET], [])
+        assert three == "_Sat 15, Sun 16 and Mon 17 are clear._"
+
+    def test_an_entirely_quiet_week_still_renders_its_heading(self):
+        """A tail with no rendered day must not leave the heading over a blank."""
+        lines = setup.agenda_lines(_tail_payload([self.QUIET, self.ALSO_QUIET], ["digest"]))
+        heading = lines.index(f"{setup.SECTION_EMOJI['ahead']} **Next 2 days**")
+        assert lines[heading + 1] == ""
+        assert lines[heading + 2] == "_Sat 15 and Sun 16 are clear. Every day: digest._"
+        assert lines[-1] == lines[heading + 2], "nothing trails the closing sentence"
 
 
 class TestAgendaCli:
@@ -463,7 +682,7 @@ class TestAgendaCli:
     def test_text_prints_the_message_the_routine_posts(self):
         result = self._run("--text", "--date", "2026-08-13")
         assert result.returncode == 0, result.stderr
-        assert result.stdout.startswith("*Today* —")
+        assert result.stdout.startswith(f"{setup.SECTION_EMOJI['today']} **Today** —")
 
     def test_a_bad_date_is_refused_rather_than_guessed(self):
         result = self._run("--date", "next tuesday")


### PR DESCRIPTION
## Summary

The daily 05:45 UTC `day-ahead` Slack post rendered as a flat wall of thirteen near-identical grey lines. Two causes, one of them an outright bug.

**The headings were broken, not just plain.** The Slack connector reads *standard Markdown*, not Slack mrkdwn, and the two disagree in the worst way — mrkdwn's `*bold*` is Markdown's *italic*. `.claude/agents/cowork-scribe.md` records that hazard and the daily digest was fixed for it in 6d18cf3, but `agenda_lines()` in `scripts/cowork_setup.py` still emitted `*Today*` and `*Next 7 days*`, so both headings had been shipping italic. It is the one message rendered in Python rather than composed by an agent, so the fix went to a routine file and never reached it — and the only test looking at it asserted `*Today*` as though that were correct.

**Nothing else carried structure.** No emphasis on routine names, no section anchors, and quiet days in the seven-day tail rendering as a routine called `nothing`.

After:

```
📅 **Today** — Sun 9 Aug (Europe/London)

`05:00`  **cd-deploy** — ships a merged change to cowork/ into the live fleet… (04:00 UTC)
`09:15`  **digest** — the open proposals, bucketed by type, waiting on your approval (08:15 UTC)

🔁 **Background** — slack-relay, 17 runs `08:00-24:00` (07:00-23:00 UTC)
🔔 **On GitHub events** — pr-opened-dod-audit, pr-merged-close-loop, release-published-announce

📆 **Next 7 days**

**Mon 10** — security-sweep, planning-sweep, performance-sweep
…
**Sat 15** — marketing-weekly

_Sun 16 is clear. Every day: cd-deploy, digest._
```

Every fact the old message carried is retained; `agenda()`, `day_plan()`, `cron_times()`, the payload schema, the `MESSENGER` omission and the UTC-bracket-only-when-it-differs rule are untouched. The four anchors are single codepoints (no variation sequence), none is ✅/❌ — which `cron/slack-relay.md` parses as approval verbs — and none collides with the digest's eleven.

Two fixes came out of the independent review pass:

- **The month marker now advances on the day that *shows* it**, not on every day walked. Spending it on a collapsed quiet day left `**Sat 31**` followed by a bare `**Mon 2**`, with November announced only in an aside below — and that recurs every month whose 1st falls on a Sunday.
- **The background anchor is emitted once per section**, not once per entry. `BACKGROUND_AFTER` is a threshold rather than a name check precisely so the second hourly routine needs no edit here, so the plural case is reachable and had to already be right.

Two guards that did not exist before: no line may carry single-asterisk emphasis (the original bug, written down as a test), and the emoji assertion is an allowlist rather than a codepoint range that had a hole over U+2300–U+23FF, through which ⏱ and ⏳ would have walked.

`.claude/agents/cowork-scribe.md` needed amending rather than merely documenting: its emoji rule said anchors were the digest's alone, so a scribe following it could reasonably have **stripped these anchors on the way to Slack**.

## Test plan

- `make test` — 10493 passed, 47 skipped
- `make lint` — clean; `ruff check scripts/` clean
- `make security` — SAST + pip-audit clean
- `make cowork-check` — clean
- Rendered and inspected across the edge cases: `2026-10-26` (month rollover on a quiet 1st), `2026-08-27` / `2026-08-29` (rollover with a quiet day adjacent), `2026-08-16` (quiet Sunday in the tail), `2026-01-12` (GMT — no UTC brackets), `2026-12-24` (five timed routines)
- Mutation-checked both new guards: the mrkdwn regex flags `*Today*` and `*Next 7 days*` while passing `**Today**`; both month tests fail against the pre-fix implementation and pass against the fix
- Deterministic synthetic-payload tests for the branches no single real week reaches — an entirely quiet tail, no background routines, two background routines, the closing sentence's four combinations, and the degraded-timezone note

**Not verified:** nothing local renders the connector's Markdown, so the final appearance in Slack is unconfirmed until the routine next fires (or a draft is posted).

## DoD exemptions

- **Item 5 (surface parity)** — does not apply. This is cowork tooling under `scripts/`, not a yeaboi capability on the five surfaces; no `CAPABILITIES` row or `FeatureTip` is implicated.
- **Item 7 (web bundles)** — does not apply; nothing under `frontend/` is touched.
- **Item 6 (observability)** — `cowork_setup.py` is a CLI script whose output *is* its observability; it uses `say`/`note`/`fail`, not `logger`.

Closes YEA-67

🤖 Generated with [Claude Code](https://claude.com/claude-code)