### PR TITLE
replace the agents pages' per-file loading spam with phase progress and instant open

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.3.0"
+version = "3.3.1"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/agentwatch/collector.py
+++ b/src/yeaboi/agentwatch/collector.py
@@ -35,6 +35,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from yeaboi.agentwatch.store import AgentWatchStore
+from yeaboi.analysis.progress import send_component_progress
 from yeaboi.redaction import _TOKEN_PATTERNS
 
 logger = logging.getLogger(__name__)
@@ -272,9 +273,17 @@ def refresh(
     store: AgentWatchStore,
     *,
     roots: tuple[tuple[str, Path], ...] | None = None,
-    on_progress: Callable[[str], None] | None = None,
+    on_progress: Callable[[object], None] | None = None,
 ) -> IngestStats:
     """Ingest new/changed session transcripts into the store. Never raises.
+
+    ``on_progress`` receives ``analysis_component`` lifecycle dicts (see
+    yeaboi.analysis.progress) carrying an aggregate files-scanned meter —
+    never per-file names, which on a cold cache is thousands of lines of
+    noise no reader can act on. Cold runs still emit one meter event per
+    *parsed* file (that is the live meter during the slow path; the consumer
+    folds them per frame); warm runs, where nearly everything is cursor-
+    skipped, are throttled to integer-percent changes.
 
     The skip path checks (size, mtime) first — transcripts are append-only, and
     the cursor keys on both fields because coarse filesystem mtimes (FAT's 2s)
@@ -287,31 +296,61 @@ def refresh(
     """
     stats = IngestStats()
     scan_failed = False
+    # Materialise across ALL roots before scanning so the progress meter has a
+    # global denominator — a per-root total would reset the bar mid-scan when
+    # a second source kicks in.
+    pending: list[tuple[str, Path]] = []
     for source, root in roots if roots is not None else _source_roots():
         try:
-            files = list(_iter_session_files(root))
+            pending.extend((source, path) for path in _iter_session_files(root))
         except OSError as exc:
             stats.warnings.append(f"cannot scan {root}: {exc}")
             scan_failed = True
+
+    total = len(pending)
+    last_pct = -1
+
+    def _emit_scan(current: int) -> None:
+        # Throttled at the call sites: first file, a parsed (non-cached) file,
+        # an integer-percent change, or the last file. Warm runs emit at most
+        # ~100 events instead of one per transcript.
+        nonlocal last_pct
+        last_pct = (current * 100) // max(1, total)
+        send_component_progress(
+            on_progress,
+            component_id="scan",
+            label="Scan agent sessions",
+            status="running",
+            current=current,
+            total=total,
+            unit="files",
+            secondary_count=stats.files_parsed,
+            secondary_unit="parsed",
+        )
+
+    if on_progress is not None and total:
+        _emit_scan(0)
+    for index, (source, path) in enumerate(pending):
+        stats.files_seen += 1
+        handled = index + 1
+        try:
+            file_stat = path.stat()
+        except OSError:
             continue
-        for path in files:
-            stats.files_seen += 1
-            try:
-                file_stat = path.stat()
-            except OSError:
-                continue
-            cursor = store.get_cursor(str(path))
-            if cursor and cursor["size"] == file_stat.st_size and cursor["mtime"] == file_stat.st_mtime:
-                # Same size AND same mtime — the only remaining way this file
-                # differs is a same-size replacement, which the head hash
-                # catches. An empty stored hash predates the check; treat it as
-                # a match rather than reparsing every file once.
-                stored_sha = cursor["first_line_sha"]
-                if not stored_sha or stored_sha == _first_line_sha(path):
-                    stats.files_skipped += 1
-                    continue
-            if on_progress is not None:
-                on_progress(f"reading {path.name}")
+        ingested = False
+        cursor = store.get_cursor(str(path))
+        skip = False
+        if cursor and cursor["size"] == file_stat.st_size and cursor["mtime"] == file_stat.st_mtime:
+            # Same size AND same mtime — the only remaining way this file
+            # differs is a same-size replacement, which the head hash
+            # catches. An empty stored hash predates the check; treat it as
+            # a match rather than reparsing every file once.
+            stored_sha = cursor["first_line_sha"]
+            skip = not stored_sha or stored_sha == _first_line_sha(path)
+        if skip:
+            stats.files_skipped += 1
+        else:
+            ingested = True
             try:
                 _ingest_one(store, source, path, stats)
             except Exception as exc:  # one bad file must not sink the sweep
@@ -323,14 +362,20 @@ def refresh(
                 # triage; the detail goes to the log.
                 logger.warning("agentwatch ingest failed for %s: %s", path, exc)
                 stats.warnings.append(f"failed to ingest {path.name} ({type(exc).__name__} — see logs)")
-                continue
-            store.set_cursor(
-                str(path),
-                source=source,
-                size=file_stat.st_size,
-                mtime=file_stat.st_mtime,
-                first_line_sha=_first_line_sha(path),
-            )
+            else:
+                store.set_cursor(
+                    str(path),
+                    source=source,
+                    size=file_stat.st_size,
+                    mtime=file_stat.st_mtime,
+                    first_line_sha=_first_line_sha(path),
+                )
+        if on_progress is not None and (ingested or handled == total or (handled * 100) // total != last_pct):
+            _emit_scan(handled)
+    # Guarantee the meter closes at N/N even when the last file's stat() failed
+    # and its per-file emit was skipped — the bar must never freeze short.
+    if on_progress is not None and total and last_pct != 100:
+        _emit_scan(total)
 
     # Drop state for transcripts that are gone from disk. Deleting the
     # transcript is how a user remediates a leaked secret, and without this the

--- a/src/yeaboi/agentwatch/engine.py
+++ b/src/yeaboi/agentwatch/engine.py
@@ -38,9 +38,26 @@ from yeaboi.agent.state import (
 )
 from yeaboi.agentwatch import collector
 from yeaboi.agentwatch.store import AgentWatchStore
+from yeaboi.analysis.progress import send_component_progress
 from yeaboi.pricing import PRICING_AS_OF, estimate_cost
 
 logger = logging.getLogger(__name__)
+
+
+def _emit(on_progress, component_id: str, status: str, *, label: str = "", detail: str = "") -> None:
+    """Send one phase lifecycle event to the caller's progress callback.
+
+    The TUI keys its phase checklist on ``component_id`` (see
+    _screens_agents.py); the label rides along for consumers that render
+    events standalone. None-safe, so engines can emit unconditionally.
+    """
+    send_component_progress(
+        on_progress,
+        component_id=component_id,
+        label=label or component_id,
+        status=status,
+        detail=detail,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -208,9 +225,15 @@ def run_agent_usage(
 
     warnings: list[str] = []
     with AgentWatchStore(_resolve_db_path(db_path)) as store:
-        if on_progress is not None:
-            on_progress("Scanning local agent sessions")
+        _emit(on_progress, "scan", "running", label="Scan agent sessions")
         stats = collector.refresh(store, on_progress=on_progress)
+        _emit(
+            on_progress,
+            "scan",
+            "completed",
+            label="Scan agent sessions",
+            detail=f"{stats.files_parsed} parsed · {stats.files_skipped} cached",
+        )
         warnings.extend(stats.warnings)
         sessions = store.list_sessions(since=period_start)
 
@@ -219,8 +242,7 @@ def run_agent_usage(
     if source:
         sessions = [s for s in sessions if s["source"] == source]
 
-    if on_progress is not None:
-        on_progress(f"Pricing {len(sessions)} transcript(s)")
+    _emit(on_progress, "price", "running", label="Price usage", detail=f"{len(sessions)} transcript(s)")
 
     model_totals: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
     project_totals: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
@@ -319,13 +341,16 @@ def run_agent_usage(
 
     if not sessions:
         warnings.append("No local agent sessions found in the window — is Claude Code used on this machine?")
+    # no_data, not completed, on an empty window — same checklist vocabulary as
+    # the insights/trackers phases' nothing-to-do case.
+    price_status = "completed" if sessions else "no_data"
+    _emit(on_progress, "price", price_status, label="Price usage", detail=f"{len(sessions)} transcript(s)")
 
     # ── The one LLM call: prose over finished numbers ─────────────────────
     insights: tuple[str, ...] = ()
     recommendations: tuple[str, ...] = ()
     if sessions and not dry_run:
-        if on_progress is not None:
-            on_progress("Writing insights")
+        _emit(on_progress, "insights", "running", label="Write insights")
         from yeaboi.prompts.agentwatch import get_usage_insights_prompt
 
         prompt = get_usage_insights_prompt(
@@ -341,6 +366,9 @@ def run_agent_usage(
         warnings.extend(llm_warnings)
         insights = _str_list(parsed.get("insights"))[:5]
         recommendations = _str_list(parsed.get("recommendations"))[:5]
+        _emit(on_progress, "insights", "fallback" if llm_warnings else "completed", label="Write insights")
+    else:
+        _emit(on_progress, "insights", "no_data", label="Write insights", detail="skipped")
     if not insights:
         # Per-field, not both-or-nothing: a model that returns usable
         # recommendations but an empty insights list used to have them thrown
@@ -447,10 +475,10 @@ def _collect_agent_repo_activity(
     from yeaboi.agent.state import AgentRepoActivityRow
 
     if tracker_sources is not None and not tracker_sources:
+        _emit(on_progress, "trackers", "no_data", label="Scan trackers", detail="skipped — local sessions only")
         return (), ("Tracker scan skipped (tracker_sources=[]) — local sessions only.",)
 
-    if on_progress is not None:
-        on_progress("Scanning trackers for agent-authored work")
+    _emit(on_progress, "trackers", "running", label="Scan trackers")
     try:
         from yeaboi.analysis.ai_usage import _classify_ai_item, collect_ai_activity
 
@@ -473,6 +501,7 @@ def _collect_agent_repo_activity(
         )
     except Exception as exc:  # noqa: BLE001 — trackers are optional context
         logger.warning("agent standup: tracker scan failed: %s", exc)
+        _emit(on_progress, "trackers", "no_data", label="Scan trackers", detail="unavailable")
         return (), (f"Tracker scan unavailable: {exc}",)
 
     # Drop non-agent automation (service hooks, scanners) before classifying —
@@ -502,6 +531,7 @@ def _collect_agent_repo_activity(
         )
     order = {"pr": 0, "commit": 1, "review": 2, "comment": 3}
     rows.sort(key=lambda r: (order.get(r.kind, 9), r.repo, r.title))
+    _emit(on_progress, "trackers", "completed", label="Scan trackers", detail=f"{len(rows)} item(s)")
     return tuple(rows), tuple(coverage)
 
 
@@ -562,9 +592,15 @@ def run_agent_standup(
 
     warnings: list[str] = []
     with AgentWatchStore(_resolve_db_path(db_path)) as store:
-        if on_progress is not None:
-            on_progress("Scanning local agent sessions")
+        _emit(on_progress, "scan", "running", label="Scan agent sessions")
         stats = collector.refresh(store, on_progress=on_progress)
+        _emit(
+            on_progress,
+            "scan",
+            "completed",
+            label="Scan agent sessions",
+            detail=f"{stats.files_parsed} parsed · {stats.files_skipped} cached",
+        )
         warnings.extend(stats.warnings)
         sessions = store.list_sessions(since=window_start)
     summaries = _summarise_sessions(sessions)
@@ -604,8 +640,7 @@ def run_agent_standup(
     attention: tuple[str, ...] = ()
     narrative = ""
     if (summaries or repo_rows) and not dry_run:
-        if on_progress is not None:
-            on_progress("Writing the digest")
+        _emit(on_progress, "digest", "running", label="Write the digest")
         from yeaboi.prompts.agentwatch import get_standup_digest_prompt
 
         prompt = get_standup_digest_prompt(
@@ -620,6 +655,9 @@ def run_agent_standup(
         highlights = _str_list(parsed.get("highlights"))[:6]
         attention = _str_list(parsed.get("attention_items"))[:6]
         narrative = str(parsed.get("narrative") or "").strip()
+        _emit(on_progress, "digest", "fallback" if llm_warnings else "completed", label="Write the digest")
+    else:
+        _emit(on_progress, "digest", "no_data", label="Write the digest", detail="skipped")
     if not narrative:
         highlights, attention, narrative = _fallback_standup_prose(summaries, repo_rows)
 
@@ -792,24 +830,30 @@ def run_agent_security(
     warnings: list[str] = []
     with AgentWatchStore(_resolve_db_path(db_path)) as store:
         if deep:
-            if on_progress is not None:
-                on_progress("Re-scanning every session transcript")
             store.reset_cursors()
-        if on_progress is not None:
-            on_progress("Scanning local agent sessions")
+        scan_label = "Re-scan every transcript" if deep else "Scan transcripts"
+        _emit(on_progress, "scan", "running", label=scan_label)
         stats = collector.refresh(store, on_progress=on_progress)
+        _emit(
+            on_progress,
+            "scan",
+            "completed",
+            label=scan_label,
+            detail=f"{stats.files_parsed} parsed · {stats.files_skipped} cached",
+        )
         warnings.extend(stats.warnings)
         sessions_scanned = _distinct_session_count(store.list_sessions())
         files_scanned = stats.files_seen
         findings = _stored_findings(store)
 
-    if on_progress is not None:
-        on_progress("Auditing agent settings")
-    findings.extend(security_checks.audit_settings())
-    if on_progress is not None:
-        on_progress("Inventorying MCP servers")
+    _emit(on_progress, "settings", "running", label="Audit settings")
+    settings_findings = security_checks.audit_settings()
+    findings.extend(settings_findings)
+    _emit(on_progress, "settings", "completed", label="Audit settings", detail=f"{len(settings_findings)} finding(s)")
+    _emit(on_progress, "mcp", "running", label="Inventory MCP servers")
     mcp_servers, mcp_findings = security_checks.inventory_mcp()
     findings.extend(mcp_findings)
+    _emit(on_progress, "mcp", "completed", label="Inventory MCP servers", detail=f"{len(mcp_servers)} server(s)")
 
     ranked = security_checks.rank_findings(findings)
     posture = security_checks.compute_posture(ranked)
@@ -820,8 +864,7 @@ def run_agent_security(
     summary = ""
     recommendations: tuple[str, ...] = ()
     if ranked and not dry_run:
-        if on_progress is not None:
-            on_progress("Writing the summary")
+        _emit(on_progress, "summary", "running", label="Write the summary")
         from yeaboi.prompts.agentwatch import get_security_summary_prompt
 
         prompt = get_security_summary_prompt(
@@ -835,6 +878,9 @@ def run_agent_security(
         warnings.extend(llm_warnings)
         summary = str(parsed.get("summary") or "").strip()
         recommendations = _str_list(parsed.get("recommendations"))[:5]
+        _emit(on_progress, "summary", "fallback" if llm_warnings else "completed", label="Write the summary")
+    else:
+        _emit(on_progress, "summary", "no_data", label="Write the summary", detail="skipped")
     if not summary:
         by_severity: dict[str, int] = {}
         for f in ranked:

--- a/src/yeaboi/agentwatch/store.py
+++ b/src/yeaboi/agentwatch/store.py
@@ -385,6 +385,15 @@ class AgentWatchStore:
             for row in rows
         ]
 
+    def latest_report(self, kind: str) -> dict | None:
+        """The newest saved report row of one kind, or None when history is empty.
+
+        Newest regardless of ``origin`` — an edited report is still the last
+        saved state the user expects to see when a page opens instantly.
+        """
+        rows = self.list_reports(kind, limit=1)
+        return rows[0] if rows else None
+
 
 _REPORT_TABLES: dict[str, tuple[str, str]] = {
     "usage": ("agent_usage_reports", "period_start"),
@@ -399,3 +408,225 @@ def _loads(raw: str, default: dict) -> dict:
     except (TypeError, ValueError):
         return default
     return parsed if isinstance(parsed, dict) else default
+
+
+# ---------------------------------------------------------------------------
+# Report rehydration — stored JSON payload → the frozen artifact dataclass
+# ---------------------------------------------------------------------------
+#
+# record_report stores asdict() JSON, so nested dataclasses come back as dicts
+# and tuples as lists. The TUI's instant-open path (and the capped renderers,
+# which go through dataclasses.replace) need the real dataclass back. Same
+# convention as standup/store.py's _dict_to_standup_report: every field via
+# .get() with the dataclass default, so a payload written by an older version
+# still loads. Deliberately NOT registered in artifacts/registry — rehydration
+# for display, not for the editable-artifact surface.
+
+
+def _str_tuple(value) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(v) for v in value)
+
+
+def _pair_tuple(value) -> tuple[tuple[str, str], ...]:
+    """Rebuild (a, b) string pairs that JSON flattened into 2-item lists."""
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple((str(p[0]), str(p[1])) for p in value if isinstance(p, (list, tuple)) and len(p) == 2)
+
+
+def _dict_to_usage_report(d: dict):
+    from yeaboi.agent.state import (
+        AgentUsageBreakdownRow,
+        AgentUsageReport,
+        DailyUsagePoint,
+        ModelUsageRow,
+        annotations_from,
+    )
+
+    def _breakdown(rows) -> tuple[AgentUsageBreakdownRow, ...]:
+        return tuple(
+            AgentUsageBreakdownRow(
+                key=str(r.get("key", "")),
+                sessions=int(r.get("sessions", 0)),
+                input_tokens=int(r.get("input_tokens", 0)),
+                output_tokens=int(r.get("output_tokens", 0)),
+                cost_usd=float(r.get("cost_usd", 0.0)),
+            )
+            for r in rows or ()
+            if isinstance(r, dict)
+        )
+
+    return AgentUsageReport(
+        period_start=str(d.get("period_start", "")),
+        period_end=str(d.get("period_end", "")),
+        session_count=int(d.get("session_count", 0)),
+        total_cost_usd=float(d.get("total_cost_usd", 0.0)),
+        total_input_tokens=int(d.get("total_input_tokens", 0)),
+        total_output_tokens=int(d.get("total_output_tokens", 0)),
+        total_cache_write_tokens=int(d.get("total_cache_write_tokens", 0)),
+        total_cache_read_tokens=int(d.get("total_cache_read_tokens", 0)),
+        unknown_model_cost_share=float(d.get("unknown_model_cost_share", 0.0)),
+        pricing_as_of=str(d.get("pricing_as_of", "")),
+        by_model=tuple(
+            ModelUsageRow(
+                model=str(r.get("model", "")),
+                input_tokens=int(r.get("input_tokens", 0)),
+                output_tokens=int(r.get("output_tokens", 0)),
+                cache_write_tokens=int(r.get("cache_write_tokens", 0)),
+                cache_read_tokens=int(r.get("cache_read_tokens", 0)),
+                calls=int(r.get("calls", 0)),
+                cost_usd=float(r.get("cost_usd", 0.0)),
+                known_pricing=bool(r.get("known_pricing", True)),
+            )
+            for r in d.get("by_model") or ()
+            if isinstance(r, dict)
+        ),
+        by_project=_breakdown(d.get("by_project")),
+        by_source=_breakdown(d.get("by_source")),
+        daily_trend=tuple(
+            DailyUsagePoint(
+                date=str(r.get("date", "")),
+                cost_usd=float(r.get("cost_usd", 0.0)),
+                input_tokens=int(r.get("input_tokens", 0)),
+                output_tokens=int(r.get("output_tokens", 0)),
+                sessions=int(r.get("sessions", 0)),
+            )
+            for r in d.get("daily_trend") or ()
+            if isinstance(r, dict)
+        ),
+        insights=_str_tuple(d.get("insights")),
+        recommendations=_str_tuple(d.get("recommendations")),
+        warnings=_str_tuple(d.get("warnings")),
+        generated_at=str(d.get("generated_at", "")),
+        annotations=annotations_from(d.get("annotations")),
+    )
+
+
+def _dict_to_standup_digest(d: dict):
+    from yeaboi.agent.state import (
+        AgentRepoActivityRow,
+        AgentSessionSummary,
+        AgentStandupDigest,
+        annotations_from,
+    )
+
+    return AgentStandupDigest(
+        digest_date=str(d.get("digest_date", "")),
+        window_start=str(d.get("window_start", "")),
+        window_end=str(d.get("window_end", "")),
+        sessions_worked=int(d.get("sessions_worked", 0)),
+        total_cost_usd=float(d.get("total_cost_usd", 0.0)),
+        agents_seen=_str_tuple(d.get("agents_seen")),
+        session_summaries=tuple(
+            AgentSessionSummary(
+                session_id=str(s.get("session_id", "")),
+                source=str(s.get("source", "")),
+                project=str(s.get("project", "")),
+                branch=str(s.get("branch", "")),
+                models=_str_tuple(s.get("models")),
+                turns=int(s.get("turns", 0)),
+                cost_usd=float(s.get("cost_usd", 0.0)),
+                top_tools=_pair_tuple(s.get("top_tools")),
+                started_at=str(s.get("started_at", "")),
+                ended_at=str(s.get("ended_at", "")),
+            )
+            for s in d.get("session_summaries") or ()
+            if isinstance(s, dict)
+        ),
+        repo_activity=tuple(
+            AgentRepoActivityRow(
+                source=str(r.get("source", "")),
+                repo=str(r.get("repo", "")),
+                kind=str(r.get("kind", "")),
+                title=str(r.get("title", "")),
+                url=str(r.get("url", "")),
+                author=str(r.get("author", "")),
+                status=str(r.get("status", "")),
+                agent_marker=str(r.get("agent_marker", "")),
+            )
+            for r in d.get("repo_activity") or ()
+            if isinstance(r, dict)
+        ),
+        highlights=_str_tuple(d.get("highlights")),
+        in_flight=_str_tuple(d.get("in_flight")),
+        attention_items=_str_tuple(d.get("attention_items")),
+        narrative=str(d.get("narrative", "")),
+        coverage_notes=_str_tuple(d.get("coverage_notes")),
+        warnings=_str_tuple(d.get("warnings")),
+        generated_at=str(d.get("generated_at", "")),
+        annotations=annotations_from(d.get("annotations")),
+    )
+
+
+def _dict_to_security_report(d: dict):
+    from yeaboi.agent.state import (
+        AgentSecurityReport,
+        McpServerRecord,
+        SecurityFinding,
+        annotations_from,
+    )
+
+    return AgentSecurityReport(
+        scan_date=str(d.get("scan_date", "")),
+        posture=str(d.get("posture", "")),
+        sessions_scanned=int(d.get("sessions_scanned", 0)),
+        files_scanned=int(d.get("files_scanned", 0)),
+        secrets_found=int(d.get("secrets_found", 0)),
+        findings=tuple(
+            SecurityFinding(
+                severity=str(f.get("severity", "info")),
+                category=str(f.get("category", "")),
+                title=str(f.get("title", "")),
+                location=str(f.get("location", "")),
+                line_no=int(f.get("line_no", 0)),
+                pattern=str(f.get("pattern", "")),
+                detail=str(f.get("detail", "")),
+                remediation=str(f.get("remediation", "")),
+            )
+            for f in d.get("findings") or ()
+            if isinstance(f, dict)
+        ),
+        mcp_servers=tuple(
+            McpServerRecord(
+                name=str(m.get("name", "")),
+                scope=str(m.get("scope", "")),
+                transport=str(m.get("transport", "")),
+                target=str(m.get("target", "")),
+                flags=_str_tuple(m.get("flags")),
+            )
+            for m in d.get("mcp_servers") or ()
+            if isinstance(m, dict)
+        ),
+        settings_flags=_str_tuple(d.get("settings_flags")),
+        summary=str(d.get("summary", "")),
+        recommendations=_str_tuple(d.get("recommendations")),
+        warnings=_str_tuple(d.get("warnings")),
+        generated_at=str(d.get("generated_at", "")),
+        annotations=annotations_from(d.get("annotations")),
+    )
+
+
+_REHYDRATORS = {
+    "usage": _dict_to_usage_report,
+    "standup": _dict_to_standup_digest,
+    "security": _dict_to_security_report,
+}
+
+
+def report_from_payload(kind: str, payload: object):
+    """Rebuild a stored report payload into its artifact dataclass, or None.
+
+    None (rather than a half-built artifact) for an unknown kind, a corrupt
+    payload, or the empty dict ``_loads`` yields for bad JSON — the caller's
+    cold-start path is the right fallback for all three.
+    """
+    rehydrate = _REHYDRATORS.get(kind)
+    if rehydrate is None or not isinstance(payload, dict) or not payload:
+        return None
+    try:
+        return rehydrate(payload)
+    except Exception as exc:  # noqa: BLE001 — a bad row must not break the page
+        logger.warning("agentwatch: could not rehydrate stored %s report: %s", kind, exc)
+        return None

--- a/src/yeaboi/analysis/progress.py
+++ b/src/yeaboi/analysis/progress.py
@@ -52,6 +52,27 @@ def append_component_progress(
     progress.append(event)
 
 
+def send_component_progress(
+    on_progress,
+    *,
+    component_id: str,
+    label: str,
+    status: str,
+    **kwargs,
+) -> None:
+    """Build one lifecycle event and hand it to a callback (None-safe).
+
+    The list-based ``append_component_progress`` suits engines that share a
+    progress list with their caller; callback-based engines (agentwatch) get
+    the same event shape through their existing ``on_progress`` callable.
+    """
+    if on_progress is None:
+        return
+    events: list = []
+    append_component_progress(events, component_id=component_id, label=label, status=status, **kwargs)
+    on_progress(events[0])
+
+
 def is_component_progress(item: Any) -> bool:
     """Return whether ``item`` is a well-formed component lifecycle event."""
     return (

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,37 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "3.3.1",
+      "date": "2026-08-09",
+      "summary": "The agent pages (Usage, Standup, Security) now load with clear progress feedback instead of a firehose of transcript lines. Phase-based checklist loading screens show what's happening (scan/price/insights) with a percentage meter and elapsed time, while the last saved report opens instantly and updates in the background. A refresh banner shows the running phase and progress so you always know the page is working, and background progress is streamed and folded into one compact meter instead of spamming the display. Stale reports stay visible if a background refresh fails, and re-running keeps the page populated.",
+      "highlights": [
+        {
+          "text": "Phase-based loading checklist with structured progress (scan/price/insights) and percent meter instead of per-file spam",
+          "areas": [
+            "usage"
+          ]
+        },
+        {
+          "text": "Instant open shows the last saved report while a fresh run loads in the background with a banner showing phase and progress",
+          "areas": [
+            "usage"
+          ]
+        },
+        {
+          "text": "Failed refresh keeps the stale report visible with an error notice; re-running refreshes the report without losing your place",
+          "areas": [
+            "usage"
+          ]
+        },
+        {
+          "text": "Progress events are throttled and folded per phase — a 737-file scan now shows one meter instead of 737 lines",
+          "areas": [
+            "usage"
+          ]
+        }
+      ]
+    },
+    {
       "version": "3.3.0",
       "date": "2026-08-09",
       "summary": "The standup page now renders each team member's work as a Jira-style story-centered member card with issue hierarchy. Your main user story becomes the visible unit of each card, with subtasks nested underneath and a status lozenge showing progress. The redesign supports both Jira and Azure DevOps hierarchy, automatically detecting issue types and parent-child relationships without extra API calls. Code and documentation changes are now filed under their referencing story, and legacy reports render unchanged for backward compatibility.",

--- a/src/yeaboi/ui/mode_select/_agents.py
+++ b/src/yeaboi/ui/mode_select/_agents.py
@@ -4,9 +4,10 @@ One dispatch entry (:func:`route_agent_mode`) instead of three more branches in
 ``select_mode``'s routing chain. Each mode wraps itself in ``mode_log`` (its own
 log file under ~/.yeaboi/logs/agentwatch/) and its one-time beta notice.
 
-All three pages share one threaded-engine loop: the pipeline runs on a
-daemon thread feeding a progress spinner, then the capped result renders
-statically (r re-runs, esc backs out).
+All three pages share one threaded-engine loop: the page opens instantly on
+the last saved report (age-stamped) while the pipeline runs on a daemon
+thread feeding a phase checklist / refresh banner, then the capped fresh
+result swaps in (r re-runs behind the visible report, esc backs out).
 
 Imports from :mod:`yeaboi.ui.mode_select` happen lazily inside function bodies —
 the package imports this module's callers, so a top-level import is a cycle.
@@ -97,6 +98,30 @@ def _run_result_action(action: str, artifact, *, label: str, export_kind: str, b
     return ""
 
 
+def _load_latest_artifact(kind: str):
+    """The newest saved report of one kind, rehydrated, plus its created_at.
+
+    None when history is empty or the stored payload cannot be rebuilt — the
+    page then falls back to the first-run loading screen. Never raises: a
+    broken history row must not take down the page it was meant to speed up.
+    """
+    from yeaboi.agentwatch.store import AgentWatchStore, report_from_payload
+    from yeaboi.paths import get_db_path
+
+    try:
+        with AgentWatchStore(get_db_path()) as store:
+            row = store.latest_report(kind)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("agent %s page: could not read report history: %s", kind, exc)
+        return None
+    if not row:
+        return None
+    artifact = report_from_payload(kind, row.get("report"))
+    if artifact is None:
+        return None
+    return artifact, str(row.get("created_at") or "")
+
+
 def _run_threaded_engine_page(
     console,
     live,
@@ -111,92 +136,165 @@ def _run_threaded_engine_page(
     export_kind: str,
     build_markdown,
 ) -> None:
-    """Shared page loop: engine on a worker thread, spinner, then the result.
+    """Shared page loop: engine on a worker thread, instant last report, result.
 
-    The engines' LLM calls can take seconds, so the page keeps animating a
-    spinner (fed by the engine's on_progress strings) while a daemon thread
-    runs the pipeline. The engines never raise (parse → fallback → format);
-    ``make_failure_artifact`` is belt-and-braces for a bug.
+    The page opens on the *last saved* report (stamped with its age) whenever
+    one exists, while a daemon thread runs a fresh engine pass behind a
+    "Refreshing…" banner — the loading screen only ever appears on a first run.
+    While loading, the engine's structured progress events (analysis_component
+    dicts) render as a phase checklist with a files meter; the queue is drained
+    every frame (latest event per phase wins) so the display never lags the
+    scan. The engines never raise (parse → fallback → format);
+    ``make_failure_artifact`` is belt-and-braces for a bug — and a failed
+    background refresh keeps the stale report on screen rather than replacing
+    it with a failure artifact.
 
     On the result screen ←/→ move between Export / Copy / Re-run / Back and
-    enter activates; `r` still re-runs and esc/q still backs out (a mid-run
-    back-out lets the daemon finish + export). Export writes the Markdown
-    artifact, Copy puts the same Markdown on the clipboard — both report back
-    through the page's notice line rather than a popup, because neither can
-    fail in a way the user must acknowledge.
+    enter activates; `r` still re-runs (keeping the current report visible) and
+    esc/q still backs out (a mid-run back-out lets the daemon finish + export).
+    Export writes the Markdown artifact, Copy puts the same Markdown on the
+    clipboard — both report back through the page's notice line rather than a
+    popup, because neither can fail in a way the user must acknowledge.
     """
     import queue
 
+    from yeaboi.analysis.progress import is_component_progress
     from yeaboi.ui.shared._music_bar import duck_working_thread
 
     logger.info("%s page opened", label)
-    while True:  # re-entered by the r (re-run) key
-        progress: queue.Queue[str] = queue.Queue()
-        result: queue.Queue = queue.Queue(maxsize=1)
+    artifact = None
+    as_of = ""
+    loaded = _load_latest_artifact(export_kind)
+    if loaded is not None:
+        artifact, as_of = loaded
+        logger.info("%s page: showing last saved report (from %s) while refreshing", label, as_of or "unknown time")
+
+    progress_q: queue.Queue = queue.Queue()
+    result_q: queue.Queue = queue.Queue(maxsize=1)
+    events_by_id: dict[str, dict] = {}
+    status = ""
+    refreshing = False
+
+    def _start_worker() -> None:
+        nonlocal progress_q, result_q, events_by_id, status, refreshing
+        pq: queue.Queue = queue.Queue()
+        rq: queue.Queue = queue.Queue(maxsize=1)
 
         def _work() -> None:
             try:
-                result.put(run_engine(progress.put))
+                rq.put(("ok", run_engine(pq.put)))
             except Exception as exc:  # noqa: BLE001 — belt and braces; the engine shouldn't raise
                 logger.exception("%s engine failed", label)
-                result.put(make_failure_artifact(exc))
+                rq.put(("err", exc))
 
+        progress_q, result_q = pq, rq
+        events_by_id = {}
+        status = ""
+        refreshing = artifact is not None
         # duck_working_thread: the corner robo bobs for the engine's lifetime,
         # same liveness cue the Humans pages give their worker runs.
-        worker = duck_working_thread(_work, name=label)
-        worker.start()
+        duck_working_thread(_work, name=label).start()
 
-        status = ""
-        start = time.monotonic()
-        artifact = None
-        while artifact is None:
-            try:
-                status = progress.get_nowait()
-            except queue.Empty:
-                pass
-            try:
-                artifact = result.get_nowait()
-            except queue.Empty:
-                pass
-            w, h = console.size
-            live.update(build_screen(None, width=w, height=h, shimmer_tick=time.monotonic() - start, status=status))
-            key = read_key(timeout=frame_time) if supports_timeout else read_key()
-            if key in ("esc", "q"):
-                logger.info("%s page: backed out while running", label)
-                return
+    _start_worker()
+    start = time.monotonic()
+    action_sel = 0
+    notice = ""
 
-        logger.info("%s page: artifact ready", label)
-        action_sel = 0
+    def _handle_rerun() -> None:
+        nonlocal notice, as_of
+        if refreshing:
+            notice = "Already refreshing…"
+            return
+        logger.info("%s page: re-run requested", label)
         notice = ""
+        as_of = artifact.generated_at
+        _start_worker()
+
+    while True:
+        # Drain everything queued since the last frame — the collector can
+        # emit faster than 60fps, and showing anything but the latest event
+        # per phase would replay stale progress.
         while True:
-            w, h = console.size
+            try:
+                item = progress_q.get_nowait()
+            except queue.Empty:
+                break
+            if is_component_progress(item):
+                events_by_id[item["component_id"]] = item
+            else:
+                status = str(item)
+        try:
+            outcome, payload = result_q.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            if outcome == "ok":
+                artifact = payload
+                refreshing = False
+                as_of = ""
+                notice = ""
+                logger.info("%s page: artifact ready", label)
+            elif artifact is not None:
+                # Keep the stale report — losing a good dashboard over a
+                # failed background refresh is the worse outcome.
+                refreshing = False
+                notice = "Refresh failed — showing the last saved report (see logs)."
+                logger.warning("%s page: background refresh failed; keeping the last saved report", label)
+            else:
+                artifact = make_failure_artifact(payload)
+                refreshing = False
+
+        w, h = console.size
+        tick = time.monotonic() - start
+        if artifact is None:
+            live.update(
+                build_screen(
+                    None,
+                    width=w,
+                    height=h,
+                    shimmer_tick=tick,
+                    status=status,
+                    progress=list(events_by_id.values()),
+                )
+            )
+        else:
             live.update(
                 build_screen(
                     artifact,
                     width=w,
                     height=h,
-                    shimmer_tick=time.monotonic() - start,
+                    shimmer_tick=tick,
                     action_sel=action_sel,
                     notice=notice,
+                    refreshing=refreshing,
+                    as_of=as_of,
+                    # The refresh banner names the running phase + meter, so
+                    # progress is visible on the common path too — not only on
+                    # the first-ever run's full checklist.
+                    progress=list(events_by_id.values()) if refreshing else None,
                 )
             )
-            key = read_key(timeout=frame_time) if supports_timeout else read_key()
-            if key in ("esc", "q"):
+        key = read_key(timeout=frame_time) if supports_timeout else read_key()
+        if key in ("esc", "q"):
+            if artifact is None or refreshing:
+                logger.info("%s page: backed out while running", label)
+            return
+        if artifact is None:
+            continue  # still loading: only esc/q act
+        if key == "r":
+            _handle_rerun()
+        elif key == "left":
+            action_sel = (action_sel - 1) % len(AGENT_RESULT_ACTIONS)
+        elif key == "right":
+            action_sel = (action_sel + 1) % len(AGENT_RESULT_ACTIONS)
+        elif key == "enter":
+            action = AGENT_RESULT_ACTIONS[action_sel]
+            logger.info("%s page: action %s", label, action)
+            if action == "Back":
                 return
-            if key == "r":
-                logger.info("%s page: re-run requested", label)
-                break  # back to the outer loop → fresh engine run
-            if key == "left":
-                action_sel = (action_sel - 1) % len(AGENT_RESULT_ACTIONS)
-            elif key == "right":
-                action_sel = (action_sel + 1) % len(AGENT_RESULT_ACTIONS)
-            elif key == "enter":
-                action = AGENT_RESULT_ACTIONS[action_sel]
-                logger.info("%s page: action %s", label, action)
-                if action == "Back":
-                    return
-                if action == "Re-run":
-                    break  # same exit as `r`: falls out to the outer loop
+            if action == "Re-run":
+                _handle_rerun()
+            else:
                 notice = _run_result_action(
                     action, artifact, label=label, export_kind=export_kind, build_markdown=build_markdown
                 )

--- a/src/yeaboi/ui/mode_select/screens/_screens_agents.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_agents.py
@@ -10,6 +10,7 @@ convention), so the page renders correctly at the minimum terminal size.
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime
 
 from rich.console import Group
 from rich.panel import Panel
@@ -17,10 +18,12 @@ from rich.text import Text
 
 from yeaboi.agent.state import AgentSecurityReport, AgentStandupDigest, AgentUsageReport
 from yeaboi.agentwatch.render import format_usage_rich
+from yeaboi.analysis.progress import is_component_progress
 from yeaboi.ui.shared._components import (
     AGENT_USAGE_THEME,
     agent_usage_title,
     build_action_buttons,
+    build_meter,
     build_page_panel,
     build_reveal_subtitle,
 )
@@ -39,6 +42,160 @@ _MAX_BREAKDOWN_ROWS = 3
 _MAX_PROSE = 2
 
 _SPINNER = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+
+# Static phase checklists, one per page — the screen owns what "pending" looks
+# like; the engines only emit lifecycle events keyed on these component ids
+# (see agentwatch/engine.py). Unknown ids still render, after the checklist.
+_USAGE_PHASES: tuple[tuple[str, str], ...] = (
+    ("scan", "Scan agent sessions"),
+    ("price", "Price usage"),
+    ("insights", "Write insights"),
+)
+_STANDUP_PHASES: tuple[tuple[str, str], ...] = (
+    ("scan", "Scan agent sessions"),
+    ("trackers", "Scan trackers"),
+    ("digest", "Write the digest"),
+)
+_SECURITY_PHASES: tuple[tuple[str, str], ...] = (
+    ("scan", "Scan transcripts"),
+    ("settings", "Audit settings"),
+    ("mcp", "Inventory MCP servers"),
+    ("summary", "Write the summary"),
+)
+
+# Marker per terminal status — same vocabulary as the analysis activity rows
+# (✓ done, ~ fallback, ! partial, ✗ failed, ○ nothing/no data).
+_STATUS_MARKS = {"completed": "✓", "fallback": "~", "partial": "!", "failed": "✗", "no_data": "○"}
+
+
+def _fmt_elapsed(seconds: float) -> str:
+    """0:07-style elapsed stamp for the progress header."""
+    total = max(0, int(seconds))
+    return f"{total // 60}:{total % 60:02d}"
+
+
+def _relative_age(iso: str, *, now: datetime | None = None) -> str:
+    """A human age for a stored report's timestamp: "5m ago", "2h ago", "3d ago".
+
+    Unparseable input returns "" — no stamp rather than a wrong one.
+    """
+    try:
+        then = datetime.fromisoformat(iso)
+    except (TypeError, ValueError):
+        return ""
+    if then.tzinfo is None:
+        then = then.replace(tzinfo=UTC)
+    resolved_now = now or datetime.now(UTC)
+    seconds = (resolved_now - then).total_seconds()
+    if seconds < 60:
+        return "just now"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m ago"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h ago"
+    return f"{int(seconds // 86400)}d ago"
+
+
+def _phase_row(label: str, event: dict | None, *, frame: str, theme) -> Text:
+    """One checklist row: pending ○, running spinner (+ meter), or its terminal mark."""
+    row = Text(justify="center")
+    if event is None:
+        row.append("○ ", style="rgb(90,90,105)")
+        row.append(label, style="rgb(110,110,125)")
+        return row
+    status = event.get("status", "")
+    detail = str(event.get("detail", "") or "")
+    if status == "running":
+        row.append(f"{frame} ", style=theme.accent_bright)
+        row.append(label, style="rgb(200,200,210)")
+        current, total = event.get("current"), event.get("total")
+        if current is not None and total:
+            row.append("  ")
+            row.append_text(build_meter(int(current), int(total), width=12, theme=theme))
+            unit = str(event.get("unit", "") or "")
+            row.append(f"  {current}/{total}{f' {unit}' if unit else ''}", style="rgb(160,160,175)")
+            secondary = event.get("secondary_count")
+            secondary_unit = str(event.get("secondary_unit", "") or "")
+            if secondary is not None and secondary_unit:
+                row.append(f" · {secondary} {secondary_unit}", style="rgb(110,110,125)")
+        elif detail:
+            row.append(f" · {detail}", style="rgb(160,160,175)")
+        return row
+    mark = _STATUS_MARKS.get(status, "○")
+    mark_style = {"✓": theme.accent, "~": theme.warn, "!": theme.warn, "✗": theme.bad}.get(mark, "rgb(90,90,105)")
+    row.append(f"{mark} ", style=mark_style)
+    row.append(label, style="rgb(160,160,175)")
+    if detail:
+        row.append(f" · {detail}", style="rgb(110,110,125)")
+    return row
+
+
+def _build_agent_progress_body(
+    phases: tuple[tuple[str, str], ...],
+    progress: list,
+    *,
+    tick: float,
+    theme,
+    status: str = "",
+) -> list:
+    """The in-progress body: header spinner + elapsed, then the phase checklist.
+
+    ``progress`` is a list of analysis_component lifecycle events (latest wins
+    per component id — folded here defensively even though the page loop
+    pre-folds). Stateless by design: elapsed derives from ``tick`` rather than
+    module clocks, so renders are pure and testable.
+    """
+    latest: dict[str, dict] = {}
+    for item in progress:
+        if is_component_progress(item):
+            latest[item["component_id"]] = item
+    frame = _SPINNER[int(tick * 10) % len(_SPINNER)]
+
+    header = Text(justify="center")
+    header.append(f"{frame} ", style=theme.accent_bright)
+    header.append("Working", style="rgb(200,200,210)")
+    header.append(f" · {_fmt_elapsed(tick)}", style="rgb(110,110,125)")
+    rows: list = [Text(""), header, Text("")]
+
+    known = {pid for pid, _ in phases}
+    for pid, label in phases:
+        rows.append(_phase_row(label, latest.get(pid), frame=frame, theme=theme))
+    for pid, event in latest.items():
+        if pid not in known:
+            rows.append(_phase_row(str(event.get("label", pid)), event, frame=frame, theme=theme))
+    if status:
+        rows.append(Text(""))
+        rows.append(Text(status, style="rgb(110,110,125)", justify="center"))
+    return rows
+
+
+def _refreshing_line(as_of: str, *, tick: float, theme, progress: list | None = None) -> Text:
+    """The one-line banner under a shown report while a fresh run replaces it.
+
+    After the first-ever run the page always opens on a saved report, so this
+    banner — not the full checklist — is where refresh progress is seen: it
+    names the running phase and, while scanning, the files meter counts.
+    """
+    frame = _SPINNER[int(tick * 10) % len(_SPINNER)]
+    line = Text(justify="center")
+    line.append(f"{frame} ", style=theme.accent_bright)
+    line.append("Refreshing", style="rgb(160,160,175)")
+    running = next(
+        (e for e in progress or [] if is_component_progress(e) and e.get("status") == "running"),
+        None,
+    )
+    if running is not None:
+        line.append(f" — {running['label']}", style="rgb(160,160,175)")
+        current, total = running.get("current"), running.get("total")
+        if current is not None and total:
+            unit = str(running.get("unit", "") or "")
+            line.append(f" {current}/{total}{f' {unit}' if unit else ''}", style="rgb(110,110,125)")
+    else:
+        line.append("…", style="rgb(160,160,175)")
+    age = _relative_age(as_of)
+    if age:
+        line.append(f" · showing report from {age}", style="rgb(110,110,125)")
+    return line
 
 
 def _result_footer(action_sel: int, notice: str, theme) -> list:
@@ -87,11 +244,16 @@ def _build_agent_usage_screen(
     status: str = "",
     action_sel: int = 0,
     notice: str = "",
+    progress: list | None = None,
+    refreshing: bool = False,
+    as_of: str = "",
 ) -> Panel:
     """The Agent Usage dashboard page.
 
-    ``report=None`` renders the in-progress state (spinner + the engine's
-    current ``status`` string); a report renders the capped dashboard.
+    ``report=None`` renders the in-progress state — the phase checklist when
+    structured ``progress`` events are given, else a one-line spinner over the
+    ``status`` string; a report renders the capped dashboard, with a
+    "Refreshing…" banner when a background re-run is replacing it.
     """
     theme = AGENT_USAGE_THEME
     parts: list = [
@@ -102,12 +264,19 @@ def _build_agent_usage_screen(
     ]
 
     if report is None:
-        frame = _SPINNER[int((shimmer_tick or 0.0) * 10) % len(_SPINNER)]
-        working = Text(justify="center")
-        working.append(f"{frame} ", style=theme.accent_bright)
-        working.append(status or "Collecting local agent sessions…", style="rgb(160,160,175)")
-        parts += [Text(""), working]
+        if progress is not None:
+            parts += _build_agent_progress_body(
+                _USAGE_PHASES, progress, tick=shimmer_tick or 0.0, theme=theme, status=status
+            )
+        else:
+            frame = _SPINNER[int((shimmer_tick or 0.0) * 10) % len(_SPINNER)]
+            working = Text(justify="center")
+            working.append(f"{frame} ", style=theme.accent_bright)
+            working.append(status or "Collecting local agent sessions…", style="rgb(160,160,175)")
+            parts += [Text(""), working]
     else:
+        if refreshing:
+            parts.append(_refreshing_line(as_of, tick=shimmer_tick or 0.0, theme=theme, progress=progress))
         capped, notes = _capped(report)
         parts.append(format_usage_rich(capped))
         for note in notes:
@@ -149,8 +318,11 @@ def _build_agent_standup_screen(
     status: str = "",
     action_sel: int = 0,
     notice: str = "",
+    progress: list | None = None,
+    refreshing: bool = False,
+    as_of: str = "",
 ) -> Panel:
-    """The Agent Standup page: spinner while running, capped digest when done."""
+    """The Agent Standup page: phase checklist while running, capped digest when done."""
     from yeaboi.agentwatch.render import format_standup_rich
     from yeaboi.ui.shared._components import AGENT_STANDUP_THEME, agent_standup_title
 
@@ -162,12 +334,19 @@ def _build_agent_standup_screen(
         Text(""),
     ]
     if digest is None:
-        frame = _SPINNER[int((shimmer_tick or 0.0) * 10) % len(_SPINNER)]
-        working = Text(justify="center")
-        working.append(f"{frame} ", style=theme.accent_bright)
-        working.append(status or "Collecting agent activity…", style="rgb(160,160,175)")
-        parts += [Text(""), working]
+        if progress is not None:
+            parts += _build_agent_progress_body(
+                _STANDUP_PHASES, progress, tick=shimmer_tick or 0.0, theme=theme, status=status
+            )
+        else:
+            frame = _SPINNER[int((shimmer_tick or 0.0) * 10) % len(_SPINNER)]
+            working = Text(justify="center")
+            working.append(f"{frame} ", style=theme.accent_bright)
+            working.append(status or "Collecting agent activity…", style="rgb(160,160,175)")
+            parts += [Text(""), working]
     else:
+        if refreshing:
+            parts.append(_refreshing_line(as_of, tick=shimmer_tick or 0.0, theme=theme, progress=progress))
         capped, notes = _capped_standup(digest)
         parts.append(format_standup_rich(capped))
         for note in notes:
@@ -205,8 +384,11 @@ def _build_agent_security_screen(
     status: str = "",
     action_sel: int = 0,
     notice: str = "",
+    progress: list | None = None,
+    refreshing: bool = False,
+    as_of: str = "",
 ) -> Panel:
-    """The Agent Security page: spinner while scanning, capped report when done."""
+    """The Agent Security page: phase checklist while scanning, capped report when done."""
     from yeaboi.agentwatch.render import format_security_rich
     from yeaboi.ui.shared._components import AGENT_SECURITY_THEME, agent_security_title
 
@@ -218,12 +400,19 @@ def _build_agent_security_screen(
         Text(""),
     ]
     if report is None:
-        frame = _SPINNER[int((shimmer_tick or 0.0) * 10) % len(_SPINNER)]
-        working = Text(justify="center")
-        working.append(f"{frame} ", style=theme.accent_bright)
-        working.append(status or "Scanning agent configuration…", style="rgb(160,160,175)")
-        parts += [Text(""), working]
+        if progress is not None:
+            parts += _build_agent_progress_body(
+                _SECURITY_PHASES, progress, tick=shimmer_tick or 0.0, theme=theme, status=status
+            )
+        else:
+            frame = _SPINNER[int((shimmer_tick or 0.0) * 10) % len(_SPINNER)]
+            working = Text(justify="center")
+            working.append(f"{frame} ", style=theme.accent_bright)
+            working.append(status or "Scanning agent configuration…", style="rgb(160,160,175)")
+            parts += [Text(""), working]
     else:
+        if refreshing:
+            parts.append(_refreshing_line(as_of, tick=shimmer_tick or 0.0, theme=theme, progress=progress))
         capped, notes = _capped_security(report)
         parts.append(format_security_rich(capped))
         for note in notes:

--- a/tests/unit/test_agentwatch_collector.py
+++ b/tests/unit/test_agentwatch_collector.py
@@ -291,3 +291,52 @@ class TestNonSessionFiles:
         assert stats.files_parsed == 1
         assert stats.sessions_upserted == 0
         assert store.list_sessions() == []
+
+
+class TestProgressEvents:
+    """refresh() emits aggregate lifecycle events — never per-file names."""
+
+    @staticmethod
+    def _multi_roots(tmp_path, n=5):
+        root = tmp_path / "projects" / "-home-dev-proj"
+        root.mkdir(parents=True)
+        for i in range(n):
+            write_fixture(root / f"sess-{i}.jsonl")
+        return (("claude_code", tmp_path / "projects"),)
+
+    def test_cold_run_events_are_valid_and_monotonic(self, store, tmp_path):
+        from yeaboi.analysis.progress import is_component_progress
+
+        roots = self._multi_roots(tmp_path)
+        events: list = []
+        collector.refresh(store, roots=roots, on_progress=events.append)
+        assert events, "a cold run over files must emit progress"
+        assert all(is_component_progress(e) for e in events)
+        assert all(e["component_id"] == "scan" for e in events)
+        assert events[0]["current"] == 0
+        assert events[0]["total"] == 5
+        currents = [e["current"] for e in events]
+        assert currents == sorted(currents)
+        assert events[-1]["current"] == events[-1]["total"] == 5
+        assert all("jsonl" not in str(e) for e in events), "filenames must never reach the progress stream"
+
+    def test_warm_run_emits_few_events(self, store, tmp_path):
+        roots = self._multi_roots(tmp_path)
+        collector.refresh(store, roots=roots)
+        events: list = []
+        collector.refresh(store, roots=roots, on_progress=events.append)
+        # Everything cursor-skipped: only the opening 0/N, percent changes and
+        # the closing N/N fire — bounded regardless of transcript count.
+        assert 0 < len(events) <= 7
+        assert events[-1]["current"] == events[-1]["total"] == 5
+
+    def test_parsed_count_rides_along(self, store, tmp_path):
+        roots = self._multi_roots(tmp_path, n=2)
+        events: list = []
+        collector.refresh(store, roots=roots, on_progress=events.append)
+        assert events[-1]["secondary_count"] == 2
+
+    def test_no_callback_is_fine(self, store, tmp_path):
+        roots = self._multi_roots(tmp_path, n=1)
+        stats = collector.refresh(store, roots=roots, on_progress=None)
+        assert stats.files_parsed == 1

--- a/tests/unit/test_agentwatch_engine.py
+++ b/tests/unit/test_agentwatch_engine.py
@@ -218,3 +218,30 @@ class TestPersistence:
         monkeypatch.setattr(export_mod, "export_artifact", _boom)
         report = engine.run_agent_usage(window_days=30, db_path=seeded, today=TODAY)
         assert report.session_count == 2
+
+
+class TestProgressPhases:
+    """The engine brackets each phase with structured lifecycle events."""
+
+    def test_dry_run_phase_sequence(self, seeded):
+        from yeaboi.analysis.progress import is_component_progress
+
+        events: list = []
+        engine.run_agent_usage(db_path=seeded, today=TODAY, dry_run=True, on_progress=events.append)
+        assert all(is_component_progress(e) for e in events)
+        assert [(e["component_id"], e["status"]) for e in events] == [
+            ("scan", "running"),
+            ("scan", "completed"),
+            ("price", "running"),
+            ("price", "completed"),
+            ("insights", "no_data"),
+        ]
+        # The scan's terminal event carries parsed/cached counts, not filenames.
+        assert events[1]["detail"] == "0 parsed · 0 cached"
+
+    def test_llm_unavailable_marks_insights_fallback(self, seeded):
+        events: list = []
+        engine.run_agent_usage(db_path=seeded, today=TODAY, on_progress=events.append)
+        seq = [(e["component_id"], e["status"]) for e in events]
+        assert ("insights", "running") in seq
+        assert ("insights", "fallback") in seq

--- a/tests/unit/test_agentwatch_export.py
+++ b/tests/unit/test_agentwatch_export.py
@@ -103,3 +103,130 @@ class TestScreen:
         many = tuple(ModelUsageRow(model=f"model-{i}", input_tokens=1, cost_usd=float(10 - i)) for i in range(8))
         out = _render(_build_agent_usage_screen(make_report(by_model=many), width=100, height=40, shimmer_tick=None))
         assert "3 more model(s) in the export" in out
+
+
+class TestProgressScreen:
+    """The structured loading state: phase checklist + files meter."""
+
+    @staticmethod
+    def _events(*specs):
+        from yeaboi.analysis.progress import append_component_progress
+
+        events: list = []
+        for spec in specs:
+            append_component_progress(events, **spec)
+        return events
+
+    def test_checklist_renders_meter_marks_and_pending(self):
+        events = self._events(
+            dict(
+                component_id="scan",
+                label="Scanning agent sessions",
+                status="running",
+                current=3,
+                total=10,
+                unit="files",
+            )
+        )
+        out = _render(_build_agent_usage_screen(None, width=100, height=40, shimmer_tick=4.0, progress=events))
+        assert "▰" in out  # the meter
+        assert "3/10 files" in out
+        assert "Scan agent sessions" in out
+        assert "○" in out  # pending phases
+        assert "Price usage" in out
+        assert "Write insights" in out
+        assert "0:04" in out  # elapsed from the tick
+
+    def test_completed_phase_shows_its_detail(self):
+        events = self._events(
+            dict(component_id="scan", label="Scan agent sessions", status="completed", detail="2 parsed · 8 cached"),
+            dict(component_id="price", label="Price usage", status="running"),
+        )
+        out = _render(_build_agent_usage_screen(None, width=100, height=40, shimmer_tick=0.2, progress=events))
+        assert "✓" in out
+        assert "2 parsed · 8 cached" in out
+
+    def test_status_only_fallback_still_renders(self):
+        # The legacy one-line path (no structured events) must keep working.
+        out = _render(_build_agent_usage_screen(None, width=100, height=30, shimmer_tick=0.2, status="warming up"))
+        assert "warming up" in out
+
+
+class TestRefreshingBanner:
+    def test_refreshing_report_carries_age_stamp(self):
+        from datetime import UTC, datetime, timedelta
+
+        as_of = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        out = _render(
+            _build_agent_usage_screen(
+                make_report(), width=100, height=40, shimmer_tick=0.5, refreshing=True, as_of=as_of
+            )
+        )
+        assert "Refreshing…" in out
+        assert "2h ago" in out
+        assert "$31.10" in out  # the stale report still renders in full
+
+    def test_not_refreshing_shows_no_banner(self):
+        out = _render(_build_agent_usage_screen(make_report(), width=100, height=40, shimmer_tick=None))
+        assert "Refreshing…" not in out
+
+
+class TestRelativeAge:
+    def test_table(self):
+        from datetime import UTC, datetime
+
+        from yeaboi.ui.mode_select.screens._screens_agents import _relative_age
+
+        now = datetime(2026, 8, 8, 12, 0, 0, tzinfo=UTC)
+        cases = [
+            ("2026-08-08T11:59:30+00:00", "just now"),
+            ("2026-08-08T11:55:00+00:00", "5m ago"),
+            ("2026-08-08T10:00:00+00:00", "2h ago"),
+            ("2026-08-05T12:00:00+00:00", "3d ago"),
+            ("2026-08-08T10:00:00", "2h ago"),  # naive timestamps are treated as UTC
+            ("not a timestamp", ""),
+            ("", ""),
+        ]
+        for iso, expected in cases:
+            assert _relative_age(iso, now=now) == expected, iso
+
+
+class TestRefreshingBannerProgress:
+    def test_banner_names_the_running_phase_and_meter(self):
+        from yeaboi.analysis.progress import append_component_progress
+
+        events: list = []
+        append_component_progress(
+            events,
+            component_id="scan",
+            label="Scan agent sessions",
+            status="running",
+            current=40,
+            total=200,
+            unit="files",
+        )
+        out = _render(
+            _build_agent_usage_screen(
+                make_report(),
+                width=110,
+                height=40,
+                shimmer_tick=0.5,
+                refreshing=True,
+                as_of="2020-01-01T00:00:00+00:00",
+                progress=events,
+            )
+        )
+        assert "Refreshing — Scan agent sessions 40/200 files" in out
+
+    def test_banner_without_events_keeps_the_plain_form(self):
+        out = _render(
+            _build_agent_usage_screen(
+                make_report(),
+                width=100,
+                height=40,
+                shimmer_tick=0.5,
+                refreshing=True,
+                as_of="2020-01-01T00:00:00+00:00",
+            )
+        )
+        assert "Refreshing…" in out

--- a/tests/unit/test_agentwatch_page_loop.py
+++ b/tests/unit/test_agentwatch_page_loop.py
@@ -1,0 +1,296 @@
+"""Tests for src/yeaboi/ui/mode_select/_agents.py — the shared threaded page loop.
+
+The loop runs the real worker thread but with fake console/live/read_key and a
+recording build_screen, so each test asserts on the kwargs the screen builder
+was handed frame by frame: drained progress, the instant-open stale report,
+the refresh banner state, and the non-destructive error path.
+"""
+
+import threading
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from yeaboi.agent.state import AgentUsageReport
+from yeaboi.agentwatch.store import AgentWatchStore
+from yeaboi.ui.mode_select import _agents
+
+_MAX_FRAMES = 2000  # safety valve: a test bug must fail, not hang
+
+
+def _tick() -> str:
+    """One polled frame: yield the GIL briefly so the worker thread can run."""
+    time.sleep(0.001)
+    return "x"
+
+
+@dataclass(frozen=True)
+class _FakeArtifact:
+    name: str = "fresh"
+    warnings: tuple = ()
+    generated_at: str = "2026-08-08T10:00:00+00:00"
+
+
+class _Screens:
+    """Records every build_screen call; returns a placeholder renderable."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, artifact, **kwargs):
+        self.calls.append((artifact, kwargs))
+        return "screen"
+
+    @property
+    def last(self):
+        return self.calls[-1]
+
+
+class _Live:
+    def update(self, renderable):
+        pass
+
+
+class _Console:
+    size = (100, 40)
+
+
+def _run_page(read_key, run_engine, screens):
+    _agents._run_threaded_engine_page(
+        _Console(),
+        _Live(),
+        read_key,
+        0.0,
+        True,
+        label="test-page",
+        run_engine=run_engine,
+        build_screen=screens,
+        make_failure_artifact=lambda exc: _FakeArtifact(name="failure"),
+        export_kind="usage",
+        build_markdown=lambda artifact: "md",
+    )
+
+
+def _seed_stale(db_path):
+    stale = AgentUsageReport(period_start="2026-07-01", period_end="2026-07-31", total_cost_usd=9.99)
+    with AgentWatchStore(db_path) as store:
+        store.record_report("usage", stale, key_date="2026-07-01")
+    return stale
+
+
+@pytest.fixture
+def empty_db(tmp_path, monkeypatch):
+    db = tmp_path / "sessions.db"
+    monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
+    return db
+
+
+@pytest.fixture
+def stale_db(empty_db):
+    _seed_stale(empty_db)
+    return empty_db
+
+
+class TestDrain:
+    def test_a_backlog_folds_into_one_frame(self, empty_db):
+        from yeaboi.analysis.progress import send_component_progress
+
+        emitted = threading.Event()
+        release = threading.Event()
+
+        def run_engine(on_progress):
+            for i in range(500):
+                send_component_progress(
+                    on_progress, component_id="scan", label="Scanning", status="running", current=i + 1, total=500
+                )
+            emitted.set()
+            release.wait(5)
+            return _FakeArtifact()
+
+        screens = _Screens()
+        frames = 0
+
+        def read_key(timeout=None):
+            nonlocal frames
+            frames += 1
+            if frames == 1:
+                emitted.wait(5)  # let the whole backlog queue up before the next frame
+                return "x"
+            release.set()
+            return "esc"
+
+        _run_page(read_key, run_engine, screens)
+        artifact, kwargs = screens.last
+        assert artifact is None
+        # 500 queued events → one latest-per-phase entry, current already at the tail.
+        assert len(kwargs["progress"]) == 1
+        assert kwargs["progress"][0]["current"] == 500
+
+
+class TestInstantOpen:
+    def test_stale_report_shows_before_the_refresh_lands(self, stale_db):
+        release = threading.Event()
+
+        def run_engine(on_progress):
+            release.wait(5)
+            return _FakeArtifact(name="fresh")
+
+        screens = _Screens()
+        frames = 0
+
+        def read_key(timeout=None):
+            nonlocal frames
+            frames += 1
+            if frames >= _MAX_FRAMES:
+                return "esc"
+            artifact, kwargs = screens.last
+            if frames == 1:
+                release.set()
+                return _tick()
+            if getattr(artifact, "name", "") == "fresh" and not kwargs["refreshing"]:
+                return "esc"
+            return _tick()
+
+        _run_page(read_key, run_engine, screens)
+        first_artifact, first_kwargs = screens.calls[0]
+        # Frame one is the finished screen with the saved report + refresh banner —
+        # never the loading screen.
+        assert isinstance(first_artifact, AgentUsageReport)
+        assert first_artifact.total_cost_usd == 9.99
+        assert first_kwargs["refreshing"] is True
+        assert first_kwargs["as_of"]
+        last_artifact, last_kwargs = screens.last
+        assert getattr(last_artifact, "name", "") == "fresh"
+        assert last_kwargs["refreshing"] is False
+        assert last_kwargs["as_of"] == ""
+
+    def test_failed_refresh_keeps_the_stale_report(self, stale_db):
+        def run_engine(on_progress):
+            raise RuntimeError("boom")
+
+        screens = _Screens()
+        frames = 0
+
+        def read_key(timeout=None):
+            nonlocal frames
+            frames += 1
+            if frames >= _MAX_FRAMES:
+                return "esc"
+            _artifact, kwargs = screens.last
+            if "Refresh failed" in kwargs.get("notice", ""):
+                return "esc"
+            return _tick()
+
+        _run_page(read_key, run_engine, screens)
+        artifact, kwargs = screens.last
+        assert isinstance(artifact, AgentUsageReport), "the stale report must survive a failed refresh"
+        assert artifact.total_cost_usd == 9.99
+        assert "Refresh failed" in kwargs["notice"]
+        assert kwargs["refreshing"] is False
+
+    def test_rerun_while_refreshing_is_a_notice_not_a_second_worker(self, stale_db):
+        release = threading.Event()
+        runs = []
+
+        def run_engine(on_progress):
+            runs.append(1)
+            release.wait(5)
+            return _FakeArtifact(name="fresh")
+
+        screens = _Screens()
+        frames = 0
+
+        def read_key(timeout=None):
+            nonlocal frames
+            frames += 1
+            if frames >= _MAX_FRAMES:
+                return "esc"
+            if frames == 1:
+                return "r"  # re-run while the initial refresh is still in flight
+            _artifact, kwargs = screens.last
+            if kwargs.get("notice") == "Already refreshing…":
+                release.set()
+                return "esc"
+            return _tick()
+
+        _run_page(read_key, run_engine, screens)
+        assert len(runs) == 1
+        _artifact, kwargs = screens.last
+        assert kwargs["notice"] == "Already refreshing…"
+
+
+class TestFirstRun:
+    def test_no_history_shows_the_loading_screen(self, empty_db):
+        release = threading.Event()
+
+        def run_engine(on_progress):
+            release.wait(5)
+            return _FakeArtifact(name="fresh")
+
+        screens = _Screens()
+        frames = 0
+
+        def read_key(timeout=None):
+            nonlocal frames
+            frames += 1
+            release.set()
+            if frames >= _MAX_FRAMES:
+                return "esc"
+            artifact, _kwargs = screens.last
+            return "esc" if artifact is not None else _tick()
+
+        _run_page(read_key, run_engine, screens)
+        first_artifact, first_kwargs = screens.calls[0]
+        assert first_artifact is None
+        assert first_kwargs["progress"] == []
+        assert getattr(screens.last[0], "name", "") == "fresh"
+
+    def test_engine_crash_with_no_history_shows_the_failure_artifact(self, empty_db):
+        def run_engine(on_progress):
+            raise RuntimeError("boom")
+
+        screens = _Screens()
+        frames = 0
+
+        def read_key(timeout=None):
+            nonlocal frames
+            frames += 1
+            if frames >= _MAX_FRAMES:
+                return "esc"
+            artifact, _kwargs = screens.last
+            return "esc" if artifact is not None else _tick()
+
+        _run_page(read_key, run_engine, screens)
+        assert getattr(screens.last[0], "name", "") == "failure"
+
+
+class TestHistoryErrors:
+    def test_unreadable_store_falls_back_to_the_loading_screen(self, stale_db, monkeypatch):
+        def _boom(_path):
+            raise RuntimeError("db locked")
+
+        monkeypatch.setattr("yeaboi.agentwatch.store.AgentWatchStore", _boom)
+        release = threading.Event()
+
+        def run_engine(on_progress):
+            release.wait(5)
+            return _FakeArtifact(name="fresh")
+
+        screens = _Screens()
+        frames = 0
+
+        def read_key(timeout=None):
+            nonlocal frames
+            frames += 1
+            release.set()
+            if frames >= _MAX_FRAMES:
+                return "esc"
+            artifact, _kwargs = screens.last
+            return "esc" if artifact is not None else _tick()
+
+        _run_page(read_key, run_engine, screens)
+        first_artifact, first_kwargs = screens.calls[0]
+        assert first_artifact is None, "a broken history store must cold-start, not crash the page"
+        assert "progress" in first_kwargs
+        assert getattr(screens.last[0], "name", "") == "fresh"

--- a/tests/unit/test_agentwatch_security.py
+++ b/tests/unit/test_agentwatch_security.py
@@ -237,3 +237,57 @@ class TestRenderAndExport:
         with console.capture() as cap:
             console.print(_build_agent_security_screen(report, width=110, height=44))
         assert "Posture" in cap.get()
+
+
+class TestProgressPhases:
+    def test_phase_sequence_over_a_clean_tree(self, clean_tree, db_path):
+        from yeaboi.analysis.progress import is_component_progress
+
+        events: list = []
+        engine.run_agent_security(db_path=db_path, today=TODAY, dry_run=True, on_progress=events.append)
+        assert all(is_component_progress(e) for e in events)
+        seq = [(e["component_id"], e["status"]) for e in events]
+        for cid in ("scan", "settings", "mcp"):
+            assert (cid, "running") in seq
+            assert (cid, "completed") in seq
+        assert ("summary", "no_data") in seq  # dry_run: the LLM step is skipped
+        mcp_done = next(e for e in events if e["component_id"] == "mcp" and e["status"] == "completed")
+        assert mcp_done["detail"] == "1 server(s)"
+
+
+class TestProgressScreen:
+    def test_checklist_and_refresh_banner(self, clean_tree, db_path):
+        from rich.console import Console
+
+        from yeaboi.analysis.progress import append_component_progress
+        from yeaboi.ui.mode_select.screens._screens_agents import _build_agent_security_screen
+
+        events: list = []
+        append_component_progress(
+            events,
+            component_id="scan",
+            label="Scanning transcripts",
+            status="running",
+            current=2,
+            total=6,
+            unit="files",
+        )
+
+        def render(panel):
+            console = Console(width=110, force_terminal=False)
+            with console.capture() as cap:
+                console.print(panel)
+            return cap.get()
+
+        out = render(_build_agent_security_screen(None, width=110, height=40, shimmer_tick=0.2, progress=events))
+        assert "2/6 files" in out
+        assert "Audit settings" in out
+        assert "Inventory MCP servers" in out
+
+        report = engine.run_agent_security(db_path=db_path, today=TODAY, dry_run=True)
+        out = render(
+            _build_agent_security_screen(
+                report, width=110, height=40, shimmer_tick=0.2, refreshing=True, as_of="2020-01-01T00:00:00+00:00"
+            )
+        )
+        assert "Refreshing…" in out

--- a/tests/unit/test_agentwatch_standup.py
+++ b/tests/unit/test_agentwatch_standup.py
@@ -254,3 +254,57 @@ class TestBuilders:
         out = cap.get()
         assert "Agent Standup" in out
         assert "webapp" in out
+
+
+class TestProgressPhases:
+    def test_local_only_run_marks_trackers_skipped(self, db_path):
+        from yeaboi.analysis.progress import is_component_progress
+
+        events: list = []
+        engine.run_agent_standup(
+            days=3, tracker_sources=[], db_path=db_path, today=MONDAY, dry_run=True, on_progress=events.append
+        )
+        assert all(is_component_progress(e) for e in events)
+        seq = [(e["component_id"], e["status"]) for e in events]
+        assert ("scan", "running") in seq
+        assert ("scan", "completed") in seq
+        assert ("trackers", "no_data") in seq
+        assert ("digest", "no_data") in seq  # dry_run: the LLM step is skipped
+
+
+class TestProgressScreen:
+    def test_checklist_and_refresh_banner(self, db_path):
+        from rich.console import Console
+
+        from yeaboi.analysis.progress import append_component_progress
+        from yeaboi.ui.mode_select.screens._screens_agents import _build_agent_standup_screen
+
+        events: list = []
+        append_component_progress(
+            events,
+            component_id="scan",
+            label="Scanning agent sessions",
+            status="running",
+            current=1,
+            total=4,
+            unit="files",
+        )
+
+        def render(panel):
+            console = Console(width=100, force_terminal=False)
+            with console.capture() as cap:
+                console.print(panel)
+            return cap.get()
+
+        out = render(_build_agent_standup_screen(None, width=100, height=40, shimmer_tick=0.2, progress=events))
+        assert "1/4 files" in out
+        assert "Scan trackers" in out
+        assert "Write the digest" in out
+
+        digest = engine.run_agent_standup(days=3, tracker_sources=[], db_path=db_path, today=MONDAY, dry_run=True)
+        out = render(
+            _build_agent_standup_screen(
+                digest, width=100, height=40, shimmer_tick=0.2, refreshing=True, as_of="2020-01-01T00:00:00+00:00"
+            )
+        )
+        assert "Refreshing…" in out

--- a/tests/unit/test_agentwatch_store.py
+++ b/tests/unit/test_agentwatch_store.py
@@ -153,3 +153,124 @@ class TestMigration:
                 row[0] for row in aw._conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
             }
         assert {"agent_sessions", "agent_ingest_files", "agent_security_findings"} <= tables
+
+
+class TestRehydration:
+    """record_report → latest_report → report_from_payload round-trips."""
+
+    @staticmethod
+    def _artifacts():
+        from yeaboi.agent.state import (
+            AgentRepoActivityRow,
+            AgentSecurityReport,
+            AgentSessionSummary,
+            AgentStandupDigest,
+            AgentUsageBreakdownRow,
+            AgentUsageReport,
+            DailyUsagePoint,
+            McpServerRecord,
+            ModelUsageRow,
+            SecurityFinding,
+        )
+
+        usage = AgentUsageReport(
+            period_start="2026-07-10",
+            period_end="2026-08-08",
+            session_count=3,
+            total_cost_usd=31.1,
+            unknown_model_cost_share=0.25,
+            pricing_as_of="2026-06-24",
+            by_model=(ModelUsageRow(model="claude-opus-5", input_tokens=1_000_000, cost_usd=30.0),),
+            by_project=(AgentUsageBreakdownRow(key="webapp", sessions=2, cost_usd=20.5),),
+            by_source=(AgentUsageBreakdownRow(key="claude_code", sessions=3, cost_usd=31.1),),
+            daily_trend=(DailyUsagePoint(date="2026-08-07", cost_usd=31.1, sessions=3),),
+            insights=("opus dominates",),
+            recommendations=("try haiku",),
+            warnings=("no key",),
+            generated_at="2026-08-08T10:00:00+00:00",
+        )
+        standup = AgentStandupDigest(
+            digest_date="2026-08-08",
+            window_start="2026-08-07",
+            window_end="2026-08-08",
+            sessions_worked=1,
+            total_cost_usd=2.5,
+            agents_seen=("claude_code",),
+            session_summaries=(
+                AgentSessionSummary(
+                    session_id="s1",
+                    source="claude_code",
+                    project="webapp",
+                    models=("claude-opus-5",),
+                    turns=4,
+                    cost_usd=2.5,
+                    top_tools=(("Bash", "7"), ("Edit", "3")),
+                    started_at="2026-08-07T10:00:00+00:00",
+                ),
+            ),
+            repo_activity=(
+                AgentRepoActivityRow(source="github", repo="webapp", kind="pr", title="fix", status="merged"),
+            ),
+            highlights=("merged a fix",),
+            narrative="one session ran.",
+            coverage_notes=("trackers skipped",),
+            generated_at="2026-08-08T10:00:00+00:00",
+        )
+        security = AgentSecurityReport(
+            scan_date="2026-08-08",
+            posture="needs-attention",
+            sessions_scanned=3,
+            files_scanned=5,
+            secrets_found=1,
+            findings=(
+                SecurityFinding(severity="high", category="secret", title="Credential", location="/x.jsonl", line_no=2),
+            ),
+            mcp_servers=(McpServerRecord(name="tracker", transport="http", target="http://x", flags=("plain-http",)),),
+            settings_flags=("bypass-permissions",),
+            summary="1 finding.",
+            recommendations=("rotate it",),
+            generated_at="2026-08-08T10:00:00+00:00",
+        )
+        return {"usage": usage, "standup": standup, "security": security}
+
+    def test_round_trip_each_kind(self, store):
+        from yeaboi.agentwatch.store import report_from_payload
+
+        for kind, artifact in self._artifacts().items():
+            store.record_report(kind, artifact, key_date="2026-08-08")
+            row = store.latest_report(kind)
+            assert row is not None
+            rebuilt = report_from_payload(kind, row["report"])
+            # Frozen-dataclass equality: every nested row and tuple must survive
+            # the JSON round trip (top_tools pairs come back as lists otherwise).
+            assert rebuilt == artifact
+
+    def test_latest_report_empty_history_is_none(self, store):
+        assert store.latest_report("usage") is None
+
+    def test_missing_keys_rehydrate_with_defaults(self):
+        from yeaboi.agentwatch.store import report_from_payload
+
+        rebuilt = report_from_payload("usage", {"period_start": "2026-08-01"})
+        assert rebuilt is not None
+        assert rebuilt.period_start == "2026-08-01"
+        assert rebuilt.by_model == ()
+        assert rebuilt.total_cost_usd == 0.0
+
+    def test_corrupt_payloads_are_none(self):
+        from yeaboi.agentwatch.store import report_from_payload
+
+        assert report_from_payload("usage", {}) is None
+        assert report_from_payload("usage", "not a dict") is None
+        assert report_from_payload("unknown-kind", {"a": 1}) is None
+
+    def test_corrupt_json_row_falls_back_to_none(self, store):
+        from yeaboi.agentwatch.store import report_from_payload
+
+        store._conn.execute(
+            "INSERT INTO agent_usage_reports (period_start, report_json, created_at) VALUES (?, ?, ?)",
+            ("2026-08-08", "{broken json", "2026-08-08T10:00:00+00:00"),
+        )
+        row = store.latest_report("usage")
+        assert row is not None
+        assert report_from_payload("usage", row["report"]) is None

--- a/tests/unit/test_analysis_progress.py
+++ b/tests/unit/test_analysis_progress.py
@@ -1,0 +1,67 @@
+"""Tests for src/yeaboi/analysis/progress.py — structured progress events."""
+
+import pytest
+
+from yeaboi.analysis.progress import (
+    append_component_progress,
+    format_analysis_progress,
+    is_component_progress,
+    send_component_progress,
+)
+
+
+class TestAppend:
+    def test_appends_a_well_formed_event(self):
+        events: list = []
+        append_component_progress(
+            events, component_id="scan", label="Scanning", status="running", current=3, total=10, unit="files"
+        )
+        assert len(events) == 1
+        assert is_component_progress(events[0])
+        assert events[0]["current"] == 3
+        assert events[0]["total"] == 10
+        assert events[0]["unit"] == "files"
+
+    def test_none_list_is_a_no_op(self):
+        append_component_progress(None, component_id="x", label="X", status="running")
+
+    def test_unknown_status_raises(self):
+        with pytest.raises(ValueError, match="unknown analysis progress status"):
+            append_component_progress([], component_id="x", label="X", status="doing-stuff")
+
+
+class TestSend:
+    def test_none_callback_is_a_no_op(self):
+        send_component_progress(None, component_id="scan", label="Scanning", status="running")
+
+    def test_delivers_one_validated_event(self):
+        received: list = []
+        send_component_progress(
+            received.append,
+            component_id="scan",
+            label="Scanning",
+            status="completed",
+            detail="3 parsed",
+            current=10,
+            total=10,
+        )
+        assert len(received) == 1
+        assert is_component_progress(received[0])
+        assert received[0]["detail"] == "3 parsed"
+        assert received[0]["status"] == "completed"
+
+    def test_unknown_status_raises_before_delivery(self):
+        received: list = []
+        with pytest.raises(ValueError):
+            send_component_progress(received.append, component_id="x", label="X", status="nope")
+        assert received == []
+
+
+class TestIsComponentProgress:
+    def test_rejects_strings_and_partial_dicts(self):
+        assert not is_component_progress("reading foo.jsonl")
+        assert not is_component_progress({"kind": "analysis_component"})
+        assert not is_component_progress({"component_id": "x", "label": "X", "status": "running"})
+
+    def test_format_falls_back_to_str_for_legacy_items(self):
+        assert format_analysis_progress("plain status") == "plain status"


### PR DESCRIPTION
## Summary

The three Agents-family TUI pages (Agent Usage / Standup / Security) had a bad loading UX: the agentwatch collector emitted a raw `reading <uuid>.jsonl` progress string per transcript (737 lines on a real cold scan), the page loop consumed only one queued message per frame so the display lagged the scan, and every page entry blocked on a full pipeline run even though every finished report is already persisted in SQLite.

- **Structured progress instead of the firehose** — `collector.refresh` now emits throttled `analysis_component` meter events (existing contract from `analysis/progress.py`, new `send_component_progress` helper) with a global `current/total` across all roots and a guaranteed `N/N` close; each engine brackets its phases (`scan/price/insights`, `scan/trackers/digest`, `scan/settings/mcp/summary`) with running/terminal lifecycle events. No engine signatures changed; MCP/CLI untouched.
- **Phase checklist loading screen** — spinner + `▰▱` files meter + elapsed + `✓/⠙/○/~/✗` marks on all three pages; the legacy `status=` one-liner path is preserved.
- **Instant open** — the page opens on the last saved report (new `latest_report` + `report_from_payload` dataclass rehydrators in `agentwatch/store.py`) under a `⠙ Refreshing — <phase> n/N · showing report from 2h ago` banner while a fresh run replaces it. A failed background refresh keeps the stale report with a notice (`("ok"|"err")` worker protocol); re-run keeps the page populated; the loading screen appears only when no report was ever saved.
- **Queue drain** — the page loop drains all pending progress each frame, folding to the latest event per phase.

An independent pre-ship review (deep tier) found no blockers; its should-fix (progress invisible during the common refresh path) is fixed — the banner names the running phase and meter. Recorded as not addressed here, per its nits: the instant-open banner does not yet stamp the stale report's scope/window (`latest_report` takes the newest row regardless of CLI filters used to produce it), the deep-security re-scan renders under the standard "Scan transcripts" checklist label, and this file's pre-existing hardcoded rgb literals are left for a file-wide `tui-standards` cleanup pass. `analysis/progress.py` is now a shared contract between the analysis and agents workstream charters.

## Test plan

- `make test` (full suite, 10,746 passed), `make lint`, `make security` (ruff SAST + pip-audit) — all green.
- 40+ new tests: collector event validity/monotonicity/throttle, engine phase sequences per pipeline, store `record → latest → rehydrate` round-trips (lossless, frozen-dataclass equality; corrupt rows → `None`), screen render tests (checklist, meter, refresh banner, `_relative_age` table), and a new `test_agentwatch_page_loop.py` driving the real threaded loop with fakes (drain folds a 500-event backlog in one frame, instant-open first frame, error-keeps-stale, no-double-worker on `r`, broken-store cold start).
- Real-data sanity: cold scan of 737 transcripts → one folded meter (was 737 filename lines); warm re-scan 0.1s; instant-open round-trip lossless against a live report.

DoD: item 7 (web bundles) does not apply — Python/TUI-only change, no `frontend/` edits. No new capability ⇒ no `CAPABILITIES`/`FeatureTip` row (existing `agent-usage` capability, UX-only change).

Closes YEA-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)