### PR TITLE
pin the go schema ceiling to sessions.py and recover sidecar handler panics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,15 @@ in the Go twin (each Go file names its Python twin in its header) — otherwise 
 fails and the change cannot merge. Purely additive Python work that the sidecar does not
 serve (new prose, new store columns, rendering) is exempt; when in doubt, run `make parity`.
 
+**One constant outside those files couples the two languages**: `sessions.py`'s
+`CURRENT_SCHEMA_VERSION`, mirrored by `currentSchemaVersion` in
+`go/internal/agentwatch/store.go`. Go refuses a database newer than it understands rather
+than writing behind Python's migrations, so bumping the schema without raising the Go
+ceiling makes the sidecar refuse every upgraded database — the agentwatch family silently
+reverts to the Python path with CI fully green. `tests/unit/test_gocore_packaging.py`
+fails on the drift; raise the Go constant once the new migration is mirrored (or leave it
+deliberately, and say why, when the sidecar must not write behind it).
+
 ## Code Style
 
 - Python 3.11+, ruff for linting/formatting (line-length 120)

--- a/contracts/v1/rpc.md
+++ b/contracts/v1/rpc.md
@@ -123,9 +123,11 @@ canonical JSON.
    `store.py`; refuse (error 1001) when the version in the `schema_info`
    table — where `sessions.py` records it; Python never sets
    `PRAGMA user_version`, which is read only as a fallback for a database
-   no Python build has opened — is > 27 (`sessions.py
-   CURRENT_SCHEMA_VERSION` at contract v1). Mirror the `agent_sessions`
-   primary-key repair check.
+   no Python build has opened — is newer than the binary's
+   `currentSchemaVersion` (`go/internal/agentwatch/store.go`), which a
+   unit test (`test_gocore_packaging.py::TestSchemaGuardLockstep`) keeps
+   equal to `sessions.py CURRENT_SCHEMA_VERSION`. Mirror the
+   `agent_sessions` primary-key repair check.
 5. **Single writer.** The active implementation is the sole writer of the
    agentwatch tables; the report-history tables (`agent_*_reports`,
    `agent_standup_digests`) are Python-only and never touched by Go.

--- a/go/cmd/yeaboi-core/main.go
+++ b/go/cmd/yeaboi-core/main.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -70,6 +71,25 @@ func serve(line string, out *rpc.Writer) {
 		return
 	}
 	id := *req.ID
+	// A panic in a handler (an index slip on an odd payload) would otherwise
+	// take the whole process down, and the accelerator stays gone for the rest
+	// of the session — Python falls back correctly either way, so the cost is
+	// silent slowness. Bound it to the one request instead. The message is a
+	// fixed string, and the local log gets the value only for runtime errors
+	// (index/nil/conversion — they carry no input) and the bare type otherwise:
+	// an arbitrary panic value can quote the input, error messages are logged
+	// by the client, and stderr is drained into the user's local log
+	// (rpc.md: no transcript content ever leaves here, logs included).
+	defer func() {
+		if r := recover(); r != nil {
+			detail := fmt.Sprintf("%T", r)
+			if runtimeErr, ok := r.(runtime.Error); ok {
+				detail = runtimeErr.Error()
+			}
+			log.Printf("panic serving %s: %s", req.Method, detail)
+			_ = out.SendError(id, rpc.CodeInternal, "handler panicked — see the sidecar log")
+		}
+	}()
 	result, rpcErr := dispatch(&req, id, out)
 	if rpcErr != nil {
 		_ = out.SendError(id, rpcErr.Code, rpcErr.Message)

--- a/go/internal/agentwatch/store.go
+++ b/go/internal/agentwatch/store.go
@@ -18,9 +18,10 @@ import (
 	_ "modernc.org/sqlite" // pure-Go SQLite driver, registered as "sqlite"
 )
 
-// currentSchemaVersion is sessions.py CURRENT_SCHEMA_VERSION at contract v1.
-// A database whose schema_info version is newer than this must be refused
-// (error 1001) — the Python side owns migrations, Go must never write ahead.
+// currentSchemaVersion mirrors sessions.py CURRENT_SCHEMA_VERSION, pinned by
+// tests/unit/test_gocore_packaging.py::TestSchemaGuardLockstep. A database
+// whose schema_info version is newer than this must be refused (error 1001)
+// — the Python side owns migrations, Go must never write ahead.
 const currentSchemaVersion = 27
 
 // ErrSchemaTooNew is the schema-guard sentinel; the RPC layer maps it to 1001.

--- a/src/yeaboi/agentwatch/store.py
+++ b/src/yeaboi/agentwatch/store.py
@@ -185,7 +185,14 @@ class AgentWatchStore:
         The connection runs in autocommit (``isolation_level = None``), so a
         cold ``collector.refresh()`` used to pay one fsync per statement —
         ~1,500 transactions over a large corpus. Wrapping a batch in
-        BEGIN…COMMIT collapses that to one. Rolls back if the block raises.
+        BEGIN…COMMIT collapses that to one. Rolls back if the exception passes
+        through the ``with`` block — which is NOT how ``refresh()`` uses it:
+        it holds the batch open across loop iterations on an ``ExitStack``, and
+        ``ExitStack.close()`` calls ``__exit__(None, None, None)``, so an
+        unwind there COMMITS the files completed so far. That is deliberate (a
+        file's rollup and its cursor land in the same batch, so committed work
+        is consistent and an interrupted file simply reparses next run), but do
+        not read this line as a rollback guarantee for that caller.
         Every other caller keeps autocommit semantics untouched. Not reentrant:
         SQLite has no nested BEGIN, and nothing here nests batches.
         """

--- a/tests/unit/test_gocore_packaging.py
+++ b/tests/unit/test_gocore_packaging.py
@@ -1,10 +1,13 @@
-"""The yeaboi-core platform wheel stays in lockstep with the Go sidecar.
+"""Constants the Go sidecar must keep in lockstep with the Python side.
 
-Three parties name the sidecar's version or its wheel, and nothing at build or
-run time compares them: ``binaryVersion`` in the Go entrypoint, the packaging
-pyproject under ``packaging/yeaboi-core/``, and the ``core`` extra's range in
-the root pyproject. Drift ships a wheel whose version lies about the binary
-inside it — so the drift fails the unit suite instead.
+Two couplings, neither compared at build or run time. Versioning: three
+parties name the sidecar's version or its wheel — ``binaryVersion`` in the Go
+entrypoint, the packaging pyproject under ``packaging/yeaboi-core/``, and the
+``core`` extra's range in the root pyproject — and drift ships a wheel whose
+version lies about the binary inside it. Schema: the Go store's
+``currentSchemaVersion`` ceiling must equal ``sessions.CURRENT_SCHEMA_VERSION``
+or the sidecar refuses every upgraded database (see ``TestSchemaGuardLockstep``).
+Both drifts fail the unit suite here instead.
 """
 
 from __future__ import annotations
@@ -58,3 +61,32 @@ class TestCoreVersionLockstep:
             if isinstance(node, ast.Assign) and any(getattr(t, "id", "") == "WHEEL_TAGS" for t in node.targets)
         )
         assert set(tags) == {"linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64", "windows/amd64"}
+
+
+class TestSchemaGuardLockstep:
+    """The Go schema guard's ceiling must track ``sessions.CURRENT_SCHEMA_VERSION``.
+
+    Nothing else can catch this drift. The guard only fires on a database that
+    has a ``schema_info`` table, and the parity fixtures build their databases
+    through ``AgentWatchStore(db_path)``, which runs the agentwatch DDL alone
+    and never writes that table — so Go falls back to ``PRAGMA user_version``,
+    reads 0, and passes. Meanwhile every *real* ``sessions.db`` carries the
+    Python version, so a bump to 28 against a Go constant still at 27 refuses
+    the database, returns 1001, and drops the whole agentwatch family back to
+    the Python path: the cold scan silently returns to 15-30s, the wheel still
+    installs, and CI is entirely green.
+    """
+
+    def test_go_schema_ceiling_matches_python(self):
+        from yeaboi.sessions import CURRENT_SCHEMA_VERSION
+
+        store_go = (REPO / "go" / "internal" / "agentwatch" / "store.go").read_text(encoding="utf-8")
+        match = re.search(r"const currentSchemaVersion = (\d+)", store_go)
+        assert match, "currentSchemaVersion const not found in go/internal/agentwatch/store.go"
+        assert int(match.group(1)) == CURRENT_SCHEMA_VERSION, (
+            f"go/internal/agentwatch/store.go pins currentSchemaVersion = {match.group(1)} but "
+            f"sessions.CURRENT_SCHEMA_VERSION is {CURRENT_SCHEMA_VERSION}. Bump the Go constant "
+            "after mirroring whatever the new migration changed in the agentwatch tables — or, if "
+            "the migration is one the sidecar genuinely must not write behind, leave it and say so "
+            "here, because the sidecar will refuse every upgraded database until it is raised."
+        )


### PR DESCRIPTION
## Summary

PR #215's second Claude Review pass posted after the merge went in, so its fixes never shipped. This follow-up carries exactly those items:

- **`TestSchemaGuardLockstep`** (`tests/unit/test_gocore_packaging.py`) — asserts Go's `currentSchemaVersion` equals `sessions.CURRENT_SCHEMA_VERSION`. Without it, a Python schema bump makes the sidecar refuse every upgraded database and the agentwatch family silently reverts to the Python path with CI fully green (parity fixtures never write `schema_info`, so nothing else can catch it). Verified to genuinely fail on drift.
- **Panic recovery in `serve`** (`go/cmd/yeaboi-core/main.go`) — a handler panic now costs one request instead of the whole process. The wire error is a fixed string; the local log gets the panic value only for `runtime.Error`s (index/nil/conversion — no input content) and the bare type otherwise, per rpc.md's privacy rule.
- **`transaction()` docstring** (`src/yeaboi/agentwatch/store.py`) — states that the ExitStack unwind commits deliberately, so the line is not misread as a rollback guarantee.
- **CLAUDE.md** — the dual-maintenance section now names the schema-version constant as the one coupling outside the mirrored modules.
- **rpc.md rule 4** no longer hardcodes `27`; it points at the constant and the lockstep test instead (independent-review finding on this branch).

Not done, deliberately: no unit test for the recover path itself — `go/cmd/yeaboi-core/` has no test seam and adding one (`var dispatchFn = dispatch`) is scope creep for a nit; noted here instead.

## Test plan

- Full `make test` (10,931 passed), `make lint`, `make security` (clean after the langgraph-checkpoint-sqlite advisory bump already on main), `gofmt`/`go build`/`go vet` clean
- `TestSchemaGuardLockstep` proven to fail when the Go constant is wrong (temporarily set to 26)
- Independent fresh-context review: spec fit clean, no blockers/should-fixes; its three actionable nits are fixed in this diff

Closes YEA-74

🤖 Generated with [Claude Code](https://claude.com/claude-code)