### PR TITLE
fix the cowork approval lane end to end

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -71,7 +71,37 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Prompt step 6 makes `make test` + `make lint` this job's own gate. With no
+      # toolchain both are `command not found`, so the gate passes by never having
+      # run. Mirrors ci.yml's install so there is one answer to "what does CI use".
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - run: uv python install 3.11
+      - run: uv sync --extra dev
+
+      # cowork/models.md: "Security never runs on `heavy`." Fable 5 reroutes
+      # cybersecurity queries to less capable models — fine for a chat, and
+      # unacceptable for an unattended run that may edit fs_policy.py or a CSP
+      # invariant, because you would not know which model actually read it.
+      # The title is checked as well as the label because a label can be lost:
+      # issue #172 had its entire set replaced when the relay applied
+      # `claude-implement`, and the `[type][workstream]` prefix cowork-scribe
+      # writes at filing time is the copy that survives that.
+      - name: Pick the model tier
+        id: model
+        env:
+          LABELS: ${{ toJSON(github.event.issue.labels.*.name) }}
+          TITLE: ${{ github.event.issue.title }}
+        run: |
+          if jq -e 'index("type:security")' <<< "$LABELS" >/dev/null \
+            || [[ "$TITLE" == \[security\]* ]]; then
+            echo "id=${{ vars.YEABOI_MODEL_DEEP || 'claude-opus-5' }}" >> "$GITHUB_OUTPUT"
+            echo "Security issue — running at deep, never heavy."
+          else
+            echo "id=${{ vars.YEABOI_MODEL_HEAVY || 'claude-opus-5' }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Implement issue
+        id: implement
         uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1.0.189
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -87,8 +117,18 @@ jobs:
           # added (it was missing, so the propose lane — which by definition builds
           # things outside the auto-lane allowlist — had a weaker gate than the auto
           # lane it dwarfs). A truncated run leaves a half-open PR behind.
+          #
+          # `--allowedTools` is not optional here and its absence is not benign.
+          # The action passes `settingSources: [user, project, local]`, so with no
+          # grant of its own this job inherits the repo's `.claude/settings.json`
+          # allowlist — which is deliberately read-only, for interactive sessions
+          # where a human approves the writes. On 2026-08-09 that combination ran
+          # issue #172 for 31 turns, denied all 17 tool calls it needed, and exited
+          # `success` having written nothing. Keep this list a superset of what the
+          # ten prompt steps below actually invoke.
           claude_args: >-
-            --model ${{ vars.YEABOI_MODEL_HEAVY || 'claude-opus-5' }} --max-turns 110
+            --model ${{ steps.model.outputs.id }} --max-turns 110
+            --allowedTools "Read,Grep,Glob,Edit,Write,Task,Bash(make:*),Bash(uv run:*),Bash(git:*),Bash(gh issue:*),Bash(gh pr:*),Bash(gh api:*)"
           prompt: |
             Implement GitHub issue #${{ github.event.issue.number }} in ${{ github.repository }}.
 
@@ -145,3 +185,50 @@ jobs:
 
             If the issue is too ambiguous to implement safely, do NOT guess: comment on the
             issue with the specific questions that need answering, and stop.
+
+      # The failure this job is most prone to, and least able to report, is
+      # succeeding at nothing: the run above can deny every write it needs and
+      # still finish with `is_error: false`, which GitHub renders as a green
+      # check. Nothing else in the fleet would notice — `digest.md` explicitly
+      # refuses to age out an issue carrying `claude-implement`, so a silent
+      # no-op leaves the issue invisible to every routine. Assert the outcome
+      # rather than the exit status.
+      - name: Assert the run produced something
+        if: always() && steps.implement.conclusion != 'skipped'
+        env:
+          ISSUE: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          log=/home/runner/work/_temp/claude-execution-output.json
+          denials=0
+          if [ -f "$log" ]; then
+            denials=$(jq '[.. | .permission_denials_count? // empty] | last // 0' "$log")
+          fi
+          if [ "${denials:-0}" -gt 0 ]; then
+            echo "::error::$denials tool call(s) denied — the --allowedTools grant above is wrong."
+            exit 1
+          fi
+          if [ -n "$(git ls-remote --heads origin "refs/heads/feature/issue-$ISSUE-*")" ]; then
+            echo "Branch for #$ISSUE pushed."
+            exit 0
+          fi
+          # The prompt's closing instruction is a legitimate no-branch exit: too
+          # ambiguous to build safely, so it asks on the issue and stops. That
+          # leaves a comment; a broken run leaves nothing, and telling those two
+          # apart is the whole point of this check.
+          #
+          # Bot authors only. The approval that starts this job usually arrives via
+          # `cron/slack-relay.md`, which comments `approved via Slack ✅ by …` on the
+          # issue seconds beforehand — under a *human* login, because the Slack
+          # connector posts as the person. Counting every recent comment would let
+          # that one stand in for the exit note and wave through the exact failure
+          # this step exists to catch.
+          asked=$(gh issue view "$ISSUE" --json comments --jq \
+            '[.comments[] | select(.author.login | endswith("[bot]"))
+              | select(.createdAt > "'"$(date -u -d '2 hours ago' +%FT%TZ)"'")] | length')
+          if [ "${asked:-0}" -gt 0 ]; then
+            echo "No branch, but the run commented on #$ISSUE — the documented ambiguous-issue exit."
+            exit 0
+          fi
+          echo "::error::No branch and no comment on #$ISSUE — the run produced nothing."
+          exit 1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -82,18 +82,26 @@ jobs:
       # cybersecurity queries to less capable models — fine for a chat, and
       # unacceptable for an unattended run that may edit fs_policy.py or a CSP
       # invariant, because you would not know which model actually read it.
-      # The title is checked as well as the label because a label can be lost:
+      #
+      # Both axes count. models.md scopes the rule to "any auto-lane item in the
+      # `security` workstream", and `workstream:security` and `type:security` are
+      # separate labels — a security-workstream bug is `[bug][security]`, which a
+      # type-only check misses entirely.
+      #
+      # The title is checked as well as the labels because a label can be lost:
       # issue #172 had its entire set replaced when the relay applied
       # `claude-implement`, and the `[type][workstream]` prefix cowork-scribe
-      # writes at filing time is the copy that survives that.
+      # writes at filing time is the copy that survives that. Matching
+      # `[security]` anywhere in the prefix covers both positions, and the only
+      # way to be wrong is to route something to `deep` unnecessarily.
       - name: Pick the model tier
         id: model
         env:
           LABELS: ${{ toJSON(github.event.issue.labels.*.name) }}
           TITLE: ${{ github.event.issue.title }}
         run: |
-          if jq -e 'index("type:security")' <<< "$LABELS" >/dev/null \
-            || [[ "$TITLE" == \[security\]* ]]; then
+          if jq -e 'index("type:security") or index("workstream:security")' <<< "$LABELS" >/dev/null \
+            || [[ "$TITLE" == *"[security]"* ]]; then
             echo "id=${{ vars.YEABOI_MODEL_DEEP || 'claude-opus-5' }}" >> "$GITHUB_OUTPUT"
             echo "Security issue — running at deep, never heavy."
           else
@@ -194,23 +202,42 @@ jobs:
       # no-op leaves the issue invisible to every routine. Assert the outcome
       # rather than the exit status.
       - name: Assert the run produced something
-        if: always() && steps.implement.conclusion != 'skipped'
+        # Only when the action actually ran. `!= 'skipped'` also matches the empty
+        # conclusion a step has when an earlier one failed, which would stack a
+        # misleading "produced nothing" on top of a genuine `uv sync` failure.
+        if: always() && (steps.implement.conclusion == 'success' || steps.implement.conclusion == 'failure')
         env:
           ISSUE: ${{ github.event.issue.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          log=/home/runner/work/_temp/claude-execution-output.json
-          denials=0
-          if [ -f "$log" ]; then
+          # `permission_denials_count` is the field the action really writes — read
+          # off run 31312744716, the 2026-08-09 no-op on #172, which reported
+          # `"permission_denials_count": 17` beside `"num_turns": 31`.
+          log="${RUNNER_TEMP}/claude-execution-output.json"
+          if [ ! -f "$log" ]; then
+            # A diagnostic that silently stops diagnosing is the failure class this
+            # step exists to remove, so say so rather than reading it as "no denials".
+            echo "::warning::no execution log at $log — denials were not checked"
+            denials=0
+          else
             denials=$(jq '[.. | .permission_denials_count? // empty] | last // 0' "$log")
           fi
           if [ "${denials:-0}" -gt 0 ]; then
             echo "::error::$denials tool call(s) denied — the --allowedTools grant above is wrong."
             exit 1
           fi
-          if [ -n "$(git ls-remote --heads origin "refs/heads/feature/issue-$ISSUE-*")" ]; then
-            echo "Branch for #$ISSUE pushed."
-            exit 0
+          branch=$(git ls-remote --heads origin "refs/heads/feature/issue-$ISSUE-*" | head -1 | sed 's|.*refs/heads/||')
+          if [ -n "$branch" ]; then
+            # A branch is not the deliverable; the PR is. A run truncated between
+            # step 8's push and its `gh pr create` — the state the --max-turns note
+            # above calls "a half-open PR" — would otherwise read as success here
+            # and be excluded from the digest's approved-with-no-PR section too.
+            if [ -n "$(gh pr list --head "$branch" --state all --json number --jq '.[0].number')" ]; then
+              echo "PR open for #$ISSUE on $branch."
+              exit 0
+            fi
+            echo "::error::Branch $branch was pushed for #$ISSUE but no PR was opened — truncated run."
+            exit 1
           fi
           # The prompt's closing instruction is a legitimate no-branch exit: too
           # ambiguous to build safely, so it asks on the issue and stops. That
@@ -223,8 +250,11 @@ jobs:
           # connector posts as the person. Counting every recent comment would let
           # that one stand in for the exit note and wave through the exact failure
           # this step exists to catch.
+          # `.author.login? // ""` — a deleted account renders `author: null`, and a
+          # raised jq under `bash -e` would abort the step with a traceback instead
+          # of the message below.
           asked=$(gh issue view "$ISSUE" --json comments --jq \
-            '[.comments[] | select(.author.login | endswith("[bot]"))
+            '[.comments[] | select((.author.login? // "") | endswith("[bot]"))
               | select(.createdAt > "'"$(date -u -d '2 hours ago' +%FT%TZ)"'")] | length')
           if [ "${asked:-0}" -gt 0 ]; then
             echo "No branch, but the run commented on #$ISSUE — the documented ambiguous-issue exit."

--- a/cowork/routines/cron/digest.md
+++ b/cowork/routines/cron/digest.md
@@ -230,14 +230,26 @@ The single decision point. It is the only routine that posts proposals to Slack.
 
    The lines carry different facts, because the states are different facts:
 
-   - **Approved, no PR yet** — an issue carrying `claude-implement` with no branch behind it.
-     `gh issue list --label claude-implement --state open --json number,title,labels,createdAt`,
-     then `git ls-remote --heads origin 'refs/heads/feature/issue-<n>-*'` per issue. Line one is
-     `**#<n>** <title>`; line two is `— approved <k> days ago, no branch`.
+   - **Approved, no PR yet** — an issue carrying `claude-implement` with no PR behind it.
+     `gh issue list --label claude-implement --state open --json number,title` for the candidates,
+     then per issue `gh pr list --search '<n> in:body' --state all --json number` to see whether one
+     was ever opened. Line one is `**#<n>** <title>`; line two is `— approved <k> days ago, <state>`,
+     where state is `no branch` or `branch pushed, no PR` — check
+     `git ls-remote --heads origin 'refs/heads/feature/issue-<n>-*'` to tell those apart, because
+     they fail differently: nothing started, versus a run truncated between its push and its
+     `gh pr create`.
+
+     **`<k>` is days since the label landed, not since the issue was filed.** Only the timeline
+     carries that:
+     `gh api repos/{owner}/{repo}/issues/<n>/timeline --jq '[.[] | select(.event == "labeled" and
+     .label.name == "claude-implement")] | last | .created_at'`. `createdAt` from `gh issue list` is
+     the filing date, which for a proposal approved after a fortnight in the queue overstates the
+     delay by that fortnight — and the "more than a day is a broken lane" reading below depends on
+     the number meaning what it says.
 
      This is the only section here about an issue rather than a workstream, and it exists because
      that window had no owner. The approval is the moment a proposal stops being a question, and
-     from then on nothing watches it: step 4 below is forbidden from ageing these out, so a build
+     from then on nothing watches it: step 4 above is forbidden from ageing these out, so a build
      that never started leaves an issue no routine will ever mention again. Issue #172 sat in this
      state from 2026-08-09 — the implement job it triggered exited green having written nothing —
      and the fleet's only report of it was the same three lines of Slack it had already posted.

--- a/cowork/routines/cron/digest.md
+++ b/cowork/routines/cron/digest.md
@@ -171,9 +171,11 @@ The single decision point. It is the only routine that posts proposals to Slack.
      would only restate them; the per-workstream remainder is the one place a reader learns which
      surface the backlog is piling up on. Omit the line entirely when the sections above listed
      everything — a remainder of zero is not a fact anyone needs.
-   - the two health sections from step 5 — 🚧 **Blocked on an open PR** and 🔇 **Silent 21+ days** —
-     sharing one divider, because they are two halves of one health report and splitting them reads
-     as two unrelated topics. Then, on Mondays only, 📊 **Calibration** from step 6 under a divider
+   - the three health sections from step 5 — ⏳ **Approved, no PR yet**, 🚧 **Blocked on an open
+     PR** and 🔇 **Silent 21+ days** — sharing one divider, because they are three parts of one
+     health report and splitting them reads as unrelated topics. Approved-with-no-PR leads: it is
+     the only one of the three where a human already said yes, so it is the only one where the
+     silence is the fleet's fault rather than the backlog's. Then, on Mondays only, 📊 **Calibration** from step 6 under a divider
      of its own.
    - last, under a final divider, the reminder that approval is ✅ on an item's thread reply
      (relayed within the hour — or `/cowork run slack-relay` for right now) or adding
@@ -221,12 +223,25 @@ The single decision point. It is the only routine that posts proposals to Slack.
 5. **Report the health lines** — if any workstream has filed nothing in 21 days, say so in the
    digest. A silent scout is usually a broken scout, not a clean codebase.
 
-   Separate the two ways a workstream goes quiet, under two headings — 🚧 **Blocked on an open PR**
-   and 🔇 **Silent 21+ days** — each an ordered list, one workstream per item, in the same two-line
-   shape as a proposal. These were one prose paragraph, which is why nobody read past the first name.
+   Separate the three ways work goes quiet, under three headings — ⏳ **Approved, no PR yet**,
+   🚧 **Blocked on an open PR** and 🔇 **Silent 21+ days** — each an ordered list, one item per
+   entry, in the same two-line shape as a proposal. These were one prose paragraph, which is why
+   nobody read past the first name.
 
-   The two lines carry different facts, because the two states are different facts:
+   The lines carry different facts, because the states are different facts:
 
+   - **Approved, no PR yet** — an issue carrying `claude-implement` with no branch behind it.
+     `gh issue list --label claude-implement --state open --json number,title,labels,createdAt`,
+     then `git ls-remote --heads origin 'refs/heads/feature/issue-<n>-*'` per issue. Line one is
+     `**#<n>** <title>`; line two is `— approved <k> days ago, no branch`.
+
+     This is the only section here about an issue rather than a workstream, and it exists because
+     that window had no owner. The approval is the moment a proposal stops being a question, and
+     from then on nothing watches it: step 4 below is forbidden from ageing these out, so a build
+     that never started leaves an issue no routine will ever mention again. Issue #172 sat in this
+     state from 2026-08-09 — the implement job it triggered exited green having written nothing —
+     and the fleet's only report of it was the same three lines of Slack it had already posted.
+     Anything listed here for more than a day is a broken lane, not a slow one.
    - **Blocked** — line one is the workstream and its linked PR, `**<workstream>** [PR #123 —
      <title>](<pr url>)`; line two is `— ` and what is actually holding that PR up, from the
      `pr_feedback.py` run below (red CI, or *n* unanswered findings).

--- a/cowork/routines/cron/slack-relay.md
+++ b/cowork/routines/cron/slack-relay.md
@@ -60,17 +60,40 @@ announce who is unauthorized.
    dropped approval that step 5 then accounts for as nothing unprocessed — the one way this routine
    fails without saying so.
 
-2. **Early exit** — if no message or reaction from an allowlisted human lacks the 🤖 marker, stop.
-   Post nothing, touch nothing. This is the common case and the whole cost model: most hourly runs
-   are a read and an exit.
+2. **Plan** — hand the thread to Python and act on what comes back:
 
-3. **Act** — process each unhandled item per the verb grammar below, oldest first.
+   ```bash
+   uv run python scripts/cowork_relay.py --plan < thread.json
+   ```
+
+   Pass one JSON array of the item replies, each `{ts, text, reactions}` with `reactions` a list of
+   `{name, users}` — the fields `slack_read_thread` and `slack_get_reactions` return, copied across
+   and nothing else. **Transcribe; do not summarise, filter or pre-judge.** Deciding which replies
+   are still owed an action is the helper's job, and every reply you drop on the way in is a
+   decision made without it.
+
+   **An empty `plan` is the early exit: stop, post nothing, touch nothing.** This is the common
+   case and the whole cost model — most hourly runs are a read and an exit.
+
+   This step used to be yours, and on 2026-08-09 it announced the same approval of #172 three
+   times. Reading a fifteen-reply thread once an hour and remembering which reaction you have
+   already answered is not judgement, it is a filter and a set membership test, and the acks it has
+   to see past are its own — the connector posts them under the human's name. So it is Python's,
+   the same way `cowork_setup.py --triggers` diffs the fleet rather than the model diffing it by
+   eye. If the helper cannot run, say so in thread and act on nothing; never fall back to deciding
+   by eye.
+
+3. **Act** — run each entry's `command` **verbatim, as given, oldest first**. Do not compose a `gh`
+   invocation of your own and do not add flags to one: the argv the helper emits is the whole
+   grant this routine has, and the one time an invocation was composed here it replaced an issue's
+   entire label set. An entry with `"verb": "ask"` carries no command — reply in thread asking for
+   a single verb, and touch nothing.
 
 4. **Acknowledge** — **every processed message gets the 🤖 marker**, whatever processing meant: an
-   action, a read-only answer, a refusal, or a question back. The marker is what step 2's early
-   exit keys on, so a reply without a marker is a reply the next sixteen runs will post again —
-   an ambiguous message answered hourly for two days is exactly the channel noise this system
-   refuses to make. Then:
+   action, a read-only answer, a refusal, or a question back. The marker is what step 2's helper
+   keys on, so a reply left unmarked is a reply the next sixteen runs will answer again — an
+   ambiguous message answered hourly for two days is exactly the channel noise this system refuses
+   to make. Then:
    - post one reply in the message's thread — for an action, exactly what was done ("added
      `claude-implement` to #231", "closed #232", "paused `cowork: security-sweep`"), one line, no
      preamble; for anything else, the answer, the refusal, or the question;
@@ -79,17 +102,28 @@ announce who is unauthorized.
      permalink tool is available, the channel name plus the message timestamp identifies the message;
      use that. The comment is what makes a label applied by a routine auditable as a human decision.
 
-5. **Account for the run** — end the session's own output with one line: how many messages and
-   reactions were read, how many were from allowlisted humans, how many were already marked, and
-   what was done. This never goes to Slack — it is the run log at claude.ai/code/routines, and it
-   is what `/cowork run slack-relay` surfaces. Without it, a wrong member ID in the allowlist, a
-   renamed Slack tool, and a genuinely quiet week all read identically as silence.
+   **Both of these happen only for work this run actually did.** If the `gh` state check in
+   Idempotency below says the verb already happened, mark the message and stop there: no thread
+   reply, no audit comment. #172 carries two identical `approved via Slack ✅` comments because a
+   run that correctly found the label already applied announced it anyway.
+
+5. **Account for the run** — end the session's own output with the helper's `counts` (replies read,
+   item replies, already marked, actionable) and what was done with each. This never goes to Slack
+   — it is the run log at claude.ai/code/routines, and it is what `/cowork run slack-relay`
+   surfaces. Report the numbers Python counted, not numbers you recall: a wrong member ID in the
+   allowlist, a renamed Slack tool, and a genuinely quiet week all read identically as silence, and
+   the counts are what tell them apart.
 
 ## Verb grammar
 
 - **✅ on a digest thread reply** (each leads with `#<issue-number>`) → `gh issue edit <n>
-  --add-label claude-implement`. The implement job fires on the label exactly as if it had been
-  added on GitHub.
+  --add-label claude-implement`, which the helper emits for you. The implement job fires on the
+  label exactly as if it had been added on GitHub. **`--add-label` adds; it never replaces.** On
+  2026-08-09 this verb was carried out with a call that replaced the set, and #172 lost
+  `cowork:proposal`, `workstream:web-ux` and `type:security` in the second it gained
+  `claude-implement` — the workstream label being the one `claude.yml` reads to find the charter
+  that says which paths the build may touch. The grant no longer includes `gh api`, so the wrong
+  call is now unavailable rather than merely forbidden.
 - **❌ on a digest thread reply**, or on any message that references exactly one open issue or PR →
   `gh issue close <n>` / `gh pr close <n>`. A message referencing several is ambiguous — ask in
   thread, act on nothing.
@@ -110,10 +144,18 @@ announce who is unauthorized.
 ## Idempotency
 
 No new state — GitHub issues are the queue, and this routine keeps it that way. The record is the
-🤖 marker plus GitHub itself:
+🤖 marker plus GitHub itself, and `scripts/cowork_relay.py` is where the first half is read:
 
+- **A reply is an input only if it leads with `#<issue-number>`**, which is the digest's thread-reply
+  contract. This routine's own acks say "added `claude-implement` to #172" — the number is not
+  leading, so they never match, and it cannot answer itself. That mattered because the Slack
+  connector posts under the allowlisted human's own member ID: an ack comes back on the next read
+  looking exactly like human input.
+- **A reply carrying 🤖 is done.** The marker sits on the message, never on a reaction — a reaction
+  cannot carry one. Marked means handled, whatever the reaction under it says.
 - Before any GitHub write, check current state. Label already present, or issue already closed:
-  the verb already happened (here or on GitHub directly) — add the marker and say nothing new.
+  the verb already happened (here or on GitHub directly) — mark the message and say nothing at all,
+  in Slack or on the issue.
 - Both ✅ and ❌ from allowlisted humans on one item: do nothing, reply asking for a single verb.
 - Once GitHub says decided, later reactions on the same item are ignored. GitHub is authoritative;
   Slack is how a decision arrives, not where it lives.

--- a/cowork/routines/cron/slack-relay.md
+++ b/cowork/routines/cron/slack-relay.md
@@ -63,14 +63,20 @@ announce who is unauthorized.
 2. **Plan** — hand the thread to Python and act on what comes back:
 
    ```bash
-   uv run python scripts/cowork_relay.py --plan < thread.json
+   uv run python scripts/cowork_relay.py --plan <<'THREAD'
+   [{"ts": "…", "text": "#172 — …", "reactions": [{"name": "white_check_mark", "users": ["U…"]}]}]
+   THREAD
    ```
+
+   A heredoc, not a file: this routine holds no `Write` and no shell verb that could create one,
+   which is deliberate — it edits nothing. The JSON goes on stdin as part of the same command.
 
    Pass one JSON array of the item replies, each `{ts, text, reactions}` with `reactions` a list of
    `{name, users}` — the fields `slack_read_thread` and `slack_get_reactions` return, copied across
-   and nothing else. **Transcribe; do not summarise, filter or pre-judge.** Deciding which replies
-   are still owed an action is the helper's job, and every reply you drop on the way in is a
-   decision made without it.
+   and nothing else. `users` matters: the helper checks every reaction against the allowlist,
+   including the 🤖 marker, so a reply passed without them is a reply it must treat as unreacted.
+   **Transcribe; do not summarise, filter or pre-judge.** Deciding which replies are still owed an
+   action is the helper's job, and every reply you drop on the way in is a decision made without it.
 
    **An empty `plan` is the early exit: stop, post nothing, touch nothing.** This is the common
    case and the whole cost model — most hourly runs are a read and an exit.

--- a/scripts/cowork_relay.py
+++ b/scripts/cowork_relay.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Decide what a Slack digest thread is asking for, so the relay does not have to.
+
+``cowork/routines/cron/slack-relay.md`` carries a human's ✅/❌ from the digest
+thread onto GitHub. Deciding *which* reactions are still unhandled used to be the
+routine's own judgement, made at the ``fast`` tier against a fifteen-reply thread,
+once an hour. On 2026-08-09 it announced the same approval of issue #172 three
+times — at 13:13, 17:12 and 19:12 BST — and left a duplicate audit comment on the
+issue, because three things line up against it:
+
+* the relay posts through the Slack connector **as the human**, so its own ack
+  replies come back on the next read indistinguishable from human input;
+* the early-exit rule was ill-typed — a *reaction* cannot carry the 🤖 marker,
+  only the message under it can, so the mapping had to be invented every run;
+* it re-read a thread that grew by one self-referential ack each time it misfired.
+
+None of that is a judgement call. It is a filter, a set membership test and a
+regex, and this module is where they live — the same split the fleet lifecycle
+already uses, where ``cowork_setup.py --triggers`` diffs the routines and the
+model posts what it is handed. The routine reads Slack and writes Slack; every
+comparison between the two happens here.
+
+**The queue is still GitHub.** This module holds no state and remembers nothing
+between runs: the 🤖 marker on a reply is the record, and the emitted command is
+checked against live GitHub state by the routine before it runs.
+
+Input is a JSON array of thread replies on stdin, each ``{ts, text, reactions}``
+with ``reactions`` a list of ``{name, users}`` — the shape Slack's own
+``conversations.replies`` returns, so a raw API response works unchanged::
+
+    $ uv run python scripts/cowork_relay.py --plan < thread.json
+    {"counts": {...}, "plan": [{"ts": "...", "issue": 172, "verb": "approve", ...}]}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+RELAY_ROUTINE = ROOT / "cowork" / "routines" / "cron" / "slack-relay.md"
+
+# The digest's thread-reply contract, from `cowork/routines/cron/digest.md`:
+# "#<issue-number> — <verbatim title> — <issue link>, the number leading so
+# cron/slack-relay.md can parse it". This regex is the whole reason the relay
+# cannot re-parse its own output: an ack reads "added `claude-implement` to #172",
+# where the number is not leading, so it never matches and is never an input.
+ITEM_RE = re.compile(r"^#(\d+)\s+—\s")
+
+# A member id as the allowlist table writes it. Anything else in that table --
+# a name, a placeholder, an example -- is not an id and cannot authorise a verb.
+MEMBER_RE = re.compile(r"`(U[A-Z0-9]{6,})`")
+
+DONE = "robot_face"
+APPROVE = "white_check_mark"
+REJECT = "x"
+
+APPROVAL_LABEL = "claude-implement"
+
+
+class RelayError(RuntimeError):
+    """The input is not something a plan can be built from."""
+
+
+def parse_allowlist(text: str) -> dict[str, str]:
+    """Pull the authorised member ids out of the relay routine's own table.
+
+    The allowlist lives in the routine file rather than here so that it stays
+    versioned in the place a reviewer already looks when asking "who can approve",
+    and so that adding a person is a reviewed diff rather than a config change.
+    """
+    found: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        match = MEMBER_RE.search(cells[0])
+        if match:
+            found[match.group(1)] = cells[1]
+    return found
+
+
+def _reactors(reaction: dict[str, Any]) -> list[str]:
+    users = reaction.get("users") or []
+    return [u for u in users if isinstance(u, str)]
+
+
+def _by_name(reply: dict[str, Any]) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for reaction in reply.get("reactions") or []:
+        name = reaction.get("name")
+        if isinstance(name, str):
+            out.setdefault(name, []).extend(_reactors(reaction))
+    return out
+
+
+def _command(verb: str, issue: int) -> list[str]:
+    """The literal argv for a verb — never a format string, never an API call.
+
+    `gh issue edit --add-label` adds; `gh api -X PUT .../labels` replaces. The
+    relay's own file has always specified the first, and on 2026-08-09 something
+    ran the second: issue #172 lost `cowork:proposal`, `workstream:web-ux` and
+    `type:security` in the same second it gained `claude-implement`. The lost
+    workstream label is the one that matters — it is what `claude.yml`'s implement
+    job reads to find the charter declaring which paths an unattended run may
+    touch. Emitting argv rather than a string is what makes that unreachable from
+    here; `tests/unit/test_cowork_relay.py` asserts no emitted command can spell
+    it.
+    """
+    if verb == "approve":
+        return ["gh", "issue", "edit", str(issue), "--add-label", APPROVAL_LABEL]
+    if verb == "reject":
+        return ["gh", "issue", "close", str(issue)]
+    raise RelayError(f"no command for verb {verb!r}")
+
+
+def build_plan(replies: list[dict[str, Any]], allowlist: dict[str, str]) -> dict[str, Any]:
+    """Turn a thread into the list of actions still owed, oldest first.
+
+    Every skip below is one of the ways the 2026-08-09 run went wrong, made
+    total rather than remembered.
+    """
+    if not allowlist:
+        # Matches the routine's own stop condition: an empty or placeholder
+        # allowlist means nobody can authorise anything, so nothing is actionable.
+        return {"counts": {"replies": len(replies), "item_replies": 0, "marked": 0, "actionable": 0}, "plan": []}
+
+    plan: list[dict[str, Any]] = []
+    item_replies = marked = 0
+
+    for reply in replies:
+        text = reply.get("text") or ""
+        match = ITEM_RE.match(text)
+        if not match:
+            continue  # not a digest item reply — the relay's own acks land here
+        item_replies += 1
+
+        reactions = _by_name(reply)
+        if DONE in reactions:
+            marked += 1
+            continue
+
+        approvers = [u for u in reactions.get(APPROVE, []) if u in allowlist]
+        rejecters = [u for u in reactions.get(REJECT, []) if u in allowlist]
+        if not approvers and not rejecters:
+            continue
+
+        issue = int(match.group(1))
+        if approvers and rejecters:
+            # The routine's rule: never guess between two verbs from a human.
+            plan.append({"ts": reply.get("ts"), "issue": issue, "verb": "ask", "who": None, "command": None})
+            continue
+
+        verb = "approve" if approvers else "reject"
+        who = allowlist[(approvers or rejecters)[0]]
+        plan.append({"ts": reply.get("ts"), "issue": issue, "verb": verb, "who": who, "command": _command(verb, issue)})
+
+    plan.sort(key=lambda item: str(item["ts"]))
+    counts = {
+        "replies": len(replies),
+        "item_replies": item_replies,
+        "marked": marked,
+        "actionable": len(plan),
+    }
+    return {"counts": counts, "plan": plan}
+
+
+def load_replies(raw: str) -> list[dict[str, Any]]:
+    """Accept a bare array or Slack's ``{"messages": [...]}`` envelope."""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RelayError(f"stdin is not JSON: {exc}") from exc
+    if isinstance(data, dict):
+        data = data.get("messages", [])
+    if not isinstance(data, list):
+        raise RelayError("expected a JSON array of thread replies")
+    return [reply for reply in data if isinstance(reply, dict)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--plan", action="store_true", help="emit the actions still owed, as JSON")
+    parser.add_argument("--allowlist-from", type=Path, default=RELAY_ROUTINE, help="routine file holding the table")
+    args = parser.parse_args(argv)
+
+    if not args.plan:
+        parser.error("nothing to do — pass --plan")
+
+    try:
+        allowlist = parse_allowlist(args.allowlist_from.read_text())
+        result = build_plan(load_replies(sys.stdin.read()), allowlist)
+    except (RelayError, OSError) as exc:
+        print(f"cowork_relay: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cowork_relay.py
+++ b/scripts/cowork_relay.py
@@ -24,6 +24,12 @@ comparison between the two happens here.
 between runs: the 🤖 marker on a reply is the record, and the emitted command is
 checked against live GitHub state by the routine before it runs.
 
+One bound worth knowing: Slack truncates a reaction's ``users`` list on heavily
+reacted messages, and a truncated list is indistinguishable here from nobody
+having reacted. ``slack_get_reactions`` returns up to 50 per emoji, and a digest
+item reply carries two, so this is a long way from mattering — but if it ever
+does, it fails toward re-processing an approval rather than toward dropping one.
+
 Input is a JSON array of thread replies on stdin, each ``{ts, text, reactions}``
 with ``reactions`` a list of ``{name, users}`` — the shape Slack's own
 ``conversations.replies`` returns, so a raw API response works unchanged::
@@ -66,6 +72,11 @@ class RelayError(RuntimeError):
     """The input is not something a plan can be built from."""
 
 
+def _is_placeholder(member: str, who: str) -> bool:
+    """A row nobody has filled in yet — `UXXXXXXXX`, or a description in angle brackets."""
+    return set(member[1:]) <= {"X", "0"} or who.startswith("<") or "placeholder" in who.lower()
+
+
 def parse_allowlist(text: str) -> dict[str, str]:
     """Pull the authorised member ids out of the relay routine's own table.
 
@@ -81,8 +92,15 @@ def parse_allowlist(text: str) -> dict[str, str]:
         if len(cells) < 2:
             continue
         match = MEMBER_RE.search(cells[0])
-        if match:
-            found[match.group(1)] = cells[1]
+        if not match:
+            continue
+        member, who = match.group(1), cells[1]
+        if _is_placeholder(member, who):
+            # The routine's stop condition is "any row is a placeholder OR the
+            # table is empty — exit without acting". A half-filled table is the
+            # more dangerous of the two: it looks configured.
+            return {}
+        found[member] = who
     return found
 
 
@@ -129,10 +147,11 @@ def build_plan(replies: list[dict[str, Any]], allowlist: dict[str, str]) -> dict
     if not allowlist:
         # Matches the routine's own stop condition: an empty or placeholder
         # allowlist means nobody can authorise anything, so nothing is actionable.
-        return {"counts": {"replies": len(replies), "item_replies": 0, "marked": 0, "actionable": 0}, "plan": []}
+        empty = {"replies": len(replies), "item_replies": 0, "marked": 0, "ignored_markers": 0, "actionable": 0}
+        return {"counts": empty, "plan": []}
 
     plan: list[dict[str, Any]] = []
-    item_replies = marked = 0
+    item_replies = marked = ignored_markers = 0
 
     for reply in replies:
         text = reply.get("text") or ""
@@ -142,9 +161,18 @@ def build_plan(replies: list[dict[str, Any]], allowlist: dict[str, str]) -> dict
         item_replies += 1
 
         reactions = _by_name(reply)
-        if DONE in reactions:
+        # The marker is gated on the same allowlist as the verbs. It is written by
+        # this routine through the Slack connector, which posts as the human — the
+        # ✅ and the 🤖 on the #172 reply are both under `U0BLM1QU3JN` — so gating
+        # costs nothing and closes a veto: ungated, any member of the channel could
+        # mark an item and suppress it from every future run, and the count would
+        # simply read as one more handled reply.
+        markers = [u for u in reactions.get(DONE, []) if u in allowlist]
+        if markers:
             marked += 1
             continue
+        if DONE in reactions:
+            ignored_markers += 1
 
         approvers = [u for u in reactions.get(APPROVE, []) if u in allowlist]
         rejecters = [u for u in reactions.get(REJECT, []) if u in allowlist]
@@ -166,6 +194,9 @@ def build_plan(replies: list[dict[str, Any]], allowlist: dict[str, str]) -> dict
         "replies": len(replies),
         "item_replies": item_replies,
         "marked": marked,
+        # Never silent: a marker from outside the allowlist is disregarded, and
+        # saying so is what stops it from looking like a handled item.
+        "ignored_markers": ignored_markers,
         "actionable": len(plan),
     }
     return {"counts": counts, "plan": plan}

--- a/scripts/cowork_setup.py
+++ b/scripts/cowork_setup.py
@@ -118,10 +118,19 @@ TOOL_OVERRIDES: dict[str, tuple[str, ...]] = {
     # second it gained ``claude-implement``, and the workstream label is what
     # ``claude.yml``'s implement job reads to find the charter declaring which
     # paths an unattended run may touch. The routine had always *said*
-    # ``--add-label``. Saying it is what failed, so the grant now says it too:
-    # ``gh api`` is absent, and there is no verb here that can replace a set.
-    # Write/Edit/Task stay absent as well — the relay edits nothing and spawns no
-    # crew.
+    # ``--add-label``. Saying it is what failed, so the grant says it too.
+    #
+    # This removes the *wholesale* loss, not every possible one: ``gh api`` is gone,
+    # so no verb here can replace a label set in one call, but ``gh issue edit``
+    # still spells ``--remove-label``. That is the right line — the relay must be
+    # able to edit labels to do its job at all — and it is the difference between a
+    # slip that takes one label and one that takes all of them.
+    #
+    # ``Bash(...)`` scoping is honoured by the routines API: a probe registered the
+    # scoped strings and read them back verbatim through ``RemoteTrigger get``, so
+    # ``trigger_plan``'s ``allowed_tools`` comparison stays stable rather than
+    # reporting drift forever. Write/Edit/Task stay absent as well — the relay edits
+    # nothing and spawns no crew.
     "slack-relay": (
         "Bash(gh issue view:*)",
         "Bash(gh issue edit:*)",
@@ -129,6 +138,10 @@ TOOL_OVERRIDES: dict[str, tuple[str, ...]] = {
         "Bash(gh issue comment:*)",
         "Bash(gh pr view:*)",
         "Bash(gh pr close:*)",
+        # The routine leaves an audit comment for issue *and* PR verbs, so closing
+        # a PR without this is a decision with no record of who made it.
+        "Bash(gh pr comment:*)",
+        "Bash(gh pr list:*)",
         "Bash(uv run python scripts/cowork_relay.py:*)",
         "Bash(uv run python scripts/cowork_setup.py --json)",
         "Glob",

--- a/scripts/cowork_setup.py
+++ b/scripts/cowork_setup.py
@@ -107,13 +107,36 @@ TOOL_OVERRIDES: dict[str, tuple[str, ...]] = {
     # routine that only reports the schedule has no business editing a file or
     # searching the tree, and narrowing it says so where the grant is reviewed.
     "day-ahead": ("Bash", "Read", "Task", "TodoWrite"),
-    # slack-relay relays a human's verbs and nothing else: gh and the manifest
-    # (Bash), the repo and its own allowlist (Read/Glob/Grep), and the routines
-    # API (RemoteTrigger) for pause/resume/run — which nothing else gets: a
-    # sweep that can reach the routines API is a sweep that can un-pause the
-    # fleet. Write/Edit/Task are deliberately absent: the relay's own file
-    # forbids editing anything, and it spawns no crew.
-    "slack-relay": ("Bash", "Glob", "Grep", "Read", "RemoteTrigger", "TodoWrite"),
+    # slack-relay relays a human's verbs and nothing else: the routines API
+    # (RemoteTrigger) for pause/resume/run — which nothing else gets, because a
+    # sweep that can reach it is a sweep that can un-pause the fleet — the repo
+    # and its own allowlist (Read/Glob/Grep), and a *scoped* shell.
+    #
+    # The scoping is not decoration. This routine held bare ``Bash`` until issue
+    # #172, where relaying one ✅ replaced the issue's whole label set: it lost
+    # ``cowork:proposal``, ``workstream:web-ux`` and ``type:security`` in the same
+    # second it gained ``claude-implement``, and the workstream label is what
+    # ``claude.yml``'s implement job reads to find the charter declaring which
+    # paths an unattended run may touch. The routine had always *said*
+    # ``--add-label``. Saying it is what failed, so the grant now says it too:
+    # ``gh api`` is absent, and there is no verb here that can replace a set.
+    # Write/Edit/Task stay absent as well — the relay edits nothing and spawns no
+    # crew.
+    "slack-relay": (
+        "Bash(gh issue view:*)",
+        "Bash(gh issue edit:*)",
+        "Bash(gh issue close:*)",
+        "Bash(gh issue comment:*)",
+        "Bash(gh pr view:*)",
+        "Bash(gh pr close:*)",
+        "Bash(uv run python scripts/cowork_relay.py:*)",
+        "Bash(uv run python scripts/cowork_setup.py --json)",
+        "Glob",
+        "Grep",
+        "Read",
+        "RemoteTrigger",
+        "TodoWrite",
+    ),
     # The two PR routines read text nobody here wrote. `gh pr view` and `gh pr
     # diff` return a title, a body and a diff authored by whoever opened the PR —
     # on a public repo that is anyone with a fork — and both routines then hold
@@ -1234,10 +1257,20 @@ def check_grants(report: Report, routines: Sequence[Routine]) -> None:
     edits nothing, and the deployer's only file write is the README URL column,
     made by ``--urls`` inside this script.
 
-    It does not make a holder harmless — both hold ``Bash``, which can write
-    anything. What it removes is the unreviewed path: a change made through this
-    script or through git ends up in a PR, and this check is what keeps the grant
-    from quietly growing a shortcut around that.
+    What it removes is the unreviewed path: a change made through this script or
+    through git ends up in a PR, and this check is what keeps the grant from
+    quietly growing a shortcut around that.
+
+    The second rule is narrower and was bought the hard way. ``Bash`` can write
+    anything, so for a long time this check conceded that it did not make a holder
+    harmless. Issue #172 is what that concession cost: relaying one ✅ replaced the
+    issue's entire label set, taking with it the ``workstream:`` label that scopes
+    which paths the implement job may touch. The relay's own file had always
+    specified ``--add-label``; prose was the only thing enforcing it. So the relay
+    — and only the relay, which runs seventeen times a day on text it did not
+    write — must carry a scoped shell rather than a bare one. ``cd-deploy`` keeps
+    bare ``Bash``: it runs ``git`` and ``gh pr create`` against a plan Python
+    composed, and enumerating that is a list that would rot.
     """
     for routine in routines:
         tools = set(routine_tools(routine.name))
@@ -1245,6 +1278,12 @@ def check_grants(report: Report, routines: Sequence[Routine]) -> None:
             report.fail(
                 f"{routine.path} holds RemoteTrigger and {', '.join(sorted(writers))}",
                 "a routine that can edit the repo must not also reprogram the fleet — drop one",
+            )
+        if routine.name == "slack-relay" and "Bash" in tools:
+            report.fail(
+                f"{routine.path} holds unscoped Bash",
+                "the relay must list the exact `gh` verbs it needs — see issue #172, where a bare "
+                "shell replaced an issue's label set while relaying a single reaction",
             )
 
 

--- a/tests/fixtures/slack_thread_172.json
+++ b/tests/fixtures/slack_thread_172.json
@@ -1,12 +1,12 @@
 {
-  "_source": "C0BMADQQN1Z thread 1786263808.836259, the 2026-08-09 digest. Trimmed to the fields cowork_relay.py reads. Replies 13-15 are the relay's own acks: one correct, two duplicates it must never have posted.",
+  "_source": "C0BMADQQN1Z thread 1786263808.836259, the 2026-08-09 digest. Trimmed to the fields cowork_relay.py reads. Replies 13-15 are the relay's own acks: one correct, two duplicates it must never have posted. Every reaction is under U0BLM1QU3JN, including the robot_face marker — verified via slack_get_reactions — because the Slack connector posts as the human rather than as an app.",
   "messages": [
     {
       "ts": "1786263812.848879",
       "text": "#172 — [security][web-ux] Third-party CDN script (unpkg lenis) loaded on all 20 docs/ pages with no SRI — <https://github.com/dinho149/yeaboi.ai/issues/172|github.com/dinho149/yeaboi.ai/issues/172>",
       "reactions": [
         {"name": "white_check_mark", "count": 1, "users": ["U0BLM1QU3JN"]},
-        {"name": "robot_face", "count": 1, "users": ["U0BLP02UZ7T"]}
+        {"name": "robot_face", "count": 1, "users": ["U0BLM1QU3JN"]}
       ]
     },
     {"ts": "1786263815.842519", "text": "#146 — [bug][platform] auto-version.yml rejects claude[bot] PRs — <https://github.com/dinho149/yeaboi.ai/issues/146|issues/146>"},
@@ -20,8 +20,8 @@
     {"ts": "1786263847.972009", "text": "#189 — [docs][web-ux] team-analysis docs omit the Code and Docs components — <https://github.com/dinho149/yeaboi.ai/issues/189|issues/189>"},
     {"ts": "1786263850.276799", "text": "#144 — [docs][web-ux] retro docs omit the carried action-item column — <https://github.com/dinho149/yeaboi.ai/issues/144|issues/144>"},
     {"ts": "1786263854.690369", "text": "#170 — [docs][analysis] \"team-learning\" plugin-skill exemption is stale — team-analysis skill already covers its tools — <https://github.com/dinho149/yeaboi.ai/issues/170|issues/170>"},
-    {"ts": "1786277618.681119", "text": "added `claude-implement` to #172", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLP02UZ7T"]}]},
-    {"ts": "1786291971.916109", "text": "added `claude-implement` to #172 (already applied)", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLP02UZ7T"]}]},
-    {"ts": "1786299129.680879", "text": "added `claude-implement` to #172 (already applied)", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLP02UZ7T"]}]}
+    {"ts": "1786277618.681119", "text": "added `claude-implement` to #172", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLM1QU3JN"]}]},
+    {"ts": "1786291971.916109", "text": "added `claude-implement` to #172 (already applied)", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLM1QU3JN"]}]},
+    {"ts": "1786299129.680879", "text": "added `claude-implement` to #172 (already applied)", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLM1QU3JN"]}]}
   ]
 }

--- a/tests/fixtures/slack_thread_172.json
+++ b/tests/fixtures/slack_thread_172.json
@@ -1,0 +1,27 @@
+{
+  "_source": "C0BMADQQN1Z thread 1786263808.836259, the 2026-08-09 digest. Trimmed to the fields cowork_relay.py reads. Replies 13-15 are the relay's own acks: one correct, two duplicates it must never have posted.",
+  "messages": [
+    {
+      "ts": "1786263812.848879",
+      "text": "#172 — [security][web-ux] Third-party CDN script (unpkg lenis) loaded on all 20 docs/ pages with no SRI — <https://github.com/dinho149/yeaboi.ai/issues/172|github.com/dinho149/yeaboi.ai/issues/172>",
+      "reactions": [
+        {"name": "white_check_mark", "count": 1, "users": ["U0BLM1QU3JN"]},
+        {"name": "robot_face", "count": 1, "users": ["U0BLP02UZ7T"]}
+      ]
+    },
+    {"ts": "1786263815.842519", "text": "#146 — [bug][platform] auto-version.yml rejects claude[bot] PRs — <https://github.com/dinho149/yeaboi.ai/issues/146|issues/146>"},
+    {"ts": "1786263818.719279", "text": "#143 — [bug][poker] concurrent finalize can double-write tracker points — <https://github.com/dinho149/yeaboi.ai/issues/143|issues/143>"},
+    {"ts": "1786263821.906479", "text": "#140 — [bug][integrations] jira cloud roster pagination crashes past page 1 — <https://github.com/dinho149/yeaboi.ai/issues/140|issues/140>"},
+    {"ts": "1786263824.498719", "text": "#179 — [feature][platform] In-TUI feedback submission has no CLI/MCP surface or recorded Exempt — <https://github.com/dinho149/yeaboi.ai/issues/179|issues/179>"},
+    {"ts": "1786263827.198699", "text": "#142 — [improvement][integrations] add work-item-type discovery to azdo sync — <https://github.com/dinho149/yeaboi.ai/issues/142|issues/142>"},
+    {"ts": "1786263832.632519", "text": "#149 — [chore][tui-ux] route re-analyse confirm dialog through build_popup — <https://github.com/dinho149/yeaboi.ai/issues/149|issues/149>"},
+    {"ts": "1786263836.562589", "text": "#148 — [chore][tui-ux] dedupe viewport math in intake and offline screens — <https://github.com/dinho149/yeaboi.ai/issues/148|issues/148>"},
+    {"ts": "1786263839.003819", "text": "#180 — [chore][platform] changelog.py absent from surface-parity CAPABILITIES registry — <https://github.com/dinho149/yeaboi.ai/issues/180|issues/180>"},
+    {"ts": "1786263847.972009", "text": "#189 — [docs][web-ux] team-analysis docs omit the Code and Docs components — <https://github.com/dinho149/yeaboi.ai/issues/189|issues/189>"},
+    {"ts": "1786263850.276799", "text": "#144 — [docs][web-ux] retro docs omit the carried action-item column — <https://github.com/dinho149/yeaboi.ai/issues/144|issues/144>"},
+    {"ts": "1786263854.690369", "text": "#170 — [docs][analysis] \"team-learning\" plugin-skill exemption is stale — team-analysis skill already covers its tools — <https://github.com/dinho149/yeaboi.ai/issues/170|issues/170>"},
+    {"ts": "1786277618.681119", "text": "added `claude-implement` to #172", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLP02UZ7T"]}]},
+    {"ts": "1786291971.916109", "text": "added `claude-implement` to #172 (already applied)", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLP02UZ7T"]}]},
+    {"ts": "1786299129.680879", "text": "added `claude-implement` to #172 (already applied)", "reactions": [{"name": "robot_face", "count": 1, "users": ["U0BLP02UZ7T"]}]}
+  ]
+}

--- a/tests/unit/test_claude_workflow.py
+++ b/tests/unit/test_claude_workflow.py
@@ -1,0 +1,126 @@
+"""Standing guards over `.github/workflows/claude.yml`'s `implement` job.
+
+This is the bridge from a human's approval to code: adding `claude-implement` to
+an issue starts an unattended run that opens a PR. It ran for the first time on
+2026-08-09, on issue #172, and did nothing at all — 31 turns, 17 denied tool
+calls, `is_error: false`, a green check, no branch. It had never carried an
+`--allowedTools` grant, so the action's `settingSources: [user, project, local]`
+left the repo's deliberately read-only `.claude/settings.json` allowlist
+governing an unattended job that has to write code. Every other Claude-invoking
+workflow in this repo passes a grant; this one's absence was invisible precisely
+because the job reported success.
+
+The class of invariant is the same one `test_codeql_triage.py` pins for the other
+unattended job that writes code, and for the same reason: nothing at run time
+notices when one of these stops being true. A denied tool call, a missing
+toolchain and a security issue routed to the wrong model all look identical from
+the outside — a green run that produced nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "claude.yml"
+
+
+@pytest.fixture(scope="module")
+def implement() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())["jobs"]["implement"]
+
+
+@pytest.fixture(scope="module")
+def action(implement) -> dict:
+    """The `claude-code-action` step — the one that does the work."""
+    return next(step for step in implement["steps"] if "claude-code-action" in str(step.get("uses", "")))
+
+
+class TestTheGrant:
+    def test_the_job_declares_allowed_tools(self, action):
+        """The regression that made this job a no-op for its entire existence.
+
+        Without it the action inherits `.claude/settings.json`, which grants
+        `Bash(git status)` and `Bash(gh pr view:*)` and nothing that writes — the
+        right answer for an interactive session where a human approves each write,
+        and the wrong one for a job whose whole purpose is to commit and push.
+        """
+        assert "--allowedTools" in action["with"]["claude_args"], (
+            "an implement job with no tool grant inherits the repo's read-only allowlist and "
+            "exits green having written nothing — see issue #172, run 31312744716"
+        )
+
+    @pytest.mark.parametrize("tool", ["Edit", "Write", "Task", "Bash(git:*)", "Bash(gh pr:*)", "Bash(make:*)"])
+    def test_the_grant_covers_what_the_prompt_asks_for(self, action, tool):
+        """Each of these is a numbered step in the prompt below it: implement (Edit,
+        Write), spawn the scribe and the reviewer (Task), branch and push (git),
+        open the PR (gh pr), run the gate (make)."""
+        assert tool in action["with"]["claude_args"]
+
+
+class TestTheModelTier:
+    def test_a_security_issue_never_runs_on_heavy(self, implement):
+        """cowork/models.md: "Security never runs on `heavy`."
+
+        Fable 5 reroutes cybersecurity queries to less capable models. Tolerable in
+        a chat; not in an unattended run that may edit `fs_policy.py` or a CSP
+        invariant, because the report would read the same either way. The direct
+        analogue of `test_codeql_triage.py::test_runs_at_deep_never_heavy` — and
+        #172, the first issue this job ever received, was `type:security`.
+        """
+        picker = next(step for step in implement["steps"] if step.get("id") == "model")
+        assert "type:security" in picker["run"]
+        assert "YEABOI_MODEL_DEEP" in picker["run"]
+
+    def test_the_tier_is_chosen_rather_than_hardcoded(self, implement, action):
+        args = action["with"]["claude_args"]
+        assert "steps.model.outputs.id" in args
+        assert "YEABOI_MODEL_HEAVY" not in args, "the tier must come from the picker, which excludes security"
+
+    def test_the_title_is_checked_as_well_as_the_label(self, implement):
+        """A label can be lost — #172's whole set was replaced while it was being
+        approved. The `[type][workstream]` title prefix cowork-scribe writes at
+        filing time is the copy that survives that, so it is the second signal."""
+        picker = next(step for step in implement["steps"] if step.get("id") == "model")
+        assert "TITLE" in picker["run"] and "security" in picker["run"]
+
+
+class TestTheToolchain:
+    def test_uv_is_installed_before_claude_runs(self, implement):
+        """Prompt step 6 makes `make test` + `make lint` this job's own gate. With
+        no toolchain both are `command not found`, so the gate passes by never
+        having run — a second, independent way for this job to look green."""
+        names = [str(step.get("uses") or step.get("run") or step.get("name")) for step in implement["steps"]]
+        uv = next(i for i, name in enumerate(names) if "setup-uv" in name)
+        claude = next(i for i, name in enumerate(names) if "claude-code-action" in name)
+        assert uv < claude
+        assert any("uv sync" in name for name in names)
+
+
+class TestTheOutcomeGuard:
+    def test_the_job_asserts_it_produced_something(self, implement):
+        """A green run that wrote no code is what hid all of the above.
+
+        Nothing downstream would have caught it either: `digest.md` explicitly
+        refuses to age out an issue carrying `claude-implement`, so #172 became
+        invisible to every routine in the fleet the moment it was approved.
+        """
+        guard = implement["steps"][-1]
+        assert "permission_denials_count" in guard["run"], "a denial in this job is always a misconfiguration"
+        assert "feature/issue-" in guard["run"], "the branch prompt step 4 promises is the evidence of work"
+        assert guard.get("if", "").startswith("always()")
+
+    def test_only_a_bot_comment_counts_as_the_ambiguous_exit(self, implement):
+        """The relay comments on the issue seconds before this job starts.
+
+        `cron/slack-relay.md` writes `approved via Slack ✅ by …` under a *human*
+        login — the Slack connector posts as the person — and that is the normal
+        way this job gets triggered at all. A guard that accepted any recent
+        comment as "the run asked a question and stopped" would therefore wave
+        through a silent no-op on the single most common path into the job.
+        """
+        guard = implement["steps"][-1]
+        assert 'endswith("[bot]")' in guard["run"]

--- a/tests/unit/test_claude_workflow.py
+++ b/tests/unit/test_claude_workflow.py
@@ -19,10 +19,17 @@ the outside — a green run that produced nothing.
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
+
+pytestmark = pytest.mark.skipif(shutil.which("jq") is None, reason="the picker script shells out to jq")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "claude.yml"
@@ -62,30 +69,75 @@ class TestTheGrant:
 
 
 class TestTheModelTier:
-    def test_a_security_issue_never_runs_on_heavy(self, implement):
-        """cowork/models.md: "Security never runs on `heavy`."
+    """The picker is a self-contained shell script with one output, so it is run
+    rather than read.
 
-        Fable 5 reroutes cybersecurity queries to less capable models. Tolerable in
-        a chat; not in an unattended run that may edit `fs_policy.py` or a CSP
-        invariant, because the report would read the same either way. The direct
-        analogue of `test_codeql_triage.py::test_runs_at_deep_never_heavy` — and
-        #172, the first issue this job ever received, was `type:security`.
-        """
-        picker = next(step for step in implement["steps"] if step.get("id") == "model")
-        assert "type:security" in picker["run"]
-        assert "YEABOI_MODEL_DEEP" in picker["run"]
+    Asserting that `"type:security"` and `"YEABOI_MODEL_DEEP"` both appear in the
+    script proves nothing: swapping the two branches keeps every substring in
+    place and routes security straight to `heavy`, which is the one thing
+    cowork/models.md forbids. These execute it instead.
+    """
 
-    def test_the_tier_is_chosen_rather_than_hardcoded(self, implement, action):
+    @staticmethod
+    def _pick(implement: dict, labels: list[str], title: str, tmp_path: Path) -> str:
+        """Run the picker's own shell and return the tier id it selected."""
+        script = next(step for step in implement["steps"] if step.get("id") == "model")["run"]
+        # The only interpolations in the script are the two tier expressions;
+        # stand each one up as its own tier name so the branch taken is visible.
+        script = re.sub(r"\$\{\{[^}]*YEABOI_MODEL_(\w+)[^}]*\}\}", r"\1", script)
+        output = tmp_path / "github_output"
+        output.touch()
+        subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", script],
+            check=True,
+            capture_output=True,
+            env={
+                "PATH": os.environ["PATH"],
+                "LABELS": json.dumps(labels),
+                "TITLE": title,
+                "GITHUB_OUTPUT": str(output),
+            },
+        )
+        return output.read_text().strip().removeprefix("id=")
+
+    @pytest.mark.parametrize(
+        ("labels", "title"),
+        [
+            (["type:security", "workstream:web-ux"], "[security][web-ux] unpkg lenis has no SRI"),
+            # The workstream axis. models.md scopes the rule to "any auto-lane item
+            # in the `security` workstream", and these are separate labels — a
+            # security-workstream bug is `[bug][security]`, which a type-only check
+            # never sees. #172, the first issue this job ever received, was the
+            # other shape.
+            (["type:bug", "workstream:security"], "[bug][security] redaction misses a token"),
+            # Labels lost entirely — #172's whole set was replaced while it was
+            # being approved, so the title is the copy that survives.
+            ([], "[bug][security] redaction misses a token"),
+            ([], "[security][web-ux] unpkg lenis has no SRI"),
+        ],
+        ids=["type-label", "workstream-label", "title-only-workstream", "title-only-type"],
+    )
+    def test_security_never_reaches_heavy(self, implement, labels, title, tmp_path):
+        assert self._pick(implement, labels, title, tmp_path) == "DEEP"
+
+    @pytest.mark.parametrize(
+        ("labels", "title"),
+        [
+            (["type:bug", "workstream:platform"], "[bug][platform] auto-version rejects bot PRs"),
+            ([], "[chore][tui-ux] dedupe viewport math"),
+        ],
+        ids=["labelled", "unlabelled"],
+    )
+    def test_everything_else_still_gets_the_heavy_tier(self, implement, labels, title, tmp_path):
+        """The narrowing must not quietly become "everything runs on deep" — heavy
+        exists for exactly this job, and paying deep prices for every chore would
+        be a silent regression in the other direction."""
+        assert self._pick(implement, labels, title, tmp_path) == "HEAVY"
+
+    def test_the_tier_is_chosen_rather_than_hardcoded(self, action):
         args = action["with"]["claude_args"]
         assert "steps.model.outputs.id" in args
         assert "YEABOI_MODEL_HEAVY" not in args, "the tier must come from the picker, which excludes security"
-
-    def test_the_title_is_checked_as_well_as_the_label(self, implement):
-        """A label can be lost — #172's whole set was replaced while it was being
-        approved. The `[type][workstream]` title prefix cowork-scribe writes at
-        filing time is the copy that survives that, so it is the second signal."""
-        picker = next(step for step in implement["steps"] if step.get("id") == "model")
-        assert "TITLE" in picker["run"] and "security" in picker["run"]
 
 
 class TestTheToolchain:

--- a/tests/unit/test_cowork_models.py
+++ b/tests/unit/test_cowork_models.py
@@ -155,6 +155,37 @@ class TestWorkflowsReadTheRepoVariables:
     WORKFLOWS = REPO_ROOT / ".github" / "workflows"
     MODEL_FLAG = re.compile(r"--model\s+(\S+)")
 
+    # `--model ${{ steps.<id>.outputs.<name> }}` — a job that picks its tier in an
+    # earlier step instead of naming one inline. `claude.yml` does this because a
+    # `type:security` issue must not reach `heavy` (models.md), and a conditional
+    # cannot be spelled in the flag without an unreadable nested ternary. The
+    # indirection is followed rather than allowed: the assertions below move to
+    # whatever that step assigns, so a model hardcoded inside the picker fails
+    # here exactly as it would in the flag.
+    STEP_OUTPUT = re.compile(r"^\s*steps\.(\w+)\.outputs\.(\w+)\s*$")
+
+    def _expressions(self, text: str, expr: str, path: Path) -> list[str]:
+        indirect = self.STEP_OUTPUT.match(expr)
+        if not indirect:
+            return [expr]
+        _, output = indirect.groups()
+        # Every branch that writes the output, not merely the ones already shaped
+        # like an expression: a picker with one interpolated branch and one
+        # hardcoded id would otherwise pass on the strength of the good half.
+        assigned = re.findall(rf"{re.escape(output)}=(.*?)\"\s*>>", text)
+        assert assigned, (
+            f"{path.name} takes its model from `{expr.strip()}`, but nothing in the file "
+            f"assigns `{output}=` — the tier cannot be checked."
+        )
+        exprs = []
+        for value in assigned:
+            assert value.startswith("${{") and value.endswith("}}"), (
+                f"{path.name} assigns `{output}={value}` literally. Every branch of a model "
+                "picker must interpolate a YEABOI_MODEL_* repo variable — see cowork/models.md."
+            )
+            exprs.append(value[3:-2])
+        return exprs
+
     @pytest.mark.parametrize(
         "path",
         sorted(p for p in (REPO_ROOT / ".github" / "workflows").glob("*.yml")),
@@ -163,15 +194,15 @@ class TestWorkflowsReadTheRepoVariables:
     def test_every_model_flag_is_a_variable_with_a_fallback(self, path: Path):
         text = path.read_text()
         for match in re.finditer(r"--model\s+\$\{\{([^}]*)\}\}", text):
-            expr = match.group(1)
-            assert "vars.YEABOI_MODEL_" in expr, (
-                f"{path.name} interpolates a model from `{expr.strip()}` rather than a "
-                "YEABOI_MODEL_* repo variable — see cowork/models.md."
-            )
-            assert "||" in expr, (
-                f"{path.name} has no `||` fallback on its --model expression. An unset "
-                "variable renders empty and `--model ` breaks the argument."
-            )
+            for expr in self._expressions(text, match.group(1), path):
+                assert "vars.YEABOI_MODEL_" in expr, (
+                    f"{path.name} interpolates a model from `{expr.strip()}` rather than a "
+                    "YEABOI_MODEL_* repo variable — see cowork/models.md."
+                )
+                assert "||" in expr, (
+                    f"{path.name} has no `||` fallback on its --model expression. An unset "
+                    "variable renders empty and `--model ` breaks the argument."
+                )
 
     @pytest.mark.parametrize(
         "path",

--- a/tests/unit/test_cowork_relay.py
+++ b/tests/unit/test_cowork_relay.py
@@ -1,0 +1,149 @@
+"""Tests for scripts/cowork_relay.py — the relay's decision, moved into Python.
+
+Every test here is a way the 2026-08-09 run on issue #172 went wrong. It
+announced the same approval three times and left a duplicate audit comment,
+because "which reactions are still unhandled" was a judgement made at the
+``fast`` tier against a fifteen-reply thread that the relay itself was appending
+to. Nothing at run time would report that: an extra ack in Slack looks exactly
+like a second approval, and GitHub absorbed the repeated writes silently.
+
+``TestRecordedFailure`` runs the real thread. The rest pin the individual rules,
+so a future edit that reintroduces one fails here rather than in the channel.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# scripts/ is not a package, so load the module straight from its file path.
+_MODULE_PATH = ROOT / "scripts" / "cowork_relay.py"
+_spec = importlib.util.spec_from_file_location("cowork_relay", _MODULE_PATH)
+relay = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(relay)
+
+HUMAN = "U0BLM1QU3JN"
+BOT = "U0BLP02UZ7T"
+ALLOWLIST = {HUMAN: "onoureldin (onoureldin@gmail.com)"}
+
+FIXTURE = ROOT / "tests" / "fixtures" / "slack_thread_172.json"
+
+
+def reply(ts: str, text: str, **reactions: list[str]) -> dict:
+    """One thread reply; ``reactions`` maps an emoji name to the users on it."""
+    return {
+        "ts": ts,
+        "text": text,
+        "reactions": [{"name": name, "count": len(users), "users": users} for name, users in reactions.items()],
+    }
+
+
+def item(number: int, ts: str = "1", **reactions: list[str]) -> dict:
+    return reply(ts, f"#{number} — [bug][platform] something — https://example.invalid/{number}", **reactions)
+
+
+class TestRecordedFailure:
+    """The #172 thread, exactly as Slack holds it."""
+
+    @pytest.fixture
+    def thread(self) -> list[dict]:
+        return relay.load_replies(FIXTURE.read_text())
+
+    def test_the_thread_that_was_acked_three_times_now_plans_nothing(self, thread):
+        result = relay.build_plan(thread, ALLOWLIST)
+        assert result["plan"] == [], "the ✅ carries the marker — re-announcing it is the bug this fixes"
+        assert result["counts"] == {"replies": 15, "item_replies": 12, "marked": 1, "actionable": 0}
+
+    def test_the_relays_own_acks_are_never_inputs(self, thread):
+        """Three replies say "added `claude-implement` to #172". None is an item.
+
+        This is the loop's fuel: the connector posts as the human, so an ack comes
+        back on the next read looking like human input. The digest contract puts
+        the issue number first; an ack does not, and that is what separates them.
+        """
+        acks = [r for r in thread if r["text"].startswith("added ")]
+        assert len(acks) == 3
+        for ack in acks:
+            assert relay.ITEM_RE.match(ack["text"]) is None
+        # and with every marker stripped, they are still not actionable
+        bare = [{**r, "reactions": []} for r in thread]
+        assert relay.build_plan(bare, ALLOWLIST)["counts"]["item_replies"] == 12
+
+    def test_stripping_the_marker_recovers_exactly_one_approval(self, thread):
+        thread[0]["reactions"] = [r for r in thread[0]["reactions"] if r["name"] != relay.DONE]
+        plan = relay.build_plan(thread, ALLOWLIST)["plan"]
+        assert [(p["issue"], p["verb"]) for p in plan] == [(172, "approve")]
+        assert plan[0]["who"] == ALLOWLIST[HUMAN]
+
+
+class TestVerbs:
+    def test_an_approval_adds_the_label_and_never_replaces_the_set(self):
+        """#172 lost three labels in the second it gained one.
+
+        `gh issue edit --add-label` adds; `gh api -X PUT .../labels` replaces. The
+        emitted value is argv, so the second cannot be spelled from here — and the
+        lost `workstream:` label is what scopes which paths the implement job may
+        touch, so this is a boundary, not bookkeeping.
+        """
+        plan = relay.build_plan([item(172, white_check_mark=[HUMAN])], ALLOWLIST)["plan"]
+        assert plan[0]["command"] == ["gh", "issue", "edit", "172", "--add-label", "claude-implement"]
+
+    def test_no_emitted_command_can_replace_a_label_set(self):
+        thread = [item(1, ts="1", white_check_mark=[HUMAN]), item(2, ts="2", x=[HUMAN])]
+        for entry in relay.build_plan(thread, ALLOWLIST)["plan"]:
+            argv = entry["command"]
+            assert "api" not in argv
+            assert not {"PUT", "-X", "--method"} & set(argv)
+            assert "--remove-label" not in argv
+
+    def test_a_rejection_closes(self):
+        plan = relay.build_plan([item(5, x=[HUMAN])], ALLOWLIST)["plan"]
+        assert plan[0]["verb"] == "reject"
+        assert plan[0]["command"] == ["gh", "issue", "close", "5"]
+
+    def test_both_verbs_from_a_human_asks_and_acts_on_nothing(self):
+        plan = relay.build_plan([item(9, white_check_mark=[HUMAN], x=[HUMAN])], ALLOWLIST)["plan"]
+        assert plan[0]["verb"] == "ask"
+        assert plan[0]["command"] is None
+
+    def test_the_plan_is_oldest_first(self):
+        thread = [item(2, ts="200.5", white_check_mark=[HUMAN]), item(1, ts="100.5", white_check_mark=[HUMAN])]
+        assert [p["issue"] for p in relay.build_plan(thread, ALLOWLIST)["plan"]] == [1, 2]
+
+
+class TestAuthorisation:
+    def test_a_reaction_from_outside_the_allowlist_authorises_nothing(self):
+        plan = relay.build_plan([item(3, white_check_mark=["U000NOTME"])], ALLOWLIST)["plan"]
+        assert plan == [], "a non-allowlisted reaction is ignored silently, not relayed"
+
+    def test_the_bots_own_marker_is_not_an_approval(self):
+        thread = [item(4, white_check_mark=[BOT])]
+        assert relay.build_plan(thread, ALLOWLIST)["plan"] == []
+
+    def test_an_empty_allowlist_stops_everything(self):
+        """The routine's own stop condition: a placeholder table means act on nothing."""
+        assert relay.build_plan([item(7, white_check_mark=[HUMAN])], {})["plan"] == []
+
+    def test_the_allowlist_is_read_from_the_routine_that_documents_it(self):
+        found = relay.parse_allowlist(relay.RELAY_ROUTINE.read_text())
+        assert HUMAN in found, "the relay routine's table is the versioned source of who may approve"
+        assert all(uid.startswith("U") for uid in found)
+
+
+class TestInput:
+    def test_a_bare_array_and_a_slack_envelope_both_load(self):
+        entries = [item(1)]
+        assert relay.load_replies(json.dumps(entries)) == entries
+        assert relay.load_replies(json.dumps({"messages": entries})) == entries
+
+    def test_a_reply_with_no_reactions_key_is_not_a_crash(self):
+        assert relay.build_plan([{"ts": "1", "text": "#8 — a thing — url"}], ALLOWLIST)["plan"] == []
+
+    def test_non_json_is_a_clean_error_not_a_traceback(self):
+        with pytest.raises(relay.RelayError):
+            relay.load_replies("not json")

--- a/tests/unit/test_cowork_relay.py
+++ b/tests/unit/test_cowork_relay.py
@@ -14,6 +14,7 @@ so a future edit that reintroduces one fails here rather than in the channel.
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 from pathlib import Path
 
@@ -57,7 +58,13 @@ class TestRecordedFailure:
     def test_the_thread_that_was_acked_three_times_now_plans_nothing(self, thread):
         result = relay.build_plan(thread, ALLOWLIST)
         assert result["plan"] == [], "the ✅ carries the marker — re-announcing it is the bug this fixes"
-        assert result["counts"] == {"replies": 15, "item_replies": 12, "marked": 1, "actionable": 0}
+        assert result["counts"] == {
+            "replies": 15,
+            "item_replies": 12,
+            "marked": 1,
+            "ignored_markers": 0,
+            "actionable": 0,
+        }
 
     def test_the_relays_own_acks_are_never_inputs(self, thread):
         """Three replies say "added `claude-implement` to #172". None is an item.
@@ -147,3 +154,84 @@ class TestInput:
     def test_non_json_is_a_clean_error_not_a_traceback(self):
         with pytest.raises(relay.RelayError):
             relay.load_replies("not json")
+
+
+class TestTheMarkerIsAuthorised:
+    """A 🤖 from outside the allowlist must not be able to bury an approval.
+
+    The marker is how this module decides an item is handled, and it is written
+    through the same Slack connector that posts as the human — the ✅ and the 🤖
+    on the #172 reply are both under `U0BLM1QU3JN`, confirmed via
+    `slack_get_reactions`. Ungated, any member of the channel could mark an item
+    and suppress it from every future run, and the run accounting would report it
+    as one more handled reply.
+    """
+
+    def test_a_marker_from_a_stranger_does_not_suppress_an_approval(self):
+        thread = [item(11, white_check_mark=[HUMAN], robot_face=["U000NOTME"])]
+        result = relay.build_plan(thread, ALLOWLIST)
+        assert [p["issue"] for p in result["plan"]] == [11], "a stranger must not be able to veto"
+        assert result["counts"]["marked"] == 0
+
+    def test_a_disregarded_marker_is_counted_rather_than_swallowed(self):
+        thread = [item(11, white_check_mark=[HUMAN], robot_face=["U000NOTME"])]
+        assert relay.build_plan(thread, ALLOWLIST)["counts"]["ignored_markers"] == 1
+
+    def test_a_marker_from_the_allowlist_still_means_handled(self):
+        thread = [item(11, white_check_mark=[HUMAN], robot_face=[HUMAN])]
+        result = relay.build_plan(thread, ALLOWLIST)
+        assert result["plan"] == []
+        assert result["counts"] == {
+            "replies": 1,
+            "item_replies": 1,
+            "marked": 1,
+            "ignored_markers": 0,
+            "actionable": 0,
+        }
+
+
+class TestPlaceholderAllowlist:
+    """The routine's stop condition is "any row is a placeholder OR the table is
+    empty". A half-filled table is the more dangerous of the two: it looks
+    configured, so nothing would prompt anyone to look at it."""
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            "| `UXXXXXXXX` | your slack member id |",
+            "| `U000000000` | fill me in |",
+            "| `U0BLM1QU3JN` | <who> |",
+            "| `U0BLM1QU3JN` | placeholder |",
+        ],
+    )
+    def test_a_placeholder_row_disables_the_whole_table(self, row):
+        assert relay.parse_allowlist(f"| id | who |\n|---|---|\n{row}\n") == {}
+
+    def test_a_real_row_still_parses(self):
+        table = "| id | who |\n|---|---|\n| `U0BLM1QU3JN` | onoureldin (onoureldin@gmail.com) |\n"
+        assert relay.parse_allowlist(table) == {HUMAN: "onoureldin (onoureldin@gmail.com)"}
+
+
+class TestEntryPoint:
+    def test_plan_is_required(self, capsys):
+        with pytest.raises(SystemExit):
+            relay.main([])
+
+    def test_a_plan_reaches_stdout_as_json(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps([item(3, white_check_mark=[HUMAN])])))
+        assert relay.main(["--plan"]) == 0
+        emitted = json.loads(capsys.readouterr().out)
+        assert emitted["plan"][0]["issue"] == 3
+
+    def test_bad_input_is_an_exit_code_not_a_traceback(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
+        assert relay.main(["--plan"]) == 2
+        assert "cowork_relay:" in capsys.readouterr().err
+
+    def test_a_missing_allowlist_file_is_reported(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr("sys.stdin", io.StringIO("[]"))
+        assert relay.main(["--plan", "--allowlist-from", str(tmp_path / "nope.md")]) == 2
+
+    def test_no_command_for_an_unknown_verb(self):
+        with pytest.raises(relay.RelayError):
+            relay._command("shrug", 1)

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -1590,6 +1590,43 @@ class TestToolOverrides:
         tools = setup.routine_tools("slack-relay")
         assert not {"Write", "Edit", "Task"} & set(tools)
 
+    def test_the_relays_shell_is_scoped_to_the_verbs_it_relays(self):
+        """Issue #172: relaying one ✅ replaced the issue's entire label set.
+
+        `gh issue edit --add-label` adds; `gh api -X PUT .../labels` replaces. The
+        routine had always specified the first, and prose was the only thing
+        enforcing it — so #172 lost `cowork:proposal`, `workstream:web-ux` and
+        `type:security` in the second it gained `claude-implement`. The workstream
+        label is what `claude.yml`'s implement job reads to find the charter
+        declaring which paths an unattended 110-turn run may touch, so this is a
+        boundary rather than bookkeeping. Bare Bash puts it back within reach.
+        """
+        tools = set(setup.routine_tools("slack-relay"))
+        assert "Bash" not in tools, "a bare shell can spell the label-replacing call the relay must not make"
+        shells = {tool for tool in tools if tool.startswith("Bash(")}
+        assert shells, "the relay still needs a shell — scoped, not absent"
+        assert not any("gh api" in shell for shell in shells), "gh api is how a label set gets replaced"
+
+    def test_the_relay_can_reach_the_helper_that_decides_for_it(self):
+        """The decision moved into `scripts/cowork_relay.py`; a grant that cannot
+        run it would send the relay straight back to judging the thread by eye."""
+        tools = set(setup.routine_tools("slack-relay"))
+        assert any("cowork_relay.py" in tool for tool in tools)
+
+    def test_the_doctor_fails_on_an_unscoped_relay(self, monkeypatch):
+        """The invariant above, through check_grants' own failure path."""
+        monkeypatch.setitem(setup.TOOL_OVERRIDES, "slack-relay", ("Bash", "Read", "RemoteTrigger"))
+        report = setup.Report()
+        setup.check_grants(report, ROUTINES)
+        assert any("unscoped Bash" in problem for problem in report.problems)
+
+    def test_the_deployer_keeps_a_bare_shell(self):
+        """The narrowing is the relay's alone. `cd-deploy` runs git and `gh pr
+        create` against a plan Python composed; enumerating that is a list that
+        would rot, and it runs once a merge rather than seventeen times a day on
+        text it did not write."""
+        assert "Bash" in set(setup.routine_tools("cd-deploy"))
+
     def test_the_day_ahead_routine_cannot_write(self):
         """`cron/day-ahead.md` states this as a safety property — it runs one script
         and posts one message — so it is pinned rather than left as prose. Task


### PR DESCRIPTION
## Summary

Reacting ✅ on the daily digest thread is meant to label a GitHub issue `claude-implement`, which
fires the `implement` job in `claude.yml` to build the change and open a PR. That path was exercised
for the first time on 2026-08-09, on issue #172, and produced nothing while reporting success — then
re-announced the same approval twice more.

Four independent defects, each of which reports as success:

| | Defect | Evidence |
|---|---|---|
| 1 | The `implement` job **had never carried `--allowedTools`**. The action passes `settingSources: [user, project, local]`, so it inherited the repo's deliberately read-only `.claude/settings.json` allowlist — correct for an interactive session where a human approves each write, wrong for an unattended job whose purpose is to commit and push. | Run [31312744716](https://github.com/dinho149/yeaboi.ai/actions/runs/31312744716): 31 turns, **17 denied tool calls**, `is_error: false`, exit success, no branch, no PR. `git log -S'allowedTools'` shows it was never present; the lane has fired 131 times and produced exactly one non-skipped run, which did nothing. |
| 2 | The same job had **no Python toolchain** — only `checkout` and the action — so the `make test` / `make lint` gate in its own prompt could never run. | `ci.yml`, `ci-sentinel.yml` and `codeql-triage.yml` all install uv; `claude.yml` did not. |
| 3 | It ran every issue at **`heavy` (fable-5)**, which `cowork/models.md` forbids for security work. #172 was `type:security`. | `codeql-triage.yml` has a test pinning that rule; `claude.yml` had none. |
| 4 | The relay **replaced** the issue's whole label set while adding one, and **re-announced** the same approval three times. | Timeline, all at `2026-08-09T12:13:31Z`: `unlabeled cowork:proposal`, `unlabeled workstream:web-ux`, `unlabeled type:security`, `labeled claude-implement`. Thread replies 13/14/15 are all `added claude-implement to #172`; reply 1 already carried the 🤖 marker. |

Defect 4's label wipe matters more than it looks: `workstream:web-ux` is what the implement job reads
to load the charter declaring **which paths an unattended 110-turn run may touch**. That is a
boundary, not bookkeeping.

Defect 4's noise had three compounding causes: the Slack connector posts the relay's own acks under
the *human's* member id, so they returned as input; the early-exit rule was ill-typed (a *reaction*
cannot carry a marker, only the message under it can); and that invention ran at the `fast` tier over
a fifteen-reply thread, hourly.

## What changed

- **`.github/workflows/claude.yml`** — a tool grant; `setup-uv` + `uv sync`; a model-tier step so a
  security issue never reaches `heavy` (checking `type:security`, `workstream:security` **and** the
  title, because a label can be lost); and a final step that fails the job on any denial, or on a run
  that produced neither a PR nor a bot comment.
- **`scripts/cowork_relay.py`** *(new)* — owns the relay's decision. Keys on the digest's `#<n> —`
  reply contract, so the relay cannot re-parse its own acks, and on the 🤖 marker, gated to the
  allowlist so a stranger cannot bury an item.
- **`scripts/cowork_setup.py`** — the relay's grant goes from bare `Bash` to scoped `gh` verbs;
  `check_grants` enforces it.
- **`cowork/routines/cron/slack-relay.md`** — acts on the helper's plan; the audit comment is written
  only when the run actually applied the label.
- **`cowork/routines/cron/digest.md`** — new ⏳ **Approved, no PR yet** section. That window had no
  owner: ageing out a `claude-implement` issue is explicitly forbidden, so #172 became invisible to
  every routine in the fleet the moment it was approved.

## Review findings answered

The independent `code-reviewer` pass raised eight should-fix items; all are addressed in the second
commit. The two most substantive:

- **The picker implemented half its own rule.** `models.md` scopes "never heavy" to the security
  *workstream* as well as the type, and those are separate labels — a `[bug][security]` issue matched
  neither test.
- **Its tests would have survived an inverted picker.** They asserted that `"type:security"` and
  `"YEABOI_MODEL_DEEP"` appeared *somewhere* in the script, which stays true if the two branches are
  swapped. They now execute the picker under `bash` and assert the tier it selects; the
  inverted-branch mutation fails them.

Two findings are **refuted with evidence**, recorded in comments rather than argued:
`permission_denials_count` is the field the action really writes (read off run 31312744716), and the
routines API does honour `Bash(...)` scoping (a probe registered the scoped strings and read them
back verbatim).

## Test plan

- `make test` — **10980 passed**, 47 skipped
- `make lint` — clean
- `make security` — clean (SAST + `pip-audit`, no known vulnerabilities)
- `make parity` — 22 passed (the Go sidecar gate this branch rebased onto; no twinned file is touched)
- `make cowork-check` — clean
- **The recorded failure as a fixture** — the real #172 thread yields an empty plan; strip the marker
  and it yields exactly one `approve` for 172, and still nothing for the three ack replies.
- **Mutation-checked, not just asserted** — verified that inverting the model picker fails the new
  tests, and that hardcoding a model inside it fails the strengthened `test_cowork_models.py` guard.

## Definition of Done

- Item 4 (security): `make security` is clean. Note this branch was rebased onto `main` during
  `/ship` — the stale worktree lock held `langgraph-checkpoint-sqlite` 3.0.3 (PYSEC-2026-3636);
  `main` already carries the fixed 3.1.1 and this branch now matches it. No dependency is changed here.
- Item 5 (surface parity): **not applicable** — no new user-facing capability; this is fleet
  plumbing, so no `CAPABILITIES` row or `FeatureTip` is owed.
- Item 7 (web bundles): **not applicable** — nothing under `frontend/` is touched.
- Items 8–9 (Notion, Slack): on merge, via `pr-merged-close-loop`.
- Item 10 (review feedback): outstanding by design — `claude-review.yml` fires after CI succeeds.

## Follow-ups, not in this PR

1. `/cowork deploy` — five routines exist in `cowork/routines/` and are **not registered**:
   `agents-standup`, `cd-deploy`, `pr-merged-close-loop`, `pr-opened-dod-audit`,
   `release-published-announce`. The second and third are the fleet's own CD and merge-side halves.
   This must run *after* merge: the relay reads its routine file from the default branch, so
   deploying the new grant before the new prose lands would mix halves.
2. **Repair #172** — restore the three wiped labels, then remove and re-add `claude-implement`.
   Re-adding a label that is already present emits no webhook, so removal is the only retry path.

Closes YEA-75

🤖 Generated with [Claude Code](https://claude.com/claude-code)