### PR TITLE
record the five newly registered routine urls

### DIFF
--- a/cowork/README.md
+++ b/cowork/README.md
@@ -154,14 +154,14 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 | Routine | Trigger | Workstream | Tier | URL |
 |---|---|---|---|---|
 | `cron/marketing-weekly.md` | `0 8 * * 6` Sat | marketing | `deep` | https://claude.ai/code/routines/trig_011f1J2fUGPhDQKSmjEMEiGs |
-| `cron/agents-standup.md` | `15 6 * * 1-5` weekdays | agents | `fast` | |
+| `cron/agents-standup.md` | `15 6 * * 1-5` weekdays | agents | `fast` | https://claude.ai/code/routines/trig_013tsooGjdnEMLRQcm7ZKU57 |
 | `cron/day-ahead.md` | `45 5 * * *` daily | — | `fast` | https://claude.ai/code/routines/trig_01DHtR33hCFgDhoz7yA5jXUi |
 | `cron/digest.md` | `15 8 * * *` | — | `standard` | https://claude.ai/code/routines/trig_01VY1hbAZKeGuKA1GLyVhbow |
 | `cron/slack-relay.md` | `0 7-23 * * *` hourly | — | `fast` | https://claude.ai/code/routines/trig_01X18LBBBZ1FWEtx2Cmffyow |
-| `cron/cd-deploy.md` | `0 4 * * *` daily + push (any branch) | — | `standard` | |
-| `events/pr-opened-dod-audit.md` | PR opened / synchronized | — | `standard` | |
-| `events/pr-merged-close-loop.md` | PR closed (merged) | — | `fast` | |
-| `events/release-published-announce.md` | Release published | — | `standard` | |
+| `cron/cd-deploy.md` | `0 4 * * *` daily + push (any branch) | — | `standard` | https://claude.ai/code/routines/trig_01AkW6ojpjKcra8H64R3Astr |
+| `events/pr-opened-dod-audit.md` | PR opened / synchronized | — | `standard` | https://claude.ai/code/routines/trig_01Egz2NXy4GwzJzRRC7Z4Zm3 |
+| `events/pr-merged-close-loop.md` | PR closed (merged) | — | `fast` | https://claude.ai/code/routines/trig_019gLyX5qWx7g5rXZkUKaDAo |
+| `events/release-published-announce.md` | Release published | — | `standard` | https://claude.ai/code/routines/trig_01VXdR2FbPJUsMqVWghA7C5T |
 
 > **Cron trap.** The fortnightly and monthly slots restrict **day-of-month only**. Standard cron
 > *ORs* day-of-month with day-of-week when both are restricted, so `30 7 1-7,15-21 * 2` fires every


### PR DESCRIPTION
## Summary

`/cowork deploy` registered the five routines that existed in `cowork/routines/` but had never been
registered — including `cd-deploy` (the fleet's own CD) and `pr-merged-close-loop`, which owns
Definition-of-Done items 8 and 9 on merge. This is the URL column catching up.

Written by `uv run python scripts/cowork_setup.py --urls`, not by hand — the table is meant to record
what is actually running, and `make cowork-check` fails when it is blank.

| Routine | Fires on |
|---|---|
| `agents-standup` | cron, weekdays 06:15 UTC |
| `cd-deploy` | GitHub `push` webhook + daily 04:00 UTC |
| `pr-opened-dod-audit` | GitHub `pull_request` — opened, synchronize |
| `pr-merged-close-loop` | GitHub `pull_request` — closed |
| `release-published-announce` | GitHub `release` — published |

## Test plan

- `uv run python scripts/cowork_setup.py --check --triggers <live snapshot>` — **clean** (was 7
  problems: 5 unregistered routines, `slack-relay` drift, 5 blank URLs)
- `make cowork-check` — clean
- Documentation only; no code changed.

## Definition of Done

- Items 2–7: **not applicable** — no code, no capability, nothing under `frontend/`.
- Item 1 (Linear): no ticket — this is the bookkeeping half of YEA-75, which is already Done.
- Items 8–9: on merge, via `pr-merged-close-loop` — which this PR is, fittingly, the first to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)