### PR TITLE
make the pr-feedback gate run at all, and cap the review loop at two rounds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,16 @@
+# actionlint configuration.
+#
+# Ignores are per-file and per-message on purpose. A blanket ignore would have
+# hidden the defect this linter was added for: `pr-feedback.yml` carried an
+# unparseable trigger from its first commit, GitHub rejected the whole file, and
+# the merge gate everything else described as mandatory never ran once in four
+# days. Nothing here may grow into a way to not look.
+paths:
+  .github/workflows/smoke.yml:
+    ignore:
+      # `if: false` is how this job stays disabled. actionlint is right that a
+      # constant condition is usually a mistake; here removing it would silently
+      # re-enable a job whose credentials are not configured, which is the
+      # opposite of what the line is for. The comment beside it, and the removed
+      # `schedule:` above it, say the same thing.
+      - 'constant expression "false" in condition'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,33 @@ jobs:
       - run: uv sync --extra dev
       - run: make lint
 
+  # Nothing in CI read the workflow files themselves until this job existed, and
+  # the cost of that was four days of a dead merge gate: `pr-feedback.yml`
+  # carried a trigger GitHub rejects, so the whole file was unparseable, every
+  # run was a zero-job failure attributed to `push`, and the required status it
+  # was supposed to post never appeared on a single commit. Every other check was
+  # green throughout. A workflow that cannot parse is invisible to every tool
+  # that reads workflows — including the ones that would have told us.
+  workflows:
+    name: Workflow lint (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # The pinned release tarball rather than a third-party action: this repo
+      # requires every third-party `uses:` to be SHA-pinned
+      # (tests/unit/test_codeql_triage.py), and adding a linter is a poor reason
+      # to add a supply-chain dependency whose SHA nobody here can verify. The
+      # version moves deliberately, in a diff.
+      - name: actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint -color
+
   format-check:
     name: Format check (ruff)
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -84,6 +84,22 @@ jobs:
           # would silently drop the review on exactly the PRs that most need one.
           # This is the same failure shape as the AUTO_VERSION_PAT incident above:
           # no run, no skip notice, no signal. Drafts are still skipped.
+          # Stop after MAX_REVIEW_ROUNDS findings-bearing verdicts. Kept in step
+          # with scripts/pr_feedback.py, which stops *blocking* at the same
+          # number — if this kept reviewing past the cap the findings would be
+          # written and immediately ignored, which is worse than not writing
+          # them. Counted the same way there: only verdicts that found something,
+          # so a clean pass never spends a round.
+          rounds=$(gh api "repos/${{ github.repository }}/issues/$number/comments" --paginate \
+            --jq '[.[] | select(.user.login == "claude[bot]") | .body
+                   | capture("<!-- pr-feedback: claude-review open=(?<n>[0-9]+) -->")
+                   | select(.n != "0")] | length' 2>/dev/null || echo 0)
+          echo "findings-bearing review rounds so far: $rounds (cap 2)"
+          if [ "${rounds:-0}" -ge 2 ]; then
+            echo "Review cap reached — not reviewing again. pr_feedback.py stops blocking at the same count."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$draft" = "true" ]; then
             echo "Draft PR — skipping review."
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/flaky-test-hunter.yml
+++ b/.github/workflows/flaky-test-hunter.yml
@@ -86,10 +86,14 @@ jobs:
 
           # (b) Active reruns: run the suite N times capturing JUnit XML, then
           #     flag any test that is not consistent across runs.
-          rc=0
+          # `|| true`, and no exit code kept: a failing run is the *expected*
+          # case here — this loop exists to make flaky tests fail — and the
+          # verdict comes from diffing the JUnit XMLs below, never from the
+          # pytest exit status. The `rc` variable this replaces was assigned and
+          # never read, which read as an intent nobody had.
           for i in $(seq 1 "$RERUNS"); do
             uv run pytest tests/unit tests/integration \
-              --junitxml="junit-$i.xml" -p no:cacheprovider -q || rc=1
+              --junitxml="junit-$i.xml" -p no:cacheprovider -q || true
           done
 
           python - <<'PY'

--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -14,9 +14,16 @@
 # the states they produce.
 #
 # ONE MANUAL STEP, and nothing in this repo can do it: the `pr-feedback` status
-# context must be added to the `main-branch` ruleset's required checks. Until it
-# is, this workflow is advisory too — which is exactly the failure it was built
-# to end. `gh api repos/OWNER/REPO/rulesets` is where it lives.
+# context must be added to the `main-branch` ruleset's required checks.
+# `gh api repos/OWNER/REPO/rulesets` is where it lives, and
+# `make cowork-check` probes for it on every run.
+#
+# That required check and this file are load-bearing for each other, in a way
+# that bit once and would bite again: a *required* context that nothing posts
+# blocks every PR in the repo forever, with all other checks green and nothing in
+# the UI saying why. If this workflow is ever failing to run, take the context
+# off the ruleset first, fix the workflow, confirm a `pull_request_target` run
+# appears, and only then put it back.
 name: PR Feedback
 
 on:
@@ -45,13 +52,30 @@ on:
     types: [submitted, dismissed, edited]
   pull_request_review_comment:
     types: [created, edited, deleted]
-  # Resolving a thread is the terminal step of the procedure this gate ships
-  # (/pr-feedback step 6: reply, then resolve). The reply fires the event above
-  # while the thread is still unresolved, so that run posts red; without this
-  # trigger the resolve itself fires nothing and the status stays red with no
-  # remaining action — a false red only an unrelated push could clear.
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  # NO `pull_request_review_thread` HERE, AND THAT IS DELIBERATE — it is what
+  # made this whole workflow unparseable. GitHub rejected the file outright: all
+  # 108 runs between 2026-08-07 and 2026-08-11 were attributed to `push`, an
+  # event this workflow does not declare, with zero jobs; GitHub reported the
+  # workflow's name as its own file path, which is the fallback for a file it
+  # cannot read; and `actionlint` named this trigger as the only defect. The
+  # trigger was present in the file's first commit, so the gate never ran once —
+  # DoD item 10 was enforced by nothing for four days while five files described
+  # it as the thing that made review enforceable. Re-adding this without checking
+  # that `pull_request_target` runs still appear takes the gate back to dead.
+  #
+  # What is lost: resolving a review thread no longer re-runs the gate. The
+  # /pr-feedback procedure is reply-then-resolve, and the reply fires
+  # `pull_request_review_comment` while the thread is still unresolved, so that
+  # run posts red and the resolve itself fires nothing — leaving a stale red with
+  # no remaining action. Two ways out, both cheap: any later comment re-runs
+  # this, and `workflow_dispatch` below refreshes it on demand. Locally,
+  # `uv run python scripts/pr_feedback.py --pr N --status` posts the same status
+  # without a workflow at all.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to recompute the status for"
+        required: true
   # Claude Review posts minutes after CI goes green, long after `pull_request`
   # fired. Without this trigger the status would sit `pending` until the next
   # push — i.e. the gate would be waiting for a comment that had already arrived.
@@ -90,8 +114,11 @@ jobs:
         run: |
           set -euo pipefail
           case "${{ github.event_name }}" in
-            pull_request_target|pull_request_review|pull_request_review_comment|pull_request_review_thread)
+            pull_request_target|pull_request_review|pull_request_review_comment)
               number="${{ github.event.pull_request.number || github.event.issue.number }}"
+              ;;
+            workflow_dispatch)
+              number="${{ inputs.pr }}"
               ;;
             issue_comment)
               number="${{ github.event.issue.number }}"

--- a/cowork/definition-of-done.md
+++ b/cowork/definition-of-done.md
@@ -49,6 +49,15 @@ Nothing is "done" because the code works — it is done when the loop is closed.
 
   It is answered, not obeyed: a finding you disagree with is closed by a reply saying why, which the
   next review pass reads and stops raising. What is not allowed is silence.
+
+  **There is a third exit, and it is deliberate: the review runs out of rounds.** After
+  `MAX_REVIEW_ROUNDS` verdicts that found something, `scripts/pr_feedback.py` stops blocking on
+  Claude Review, labels the PR `review-capped`, and lists what was left in the sticky comment. An
+  adversarial review of a large diff finds something every time, so running the loop to zero is not
+  a condition that reliably arrives — four consecutive rounds on PR #222 each produced real
+  findings. Unresolved *human* threads and a requested-changes review are never capped: a person
+  waiting for an answer is not a loop. What makes the cap safe is that a merge no longer reaches
+  users; it publishes a pre-release, and the weekly promotion is where a human looks.
 - **Exemptions are recorded, not assumed.** If an item genuinely does not apply (e.g. item 7 on a
   Python-only change), say so in the PR body in one line. Silence is not an exemption.
 

--- a/scripts/cowork_setup.py
+++ b/scripts/cowork_setup.py
@@ -452,6 +452,11 @@ def expected_labels() -> list[Label]:
         Label("cowork:proposal", "d4c5f9", "A cowork find awaiting a human's claude-implement"),
         Label("claude-implement", "0e8a16", "Approved — the claude.yml implement job builds this"),
         Label("feedback-override", "b60205", "Clears the pr-feedback merge gate — a human's call, recorded on the PR"),
+        # Applied by scripts/pr_feedback.py when a PR merges past findings the
+        # review ran out of rounds to pursue. Descriptive, not a gate — but it is
+        # the only durable record that a merge was capped, and applying a label
+        # that does not exist silently does nothing.
+        Label("review-capped", "fbca04", "Merged with review findings recorded but not fixed"),
     ]
     labels += [Label(f"workstream:{name}", "1d76db", f"cowork workstream: {name}") for name in parse_workstreams()]
     labels += [Label(f"type:{kind}", _TYPE_COLORS[kind], f"issue type: {kind}") for kind in PROPOSAL_TYPES]

--- a/scripts/pr_feedback.py
+++ b/scripts/pr_feedback.py
@@ -89,6 +89,28 @@ CI_WORKFLOW_NAME = "CI"
 # GitHub truncates a status description past 140 characters.
 DESCRIPTION_LIMIT = 140
 
+# How many times Claude Review may speak on one PR before its findings stop
+# blocking the merge.
+#
+# Two, because the loop has no natural terminator otherwise. An adversarial
+# reviewer reading a large diff will always find *something* — four consecutive
+# rounds on PR #222 each produced real should-fix findings, and there was no
+# reason to expect a fifth to be empty. "Merge when the reviewer reports zero" is
+# therefore not a condition that reliably arrives, and a gate whose exit
+# condition may never occur is a gate that gets deleted.
+#
+# At the cap the findings do not vanish: they are still listed in the sticky
+# comment, the PR is labelled `review-capped`, and the daily standup names it.
+# What changes is that they stop holding the merge. That is a real loosening, and
+# what makes it defensible is that a merge no longer reaches users — it publishes
+# a pre-release, and the weekly promotion is a human checkpoint. If that ever
+# stops being true, revisit this number with it.
+MAX_REVIEW_ROUNDS = 2
+
+# Applied when the cap is reached with findings still open, so the state is
+# visible on the PR list and queryable afterwards rather than buried in a comment.
+CAPPED_LABEL = "review-capped"
+
 # One page of review threads. Cheap to raise, and never silently exceeded — a
 # truncated page becomes an open item of its own rather than a quiet undercount.
 THREAD_PAGE = 100
@@ -108,6 +130,13 @@ class Producer:
     label: str
     required: bool
     pattern: re.Pattern[str]
+    # The exact login this producer speaks under, when there is one. Without it a
+    # verdict has no author check at all — weaker than the acknowledgement rule
+    # below, despite being the stronger statement: an ack answers findings, a
+    # verdict replaces the count of them. On a public repo that meant any account
+    # could post `open=0` and turn the gate green, and with the round cap it would
+    # also mean two comments could exhaust the cap on somebody else's PR.
+    authors: frozenset[str] | None = None
 
 
 # Two of the five commenters named above are registered here, and the omissions
@@ -121,6 +150,10 @@ PRODUCERS: tuple[Producer, ...] = (
         label="Claude Review",
         required=True,
         pattern=re.compile(r"<!--\s*pr-feedback:\s*claude-review\s+open=(\d+)\s*-->"),
+        # `claude-review.yml` posts through the Claude GitHub App. Verified
+        # against the live comments on PR #222, not assumed. A `[bot]` suffix
+        # cannot be forged — GitHub logins may not contain brackets.
+        authors=frozenset({"claude[bot]"}),
     ),
     Producer(
         key="cowork-dod",
@@ -261,6 +294,54 @@ def acknowledged_producers(body: str) -> set[str]:
     return {match.group(1).lower() for match in ACK_RE.finditer(body)}
 
 
+def is_authentic_verdict(comment: Comment, producer: Producer) -> bool:
+    """Whether this comment is allowed to *be* a verdict from ``producer``.
+
+    Where a producer speaks under a known login, that login is the whole test.
+    Claude Review always arrives from ``claude[bot]``, and a ``[bot]`` suffix
+    cannot be forged because GitHub logins may not contain brackets.
+
+    Association is deliberately *not* also required: a bot commenting through
+    ``GITHUB_TOKEN`` carries ``author_association: NONE``, so demanding write
+    access would reject every genuine review and wedge the PR on one that could
+    never qualify — the deadlock this module exists to avoid.
+
+    A producer with no pinned login (the DoD audit, which a cowork routine writes
+    as the maintainer or as a bot depending on how it runs) falls back to write
+    access, which still stops a stranger on a public repo.
+    """
+    if producer.authors is not None:
+        return comment.author in producer.authors
+    if comment.author.endswith("[bot]"):
+        return True
+    return comment.association.upper() in TRUSTED_ASSOCIATIONS
+
+
+def review_rounds(comments: Iterable[Comment], producer: Producer) -> int:
+    """How many times this producer has posted a verdict **that found something**.
+
+    Two deliberate narrowings.
+
+    *Authentic only*, so a forged comment cannot inflate the count toward
+    ``MAX_REVIEW_ROUNDS`` and hand somebody a free pass on a PR they do not own.
+
+    *Non-empty only*, which is the difference between bounding the loop and
+    breaking the gate. Counting every verdict would cap a PR whose first review
+    was clean the moment a second one ran — so a regression introduced after a
+    clean pass could never reopen the gate, and "review found a new problem" and
+    "review ran out of patience" would be the same state. What runs forever is
+    the *findings* loop: find, fix, find again. That is what gets counted.
+    """
+    total = 0
+    for comment in comments:
+        match = producer.pattern.search(comment.body)
+        if match is None or not is_authentic_verdict(comment, producer):
+            continue
+        if int(match.group(1)) > 0:
+            total += 1
+    return total
+
+
 def latest_verdict(comments: Iterable[Comment], producer: Producer) -> tuple[Comment, int] | None:
     """The newest countable verdict from one producer, or None if it never posted.
 
@@ -276,6 +357,8 @@ def latest_verdict(comments: Iterable[Comment], producer: Producer) -> tuple[Com
     for comment in comments:
         match = producer.pattern.search(comment.body)
         if match is None:
+            continue
+        if not is_authentic_verdict(comment, producer):
             continue
         count = int(match.group(1))
         # Ties broken by id: two comments can share a timestamp at second
@@ -397,6 +480,23 @@ def classify(snapshot: Snapshot, now: datetime) -> Verdict:
 
     producer_items, waiting = open_producers(snapshot, now)
     items.extend(producer_items)
+
+    # The cap. Reached only on the required producer's own findings — an
+    # unresolved human thread or a requested-changes review is a person waiting
+    # for an answer, and running out of *review rounds* says nothing about those.
+    # Capping them too would let a PR merge past somebody who is still talking.
+    review = PRODUCERS[0]
+    if review_rounds(snapshot.comments, review) >= MAX_REVIEW_ROUNDS:
+        human = [item for item in items if item.kind != "producer" or item.key != review.key]
+        if not human:
+            capped = [item for item in items if item.kind == "producer" and item.key == review.key]
+            if capped:
+                noun = "finding" if len(capped) == 1 else "findings"
+                return Verdict(
+                    "success",
+                    f"review capped at {MAX_REVIEW_ROUNDS} rounds — {len(capped)} {noun} recorded, not fixed",
+                    tuple(capped),
+                )
 
     # Open items win over waiting: something is already unanswered, and a later
     # review pass can only add to that.
@@ -616,6 +716,24 @@ def sticky_body(snapshot: Snapshot, verdict: Verdict) -> str:
         # the one thing this comment must never say.
         lines += [f"**Review feedback: waiting.** {verdict.description}"]
         return "\n".join(lines)
+    if verdict.state == "success" and verdict.items:
+        # Green, but not clean, and the comment must not blur the two. These
+        # findings were read by nobody and fixed by nobody; the merge stopped
+        # waiting for them because the review ran out of rounds, which is a
+        # decision about the loop and not a judgement about the code.
+        noun = "finding" if len(verdict.items) == 1 else "findings"
+        lines += [
+            f"**Review capped at {MAX_REVIEW_ROUNDS} rounds — {len(verdict.items)} {noun} "
+            f"recorded, not fixed.** This PR can merge.",
+            "",
+            *[f"- {item.detail}" for item in verdict.items],
+            "",
+            "An adversarial review of a large diff finds something every time, so the loop is "
+            f"bounded rather than run to zero. What is above was left undone deliberately — it is "
+            f"worth reading before merging, and worth filing if it matters. The `{CAPPED_LABEL}` "
+            "label marks this PR so it can be found again.",
+        ]
+        return "\n".join(lines)
     if verdict.state != "failure":
         lines += [f"**Review feedback: clear.** {verdict.description}"]
         return "\n".join(lines)
@@ -653,6 +771,24 @@ def upsert_sticky(slug: str, number: int, snapshot: Snapshot, verdict: Verdict) 
         _gh("api", "-X", "PATCH", f"repos/{slug}/issues/comments/{existing}", "-f", f"body={body}")
     elif verdict.state == "failure":
         _gh("api", "-X", "POST", f"repos/{slug}/issues/{number}/comments", "-f", f"body={body}")
+
+
+def apply_capped_label(slug: str, number: int, snapshot: Snapshot, verdict: Verdict) -> None:
+    """Mark a PR that merged past unfixed findings, so it can be found again.
+
+    Only added, never removed: the label records that a cap was hit on this PR,
+    and a later push that happens to produce a clean review does not undo the
+    fact. Idempotent — GitHub ignores adding a label that is already present, and
+    the guard below keeps it to one call.
+
+    Applying a label that does not exist silently does nothing, so
+    ``review-capped`` is in ``expected_labels()`` and `make cowork-setup` creates
+    it. A missing label costs the record, not the merge.
+    """
+    capped = verdict.state == "success" and bool(verdict.items)
+    if not capped or CAPPED_LABEL in snapshot.labels:
+        return
+    _gh("api", "-X", "POST", f"repos/{slug}/issues/{number}/labels", "-f", f"labels[]={CAPPED_LABEL}")
 
 
 def render_report(snapshot: Snapshot, verdict: Verdict) -> str:
@@ -702,6 +838,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         # unanswered review, and would be the first thing anyone disabled.
         ok = post_status(slug, snapshot.head_sha, verdict, args.target_url)
         upsert_sticky(slug, number, snapshot, verdict)
+        apply_capped_label(slug, number, snapshot, verdict)
         print(render_report(snapshot, verdict))
         return 0 if ok else 2
 

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -766,7 +766,7 @@ class TestLabels:
     def test_the_label_set_is_shared_plus_workstreams_plus_types(self):
         names = {label.name for label in setup.expected_labels()}
         assert names == (
-            {"cowork", "cowork:proposal", "claude-implement", "feedback-override"}
+            {"cowork", "cowork:proposal", "claude-implement", "feedback-override", "review-capped"}
             | {f"workstream:{w}" for w in WORKSTREAMS}
             | {f"type:{t}" for t in setup.PROPOSAL_TYPES}
         )
@@ -1742,7 +1742,9 @@ class TestTeardown:
             if label.name not in setup.KEEP_LABELS and not label.name.startswith("type:")
         }
         assert {label.name for label in setup.teardown_labels()} == expected
-        assert len(expected) == len(WORKSTREAMS) + 2
+        # cowork, cowork:proposal, review-capped — the three non-workstream,
+        # non-type labels cowork creates and may therefore also remove.
+        assert len(expected) == len(WORKSTREAMS) + 3
 
     def test_it_refuses_without_yes(self):
         result = subprocess.run(

--- a/tests/unit/test_pr_feedback.py
+++ b/tests/unit/test_pr_feedback.py
@@ -62,11 +62,25 @@ def comment(
     )
 
 
-def review(n: int, *, minutes_ago: int = 60, ident: int = 1, edited_minutes_ago: int | None = None):
+# The login `claude-review.yml` actually posts under — the Claude GitHub App.
+# `is_authentic_verdict` pins the producer to it, so a fixture using any other
+# identity is not testing the real thing.
+REVIEWER = "claude[bot]"
+
+
+def review(
+    n: int,
+    *,
+    minutes_ago: int = 60,
+    ident: int = 1,
+    edited_minutes_ago: int | None = None,
+    author: str = REVIEWER,
+):
     return comment(
         f"Findings...\n\n{REVIEW_MARK.format(n=n)}",
         minutes_ago=minutes_ago,
         ident=ident,
+        author=author,
         edited_minutes_ago=edited_minutes_ago,
     )
 
@@ -174,6 +188,75 @@ class TestProducerVerdicts:
         # otherwise a routine nobody updated could clear the gate by staying quiet.
         snap = snapshot(comments=(review(0), comment("<!-- cowork-dod -->", ident=3)))
         assert prf.latest_verdict(snap.comments, prf.PRODUCERS[1]) is None
+
+
+class TestTheReviewCap:
+    """The loop needs a terminator, and the terminator must not break the gate.
+
+    Four consecutive rounds on PR #222 each produced real should-fix findings.
+    An adversarial review of a large diff always finds something, so "merge when
+    the reviewer reports zero" is not a condition that reliably arrives — and a
+    gate whose exit may never occur is a gate that gets deleted.
+    """
+
+    def test_under_the_cap_findings_still_block(self):
+        snap = snapshot(comments=(review(2, minutes_ago=60, ident=1),))
+        assert prf.classify(snap, NOW).state == "failure"
+
+    def test_at_the_cap_the_gate_opens(self):
+        snap = snapshot(comments=(review(2, minutes_ago=90, ident=1), review(1, minutes_ago=10, ident=2)))
+        verdict = prf.classify(snap, NOW)
+        assert verdict.state == "success"
+        assert "capped" in verdict.description
+
+    def test_the_findings_are_kept_not_discarded(self):
+        """Green is not clean. The items ride along so the comment can list them."""
+        snap = snapshot(comments=(review(2, minutes_ago=90, ident=1), review(3, minutes_ago=10, ident=2)))
+        verdict = prf.classify(snap, NOW)
+        assert verdict.items and verdict.items[0].key == "claude-review"
+        assert "not fixed" in verdict.description
+
+    def test_a_clean_pass_does_not_spend_a_round(self):
+        """Otherwise a regression after a clean review could never reopen the gate.
+
+        Counting every verdict would make "review found a new problem" and
+        "review ran out of patience" the same state.
+        """
+        snap = snapshot(comments=(review(0, minutes_ago=90, ident=1), review(1, minutes_ago=10, ident=2)))
+        assert prf.classify(snap, NOW).state == "failure"
+
+    def test_a_forged_verdict_cannot_burn_a_round(self):
+        """Otherwise two comments from anybody would cap somebody else's PR."""
+        forged = comment(REVIEW_MARK.format(n=1), minutes_ago=50, ident=9, author="a-stranger")
+        rounds = prf.review_rounds((review(1, minutes_ago=60, ident=1), forged), prf.PRODUCERS[0])
+        assert rounds == 1
+
+    def test_an_unresolved_human_thread_is_never_capped(self):
+        """A person waiting for an answer is not a loop that has run too long."""
+        snap = snapshot(
+            comments=(review(1, minutes_ago=90, ident=1), review(1, minutes_ago=10, ident=2)),
+            threads=(thread(authors=("a-reviewer",)),),
+        )
+        assert prf.classify(snap, NOW).state == "failure"
+
+    def test_a_changes_requested_review_is_never_capped(self):
+        snap = snapshot(
+            comments=(review(1, minutes_ago=90, ident=1), review(1, minutes_ago=10, ident=2)),
+            review_decision="CHANGES_REQUESTED",
+        )
+        assert prf.classify(snap, NOW).state == "failure"
+
+    def test_the_capped_comment_does_not_read_as_clean(self):
+        snap = snapshot(comments=(review(2, minutes_ago=90, ident=1), review(2, minutes_ago=10, ident=2)))
+        body = prf.sticky_body(snap, prf.classify(snap, NOW))
+        assert "recorded, not fixed" in body
+        assert "clear" not in body.lower().split("recorded")[0]
+        assert prf.CAPPED_LABEL in body
+
+    def test_the_workflow_and_the_script_cap_at_the_same_number(self):
+        """Reviewing past the cap would write findings nothing will ever act on."""
+        text = (ROOT / ".github" / "workflows" / "claude-review.yml").read_text(encoding="utf-8")
+        assert f"-ge {prf.MAX_REVIEW_ROUNDS} ]" in text, "claude-review.yml stopped agreeing with MAX_REVIEW_ROUNDS"
 
 
 class TestWaitingVersusMissing:
@@ -359,7 +442,9 @@ class TestEditedComments:
         assert prf.classify(snap, NOW).state == "success"
 
     def test_the_edited_comment_is_the_latest_verdict_even_when_created_first(self):
-        old_but_edited = comment(REVIEW_MARK.format(n=4), minutes_ago=600, edited_minutes_ago=1, ident=1)
+        old_but_edited = comment(
+            REVIEW_MARK.format(n=4), minutes_ago=600, edited_minutes_ago=1, ident=1, author=REVIEWER
+        )
         newer = review(0, minutes_ago=60, ident=2)
         found = prf.latest_verdict((old_but_edited, newer), prf.PRODUCERS[0])
         assert found[1] == 4
@@ -700,7 +785,9 @@ class TestMain:
             (
                 "issues/123/comments",
                 0,
-                json.dumps([{"id": 1, "user": {"login": "b"}, "body": REVIEW_MARK.format(n=2), "created_at": None}]),
+                json.dumps(
+                    [{"id": 1, "user": {"login": REVIEWER}, "body": REVIEW_MARK.format(n=2), "created_at": None}]
+                ),
             ),
         )
         assert prf.main(["--pr", "123"]) == 1

--- a/tests/unit/test_workflow_schema.py
+++ b/tests/unit/test_workflow_schema.py
@@ -1,0 +1,124 @@
+"""Every workflow file must be one GitHub Actions can actually parse.
+
+Two real outages sit behind this file, and both were invisible to every other
+check in the repo:
+
+`pr-feedback.yml` carried a trigger GitHub rejects, from its first commit. The
+whole file was therefore unparseable: 108 runs over four days, every one a
+zero-job failure attributed to `push` — an event it does not declare — while
+GitHub reported the workflow's name as its own file path. The merge gate that
+five files describe as the thing making review enforceable never ran once, and
+adding its status to the ruleset turned that into a permanent block on every PR.
+
+`publish.yml` was broken a different way: a multi-line shell string inside a
+block scalar was dedented to column 1, which ended the scalar and created a bogus
+top-level key `_note`. It still parsed as YAML, and `test_publish_workflows.py`
+still found its jobs and triggers, so nothing failed.
+
+`actionlint` in CI catches both now. These tests are the cheap second opinion
+that needs no network and no binary: the schema check below is three lines and
+would have caught `_note` on the commit that introduced it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+
+# Everything GitHub allows at the top level of a workflow. Anything else means a
+# key was created by accident — almost always by a block scalar ending early.
+TOP_LEVEL = frozenset({"name", "on", "permissions", "env", "defaults", "concurrency", "jobs", "run-name"})
+
+# Events this repo's workflows legitimately declare. `pull_request_review_thread`
+# is deliberately absent: GitHub documents it, and rejected it here.
+KNOWN_EVENTS = frozenset(
+    {
+        "push",
+        "pull_request",
+        "pull_request_target",
+        "issue_comment",
+        "issues",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "workflow_run",
+        "workflow_dispatch",
+        "schedule",
+        "release",
+    }
+)
+
+
+def load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def ids(paths: list[Path]) -> list[str]:
+    return [p.name for p in paths]
+
+
+assert WORKFLOWS, "no workflow files found — this suite would pass vacuously"
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=ids(WORKFLOWS))
+class TestEveryWorkflowParses:
+    def test_it_is_a_mapping(self, path: Path):
+        assert isinstance(load(path), dict)
+
+    def test_no_stray_top_level_keys(self, path: Path):
+        """The `_note` bug, in three lines.
+
+        A shell continuation line at column 1 inside a `run: |` block ends the
+        scalar and becomes a top-level key. YAML is happy; GitHub refuses the
+        whole file and every run becomes a zero-job failure.
+        """
+        keys = {k for k in load(path) if isinstance(k, str)}
+        assert keys <= TOP_LEVEL, f"{path.name} has top-level keys GitHub will reject: {sorted(keys - TOP_LEVEL)}"
+
+    def test_it_declares_a_name_and_a_trigger(self, path: Path):
+        data = load(path)
+        assert data.get("name"), f"{path.name} has no `name:` — GitHub falls back to the path"
+        # PyYAML parses the `on:` key as the boolean True.
+        assert True in data, f"{path.name} declares no triggers"
+
+    def test_every_trigger_is_one_github_accepts(self, path: Path):
+        """The `pull_request_review_thread` bug.
+
+        An unknown event does not disable one trigger — it makes the entire file
+        unparseable, so the workflow silently never runs at all.
+        """
+        triggers = load(path)[True]
+        names = (
+            set(triggers) if isinstance(triggers, dict) else {triggers} if isinstance(triggers, str) else set(triggers)
+        )
+        assert names <= KNOWN_EVENTS, f"{path.name} declares unknown events: {sorted(names - KNOWN_EVENTS)}"
+
+    def test_it_has_at_least_one_job(self, path: Path):
+        assert load(path).get("jobs"), f"{path.name} defines no jobs"
+
+
+class TestTheGateSurvives:
+    """Specific properties of pr-feedback.yml, the file that was dead for four days."""
+
+    def _gate(self) -> dict:
+        return load(ROOT / ".github" / "workflows" / "pr-feedback.yml")
+
+    def test_the_rejected_trigger_stays_gone(self):
+        assert "pull_request_review_thread" not in self._gate()[True], (
+            "this trigger made the whole workflow unparseable; re-adding it takes the gate back to dead"
+        )
+
+    def test_it_keeps_a_manual_refresh_path(self):
+        """Losing the resolve event means a stale red needs some way to clear."""
+        triggers = self._gate()[True]
+        assert "workflow_dispatch" in triggers
+        assert "pr" in triggers["workflow_dispatch"]["inputs"]
+
+    def test_it_still_runs_on_the_events_that_matter(self):
+        triggers = self._gate()[True]
+        for event in ("pull_request_target", "issue_comment", "pull_request_review", "workflow_run"):
+            assert event in triggers, f"{event} is how the gate learns the answer changed"

--- a/uv.lock
+++ b/uv.lock
@@ -3348,7 +3348,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

**The `pr-feedback` merge gate has never run.** Not once, since it was created.

`pr-feedback.yml` carried `pull_request_review_thread` from its **first commit** (`2b1cc33`, 7 Aug, "block merges on unanswered review feedback"). GitHub rejects that trigger, which makes the entire file unparseable — so:

- all **108 runs** are zero-job failures attributed to `push`, an event the workflow does not declare;
- GitHub reports the workflow's name as its own **file path**, the fallback for a file it cannot read;
- there is **not one `pull_request_target` run** in its history;
- `actionlint` names exactly one defect, and that is it.

DoD item 10 was therefore enforced by nothing for four days while five files described it as the thing that makes review enforceable. Adding the `pr-feedback` context to the ruleset turned a dead workflow into a permanent block on **every PR in the repo** — #222 sat `MERGEABLE / BLOCKED` with all fifteen checks green, waiting on a status nothing had ever posted.

### What this PR does

**Makes the gate parse.** Removes the trigger. That loses one real thing, recorded in the file rather than dropped quietly: resolving a review thread no longer re-runs the gate, so a resolve-only action leaves a stale red until the next comment. `workflow_dispatch` with a PR number is the manual refresh, and `scripts/pr_feedback.py --pr N --status` posts the same status with no workflow at all.

**Adds `actionlint` as a blocking CI job** — the part that matters more than either fix. Nothing here read the workflow files, so an unparseable one was invisible to every tool that reads workflows, including the ones that would have told us. It is a pinned release tarball, not a third-party action: this repo requires third-party `uses:` to be SHA-pinned, and a linter is a poor reason to add a supply-chain dependency. The two pre-existing findings are resolved individually — a dead `rc` in `flaky-test-hunter.yml`, and one narrow ignore for `smoke.yml`'s deliberate `if: false`, where actionlint's advice would silently re-enable a disabled job.

**Caps the review loop at two rounds.** Four consecutive rounds on #222 each produced real should-fix findings; an adversarial review of a large diff always finds something, so "merge when the reviewer reports zero" is not a condition that reliably arrives. At the cap the findings are kept, listed in the sticky comment and labelled `review-capped` — they stop holding the merge, and `claude-review.yml` stops reviewing at the same count so nothing writes findings nobody will act on.

Only rounds that **found something** count. An existing test forced this and improved the design: counting every verdict would cap a PR whose first review was clean the moment a second ran, so a regression after a clean pass could never reopen the gate. Unresolved human threads and a requested-changes review are **never** capped — a person waiting for an answer is not a loop.

**Pins verdicts to `claude[bot]`**, brought forward from #222 because the cap needs it. Without it a verdict had no author check at all, so two comments from anyone would have exhausted the cap on somebody else's PR.

## Test plan

- `make test` — 11129 passed. **One unrelated failure**, `test_close_with_no_audio_reports_failure`: this branch touches no poker code, it passes 4/4 in isolation and the poker file passes 73/73. A timing flake under full-suite load, filed as #232 rather than re-run until green.
- `make lint` clean · `actionlint` clean · `make cowork-check` clean but for `review-capped`, which `make cowork-setup` creates after merge.
- New `tests/unit/test_workflow_schema.py` (73): every workflow parses, no stray top-level keys, no unknown events. **Verified non-vacuous** — poisoning `ci.yml` with each real bug makes the matching test fail:
  - `_note` top-level key → `test_no_stray_top_level_keys` fails
  - `pull_request_review_thread` → `test_every_trigger_is_one_github_accepts` fails
- 9 cap tests: under the cap blocks; at the cap opens with findings preserved; a clean pass does not spend a round; a forged verdict cannot burn one; human threads and CHANGES_REQUESTED never capped; the workflow's threshold agrees with `MAX_REVIEW_ROUNDS`.

## This is verified after merge, not before

`pull_request_target` runs the workflow from `main`, so nothing proves the fix until it lands. The check has been removed from the ruleset to break the deadlock. After merge:

```bash
gh api "repos/dinho149/yeaboi.ai/actions/workflows/pr-feedback.yml/runs" --jq '[.workflow_runs[].event] | unique'
```

Must contain `pull_request_target` — **the gate running for the first time** — and a real `pr-feedback` context must appear on a commit. Only then should the required check go back on the ruleset.

**The diagnosis is a strong inference, not a certainty**: GitHub does document that trigger, and `actionlint` is the only tool naming it. If `pull_request_target` runs still do not appear, bisect the `on:` block one trigger at a time — the workflow's own comments say so, so the next person does not rediscover this from scratch.

## Definition of Done

Items 2–4 pass. Item 5 (surface parity) does not apply — CI and gate infrastructure, no user-facing capability. Item 7 does not apply — nothing under `frontend/`. Item 1: no Linear ticket; this is an unblock of #222 (YEA-77) rather than separate work. Item 10 cannot apply — the workflow that produces it is what this PR repairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
