### PR TITLE
reach github without the gh cli so cd-deploy stops no-opping

### DIFF
--- a/cowork/README.md
+++ b/cowork/README.md
@@ -155,10 +155,10 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 |---|---|---|---|---|
 | `cron/marketing-weekly.md` | `0 8 * * 6` Sat | marketing | `deep` | https://claude.ai/code/routines/trig_011f1J2fUGPhDQKSmjEMEiGs |
 | `cron/agents-standup.md` | `15 6 * * 1-5` weekdays | agents | `fast` | https://claude.ai/code/routines/trig_013tsooGjdnEMLRQcm7ZKU57 |
-| `cron/shipped-standup.md` | `0 18 * * *` daily | — | `standard` |  |
+| `cron/shipped-standup.md` | `0 18 * * *` daily | — | `standard` | https://claude.ai/code/routines/trig_0118jEhPuaKrCaUWCYQtVgEv |
 | `cron/digest.md` | `15 8 * * *` | — | `standard` | https://claude.ai/code/routines/trig_01VY1hbAZKeGuKA1GLyVhbow |
 | `cron/slack-relay.md` | `0 7-23 * * *` hourly | — | `fast` | https://claude.ai/code/routines/trig_01X18LBBBZ1FWEtx2Cmffyow |
-| `cron/release-promote-ask.md` | `0 9 * * 1` Mon | — | `fast` |  |
+| `cron/release-promote-ask.md` | `0 9 * * 1` Mon | — | `fast` | https://claude.ai/code/routines/trig_01G4TuU1wYY7GXJ1cEXZUNSu |
 | `cron/cd-deploy.md` | `0 4 * * *` daily + push (any branch) | — | `standard` | https://claude.ai/code/routines/trig_01AkW6ojpjKcra8H64R3Astr |
 | `events/pr-opened-dod-audit.md` | PR opened / synchronized | — | `standard` | https://claude.ai/code/routines/trig_01Egz2NXy4GwzJzRRC7Z4Zm3 |
 | `events/pr-merged-close-loop.md` | PR closed (merged) | — | `fast` | https://claude.ai/code/routines/trig_019gLyX5qWx7g5rXZkUKaDAo |

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -230,9 +230,16 @@ same drift in `make test-fast`.
 `make cowork-check` additionally probes the **`pr-feedback` required status check** on the
 `main-branch` ruleset, because that one setting decides whether the auto lane merges anything
 and the workflows that depend on it fail *quietly* — declining to arm `--auto` looks exactly
-like a lane that had nothing to do. `cron/cd-deploy.md` runs the same check on every merge to
-`main`, so removing the context later is noticed rather than silently absorbed. No `gh`, or a
+like a lane that had nothing to do. `cron/cd-deploy.md` reports the same probe on every merge to
+`main` — from its apply step, not its check step, which is deliberately `--local` there — so
+removing the context later is noticed rather than silently absorbed. No transport, or a
 failed query, is reported as a note: an unanswerable question is not the same as a missing gate.
+
+**How the script reaches GitHub.** `gh` when it is installed and authenticated; the REST API with
+`GH_TOKEN`/`GITHUB_TOKEN` when it is not. The second path is not a convenience — a cloud routine
+session is handed a token and no CLI, so `cron/cd-deploy.md` had no way to apply a label at all, and
+its own stop condition turned that into a halted deploy on every firing. Only when *neither* answers
+is it a degradation, and under `--strict` that is what exits non-zero.
 
 **What each command covers.** `make cowork-setup` does the twenty-nine GitHub labels (`cowork`,
 `cowork:proposal`, `claude-implement`, `feedback-override`, the `release:promotion`/`release:promote`

--- a/cowork/routines/cron/cd-deploy.md
+++ b/cowork/routines/cron/cd-deploy.md
@@ -59,22 +59,49 @@ test has ever seen.
    Deploy what is on `origin/main` and nothing else: a feature branch's `cowork/` edits are not
    deployable, because nobody has reviewed them.
 
-2. **`make cowork-check`** — abort on non-zero, reporting to Slack. This is not redundant with CI: it
-   is what stops step 4 composing a prompt that points at a file which does not exist. A README row
-   naming a missing routine file registers a routine that wakes up, cannot read its own instructions,
-   and does something unpredictable — and it would be *this* run that did it.
+2. **`uv run python scripts/cowork_setup.py --check --local`** — abort on non-zero, reporting to
+   Slack. This is not redundant with CI: it is what stops step 4 composing a prompt that points at a
+   file which does not exist. A README row naming a missing routine file registers a routine that
+   wakes up, cannot read its own instructions, and does something unpredictable — and it would be
+   *this* run that did it.
+
+   **`--local`, not the full `make cowork-check`, and the flag is load-bearing.** The full check also
+   asks GitHub whether every label exists and every `YEABOI_MODEL_*` matches `models.md`, and a
+   missing label is a `check: 1 problem(s)` — so a run deploying a *new* workstream or a changed
+   model id would abort here, one step before step 3 creates the very thing it just failed on. That
+   is the same halted-deploy this routine was repaired for, moved earlier. The GitHub half belongs to
+   step 3, which applies rather than merely reports, and which prints the `pr-feedback` merge-gate
+   probe on its way through.
 
 3. **`uv run python scripts/cowork_setup.py --strict`** — the GitHub labels and the four
-   `YEABOI_MODEL_*` repository variables. `--strict` is the point: without it a rejected `gh` call is
-   a note on a stream nobody is reading, and "created no labels, exited 0" reads exactly like
-   success. If it fails, report and stop — do not proceed to the routines with a half-applied repo.
+   `YEABOI_MODEL_*` repository variables. `--strict` is the point: without it a rejected write is a
+   note on a stream nobody is reading, and "created no labels, exited 0" reads exactly like success.
+   The script reaches GitHub through `gh` when it is there and the REST API with `GH_TOKEN` when it
+   is not, which is what makes this step work at all from a session that has no CLI.
+
+   **Read the exit code; it decides whether the run continues.**
+
+   - **2 — stop.** `cowork/` disagrees with itself. Report and stop: registering anything from
+     files in that state is how a routine ends up pointing at instructions that do not exist.
+   - **1 — note it and carry on to step 4.** A GitHub write degraded: a label was not created, or
+     a variable was rejected for want of `administration: write`. Record the exact note text and
+     carry it into the step 7 post — but do **not** stop. A label has no bearing on a trigger
+     body: those are built from the `cowork/` files step 2 just validated, not from anything this
+     step touches. This step used to stop the run outright, and a routine session with no `gh`
+     binary therefore halted every automatic deploy at this line while reporting a clean repo.
+   - **0 — carry on.**
+
+   This is deliberately not step 4's rule, where exit 1 *does* stop the run. The difference is what
+   the exit code is about: there, a degraded plan is untrustworthy input to a POST, and applying it
+   would write the fleet from a snapshot the script itself declined to stand behind. Here, nothing
+   downstream reads the labels.
 
 4. **Reconcile the routines.** `RemoteTrigger` `action: "list"`, save the response **verbatim** to a
    scratch file, then
    `uv run python scripts/cowork_setup.py --plan --strict --no-create --triggers <file>`.
    - **If the plan is empty, exit silently.** This is the common outcome and the reason step 1 does
      not try to guess: most firings reach here, find a fleet that already matches, and stop.
-   - Exit 1 means a step degraded — a `gh` call was rejected. Report it and stop; nothing was applied.
+   - Exit 1 means a step degraded — a GitHub call was rejected. Report it and stop; nothing was applied.
    - Exit 2 means the plan refused itself — a suspicious snapshot, an unresolved `needs`, or more
      routines created and updated together than `MASS_CHANGE_LIMIT`. Report the stderr to Slack and
      stop. **Never** re-run it without `--strict`, and never pass `--allow-mass-change`, to get past
@@ -112,16 +139,25 @@ test has ever seen.
 
 7. **Report.** Spawn `cowork-scribe` for the Linear `workstream:*` label mirroring and one
    `#yeaboi-claude` post: what was updated (field by field), anything in `creates_blocked` that needs
-   `/cowork deploy`, any orphans, any blocked webhooks, and the README PR link. **If `self_update` in the plan is not null, say so
-   explicitly with both the live and the wanted value** — that is this routine changing itself, and
-   it is the one change that must never land quietly.
+   `/cowork deploy`, any orphans, any blocked webhooks, the README PR link, and **any labels or
+   variables step 3 could not apply** — named, with the reason.
+
+   That last one is the price of no longer stopping on it: a scope gap nobody ever reads about is a
+   scope gap that never gets fixed, and unlike the fleet reconciliation there is nothing else in the
+   day that would mention it.
+
+   **If `self_update` in the plan is not null, say so explicitly with both the live and the wanted
+   value** — that is this routine changing itself, and it is the one change that must never land
+   quietly.
 
 ## Stop conditions
 
 - **Nothing to do is the common outcome**, and by design it is *most* runs — the webhook fires on
   every push to every branch, and all but a few of those reach step 4 and find a fleet that already
   matches. An empty plan posts nothing to Slack at all. A routine that reports every morning is a
-  routine nobody reads by Thursday.
+  routine nobody reads by Thursday. The one thing that breaks the silence without a plan is a step 3
+  degradation: a label or variable that could not be applied is posted even when the fleet needed no
+  change, because nothing else in the day would mention it.
 - **Never compose a request body.** Only bodies that came out of `--plan` are ever POSTed. In
   particular never send `{"enabled": …}`: the plan never carries it, because `pause` is a supported
   verb and a deploy that silently un-paused the fleet would undo a human's decision with nothing

--- a/scripts/cowork_setup.py
+++ b/scripts/cowork_setup.py
@@ -15,6 +15,12 @@ None of that data needs re-authoring. Every routine file carries a regular
 ``models.md`` maps a tier to an id. This script parses those and applies what a
 shell can apply.
 
+**It reaches GitHub two ways.** `gh` when it is installed and authenticated, and
+the REST API with ``GH_TOKEN``/``GITHUB_TOKEN`` when it is not. The fallback is
+not a convenience: `cron/cd-deploy.md` runs this script from a cloud routine
+session that is handed a token and no CLI, so without it every automatic deploy
+stopped at the labels step and the fleet was never reconciled.
+
 **It deliberately names no model.** The ids come out of ``cowork/models.md`` at
 run time, because that file being the only place a model is written down is the
 whole contract — see ``tests/unit/test_cowork_models.py``, which fails if one is
@@ -43,16 +49,30 @@ Usage::
 
     # …and the shell half of teardown (routines are /cowork teardown's job):
     uv run python scripts/cowork_setup.py --teardown --labels --variables --yes
+
+Exit codes on the default (apply) run, which `cron/cd-deploy.md` step 3 reads to
+decide whether to keep going:
+
+    0   applied, or nothing needed applying
+    1   a GitHub write degraded — reported as a note, and non-zero only under
+        --strict. Nothing downstream reads a label, so this does not invalidate
+        a routine reconciliation.
+    2   `cowork/` disagrees with itself. Nothing was applied and nothing further
+        should be registered from these files. Same meaning as --plan's 2.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, time, timedelta
@@ -1422,64 +1442,382 @@ def check_charter_coverage(report: Report) -> None:
         )
 
 
-# --- gh ----------------------------------------------------------------------
+# --- GitHub ------------------------------------------------------------------
+#
+# Two transports behind one set of operations. `gh` is preferred whenever it is
+# there — it is what a developer has already authenticated, and keeping that path
+# byte-for-byte identical means this script behaves locally exactly as it always
+# has.
+#
+# The REST fallback exists because the environment that matters most has no `gh`
+# at all. `cron/cd-deploy.md` runs this script from a cloud routine session, and
+# that session is handed a GitHub *token* rather than the CLI. So every firing
+# took the "not on PATH" branch, exited 1 under `--strict`, and the routine's own
+# stop condition halted it before step 4 — the fleet reconciliation it exists to
+# do. A missing binary is not a reason to stop deploying, and a token that is
+# sitting right there is not a reason to report nothing was applied.
+#
+# stdlib only, deliberately: this script imports nothing from `src/yeaboi` and
+# nothing off PyPI, so it runs in a checkout with no environment built.
+
+GITHUB_API = "https://api.github.com"
+
+# Which transport this run resolved. "gh" is the default rather than None so a
+# caller that never asked keeps the historical path; `github_ready()` is what
+# actually chooses, and `main()` resets this the way it resets STRICT.
+TRANSPORT = "gh"
+
+# `repo_slug()`'s memo. A distinct sentinel, because None is a real answer here —
+# "this checkout has no GitHub remote" — and caching a miss matters as much as
+# caching a hit: without the distinction every miss re-shells the whole lookup.
+_UNRESOLVED = object()
+_SLUG: object = _UNRESOLVED
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    """A REST call's outcome.
+
+    Shaped like the ``returncode``/``stderr`` pair the `gh` branch inspects, so
+    both halves of every operation below read the same and neither needs to know
+    which one ran.
+    """
+
+    ok: bool
+    data: object = None
+    error: str = ""
 
 
 def _gh(*args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    """One `gh` call, reporting a missing binary the way `gh` reports a failure.
+
+    127 rather than an exception, matching the shell: every caller here already
+    branches on ``returncode``, and there is now a path — `repo_slug()` resolving
+    from the git remote — that can reach a `gh` call on a machine with no `gh` at
+    all. A FileNotFoundError there is a traceback out of a script whose entire
+    contract is to degrade with the remedy printed.
+    """
+    try:
+        return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    except OSError as error:
+        return subprocess.CompletedProcess(["gh", *args], 127, "", str(error))
+
+
+def github_token() -> str | None:
+    """The token the REST transport authenticates with.
+
+    ``GH_TOKEN`` first, matching `gh`'s own precedence, so a machine that sets
+    both gets the same identity either way. (``src/yeaboi/config.py`` reads only
+    ``GITHUB_TOKEN`` — that is the library's environment, not this script's.)
+    """
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or None
+
+
+def _api(method: str, path: str, body: dict | None = None) -> ApiResult:
+    """One REST call against `GITHUB_API`. Never raises; never logs the token.
+
+    The URL is a literal scheme and host with a caller-supplied path appended, so
+    the S310 audit — "check for permitted schemes" — has a fixed answer here.
+    """
+    token = github_token()
+    if not token:
+        return ApiResult(False, error="no GH_TOKEN or GITHUB_TOKEN in the environment")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "yeaboi-cowork-setup",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(  # noqa: S310 - GITHUB_API is a literal https:// host
+        f"{GITHUB_API}{path}",
+        method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - GITHUB_API is a literal https:// host
+            raw = response.read().decode()
+        parsed = json.loads(raw) if raw.strip() else None
+    except urllib.error.HTTPError as error:
+        # The response body carries GitHub's own message — "Resource not
+        # accessible by integration" for a scope gap, which is the failure most
+        # worth reading, and the one a token-shaped setup actually hits. The
+        # request headers carry the token and are never surfaced.
+        try:
+            detail = error.read().decode()[:300]
+        except Exception:
+            detail = ""
+        return ApiResult(False, error=f"HTTP {error.code} on {method} {path}" + (f": {detail}" if detail else ""))
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        return ApiResult(False, error=f"{method} {path} failed: {error}")
+    except (ValueError, UnicodeDecodeError) as error:
+        # A 2xx body that is not JSON is what an egress proxy's HTML error page
+        # looks like, which is a plausible shape in exactly the cloud session
+        # this transport exists for. A failure, not a traceback.
+        return ApiResult(False, error=f"{method} {path} returned a body that is not JSON: {error}")
+    return ApiResult(True, parsed)
+
+
+def _segment(name: str) -> str:
+    """One path segment, escaped. Label names carry a `:` (`workstream:security`,
+    `type:bug`), which is why this is not optional — and it is applied to every
+    segment rather than only the ones needing it today, so a name that starts
+    needing it later does not become a 404 nobody expects."""
+    return urllib.parse.quote(name, safe="")
+
+
+def _api_paged(path: str, key: str | None = None) -> ApiResult:
+    """Every page of a list endpoint, concatenated.
+
+    `gh label list --limit 200` asked for one oversized page and got it. REST
+    caps a page at 100, and this repo already carries twenty-nine cowork labels
+    on top of whatever else it has, so the second page is not hypothetical.
+
+    ``key`` names the wrapper field for endpoints that return an object rather
+    than a bare array — ``/actions/variables`` is the one that does.
+    """
+    items: list = []
+    for page in range(1, 21):  # 2000 items; a repo past that is not one this script set up
+        result = _api("GET", f"{path}?per_page=100&page={page}")
+        if not result.ok:
+            return result
+        batch = result.data
+        if key is not None and isinstance(batch, dict):
+            batch = batch.get(key)
+        if not isinstance(batch, list):
+            return ApiResult(False, error=f"GET {path} returned no list of results")
+        items.extend(batch)
+        if len(batch) < 100:
+            return ApiResult(True, items)
+    # Ran out of pages with a full one still in hand. A failure rather than a
+    # short answer: the callers turn a partial list into "these labels do not
+    # exist", which is the same "an empty set read as truth" trap that
+    # `existing_labels` returns None for.
+    return ApiResult(False, error=f"GET {path} did not end within 20 pages")
 
 
 def gh_ready() -> bool:
-    """Whether `gh` is installed and authenticated, with the remedy printed if not."""
+    """Whether the `gh` CLI is installed and authenticated.
+
+    Reports nothing on its own: "no `gh`" is only a degradation once the REST
+    transport has also declined, and `github_ready()` owns that judgement. Kept
+    as its own function because it is the seam a test forces to pick a transport.
+    """
     if shutil.which("gh") is None:
-        STRICT.note(
-            "`gh` is not on PATH — skipping every GitHub check",
-            "install it: brew install gh",
-        )
         return False
-    if _gh("auth", "status").returncode != 0:
-        STRICT.note(
-            "`gh` is not authenticated — skipping every GitHub check",
-            "run: gh auth login",
-        )
-        return False
-    return True
+    return _gh("auth", "status").returncode == 0
+
+
+def api_ready() -> bool:
+    """Whether the REST transport has both halves it needs: a token, and a
+    repository to point it at. Neither is worth a note on its own — a machine
+    with `gh` working needs neither."""
+    return bool(github_token()) and bool(repo_slug())
+
+
+def _why_no_gh() -> tuple[str, str]:
+    """Which of the two `gh` problems this is, and what fixes it. Said the same
+    way whether it ends in a fallback or a degradation."""
+    if shutil.which("gh") is None:
+        return "is not on PATH", "install it: brew install gh"
+    return "is not authenticated", "run: gh auth login"
+
+
+def github_ready() -> bool:
+    """Choose this run's transport, reporting the remedy when neither answers."""
+    global TRANSPORT
+    if gh_ready():
+        TRANSPORT = "gh"
+        return True
+    problem, remedy = _why_no_gh()
+    if api_ready():
+        TRANSPORT = "api"
+        say(f"github: `gh` {problem} — using the REST API against {repo_slug()}")
+        return True
+    TRANSPORT = "gh"
+    STRICT.note(
+        f"`gh` {problem} and no API token answered — skipping every GitHub check",
+        f"{remedy} — or export GH_TOKEN, which is all the REST fallback needs",
+    )
+    return False
 
 
 def existing_labels() -> set[str] | None:
     """Every label on the repo, or None if the query itself failed.
 
     None rather than an empty set, and the same for the variables below: they are
-    different facts and the difference matters. ``gh_ready()`` passing does not
-    mean the next call succeeds — a missing remote, the wrong repo, a rate limit —
+    different facts and the difference matters. A ready transport does not mean
+    the next call succeeds — a missing remote, the wrong repo, a rate limit —
     and an empty set read as truth makes the doctor report all twenty-nine labels
     missing and ``apply_labels`` try to create every one of them.
     """
-    result = _gh("label", "list", "--limit", "200", "--json", "name")
-    if result.returncode != 0:
-        STRICT.note("could not list the repo's labels", result.stderr.strip() or "unknown gh error")
+    if TRANSPORT == "gh":
+        result = _gh("label", "list", "--limit", "200", "--json", "name")
+        if result.returncode != 0:
+            STRICT.note("could not list the repo's labels", result.stderr.strip() or "unknown gh error")
+            return None
+        return {item["name"] for item in json.loads(result.stdout or "[]")}
+    slug = repo_slug()
+    if not slug:
+        STRICT.note("could not list the repo's labels", "no owner/name resolved for this checkout")
         return None
-    return {item["name"] for item in json.loads(result.stdout or "[]")}
+    result = _api_paged(f"/repos/{slug}/labels")
+    if not result.ok:
+        STRICT.note("could not list the repo's labels", result.error)
+        return None
+    return {item["name"] for item in result.data}
 
 
 def existing_variables() -> dict[str, str] | None:
-    result = _gh("variable", "list", "--json", "name,value")
-    if result.returncode != 0:
-        STRICT.note("could not list the repo's variables", result.stderr.strip() or "unknown gh error")
+    if TRANSPORT == "gh":
+        result = _gh("variable", "list", "--json", "name,value")
+        if result.returncode != 0:
+            STRICT.note("could not list the repo's variables", result.stderr.strip() or "unknown gh error")
+            return None
+        return {item["name"]: item.get("value", "") for item in json.loads(result.stdout or "[]")}
+    slug = repo_slug()
+    if not slug:
+        STRICT.note("could not list the repo's variables", "no owner/name resolved for this checkout")
         return None
-    return {item["name"]: item.get("value", "") for item in json.loads(result.stdout or "[]")}
+    result = _api_paged(f"/repos/{slug}/actions/variables", key="variables")
+    if not result.ok:
+        STRICT.note("could not list the repo's variables", result.error)
+        return None
+    return {item["name"]: item.get("value", "") for item in result.data}
+
+
+def create_label(label: Label) -> tuple[bool, str]:
+    """Create one label. Returns (created, why not) so the caller does the noting."""
+    if TRANSPORT == "gh":
+        result = _gh(
+            "label",
+            "create",
+            label.name,
+            "--color",
+            label.color,
+            "--description",
+            label.description,
+        )
+        return result.returncode == 0, result.stderr.strip() or "unknown gh error"
+    slug = repo_slug()
+    if not slug:
+        return False, "no owner/name resolved for this checkout"
+    # Bare hex, no leading `#` — which is how expected_labels() already spells
+    # every colour, because that is what `gh label create --color` wanted too.
+    result = _api(
+        "POST",
+        f"/repos/{slug}/labels",
+        {"name": label.name, "color": label.color.lstrip("#"), "description": label.description},
+    )
+    return result.ok, result.error
+
+
+def set_variable(name: str, value: str, exists: bool) -> tuple[bool, str]:
+    """Set one repository variable, creating or updating as needed.
+
+    `gh variable set` is one verb for both. REST is not: a create is a POST to
+    the collection and an update is a PATCH to the item, and using the wrong one
+    is a 409 or a 404 rather than a silent no-op. The caller already knows which
+    it is — it had to list them to decide there was anything to do.
+    """
+    if TRANSPORT == "gh":
+        result = _gh("variable", "set", name, "--body", value)
+        return result.returncode == 0, result.stderr.strip() or "unknown gh error"
+    slug = repo_slug()
+    if not slug:
+        return False, "no owner/name resolved for this checkout"
+    if exists:
+        result = _api("PATCH", f"/repos/{slug}/actions/variables/{_segment(name)}", {"name": name, "value": value})
+    else:
+        result = _api("POST", f"/repos/{slug}/actions/variables", {"name": name, "value": value})
+    return result.ok, result.error
+
+
+def delete_label(name: str) -> tuple[bool, str]:
+    if TRANSPORT == "gh":
+        result = _gh("label", "delete", name, "--yes")
+        return result.returncode == 0, result.stderr.strip() or "unknown gh error"
+    slug = repo_slug()
+    if not slug:
+        return False, "no owner/name resolved for this checkout"
+    result = _api("DELETE", f"/repos/{slug}/labels/{_segment(name)}")
+    return result.ok, result.error
+
+
+def delete_variable(name: str) -> tuple[bool, str]:
+    if TRANSPORT == "gh":
+        result = _gh("variable", "delete", name)
+        return result.returncode == 0, result.stderr.strip() or "unknown gh error"
+    slug = repo_slug()
+    if not slug:
+        return False, "no owner/name resolved for this checkout"
+    result = _api("DELETE", f"/repos/{slug}/actions/variables/{_segment(name)}")
+    return result.ok, result.error
 
 
 def repo_slug() -> str | None:
-    result = _gh("repo", "view", "--json", "nameWithOwner")
+    """``owner/name`` for the repository this checkout points at, resolved once.
+
+    Cached because it is now asked per operation rather than once: `create_label`
+    needs it for each of the twenty-nine labels, and on a machine with `gh`
+    installed but unauthenticated the uncached version shells `gh repo view` — a
+    network round-trip — every single time. `main()` clears the memo the way it
+    clears STRICT.
+
+    Three sources, and deliberately independent of the transport — `api_ready()`
+    asks this before a transport exists. `gh` when it is there, the
+    ``GITHUB_REPOSITORY`` a workflow exports, and otherwise the `origin` remote.
+    The remote is what makes the REST transport work in a routine session: step 1
+    of `cron/cd-deploy.md` runs `git fetch origin main`, so a remote is
+    guaranteed there even though `gh` is not.
+    """
+    global _SLUG
+    if _SLUG is not _UNRESOLVED:
+        return _SLUG
+    _SLUG = _resolve_slug()
+    return _SLUG
+
+
+def _resolve_slug() -> str | None:
+    if shutil.which("gh"):
+        result = _gh("repo", "view", "--json", "nameWithOwner")
+        if result.returncode == 0:
+            slug = json.loads(result.stdout or "{}").get("nameWithOwner")
+            if slug:
+                return slug
+    from_env = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if from_env.count("/") == 1:
+        return from_env
+    return _slug_from_remote()
+
+
+def _slug_from_remote() -> str | None:
+    """``owner/name`` parsed out of `git remote get-url origin`.
+
+    Both forms GitHub hands out: ``git@github.com:owner/name.git`` and
+    ``https://github.com/owner/name(.git)``, with or without the suffix.
+    """
+    result = subprocess.run(  # noqa: S603 - literal argv
+        ["git", "-C", str(REPO_ROOT), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     if result.returncode != 0:
         return None
-    return json.loads(result.stdout or "{}").get("nameWithOwner")
+    url = result.stdout.strip()
+    if not url:
+        return None
+    tail = url.split("github.com", 1)[-1].lstrip(":/") if "github.com" in url else ""
+    tail = tail.removesuffix(".git").strip("/")
+    return tail if tail.count("/") == 1 else None
 
 
 def repo_url() -> str | None:
     """The clone URL a routine's ``git_repository`` source points at."""
-    slug = repo_slug() if shutil.which("gh") else None
+    slug = repo_slug()
     return f"https://github.com/{slug}" if slug else None
 
 
@@ -1501,19 +1839,11 @@ def apply_labels() -> None:
         say(f"labels: all {len(expected_labels())} already present")
         return
     for label in missing:
-        result = _gh(
-            "label",
-            "create",
-            label.name,
-            "--color",
-            label.color,
-            "--description",
-            label.description,
-        )
-        if result.returncode == 0:
+        created, why = create_label(label)
+        if created:
             say(f"labels: created {label.name}")
         else:
-            STRICT.note(f"labels: could not create {label.name}", result.stderr.strip() or "unknown gh error")
+            STRICT.note(f"labels: could not create {label.name}", why)
     say(f"labels: {len(present)} already present, {len(missing)} attempted")
 
 
@@ -1531,49 +1861,75 @@ def apply_variables() -> None:
         if current.get(name) == value:
             say(f"variables: {name} already set")
             continue
-        result = _gh("variable", "set", name, "--body", value)
-        if result.returncode == 0:
+        was_set, why = set_variable(name, value, exists=name in current)
+        if was_set:
             say(f"variables: set {name}")
         else:
             STRICT.note(
                 f"variables: could not set {name}",
-                result.stderr.strip()
+                why
                 or "repository variables need admin on the repo — "
-                "`gh auth refresh -h github.com -s repo` (a 403 here is the silent-green case)",
+                "`gh auth refresh -h github.com -s repo`, or a token carrying "
+                "`administration: write` (a 403 here is the silent-green case)",
             )
 
 
 def merge_gate_armed() -> bool | None:
     """Whether `pr-feedback` is a required status check on the `main-branch` ruleset.
 
-    None when the question could not be asked — no `gh`, no repo, or a failed
-    query — which is deliberately not the same answer as False. A missing gate is
-    a finding; an unanswerable question is a note, and conflating them would fail
-    the doctor on every machine without `gh` authenticated.
+    None when the question could not be asked — no transport, no repo, or a
+    failed query — which is deliberately not the same answer as False. A missing
+    gate is a finding; an unanswerable question is a note, and conflating them
+    would fail the doctor on every machine with neither `gh` nor a token.
 
     This is the setting that decides whether the auto lane merges anything. Every
     workflow that would arm `gh pr merge --auto` runs this same query first and
     refuses when it is false, so without it the lane opens PRs that sit waiting
     for a human click — the thing it exists to remove.
     """
-    if not shutil.which("gh"):
-        return None
     slug = repo_slug()
     if not slug:
         return None
-    query = (
-        'any(.[]; .type=="required_status_checks" and '
-        'any(.parameters.required_status_checks[]; .context=="pr-feedback"))'
-    )
-    result = subprocess.run(  # noqa: S603 - literal argv
-        ["gh", "api", f"repos/{slug}/rules/branches/main", "--jq", query],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
+    # Keyed on the transport this run resolved, not on `gh` being on PATH: a
+    # machine with `gh` installed but unauthenticated and a token exported reads
+    # every other check over REST, and having this one alone answer "cannot ask"
+    # would report the gate unchecked on a run that checked everything else.
+    if TRANSPORT == "gh":
+        # `shutil.which` is still consulted here, because this is the one probe
+        # reached on a run where no transport resolved at all:
+        # `report_manual_remainder()` calls it after `github_ready()` has already
+        # declined, and TRANSPORT is "gh" then by default rather than by evidence.
+        if shutil.which("gh") is None:
+            return None
+        query = (
+            'any(.[]; .type=="required_status_checks" and '
+            'any(.parameters.required_status_checks[]; .context=="pr-feedback"))'
+        )
+        result = subprocess.run(  # noqa: S603 - literal argv
+            ["gh", "api", f"repos/{slug}/rules/branches/main", "--jq", query],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() == "true"
+    if not github_token():
         return None
-    return result.stdout.strip() == "true"
+    # The same question the jq expression above asks, asked in Python because
+    # there is no jq here either.
+    answer = _api("GET", f"/repos/{slug}/rules/branches/main")
+    if not answer.ok or not isinstance(answer.data, list):
+        return None
+    return any(
+        rule.get("type") == "required_status_checks"
+        and any(
+            check.get("context") == "pr-feedback"
+            for check in (rule.get("parameters") or {}).get("required_status_checks") or []
+        )
+        for rule in answer.data
+        if isinstance(rule, dict)
+    )
 
 
 def check_merge_gate(report: Report) -> None:
@@ -1669,7 +2025,7 @@ def manifest() -> dict:
     routine pointing at a file that does not exist.
     """
     return {
-        "repo": repo_slug() if shutil.which("gh") else None,
+        "repo": repo_slug(),
         "repo_url": repo_url(),
         "connectors": list(CONNECTORS),
         "default_allowed_tools": list(ALLOWED_TOOLS),
@@ -2538,7 +2894,7 @@ def apply_teardown(labels: bool, variables: bool) -> int:
             "pass --labels and/or --variables; the routines are /cowork teardown's half",
         )
         return 1
-    if not gh_ready():
+    if not github_ready():
         return 1
 
     if labels:
@@ -2548,11 +2904,11 @@ def apply_teardown(labels: bool, variables: bool) -> int:
         for label in teardown_labels():
             if label.name not in present:
                 continue
-            result = _gh("label", "delete", label.name, "--yes")
-            if result.returncode == 0:
+            deleted, why = delete_label(label.name)
+            if deleted:
                 say(f"teardown: deleted label {label.name}")
             else:
-                note(f"teardown: could not delete {label.name}", result.stderr.strip() or "unknown gh error")
+                note(f"teardown: could not delete {label.name}", why)
         say(f"teardown: kept {', '.join(sorted(KEEP_LABELS))} — live gates outside cowork depend on them")
         say("teardown: kept the type:* labels — the feedback system shares them")
 
@@ -2563,11 +2919,11 @@ def apply_teardown(labels: bool, variables: bool) -> int:
         for name in parse_model_variables():
             if name not in current:
                 continue
-            result = _gh("variable", "delete", name)
-            if result.returncode == 0:
+            unset, why = delete_variable(name)
+            if unset:
                 say(f"teardown: unset {name}")
             else:
-                note(f"teardown: could not unset {name}", result.stderr.strip() or "unknown gh error")
+                note(f"teardown: could not unset {name}", why)
         note(
             "teardown: the workflows now fall back to their pinned defaults",
             "that is by design — every --model expression carries a `||` fallback",
@@ -2631,7 +2987,7 @@ def run_check(local_only: bool, triggers: str | None = None) -> int:
 
     if local_only:
         note("--local: skipping every GitHub check")
-    elif gh_ready():
+    elif github_ready():
         check_merge_gate(report)
         # A failed query is not an empty repo. Reported by the helper and skipped
         # here, rather than turning one gh error into twenty-two findings.
@@ -2726,9 +3082,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     # Reset, not just set: `main()` is called more than once in a process by the
     # test suite, and a degradation carried over from a previous call would fail a
-    # run that did nothing wrong.
+    # run that did nothing wrong. TRANSPORT is reset for the same reason — a run
+    # that resolved REST must not decide the next run's transport for it.
+    global TRANSPORT, _SLUG
     STRICT.strict = args.strict
     STRICT.degraded.clear()
+    TRANSPORT = "gh"
+    _SLUG = _UNRESOLVED
 
     if (args.plan or args.urls) and not args.triggers:
         fail("--plan and --urls need a snapshot: --triggers <file> (see /cowork)")
@@ -2825,17 +3185,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     report = Report()
     check_repo(report)
     if not report.ok:
+        # 2, not 1, and the difference is what `cron/cd-deploy.md` step 3 reads.
+        # 1 here means the GitHub apply degraded, which has no bearing on a
+        # routine's trigger body — those are built from these same files, and
+        # these files are fine. 2 means the files are not, and nothing further
+        # should be registered from them. Same convention as `--plan`, where 2 is
+        # already "it refused itself; a human should look".
         fail("cowork/ disagrees with itself — fix this before registering anything:")
         for problem in report.problems:
             fail(f"  ✗ {problem}")
-        return 1
+        return 2
 
     routines = parse_routines()
-    if gh_ready():
+    if github_ready():
         apply_labels()
         apply_variables()
     else:
-        STRICT.note("nothing was applied to GitHub", "authenticate with `gh auth login`, then re-run")
+        STRICT.note(
+            "nothing was applied to GitHub",
+            "authenticate with `gh auth login`, or export GH_TOKEN, then re-run",
+        )
 
     report_manual_remainder(routines)
     return strict_exit()

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -13,7 +13,12 @@ a sweep that ran on a Tuesday it was never meant to. So it is caught statically
 here, the same way ``test_cowork_models.py`` catches a pasted model id.
 
 No test in this file calls ``gh`` or touches the network: every parser takes text,
-and ``--check --local`` skips the remote half by design.
+``--check --local`` skips the remote half by design, and the two GitHub
+transports are reached only through their seams — ``_gh`` for the CLI half and
+``_api`` for the REST half. Anything asserting on the REST transport must also
+clear ``GH_TOKEN``/``GITHUB_TOKEN`` from the environment (the ``no_token``
+fixture does), or a developer who exports one turns a unit test into a live call
+against their own repository.
 """
 
 from __future__ import annotations
@@ -21,12 +26,14 @@ from __future__ import annotations
 import calendar
 import dataclasses
 import importlib.util
+import io
 import json
 import re
 import shutil
 import subprocess
 import sys
 import unicodedata
+import urllib.error
 from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
 
@@ -43,6 +50,11 @@ setup = importlib.util.module_from_spec(_spec)
 sys.modules["cowork_setup"] = setup
 _spec.loader.exec_module(setup)
 
+# Captured before `_no_live_github` swaps `_api` out for a refusal: the tests
+# that exercise the transport itself need the real one, and every other test
+# must not have it.
+_REAL_API = setup._api
+
 ROUTINES = setup.parse_routines()
 TIERS = setup.parse_tiers()
 WORKSTREAMS = setup.parse_workstreams()
@@ -51,6 +63,34 @@ CRON_ROUTINES = [r for r in ROUTINES if r.kind == "cron"]
 
 def _routine_ids(routine) -> str:
     return routine.path
+
+
+@pytest.fixture(autouse=True)
+def _no_live_github(monkeypatch):
+    """Nothing in this file may reach GitHub, by either transport.
+
+    ``_gh`` used to be the only seam, and faking it was enough. There are two
+    now, and the second authenticates from the *environment*: on a machine with
+    no `gh` installed and ``GH_TOKEN`` exported, `apply_teardown`'s tests would
+    resolve the developer's own repository from `origin` and issue real DELETEs
+    against their labels. Nothing in the test body would look wrong.
+
+    So: both token variables cleared for every test, ``_api`` refusing by
+    default so any new test that falls through the seam fails loudly rather than
+    silently going live, and the per-run module state the transports memoise
+    reset — ``_SLUG`` in particular, which otherwise carries one test's fake
+    remote into the next.
+    """
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.setattr(setup, "TRANSPORT", "gh")
+    monkeypatch.setattr(setup, "_SLUG", setup._UNRESOLVED)
+
+    def refuse(method, path, body=None):
+        raise AssertionError(f"a test reached the REST transport unstubbed: {method} {path}")
+
+    monkeypatch.setattr(setup, "_api", refuse)
 
 
 class TestRoutinesResolve:
@@ -1102,8 +1142,40 @@ class TestMergeGateCheck:
         assert report.ok
         assert report.notes and "not checked" in report.notes[0]
 
-    def test_the_probe_reports_none_without_gh(self, monkeypatch):
+    def test_the_probe_reports_none_without_gh_or_a_token(self, monkeypatch):
+        """Neither transport can answer, so the answer is None.
+
+        The token has to be cleared explicitly: without `gh` the probe now falls
+        through to REST, and a developer with GH_TOKEN exported would otherwise
+        have this test make a real request against their own repo.
+        """
+        monkeypatch.setattr(setup, "TRANSPORT", "api")
         monkeypatch.setattr(setup.shutil, "which", lambda name: None)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert setup.merge_gate_armed() is None
+
+    def test_the_probe_reads_the_ruleset_over_rest(self, monkeypatch):
+        """The jq expression's answer, computed in Python — there is no jq in a
+        routine session either."""
+        monkeypatch.setattr(setup, "TRANSPORT", "api")
+        monkeypatch.setenv("GH_TOKEN", "t")
+        monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
+        ruleset = [
+            {"type": "deletion"},
+            {"type": "required_status_checks", "parameters": {"required_status_checks": [{"context": "ci"}]}},
+        ]
+        monkeypatch.setattr(setup, "_api", lambda *a, **k: setup.ApiResult(True, ruleset))
+        assert setup.merge_gate_armed() is False
+
+        ruleset[1]["parameters"]["required_status_checks"].append({"context": "pr-feedback"})
+        assert setup.merge_gate_armed() is True
+
+    def test_a_failed_rest_query_is_still_unanswerable(self, monkeypatch):
+        monkeypatch.setattr(setup, "TRANSPORT", "api")
+        monkeypatch.setenv("GH_TOKEN", "t")
+        monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
+        monkeypatch.setattr(setup, "_api", lambda *a, **k: setup.ApiResult(False, error="HTTP 404"))
         assert setup.merge_gate_armed() is None
 
     def test_the_probe_reports_none_when_the_query_fails(self, monkeypatch):
@@ -1221,6 +1293,46 @@ class TestCheckMode:
         result = self._run(repo_copy)
         assert result.returncode == 1
         assert "day-of-month AND day-of-week" in result.stderr
+
+
+class TestApplyRunExitCodes:
+    """The default run's exit codes, which `cron/cd-deploy.md` step 3 branches on.
+
+    Not part of `TestCheckMode` above: this is neither ``--check`` nor
+    ``--local``. It is the apply run, and the only reason it is assertable
+    without a network is that it refuses before choosing a transport.
+    """
+
+    @pytest.fixture
+    def repo_copy(self, tmp_path: Path) -> Path:
+        """A throwaway copy of cowork/ + the script, safe to corrupt."""
+        copy = tmp_path / "repo"
+        (copy / "scripts").mkdir(parents=True)
+        shutil.copy(_MODULE_PATH, copy / "scripts" / "cowork_setup.py")
+        shutil.copytree(ROOT / "cowork", copy / "cowork")
+        return copy
+
+    def test_the_default_run_refuses_a_disagreeing_repo_with_exit_2(self, repo_copy: Path):
+        """2, not 1, and `cron/cd-deploy.md` step 3 is what reads the difference.
+
+        1 from that step means the GitHub apply degraded — no labels created, or
+        a variable rejected — which says nothing about a routine's trigger body
+        and must not stop the deploy. 2 means `cowork/` itself disagrees, and
+        registering anything from it would be registering a routine that cannot
+        read its own instructions. The run reaches neither transport: it refuses
+        before `github_ready()` is ever called, which is what makes this
+        assertable without a network.
+        """
+        (repo_copy / "cowork" / "routines" / "cron" / "digest.md").unlink()
+        result = subprocess.run(
+            [sys.executable, str(repo_copy / "scripts" / "cowork_setup.py")],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": "/usr/bin:/bin", "HOME": str(repo_copy)},
+        )
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "disagrees with itself" in result.stderr
 
 
 # --- the account half --------------------------------------------------------
@@ -1845,8 +1957,10 @@ class TestTeardown:
 class TestGhWrites:
     """The half of the script that mutates anything.
 
-    ``_gh`` is the single seam every GitHub call goes through, so all of this is
-    reachable with one monkeypatch and none of it touches the network.
+    ``_gh`` is the seam the CLI half goes through, so all of this is reachable
+    with one monkeypatch. It is no longer the *only* seam — `_no_live_github`
+    above keeps the REST one shut for this class, and the fixture below pins the
+    transport so these assertions stay assertions about `gh`.
     """
 
     @pytest.fixture
@@ -1861,6 +1975,10 @@ class TestGhWrites:
             return subprocess.CompletedProcess(args, code, out, "boom" if code else "")
 
         monkeypatch.setattr(setup, "_gh", fake)
+        # `apply_teardown()` picks a transport before it writes anything, and
+        # `gh_ready()` would otherwise shell a real `gh auth status` here — or,
+        # on a machine without `gh`, hand these tests to the REST transport.
+        monkeypatch.setattr(setup, "gh_ready", lambda: True)
         return type("Gh", (), {"calls": calls, "replies": replies})()
 
     def _label_list(self, names: list[str]) -> tuple[int, str]:
@@ -1959,6 +2077,358 @@ class TestGhWrites:
         assert setup.missing_urls(readme.read_text()) == []
         once = readme.read_text()
         assert setup.apply_urls(path) == 0 and readme.read_text() == once
+
+
+class TestApiTransport:
+    """The half that runs where `gh` does not.
+
+    `cron/cd-deploy.md` executes this script from a cloud routine session, and
+    that session has a GitHub token but no CLI. Every firing therefore took
+    `gh_ready()`'s "not on PATH" branch, exited 1 under ``--strict``, and the
+    routine's stop condition halted it before reconciling the fleet — the one
+    thing it exists to do. Nothing here was covered by a test, which is why it
+    ran that way for as long as it did.
+
+    ``_api`` is the seam, the way ``_gh`` is for the CLI half. Nothing below
+    opens a socket.
+    """
+
+    @pytest.fixture
+    def api(self, monkeypatch):
+        """Record every REST call; reply from a per-test script keyed on
+        ``(method, path)`` with the query string stripped."""
+        calls: list[tuple[str, str, dict | None]] = []
+        replies: dict[tuple[str, str], object] = {}
+
+        def fake(method: str, path: str, body: dict | None = None):
+            calls.append((method, path, body))
+            key = (method, path.split("?")[0])
+            if key in replies:
+                answer = replies[key]
+                if isinstance(answer, setup.ApiResult):
+                    return answer
+                return setup.ApiResult(True, answer)
+            return setup.ApiResult(True, [])
+
+        monkeypatch.setattr(setup, "_api", fake)
+        monkeypatch.setattr(setup, "TRANSPORT", "api")
+        monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
+        monkeypatch.setenv("GH_TOKEN", "t")
+        return type("Api", (), {"calls": calls, "replies": replies})()
+
+    # --- token resolution ----------------------------------------------------
+
+    def test_gh_token_wins_over_github_token(self, monkeypatch):
+        """`gh`'s own precedence, so a machine setting both gets one identity."""
+        monkeypatch.setenv("GITHUB_TOKEN", "second")
+        assert setup.github_token() == "second"
+        monkeypatch.setenv("GH_TOKEN", "first")
+        assert setup.github_token() == "first"
+
+    def test_no_token_is_none_not_empty(self):
+        assert setup.github_token() is None
+
+    # --- transport selection -------------------------------------------------
+
+    def test_gh_is_preferred_when_it_is_there(self, monkeypatch):
+        """Local behaviour must not change: an authenticated CLI still wins."""
+        monkeypatch.setattr(setup, "gh_ready", lambda: True)
+        monkeypatch.setenv("GH_TOKEN", "t")
+        assert setup.github_ready() is True
+        assert setup.TRANSPORT == "gh"
+
+    def test_rest_takes_over_when_gh_is_absent(self, monkeypatch, capsys):
+        monkeypatch.setattr(setup, "gh_ready", lambda: False)
+        monkeypatch.setattr(setup.shutil, "which", lambda name: None)
+        monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
+        monkeypatch.setenv("GH_TOKEN", "t")
+        assert setup.github_ready() is True
+        assert setup.TRANSPORT == "api"
+        out = capsys.readouterr().out
+        assert "REST API" in out and "is not on PATH" in out
+
+    def test_rest_takes_over_when_gh_is_merely_unauthenticated(self, monkeypatch, capsys):
+        """The other half of the same fallback, said accurately: an installed but
+        logged-out `gh` is a different problem from a missing one, and printing
+        the wrong one sends the reader to the wrong remedy."""
+        monkeypatch.setattr(setup, "gh_ready", lambda: False)
+        monkeypatch.setattr(setup.shutil, "which", lambda name: "/usr/bin/gh")
+        monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
+        monkeypatch.setenv("GH_TOKEN", "t")
+        assert setup.github_ready() is True
+        assert setup.TRANSPORT == "api"
+        assert "is not authenticated" in capsys.readouterr().out
+
+    def test_neither_transport_degrades_exactly_once(self, monkeypatch, capsys):
+        """The production failure, and the case nothing asserted before."""
+        monkeypatch.setattr(setup, "gh_ready", lambda: False)
+        monkeypatch.setattr(setup.shutil, "which", lambda name: None)
+        setup.STRICT.degraded.clear()
+        assert setup.github_ready() is False
+        assert len(setup.STRICT.degraded) == 1
+        out = capsys.readouterr().out
+        assert "GH_TOKEN" in out, "the remedy must name the fallback, not just `brew install gh`"
+
+    def test_a_token_with_no_repo_is_not_ready(self, monkeypatch):
+        """Both halves or neither — a token pointed at nothing cannot be used."""
+        monkeypatch.setenv("GH_TOKEN", "t")
+        monkeypatch.setattr(setup, "repo_slug", lambda: None)
+        assert setup.api_ready() is False
+
+    # --- reads ---------------------------------------------------------------
+
+    def test_labels_are_read_from_the_rest_endpoint(self, api):
+        api.replies[("GET", "/repos/o/r/labels")] = [{"name": "cowork"}, {"name": "type:bug"}]
+        assert setup.existing_labels() == {"cowork", "type:bug"}
+        assert api.calls[0][0] == "GET"
+        assert api.calls[0][1].startswith("/repos/o/r/labels?per_page=100")
+
+    def test_variables_are_unwrapped_from_their_envelope(self, api):
+        """`/actions/variables` returns an object around the list; `/labels` does
+        not. Reading the wrong shape would look like an empty repo."""
+        api.replies[("GET", "/repos/o/r/actions/variables")] = {
+            "total_count": 1,
+            "variables": [{"name": "YEABOI_MODEL_HEAVY", "value": "x"}],
+        }
+        assert setup.existing_variables() == {"YEABOI_MODEL_HEAVY": "x"}
+
+    def test_a_failed_query_is_none_not_an_empty_repo(self, api):
+        """The invariant `TestGhWrites` pins for the CLI half, on this one too:
+        None and empty are different facts, and the difference is 29 findings."""
+        api.replies[("GET", "/repos/o/r/labels")] = setup.ApiResult(False, error="HTTP 403")
+        api.replies[("GET", "/repos/o/r/actions/variables")] = setup.ApiResult(False, error="HTTP 403")
+        assert setup.existing_labels() is None
+        assert setup.existing_variables() is None
+
+    def test_no_slug_is_a_degradation_not_a_crash(self, api, monkeypatch):
+        monkeypatch.setattr(setup, "repo_slug", lambda: None)
+        setup.STRICT.degraded.clear()
+        assert setup.existing_labels() is None
+        assert setup.STRICT.degraded
+
+    # --- writes --------------------------------------------------------------
+
+    def test_only_missing_labels_are_posted(self, api):
+        api.replies[("GET", "/repos/o/r/labels")] = [{"name": label.name} for label in setup.expected_labels()][:2]
+        setup.apply_labels()
+        posted = [body["name"] for method, path, body in api.calls if method == "POST" and path == "/repos/o/r/labels"]
+        assert len(posted) == len(setup.expected_labels()) - 2
+        assert "workstream:security" in posted
+
+    def test_a_posted_label_carries_bare_hex(self, api):
+        """REST rejects a leading `#`. `expected_labels()` already spells them
+        bare, which is what `gh label create --color` wanted too — asserted
+        rather than assumed, because nothing else would catch it changing."""
+        setup.apply_labels()
+        colors = [body["color"] for method, path, body in api.calls if method == "POST"]
+        assert colors and all(re.fullmatch(r"[0-9a-fA-F]{6}", color) for color in colors)
+
+    def test_a_new_variable_is_posted_to_the_collection(self, api):
+        api.replies[("GET", "/repos/o/r/actions/variables")] = {"variables": []}
+        setup.apply_variables()
+        writes = [(method, path, body) for method, path, body in api.calls if method in {"POST", "PATCH"}]
+        assert writes and all(method == "POST" for method, _, _ in writes)
+        assert all(path == "/repos/o/r/actions/variables" for _, path, _ in writes)
+
+    def test_an_existing_variable_is_patched_on_its_item(self, api):
+        """One `gh variable set` is two different REST calls, and using the
+        collection for an update is a 409 rather than a silent no-op."""
+        wanted = setup.parse_model_variables()
+        name = next(iter(wanted))
+        api.replies[("GET", "/repos/o/r/actions/variables")] = {
+            "variables": [{"name": name, "value": "stale"}],
+        }
+        setup.apply_variables()
+        patches = [(path, body) for method, path, body in api.calls if method == "PATCH"]
+        assert (f"/repos/o/r/actions/variables/{name}", {"name": name, "value": wanted[name]}) in patches
+
+    def test_a_rejected_write_degrades_with_the_api_reason(self, api, capsys):
+        api.replies[("GET", "/repos/o/r/actions/variables")] = {"variables": []}
+        api.replies[("POST", "/repos/o/r/actions/variables")] = setup.ApiResult(
+            False, error="HTTP 403 on POST: Resource not accessible by integration"
+        )
+        setup.STRICT.degraded.clear()
+        setup.apply_variables()
+        assert setup.STRICT.degraded
+        assert "not accessible by integration" in capsys.readouterr().out
+
+    def test_teardown_deletes_by_item_path(self, api):
+        api.replies[("GET", "/repos/o/r/labels")] = [{"name": "workstream:security"}]
+        api.replies[("GET", "/repos/o/r/actions/variables")] = {"variables": []}
+        setup.apply_teardown(labels=True, variables=False)
+        deletes = [path for method, path, _ in api.calls if method == "DELETE"]
+        assert "/repos/o/r/labels/workstream%3Asecurity" in deletes
+
+    # --- pagination ----------------------------------------------------------
+
+    def test_a_second_page_is_fetched(self, monkeypatch):
+        """`gh label list --limit 200` was one oversized page. REST caps at 100,
+        and this repo already carries more cowork labels than fit in one."""
+        pages = {1: [{"name": f"l{i}"} for i in range(100)], 2: [{"name": "last"}]}
+        seen: list[int] = []
+
+        def fake(method: str, path: str, body: dict | None = None):
+            page = int(re.search(r"[?&]page=(\d+)", path).group(1))
+            seen.append(page)
+            return setup.ApiResult(True, pages.get(page, []))
+
+        monkeypatch.setattr(setup, "_api", fake)
+        result = setup._api_paged("/repos/o/r/labels")
+        assert seen == [1, 2]
+        assert len(result.data) == 101
+
+    # --- slug resolution -----------------------------------------------------
+
+    def test_the_env_names_the_repo_when_gh_cannot(self, monkeypatch):
+        monkeypatch.setattr(setup.shutil, "which", lambda name: None)
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/name")
+        assert setup.repo_slug() == "owner/name"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "git@github.com:owner/name.git",
+            "https://github.com/owner/name.git",
+            "https://github.com/owner/name",
+            "ssh://git@github.com/owner/name.git",
+        ],
+    )
+    def test_the_origin_remote_names_the_repo(self, monkeypatch, url):
+        """What actually resolves it in a routine session: step 1 of
+        `cron/cd-deploy.md` runs `git fetch origin main`, so a remote is there
+        even though `gh` is not."""
+        monkeypatch.setattr(setup.shutil, "which", lambda name: None)
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        monkeypatch.setattr(
+            setup.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, url + "\n", "")
+        )
+        assert setup.repo_slug() == "owner/name"
+
+    def test_an_unreadable_remote_is_none(self, monkeypatch):
+        monkeypatch.setattr(setup.shutil, "which", lambda name: None)
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        monkeypatch.setattr(setup.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "boom"))
+        assert setup.repo_slug() is None
+
+    # --- the token never leaks ----------------------------------------------
+
+    def test_the_token_is_never_printed(self, monkeypatch, capsys):
+        """It is a token even when it is not a secret-shaped one, and this script
+        prints everything it does."""
+        monkeypatch.setattr(setup, "gh_ready", lambda: False)
+        monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
+        monkeypatch.setenv("GH_TOKEN", "ghp_notarealtoken")
+        monkeypatch.setattr(setup, "_api", lambda *a, **k: setup.ApiResult(False, error="HTTP 403"))
+        setup.STRICT.degraded.clear()
+        setup.github_ready()
+        setup.existing_labels()
+        captured = capsys.readouterr()
+        assert "ghp_notarealtoken" not in captured.out + captured.err
+        setup.STRICT.degraded.clear()
+
+
+class TestApiRequests:
+    """``_api`` itself — the one function that touches a socket and the only
+    place the token is handled.
+
+    Everything else stubs it, so without this nothing covers the URL, the header
+    set, or the promise in its docstring that it never raises and never logs the
+    token. `urlopen` is the seam here; no socket is opened.
+    """
+
+    @pytest.fixture
+    def urlopen(self, monkeypatch):
+        """Record the Request objects; reply with a scripted body or raise."""
+        sent: list = []
+        outcome: dict = {"body": "{}", "raise": None}
+
+        class _Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                body = outcome["body"]
+                return body.encode() if isinstance(body, str) else body
+
+        def fake(request, timeout=None):
+            sent.append(request)
+            if outcome["raise"] is not None:
+                raise outcome["raise"]
+            return _Response()
+
+        monkeypatch.setattr(setup.urllib.request, "urlopen", fake)
+        monkeypatch.setenv("GH_TOKEN", "ghp_notarealtoken")
+        return type("U", (), {"sent": sent, "outcome": outcome})()
+
+    def test_the_url_is_the_literal_host_plus_the_path(self, urlopen):
+        _REAL_API("GET", "/repos/o/r/labels?per_page=100&page=1")
+        assert urlopen.sent[0].full_url == "https://api.github.com/repos/o/r/labels?per_page=100&page=1"
+        assert urlopen.sent[0].get_method() == "GET"
+
+    def test_the_headers_authenticate_and_pin_the_api_version(self, urlopen):
+        _REAL_API("GET", "/repos/o/r/labels")
+        headers = {k.lower(): v for k, v in urlopen.sent[0].header_items()}
+        assert headers["authorization"] == "Bearer ghp_notarealtoken"
+        assert headers["accept"] == "application/vnd.github+json"
+        assert headers["x-github-api-version"] == "2022-11-28"
+        assert "user-agent" in headers
+
+    def test_a_body_is_json_and_only_then_is_a_content_type_sent(self, urlopen):
+        _REAL_API("GET", "/repos/o/r/labels")
+        assert "Content-type" not in dict(urlopen.sent[0].header_items())
+        _REAL_API("POST", "/repos/o/r/labels", {"name": "cowork", "color": "5319e7"})
+        request = urlopen.sent[1]
+        assert request.get_method() == "POST"
+        assert json.loads(request.data.decode()) == {"name": "cowork", "color": "5319e7"}
+        assert dict(request.header_items())["Content-type"] == "application/json"
+
+    def test_no_token_never_reaches_the_socket(self, monkeypatch):
+        opened = []
+        monkeypatch.setattr(setup.urllib.request, "urlopen", lambda *a, **k: opened.append(a))
+        result = _REAL_API("GET", "/repos/o/r/labels")
+        assert result.ok is False and "GH_TOKEN" in result.error
+        assert opened == []
+
+    def test_an_empty_body_is_success_with_no_data(self, urlopen):
+        """A 204 is what `DELETE` and `PATCH` on a variable answer with."""
+        urlopen.outcome["body"] = ""
+        result = _REAL_API("DELETE", "/repos/o/r/labels/cowork")
+        assert result.ok is True and result.data is None
+
+    def test_an_http_error_carries_githubs_own_message(self, urlopen):
+        urlopen.outcome["raise"] = urllib.error.HTTPError(
+            "https://api.github.com/x",
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(b'{"message": "Resource not accessible by integration"}'),
+        )
+        result = _REAL_API("POST", "/repos/o/r/actions/variables", {"name": "X", "value": "y"})
+        assert result.ok is False
+        assert "403" in result.error and "not accessible by integration" in result.error
+
+    def test_a_transport_error_is_a_result_not_an_exception(self, urlopen):
+        urlopen.outcome["raise"] = urllib.error.URLError("name resolution failed")
+        result = _REAL_API("GET", "/repos/o/r/labels")
+        assert result.ok is False and "failed" in result.error
+
+    def test_a_non_json_body_is_a_failure_not_a_traceback(self, urlopen):
+        """What an egress proxy's HTML error page looks like — a plausible shape
+        in exactly the cloud session this transport exists for."""
+        urlopen.outcome["body"] = "<html>502 Bad Gateway</html>"
+        result = _REAL_API("GET", "/repos/o/r/labels")
+        assert result.ok is False and "not JSON" in result.error
+
+    def test_the_token_is_in_no_error_it_returns(self, urlopen):
+        urlopen.outcome["raise"] = urllib.error.URLError("connect to api.github.com failed")
+        assert "ghp_notarealtoken" not in _REAL_API("GET", "/repos/o/r/labels").error
+        urlopen.outcome["raise"] = urllib.error.HTTPError(
+            "https://api.github.com/x", 401, "Unauthorized", {}, io.BytesIO(b"bad credentials")
+        )
+        assert "ghp_notarealtoken" not in _REAL_API("GET", "/repos/o/r/labels").error
 
 
 class TestSnapshotFlags:


### PR DESCRIPTION
## Summary

`cron/cd-deploy.md` is the safety net that carries a merged `cowork/` change into the live routine fleet. It has been failing on every firing, always at step 3, and the fleet has not been reconciled since.

The cause was not drift. `scripts/cowork_setup.py` reached GitHub **only** by shelling out to `gh`. The cloud routine session that runs the routine has no `gh` binary but does have `GH_TOKEN`, so `gh_ready()` took its "not on PATH" branch, `strict_exit()` returned 1, and step 3's stop condition — *"report and stop — do not proceed to the routines with a half-applied repo"* — halted the run before step 4, the reconciliation the routine exists to do. Every automatic deploy was a clean no-op while reporting a clean repo.

**Two transports, one set of operations.** `gh` is still preferred and its path is unchanged; when `gh` is missing or logged out, the same eight operations go over the REST API with `GH_TOKEN`/`GITHUB_TOKEN` through stdlib `urllib` (the script still imports nothing from `src/yeaboi` and nothing off PyPI). Two details the CLI hid: `gh variable set` is one verb but a POST to create and a PATCH to update (the wrong one is a 409, not a no-op), and `gh label list --limit 200` was one oversized page where REST caps at 100. The repo slug resolves from `gh`, then `GITHUB_REPOSITORY`, then the `origin` remote — the last is what makes it work in a routine session, since step 1 of the routine runs `git fetch`.

**Step 3 no longer stops the deploy.** The routine now reads the exit code: **2** means `cowork/` disagrees with itself and still stops; **1** means a GitHub write degraded — noted, carried into the Slack post, and the run continues. A label has no bearing on a trigger body, which is built from the `cowork/` files step 2 just validated. To make that rule mechanical rather than inferred from prose, the repo-disagreement path returns 2 (it previously shared 1 with the degradation case).

**Step 2 drops to `--check --local`.** Caught in review: the full `make cowork-check` now reaches GitHub too, so a run deploying a *new* workstream or a changed model id would abort on a missing label one step before step 3 creates it — the same halted deploy, moved earlier. The `pr-feedback` merge-gate probe is still reported, from the apply step.

A side effect worth noting: cloud runs of the doctor previously reported "clean" while silently skipping every GitHub check. They now actually check.

The branch also carries one earlier commit, `53856e3` "record the two newly registered routine urls" — an unrelated `cowork/README.md` URL-column edit that was already on this branch.

## Test plan

- `make test` — 11363 passed, 47 skipped
- `make lint`, `ruff check scripts/`, `make security` — all clean
- **The production shape, reproduced locally** — `env PATH=/usr/bin:/bin GH_TOKEN=… scripts/cowork_setup.py --strict`: exit 0, labels and all four variables applied over REST, merge gate read. Previously exit 1.
- No `gh` and no token: degrades with both remedies named, exit 1 under `--strict`, 0 without.
- `gh` present: byte-identical behaviour, `make cowork-check` still clean.
- ~45 new tests. The case that was actually failing in production — no `gh`, no token, under `--strict` — had no test at all, which is why it ran that way for as long as it did.
- A module-wide `_no_live_github` fixture now clears both token variables, resets the memoised transport state, and makes `_api` refuse by default. Without it, a developer with `GH_TOKEN` exported and no `gh` installed would have had the teardown tests resolve their own repository from `origin` and issue real label DELETEs — found in review, not hypothetical.

## Review findings

An independent `code-reviewer` pass raised 2 blockers, 3 should-fixes and 3 nits. **All eight are fixed in this branch**, including a crash it found that I had introduced and my own verification had missed: `merge_gate_armed()` keyed on the resolved transport could reach `gh api` on a machine with no `gh`, tracebacking `make cowork-setup` on a fresh clone. `_gh()` now reports a missing binary as exit 127 rather than raising.

## Definition of Done

Items 8 (Notion) and 9 (Slack) are handled by `pr-merged-close-loop` on merge. Item 10 (review feedback) is outstanding by definition — `claude-review.yml` has not run yet.

Closes YEA-81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
