### PR TITLE
let only a maintainer say which tree gets released

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
       tag: ${{ steps.pin.outputs.tag }}
       go: ${{ steps.v.outputs.go }}
       left_behind: ${{ steps.v.outputs.left_behind }}
+      left_count: ${{ steps.v.outputs.left_count }}
       asked: ${{ steps.v.outputs.asked }}
     steps:
       - uses: actions/checkout@v7
@@ -99,7 +100,22 @@ jobs:
             # own `|| true` covers its greps, and a rate-limited or transient `gh`
             # would still abort the step under `set -e` — turning "no marker" into
             # "no release", which is the opposite of what this block promises.
-            TAG=$(gh issue view "$N" --json comments --jq '.comments[].body' 2>/dev/null | marker tested || true)
+            #
+            # **Maintainers only, and that filter is the whole authorization.**
+            # This marker names the tree the job below checks out, tests, builds
+            # and tags as the official release, and the ask is an open issue on a
+            # public repo. The regex validates the marker's shape and the lookup
+            # validates that the tag exists; neither asks who wrote it. Without
+            # the `select`, a stranger commenting a real older `beta/…` tag lands
+            # after the maintainer's genuine sign-off, `tail -1` prefers it, and
+            # the release is cut from a tree nobody signed for — with only the
+            # `::notice::promoting the tree behind …` line to show for it.
+            TAG=$(gh issue view "$N" --json comments \
+              --jq '.comments[]
+                    | select(.authorAssociation == "OWNER"
+                          or .authorAssociation == "MEMBER"
+                          or .authorAssociation == "COLLABORATOR")
+                    | .body' 2>/dev/null | marker tested || true)
           fi
           if [ -z "$TAG" ]; then
             TAG=$(printf '%s' "${ISSUE_BODY:-}" | marker beta)
@@ -218,8 +234,12 @@ jobs:
           # That is the same trap the comment above describes, and it bites in the
           # one case this line exists for — more than fifty commits left behind.
           LEFT=$(git log --oneline --no-merges -n 50 "${{ steps.pin.outputs.sha }}..origin/main")
+          # Counted separately, not from `$LEFT`: the list is capped at 50, so
+          # deriving the number from it reports exactly "50 commits" in the one
+          # case the cap exists for — understating a gap at the moment it is
+          # largest. `rev-list --count` needs no pipe and no cap.
+          COUNT=$(git rev-list --count --no-merges "${{ steps.pin.outputs.sha }}..origin/main")
           if [ -n "$LEFT" ]; then
-            COUNT=$(printf '%s\n' "$LEFT" | wc -l | tr -d ' ')
             echo "::warning::$COUNT commits on main are not in this release; they ride the next one."
             printf '%s\n' "$LEFT"
           fi
@@ -229,6 +249,9 @@ jobs:
             echo "left_behind<<GHEOF"
             printf '%s\n' "$LEFT"
             echo "GHEOF"
+            # The true number, beside the capped list — the close-out comment
+            # quotes it rather than counting the fifty lines it was given.
+            echo "left_count=${COUNT:-0}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Close out a duplicate approval
@@ -340,7 +363,9 @@ jobs:
             MSG="${MSG}"$'\n\n'"_cut from \`main\` at \`${SHA:0:8}\` — no signed-off pre-release was named on this ask._"
           fi
           if [ -n "${LEFT:-}" ]; then
-            COUNT=$(printf '%s\n' "$LEFT" | wc -l | tr -d ' ')
+            # `left_count` for the same reason the warning uses it: `$LEFT` is
+            # capped at 50 and would report 50 however many there really are.
+            COUNT="${{ needs.check.outputs.left_count }}"
             MSG="${MSG}"$'\n\n'"_${COUNT} commits on \`main\` are **not** in this release and ride the next one:_"$'\n'"$(printf '%s\n' "$LEFT" | sed 's/^/- /')"
           fi
           gh issue comment "$N" --body "$MSG"

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -196,7 +196,7 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 
 | Routine | Trigger | Workstream | Tier | URL |
 |---|---|---|---|---|
-| `cron/integrations-campaign.md` | `20 7 * * 1-5` weekdays | integrations | `deep` | — |
+| `cron/integrations-campaign.md` | `20 7 * * 1-5` weekdays | integrations | `deep` | https://claude.ai/code/routines/trig_019w6RJqz8aWJ13TkXmPUgtX |
 | `cron/agents-standup.md` | `15 6 * * 1-5` weekdays | agents | `fast` | https://claude.ai/code/routines/trig_013tsooGjdnEMLRQcm7ZKU57 |
 | `cron/shipped-standup.md` | `0 18 * * *` daily | — | `standard` | https://claude.ai/code/routines/trig_0118jEhPuaKrCaUWCYQtVgEv |
 | `cron/digest.md` | `15 8 * * *` | — | `standard` | https://claude.ai/code/routines/trig_01VY1hbAZKeGuKA1GLyVhbow |

--- a/scripts/beta_signoff.py
+++ b/scripts/beta_signoff.py
@@ -125,10 +125,34 @@ def open_ask(asks: list[dict]) -> dict | None:
     return next((ask for ask in asks if str(ask.get("state", "")).upper() == "OPEN"), None)
 
 
+# Who may sign a build off. `authorAssociation` as GitHub reports it on a comment:
+# the three that mean write access to this repository, and nothing else.
+SIGNERS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+
 def _comment_bodies(issue: int) -> list[str]:
+    """Every comment on the ask that a maintainer wrote.
+
+    **The filter is the authorization, and there is no other one.** A sign-off
+    marker names the tree `publish.yml` checks out, tests, builds and tags as the
+    official release — and the ask is an open issue on a public repository, so
+    anybody at all can comment on it. The regex that reads the marker validates
+    its *shape*, and the tag lookup validates that the ref *exists*; neither asks
+    who said it. Without this, a stranger's `<!-- tested: beta/1.2.3rc4 -->`
+    naming any real older pre-release outranks the maintainer's genuine sign-off
+    on the newest one, and the release is cut from a tree nobody signed for.
+
+    An unrecognised association reads as an outsider. That is the safe direction:
+    the cost is a sign-off that has to be repeated by someone the API does
+    recognise, and the other way round is a release nobody chose.
+    """
     data = _json("issue", "view", str(issue), "--json", "comments")
     comments = data.get("comments") if isinstance(data, dict) else None
-    return [str(entry.get("body", "")) for entry in comments] if isinstance(comments, list) else []
+    if not isinstance(comments, list):
+        return []
+    return [
+        str(entry.get("body", "")) for entry in comments if str(entry.get("authorAssociation", "")).upper() in SIGNERS
+    ]
 
 
 def newest_tested(asks: list[dict]) -> str | None:

--- a/tests/unit/test_beta_signoff.py
+++ b/tests/unit/test_beta_signoff.py
@@ -520,3 +520,47 @@ class TestMarkerRoundTrip:
         rendered = "<!-- beta: beta/3.10.0rc14 -->"
         assert re.compile(r"<!-- beta: beta/[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+ -->").search(rendered)
         assert json.dumps(rendered)  # no stray control characters
+
+
+class TestOnlyAMaintainerCanSignABuildOff:
+    """The ask is an open issue on a public repo, so anybody can comment on it.
+
+    A `<!-- tested: … -->` marker names the tree `publish.yml` checks out, tests,
+    builds and tags as the official release. The regex validates its shape and
+    the tag lookup validates that the ref exists — neither asks who wrote it. So
+    the author filter is the only authorization there is, and without it a
+    stranger naming any real older pre-release outranks the maintainer's genuine
+    sign-off on the newest one.
+    """
+
+    def _comments(self, monkeypatch, comments: list[dict]) -> None:
+        monkeypatch.setattr(signoff, "_json", lambda *a: {"comments": comments})
+
+    def test_an_outsiders_marker_is_not_read(self, monkeypatch):
+        self._comments(
+            monkeypatch,
+            [
+                {"body": "<!-- tested: beta/1.1.0rc9 -->", "authorAssociation": "OWNER"},
+                {"body": "<!-- tested: beta/1.1.0rc1 -->", "authorAssociation": "NONE"},
+            ],
+        )
+        assert signoff._comment_bodies(1) == ["<!-- tested: beta/1.1.0rc9 -->"]
+
+    def test_every_association_that_means_write_access_is_read(self, monkeypatch):
+        for association in ("OWNER", "MEMBER", "COLLABORATOR"):
+            self._comments(monkeypatch, [{"body": "signed", "authorAssociation": association}])
+            assert signoff._comment_bodies(1) == ["signed"], association
+
+    def test_an_unrecognised_association_reads_as_an_outsider(self, monkeypatch):
+        """The safe direction: a sign-off repeated, rather than a release nobody chose."""
+        for association in ("CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "", "MANNEQUIN"):
+            self._comments(monkeypatch, [{"body": "signed", "authorAssociation": association}])
+            assert signoff._comment_bodies(1) == [], association
+
+    def test_the_workflow_applies_the_same_filter_to_the_same_marker(self):
+        """Two readers of one input; a filter on only one of them is no filter."""
+        text = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+        pin = text.split("- id: pin", 1)[1].split("- id: notes", 1)[0]
+        assert "--json comments" in pin
+        for association in sorted(signoff.SIGNERS):
+            assert f'.authorAssociation == "{association}"' in pin, association

--- a/tests/unit/test_publish_workflows.py
+++ b/tests/unit/test_publish_workflows.py
@@ -271,8 +271,9 @@ class TestTheReleaseStepsCannotDieOnTheirOwnPlumbing:
         an absent comment.
         """
         text = self._step("--json comments")
-        line = next(line for line in text.splitlines() if "--json comments" in line)
-        assert line.rstrip().endswith("|| true)"), "a failed `gh issue view` would abort the promotion"
+        # The assignment spans several lines (the author filter), so the check is
+        # on where it ends rather than on one line of it.
+        assert "marker tested || true)" in text, "a failed `gh issue view` would abort the promotion"
 
 
 class TestTheRepoSetupJobIsRedOnlyForRealProblems:


### PR DESCRIPTION
## Summary

Answers the should-fix finding Claude Review left on #237. It was found before that PR merged; the fix was still in the working tree when the merge landed, so it needs its own PR.

`publish.yml`'s `pin` step resolves **which tree to release** from a `<!-- tested: beta/X.Y.ZrcN -->` marker in any comment on the promotion ask, newest wins. That ask is an open issue on a public repository. The regex validated the marker's *shape* and the tag lookup validated that the ref *exists* — neither asked who wrote it.

So a stranger commenting any real older pre-release tag lands after the maintainer's genuine sign-off, `tail -1` prefers it, and the official `X.Y.Z` is checked out, tested, built and tagged from a tree nobody signed for. The `::notice::promoting the tree behind …` line is the only trace, and the `left_behind` warning reads as ordinary drift rather than as a substitution. The same input feeds `beta_signoff.track_floors`, where a planted marker seeds every track's floor, so `promote` stops refusing an unsigned track and `pending(since=…)` narrows the batch past work nobody read.

Applying `release:promote` still needs repo write, so this could never *start* a release. It steered one a maintainer started — worse in the one way that matters, because it looks exactly like a promotion that went as asked.

**The fix:** both readers filter on `authorAssociation` ∈ {`OWNER`, `MEMBER`, `COLLABORATOR`} — the three that mean write access here. `_comment_bodies` is the single chokepoint on the Python side; the workflow carries the same `select` in its `--jq`. A test diffs the two, because a filter on one of two readers is no filter. An association GitHub does not report reads as an outsider: the cost is a sign-off repeated by somebody it recognises, and the other way round is a release nobody chose.

Also in here, from the same review's nits:

- `left_behind` is capped at 50 lines and `COUNT` was derived from that list, so a promotion leaving 200 commits behind reported "50 commits are not in this release" — understating the gap exactly when it is largest. It comes from `git rev-list --count` now and rides to the close-out comment as its own `left_count` output.
- `cowork/README.md` records the URL of `cowork: integrations-campaign`, registered in the deploy that followed #237. That column is the ledger the paged read checks itself against, so it is not decoration.

I did not take the review's other nit — `open_proposals` not passing `--paginate` on its `gh` branch. At `PROPOSAL_CAP = 2`, a queue past one page is a full queue either way, which is the reviewer's own reasoning.

## Test plan

- `make test` — 11 572 passed, 47 skipped
- `make lint`, `make security` — clean
- Four new tests in `test_beta_signoff.py`: an outsider's marker is not read; each of the three write-access associations is; an unrecognised association reads as an outsider; and the workflow's `--jq` filter is diffed against `SIGNERS`
- `authorAssociation` confirmed present on `gh issue view --json comments` against this repo

Closes YEA-85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
