### PR TITLE
make the chat box's newline, clear and paste limits discoverable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.8.0"
+version = "3.8.1"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,9 +2,46 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "3.8.1",
+      "date": "2026-08-12",
+      "summary": "Fixed critical paste handling defects in the chat box that corrupted input and broke keyboard ergonomics. Pasted text larger than 10,000 characters now drains fully and stays within the cap instead of overflowing into the tty as keystrokes; newlines are preserved across platforms (Windows CRLF, Unix LF, old Mac CR); UTF-8 characters no longer decode as replacement characters; and escape sequences in the read-ahead tail no longer phantom-quit the chat. The newline key hint was corrected: Ctrl+N has always worked but was invisible, while the advertised Alt+Enter needs iTerm2/Terminal.app configuration that many users don't have. The hint row is now dynamic, dropping lower-priority hints by segment rather than ellipsizing mid-word on narrow terminals. Ctrl+U now clearly indicates what it does and remembers the previous draft for one Ctrl+U press, so you can undo a clear without re-typing. All changes are keyboard ergonomics only \u2014 no new user-facing features.",
+      "highlights": [
+        {
+          "text": "Paste handling fixed: oversized pastes drain to 10,000 characters (not spilling as keystrokes), newlines preserved across platforms, UTF-8 decodes correctly, no character corruption",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Newline key now clearly advertises Ctrl+N (always worked, now visible) over Alt+Enter (which needs terminal config)",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Hint row now drops lower-priority segments instead of ellipsizing mid-word on narrow terminals, keeping the essential hints visible",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Ctrl+U shows what it does and restores the previous draft on the next Ctrl+U, so you can undo a clear without re-typing",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Fixed: escape sequences in the read-ahead buffer no longer phantom-quit the chat and type literal characters",
+          "areas": [
+            "general"
+          ]
+        }
+      ]
+    },
+    {
       "version": "3.8.0",
       "date": "2026-08-12",
-      "summary": "Daily Standup now offers GitHub organization-level scoping, bringing it to feature parity with Azure DevOps project selection. Instead of manually ticking individual repositories, you can now pick GitHub organisations in Configure → Code Sources, and the standup automatically discovers and tracks all repositories within those organisations. The picker intelligently expands owners per run (not at configure time), so newly created repositories are immediately available without any reconfiguration. Repository discovery is capped at the 10 most recently pushed per owner to keep the collector efficient, and GitHub API errors are handled gracefully as warnings rather than blocking the entire source.",
+      "summary": "Daily Standup now offers GitHub organization-level scoping, bringing it to feature parity with Azure DevOps project selection. Instead of manually ticking individual repositories, you can now pick GitHub organisations in Configure \u2192 Code Sources, and the standup automatically discovers and tracks all repositories within those organisations. The picker intelligently expands owners per run (not at configure time), so newly created repositories are immediately available without any reconfiguration. Repository discovery is capped at the 10 most recently pushed per owner to keep the collector efficient, and GitHub API errors are handled gracefully as warnings rather than blocking the entire source.",
       "highlights": [
         {
           "text": "GitHub organizations now appear in the code sources picker alongside Azure DevOps projects",

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -78,7 +78,7 @@ from yeaboi.ui.shared._animations import (
 )
 from yeaboi.ui.shared._beta_notice import show_beta_notice
 from yeaboi.ui.shared._click import button_click, parse_click
-from yeaboi.ui.shared._input import esc_came_from_back_tab, set_text_entry
+from yeaboi.ui.shared._input import esc_came_from_back_tab, paste_payload, set_text_entry
 from yeaboi.ui.shared._input import read_key as _read_key
 from yeaboi.ui.shared._music_bar import duck_working_thread, make_live
 from yeaboi.ui.shared._scroll import SCROLL_KEYS, coalesce_scroll, coalesce_steps
@@ -1526,7 +1526,7 @@ def _settings_edit_keypress(sk: str, edit: dict) -> None:
     elif sk == "end":
         edit["cur"] = len(buf)
     elif isinstance(sk, str) and sk.startswith("paste:"):
-        txt = sk[len("paste:") :]
+        txt = paste_payload(sk)
         edit["buf"], edit["cur"] = buf[:cur] + txt + buf[cur:], cur + len(txt)
     elif isinstance(sk, str) and len(sk) == 1 and sk.isprintable():
         edit["buf"], edit["cur"] = buf[:cur] + sk + buf[cur:], cur + 1
@@ -3151,7 +3151,7 @@ def _standup_read_line(
         elif k == "word_backspace":  # Ctrl+W
             value = value.rstrip().rsplit(" ", 1)[0] if " " in value.strip() else ""
         elif isinstance(k, str) and k.startswith("paste:"):
-            value += k[len("paste:") :]
+            value += paste_payload(k, multiline=box_rows > 1)
         elif k == "ctrl+v":
             if attachments is None:
                 unsupported_notice(_set_notice)
@@ -15007,7 +15007,7 @@ def select_mode(
                             import_value = ""
                             import_error = ""
                         elif key.startswith("paste:") if isinstance(key, str) else False:
-                            import_value += key[6:]
+                            import_value += paste_payload(key)
                             import_error = ""
                         elif key == "ctrl+v":
                             # A file-path field never reaches an LLM — reject image paste.

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -5704,7 +5704,7 @@ def _build_standup_input_screen(
             overflow="ellipsis",
         )
     else:
-        newline_hint = "  ·  Alt+Enter (or Ctrl+N) for a new line" if box_rows > 1 else ""
+        newline_hint = "  ·  Ctrl+N (or Alt+Enter) for a new line" if box_rows > 1 else ""
         hints = (
             "Enter to confirm  ·  Esc to cancel"
             + newline_hint

--- a/src/yeaboi/ui/provider_select/__init__.py
+++ b/src/yeaboi/ui/provider_select/__init__.py
@@ -49,7 +49,7 @@ from yeaboi.ui.shared._animations import COLOR_RGB, FADE_IN_LEVELS, FADE_OUT_LEV
 # Ctrl+V response for token/model fields — their content never reaches an LLM,
 # so image paste is rejected with the standard notice (see ui/shared/_attachments.py).
 from yeaboi.ui.shared._attachments import UNSUPPORTED_MESSAGE as _IMG_UNSUPPORTED
-from yeaboi.ui.shared._input import disable_bracketed_paste, enable_bracketed_paste
+from yeaboi.ui.shared._input import disable_bracketed_paste, enable_bracketed_paste, paste_payload
 from yeaboi.ui.shared._input import read_key as _read_key  # noqa: F401 — re-export for compat
 from yeaboi.ui.shared._music_bar import duck_working_thread, make_live
 
@@ -429,7 +429,7 @@ def select_provider(
                         err = ""
                         verified = None
                     elif key.startswith("paste:"):
-                        val += key[6:]
+                        val += paste_payload(key)
                         err = ""
                         verified = None
                     elif key == "ctrl+v":
@@ -667,7 +667,7 @@ def select_provider(
                         error = ""
                         verified = None
                     elif key.startswith("paste:"):
-                        input_value += key[6:]
+                        input_value += paste_payload(key)
                         error = ""
                         verified = None
                     elif key == "ctrl+v":
@@ -1019,7 +1019,7 @@ def select_provider(
                         vc_error = ""
                         vc_verified = None
                     elif key.startswith("paste:"):
-                        vc_input += key[6:]
+                        vc_input += paste_payload(key)
                         vc_error = ""
                         vc_verified = None
                     elif key == "ctrl+v":

--- a/src/yeaboi/ui/provider_select/_phase_confluence.py
+++ b/src/yeaboi/ui/provider_select/_phase_confluence.py
@@ -33,6 +33,7 @@ from yeaboi.ui.provider_select.screens._screens import (
 )
 from yeaboi.ui.provider_select.screens._screens_vc import _build_issue_tracking_screen
 from yeaboi.ui.shared._animations import FRAME_TIME_30FPS
+from yeaboi.ui.shared._input import paste_payload
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +299,7 @@ def _run_confluence_form(
         elif key == "tab":
             selected = (selected + 1) % n
         elif key.startswith("paste:"):
-            values[selected] = values.get(selected, "") + key[6:]
+            values[selected] = values.get(selected, "") + paste_payload(key)
             errors.pop(selected, None)
             verified.pop(selected, None)
         elif key == "ctrl+v":

--- a/src/yeaboi/ui/provider_select/_phase_issue_tracking.py
+++ b/src/yeaboi/ui/provider_select/_phase_issue_tracking.py
@@ -24,6 +24,7 @@ from yeaboi.ui.provider_select._nav import StepNav, nav_for_key
 from yeaboi.ui.provider_select._verification import _verify_azdevops, _verify_jira
 from yeaboi.ui.provider_select.screens._screens_vc import _build_issue_tracking_screen
 from yeaboi.ui.shared._animations import FRAME_TIME_30FPS
+from yeaboi.ui.shared._input import paste_payload
 from yeaboi.ui.shared._music_bar import duck_working_thread, make_live
 
 logger = logging.getLogger(__name__)
@@ -353,7 +354,7 @@ def _run_issue_tracking(
             elif key == "tab":
                 it_selected = (it_selected + 1) % it_n
             elif key.startswith("paste:"):
-                it_values[it_selected] = it_values.get(it_selected, "") + key[6:]
+                it_values[it_selected] = it_values.get(it_selected, "") + paste_payload(key)
                 it_errors.pop(it_selected, None)
                 it_verified.pop(it_selected, None)
             elif key == "ctrl+v":

--- a/src/yeaboi/ui/provider_select/_phase_notion.py
+++ b/src/yeaboi/ui/provider_select/_phase_notion.py
@@ -34,6 +34,7 @@ from yeaboi.ui.provider_select.screens._screens import (
 )
 from yeaboi.ui.provider_select.screens._screens_vc import _build_issue_tracking_screen
 from yeaboi.ui.shared._animations import FRAME_TIME_30FPS
+from yeaboi.ui.shared._input import paste_payload
 
 logger = logging.getLogger(__name__)
 
@@ -259,7 +260,7 @@ def _run_notion_form(
         elif key == "tab":
             selected = (selected + 1) % n
         elif key.startswith("paste:"):
-            values[selected] = values.get(selected, "") + key[6:]
+            values[selected] = values.get(selected, "") + paste_payload(key)
             errors.pop(selected, None)
             verified.pop(selected, None)
         elif key == "ctrl+v":

--- a/src/yeaboi/ui/session/chat/_commands.py
+++ b/src/yeaboi/ui/session/chat/_commands.py
@@ -18,6 +18,8 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from ._composer import NEWLINE_KEY, InsertResult, paste_notice
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,7 +35,7 @@ class ChatContext:
     run_turn: Callable[[str], None]  # submit a synthetic user turn (guardrail-exempt)
     add_system: Callable[[str], None]  # dim notice line in the transcript
     add_artifact: Callable[[str], None]  # push an artifact card by kind
-    insert_text: Callable[[str], bool]  # composer insert; False = truncated
+    insert_text: Callable[[str], InsertResult]  # composer insert; .dropped > 0 = did not all fit
     trigger_voice: Callable[[], None]
     trigger_image: Callable[[], None]
     export: Callable[[str], None]  # scope: "plan" | "transcript" | "both" | "" (ask)
@@ -64,8 +66,8 @@ def _cmd_help(ctx: ChatContext, args: str) -> None:
             lines.append(f"/{cmd.name} — {cmd.help}")
     lines.append("")
     lines.append(
-        "Shortcuts: Enter send · Alt+Enter newline · Ctrl+V paste screenshot · "
-        "double-tap Space voice · ↑/↓ choices or cursor · Esc Esc leave"
+        f"Shortcuts: Enter send · {NEWLINE_KEY} newline · Ctrl+U clear the box (Ctrl+U again undoes) · "
+        "Ctrl+V paste screenshot · double-tap Space voice · ↑/↓ choices or cursor · Esc Esc leave"
     )
     ctx.add_system("\n".join(lines))
 
@@ -122,19 +124,18 @@ def _cmd_voice(ctx: ChatContext, args: str) -> None:
 
 
 def _cmd_paste(ctx: ChatContext, args: str) -> None:
-    # Newline-preserving paste: terminal bracketed paste strips every newline
-    # (see ui/shared/_input.py), so long/structured text goes through the
-    # clipboard directly — same escape hatch the standup transcript uses.
+    # Reads the clipboard directly rather than through the terminal, so it also
+    # sidesteps whatever the terminal does to a paste of its own (size caps,
+    # flow control) — same escape hatch the standup transcript uses.
     from yeaboi.clipboard import read_clipboard_text
 
     text = read_clipboard_text()
     if not text:
         ctx.add_system("Clipboard is empty (or unreadable) — copy the text first, then /paste.")
         return
-    if not ctx.insert_text(text):
-        from yeaboi.input_guardrails import MAX_CHAT_INPUT_CHARS
-
-        ctx.add_system(f"Paste truncated at {MAX_CHAT_INPUT_CHARS:,} characters.")
+    result = ctx.insert_text(text)
+    if not result.ok:
+        ctx.add_system(paste_notice(result))
 
 
 def _cmd_small(ctx: ChatContext, args: str) -> None:

--- a/src/yeaboi/ui/session/chat/_composer.py
+++ b/src/yeaboi/ui/session/chat/_composer.py
@@ -38,11 +38,98 @@ class PasteImage:
 
 
 @dataclass(frozen=True)
-class Truncated:
-    """A paste was cut at MAX_CHAT_INPUT_CHARS — the driver shows a notice."""
+class InsertResult:
+    """What an insertion actually managed to do.
+
+    ``offered`` counts what the user tried to insert, INCLUDING anything the
+    reader already dropped at its own paste ceiling — so a notice can quote what
+    was pasted rather than only what survived the terminal. ``kept`` is what
+    reached the buffer.
+    """
+
+    offered: int
+    kept: int
+    dropped: int
+
+    @property
+    def ok(self) -> bool:
+        return self.dropped == 0
 
 
-ComposerEvent = Submit | Voice | PasteImage | Truncated
+@dataclass(frozen=True)
+class Truncated(InsertResult):
+    """An insertion hit MAX_CHAT_INPUT_CHARS — the driver shows a loud notice.
+
+    Subclasses InsertResult (adding no fields) so one formatter — paste_notice —
+    serves both the bracketed-paste event and /paste's return value.
+    """
+
+
+@dataclass(frozen=True)
+class Cleared:
+    """Ctrl+U on a box with content: buffer and chips stashed, box emptied."""
+
+    chars: int
+    images: int
+
+
+@dataclass(frozen=True)
+class Restored:
+    """Ctrl+U on an empty box holding a stash: the previous draft is back."""
+
+    chars: int
+    images: int
+
+
+ComposerEvent = Submit | Voice | PasteImage | Truncated | Cleared | Restored
+
+NEWLINE_KEY = "Ctrl+N"
+"""The newline key we advertise.
+
+Alt+Enter and Shift+Enter also arrive as "alt+enter" (see ui/shared/_input.py),
+but neither reaches the app on a default iTerm2 or Terminal.app profile —
+Alt+Enter needs Option-as-Meta and Shift+Enter needs CSI-u modifier reporting.
+Ctrl+N works in every terminal, so it is the only one we promise; the hint used
+to name Alt+Enter, which is precisely the one most users cannot press.
+"""
+
+
+@dataclass(frozen=True)
+class _Stash:
+    """A cleared draft, held for one Ctrl+U undo. Immutable so a later edit of
+    the live buffer cannot reach back into it."""
+
+    lines: tuple[str, ...]
+    row: int
+    col: int
+    attachments: tuple[str, ...]
+
+
+def clear_notice(event: Cleared | Restored) -> str:
+    """The hint-line notice for a Ctrl+U clear or its undo."""
+    images = ""
+    if event.images:
+        images = f", {event.images} image{'' if event.images == 1 else 's'}"
+    if isinstance(event, Cleared):
+        return f"Cleared the message ({event.chars:,} characters{images}) — Ctrl+U again to undo."
+    return f"Restored your message ({event.chars:,} characters{images})."
+
+
+def paste_notice(result: InsertResult) -> str:
+    """The loud notice for a paste that did not fit.
+
+    Numbers first: the hint row clips at roughly 70 cells on an 80-column
+    terminal, and the counts are the part that has to survive the cut.
+    """
+    if result.kept == 0:
+        return (
+            f"Nothing pasted — the message is already at the {MAX_CHAT_INPUT_CHARS:,}-character "
+            "limit. Shorten it, then paste again."
+        )
+    return (
+        f"Pasted {result.offered:,} characters — kept {result.kept:,}, dropped {result.dropped:,}. "
+        f"The message limit is {MAX_CHAT_INPUT_CHARS:,} characters."
+    )
 
 
 @dataclass
@@ -54,6 +141,7 @@ class ChatComposer:
     col: int = 0
     attachments: list[str] = field(default_factory=list)
     _dts: DoubleTapSpace = field(default_factory=DoubleTapSpace)
+    _stash: _Stash | None = None
 
     # -- content -----------------------------------------------------------
 
@@ -64,9 +152,51 @@ class ChatComposer:
         return not self.text().strip()
 
     def reset(self) -> None:
+        """Empty the buffer, leaving ``attachments`` alone.
+
+        Deliberate: _input_loop calls this the instant a message is submitted,
+        and the caller reads composer.attachments AFTERWARDS to resolve image
+        chips. Clearing them here would silently detach every image on send.
+        Ctrl+U clears both — see clear_with_stash.
+        """
         self.lines = [""]
         self.row = 0
         self.col = 0
+
+    def has_content(self) -> bool:
+        """Anything Ctrl+U would throw away: any character at all, or any chip.
+
+        Deliberately not is_empty(), which strips — that one answers "does this
+        look empty to the user" (ghost placeholder, choice navigation). Ctrl+U
+        asks "is there something to destroy", and a box holding three spaces has
+        something to destroy.
+        """
+        return bool(self.text()) or bool(self.attachments)
+
+    def has_stash(self) -> bool:
+        """True while a cleared draft is still recoverable."""
+        return self._stash is not None
+
+    def clear_with_stash(self) -> Cleared | Restored | None:
+        """Ctrl+U: empty the box, stashing it — or restore the last stash.
+
+        Single level on purpose: a second Ctrl+U means "give it back", not "go
+        further back". Returns None on an empty box with nothing stashed, so the
+        driver shows no notice for a keypress that did nothing.
+        """
+        if self.has_content():
+            self._stash = _Stash(tuple(self.lines), self.row, self.col, tuple(self.attachments))
+            event = Cleared(chars=len(self.text()), images=len(self.attachments))
+            self.reset()
+            self.attachments = []
+            return event
+        if self._stash is None:
+            return None
+        stash, self._stash = self._stash, None
+        self.lines = list(stash.lines)
+        self.row, self.col = stash.row, stash.col
+        self.attachments = list(stash.attachments)
+        return Restored(chars=len(self.text()), images=len(self.attachments))
 
     def set_text(self, text: str) -> None:
         """Replace the buffer (suggestion prefill), cursor at the start."""
@@ -91,19 +221,22 @@ class ChatComposer:
             end += 1
         return line[start:end], start
 
-    def insert_text(self, text: str) -> bool:
+    def insert_text(self, text: str, *, already_dropped: int = 0) -> InsertResult:
         """Insert text at the cursor (paste, voice, chips), splitting on newlines.
 
-        Returns False when the insertion was truncated at MAX_CHAT_INPUT_CHARS
-        — the same constant submit-time validation uses, so truncation and
-        validation can never disagree.
+        Truncates at MAX_CHAT_INPUT_CHARS — the same constant submit-time
+        validation uses, so truncation and validation can never disagree — and
+        reports what that cost. ``already_dropped`` counts characters the reader
+        threw away above its own paste ceiling before handing the text over: the
+        composer never sees them, but they belong in ``offered`` so the notice
+        can name what the user actually pasted.
         """
-        budget = MAX_CHAT_INPUT_CHARS - len(self.text())
-        truncated = len(text) > budget
-        if truncated:
-            text = text[: max(0, budget)]
+        offered = len(text) + already_dropped
+        budget = max(0, MAX_CHAT_INPUT_CHARS - len(self.text()))
+        text = text[:budget]
+        result = InsertResult(offered=offered, kept=len(text), dropped=offered - len(text))
         if not text:
-            return not truncated
+            return result
 
         parts = text.split("\n")
         line = self.lines[self.row]
@@ -115,19 +248,25 @@ class ChatComposer:
             self.lines.insert(self.row, part)
             self.col = len(part)
         self.lines[self.row] += tail
-        return not truncated
+        return result
 
     # -- key handling ------------------------------------------------------
 
-    def handle_key(self, key: str, *, now: float | None = None) -> ComposerEvent | None:
+    def handle_key(self, key: str, *, now: float | None = None, dropped: int = 0) -> ComposerEvent | None:
         """Apply one key to the buffer. Returns an event for the driver, or None.
 
         Only buffer-editing keys are handled here; the driver routes scroll
         keys, choice navigation, and Esc before calling this.
+
+        ``dropped`` is the reader's paste overflow (ui.shared.take_paste_dropped),
+        passed in rather than read here so the composer stays terminal-free.
         """
         if key == "enter":
             text = self.text().strip()
             if text:
+                # A sent message is not undoable: resurrecting it on a later
+                # Ctrl+U would read as a bug, not as an undo.
+                self._stash = None
                 return Submit(text)
             return None
         if key == "alt+enter":
@@ -148,7 +287,7 @@ class ChatComposer:
                 self.row -= 1
                 self.col = prev_len
         elif key == "clear":
-            self.reset()
+            return self.clear_with_stash()
         elif key == "up":
             if self.row > 0:
                 self.row -= 1
@@ -187,10 +326,12 @@ class ChatComposer:
         elif key == "ctrl+v":
             return PasteImage()
         elif key.startswith("paste:"):
-            # Bracketed paste (newlines already stripped by read_key; /paste is
-            # the newline-preserving alternative via read_clipboard_text).
-            if not self.insert_text(key[6:]):
-                return Truncated()
+            # Taken whole: this is the multiline case of ui.shared.paste_payload
+            # (insert_text splits on "\n"), so no reshaping is needed and the
+            # composer stays free of any terminal import.
+            result = self.insert_text(key[len("paste:") :], already_dropped=dropped)
+            if not result.ok:
+                return Truncated(offered=result.offered, kept=result.kept, dropped=result.dropped)
         elif len(key) == 1 and key.isprintable():
             line = self.lines[self.row]
             prev_is_space = self.col > 0 and line[self.col - 1] == " "

--- a/src/yeaboi/ui/session/chat/_composer.py
+++ b/src/yeaboi/ui/session/chat/_composer.py
@@ -177,6 +177,17 @@ class ChatComposer:
         """True while a cleared draft is still recoverable."""
         return self._stash is not None
 
+    def forget_stash(self) -> None:
+        """Drop the undo history — the draft it belonged to has been sent.
+
+        handle_key's Submit branch does this for a typed message, but the input
+        loop also returns from a choices answer and from an inline /command,
+        and neither goes through handle_key. A stash surviving the turn both
+        blocks every later suggestion prefill (the guard tests has_stash) and
+        lets a Ctrl+U three questions later resurrect a draft from this one.
+        """
+        self._stash = None
+
     def clear_with_stash(self) -> Cleared | Restored | None:
         """Ctrl+U: empty the box, stashing it — or restore the last stash.
 

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -288,6 +288,20 @@ class _ChatDriver:
         self.transcript.add_system(text)
         self._pin_bottom()
 
+    def _composer_cleared(self, event: Cleared | Restored) -> None:
+        """Report a Ctrl+U clear or its undo.
+
+        Logged as well as shown: it is the one destructive thing the box does,
+        so "my draft vanished" needs to be answerable from the log.
+        """
+        logger.info(
+            "Chat composer %s: chars=%d images=%d",
+            "cleared" if isinstance(event, Cleared) else "restored",
+            event.chars,
+            event.images,
+        )
+        self.notice = clear_notice(event)
+
     def _paste_truncated(self, event: Truncated) -> None:
         """Report a paste that did not fit — loudly, and in two places.
 
@@ -744,7 +758,7 @@ class _ChatDriver:
             # Voice and image capture stay suppressed mid-turn, as before.
             event = self.composer.handle_key(key, dropped=take_paste_dropped())
             if isinstance(event, Cleared | Restored):
-                self.notice = clear_notice(event)
+                self._composer_cleared(event)
             elif isinstance(event, Truncated):
                 self._paste_truncated(event)
 
@@ -1271,7 +1285,7 @@ class _ChatDriver:
             elif isinstance(event, PasteImage):
                 self._paste_image()
             elif isinstance(event, Cleared | Restored):
-                self.notice = clear_notice(event)
+                self._composer_cleared(event)
             elif isinstance(event, Truncated):
                 self._paste_truncated(event)
         return None

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -35,12 +35,12 @@ from rich.live import Live
 from yeaboi.agent.chat_intake import GREETING_TEXT, SIZE_QUESTION_TEXT, parse_size_reply, resolve_intake_mode
 from yeaboi.agent.state import TOTAL_QUESTIONS, QuestionnaireState, ReviewDecision
 from yeaboi.agent.streaming import ChatStreamCancelledError, predict_next_node, stream_chat_turn
-from yeaboi.input_guardrails import MAX_CHAT_INPUT_CHARS, validate_chat_input
+from yeaboi.input_guardrails import validate_chat_input
 from yeaboi.persistence import save_project_snapshot
 from yeaboi.prompts.intake import decorate_question_for_chat
 from yeaboi.ui.shared._animations import FRAME_TIME_30FPS
 from yeaboi.ui.shared._attachments import handle_ctrl_v, referenced_images
-from yeaboi.ui.shared._input import set_text_entry
+from yeaboi.ui.shared._input import set_text_entry, take_paste_dropped
 from yeaboi.ui.shared._music_bar import (
     poke_duck,
     quack_duck,
@@ -51,7 +51,17 @@ from yeaboi.ui.shared._music_bar import (
 from yeaboi.ui.shared._scroll import SCROLL_BOTTOM, coalesce_scroll
 
 from ._commands import ChatContext, dispatch, matching_commands
-from ._composer import ChatComposer, PasteImage, Submit, Truncated, Voice
+from ._composer import (
+    ChatComposer,
+    Cleared,
+    PasteImage,
+    Restored,
+    Submit,
+    Truncated,
+    Voice,
+    clear_notice,
+    paste_notice,
+)
 from ._duck import ChatDuck
 from ._question_view import derive_question_view
 from ._screen import ChoiceRows, PipelineProgress, build_chat_screen
@@ -277,6 +287,19 @@ class _ChatDriver:
     def _note(self, text: str) -> None:
         self.transcript.add_system(text)
         self._pin_bottom()
+
+    def _paste_truncated(self, event: Truncated) -> None:
+        """Report a paste that did not fit — loudly, and in two places.
+
+        The hint line is gone on the very next keypress and clips below ~120
+        columns, so the same sentence also goes into the transcript, which wraps
+        and stays put. Someone who pastes a document and keeps typing must still
+        be able to find out that half of it never arrived.
+        """
+        message = paste_notice(event)
+        logger.info("Chat paste truncated: offered=%d kept=%d dropped=%d", event.offered, event.kept, event.dropped)
+        self.notice = message
+        self._note(message)
 
     def _bubble(self, text: str, hold: float | None = None) -> None:
         """Give the corner duck an ephemeral line (an ack, a stage quip).
@@ -567,7 +590,11 @@ class _ChatDriver:
 
         spoken = record_voice_input(self.live, self.console, self._key, render_status=render_status)
         if spoken:
-            self.composer.insert_text(spoken)
+            result = self.composer.insert_text(spoken)
+            if not result.ok:
+                # A long dictation can hit the cap; an image chip (~11 chars)
+                # cannot, which is why _paste_image ignores its result.
+                self._paste_truncated(Truncated(offered=result.offered, kept=result.kept, dropped=result.dropped))
 
     # ------------------------------------------------------------- graph turns
 
@@ -711,7 +738,15 @@ class _ChatDriver:
         elif key == "enter":
             self.notice = "Still working — your message will send when this finishes."
         else:
-            self.composer.handle_key(key)
+            # Typing continues during a turn, so clearing and truncation have to
+            # report here too — this branch used to discard the event entirely,
+            # which made both silent for the whole time the graph was working.
+            # Voice and image capture stay suppressed mid-turn, as before.
+            event = self.composer.handle_key(key, dropped=take_paste_dropped())
+            if isinstance(event, Cleared | Restored):
+                self.notice = clear_notice(event)
+            elif isinstance(event, Truncated):
+                self._paste_truncated(event)
 
     def _at_intake_summary(self) -> bool:
         """True when the newest reply is the intake summary awaiting a verdict.
@@ -1226,7 +1261,7 @@ class _ChatDriver:
                 if inline is not None:
                     return inline
 
-            event = self.composer.handle_key(key)
+            event = self.composer.handle_key(key, dropped=take_paste_dropped())
             if isinstance(event, Submit):
                 text = event.text
                 self.composer.reset()
@@ -1235,8 +1270,10 @@ class _ChatDriver:
                 self._voice()
             elif isinstance(event, PasteImage):
                 self._paste_image()
+            elif isinstance(event, Cleared | Restored):
+                self.notice = clear_notice(event)
             elif isinstance(event, Truncated):
-                self.notice = f"Paste truncated at {MAX_CHAT_INPUT_CHARS:,} characters."
+                self._paste_truncated(event)
         return None
 
     def _pop_inline_command(self) -> str | None:
@@ -1651,7 +1688,15 @@ class _ChatDriver:
                     )
                 else:
                     self.choices = None
-                    if view.suggestion and self.composer.is_empty() and self._prefilled_q != view.current_question:
+                    # not has_stash(): a box emptied by Ctrl+U is waiting for its
+                    # undo, and prefilling the suggestion into it would make the
+                    # second Ctrl+U clear the suggestion instead of restoring.
+                    if (
+                        view.suggestion
+                        and self.composer.is_empty()
+                        and not self.composer.has_stash()
+                        and self._prefilled_q != view.current_question
+                    ):
                         self.composer.set_text(view.suggestion)
                         # set_text resets the cursor to 0,0 — typing must land
                         # after the suggestion, not before it.

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -1273,6 +1273,7 @@ class _ChatDriver:
             if key == "enter":
                 inline = self._pop_inline_command()
                 if inline is not None:
+                    self.composer.forget_stash()
                     return inline
 
             event = self.composer.handle_key(key, dropped=take_paste_dropped())
@@ -1321,6 +1322,9 @@ class _ChatDriver:
 
     def _choice_answer(self) -> str:
         assert self.choices is not None
+        # This return leaves the input loop without touching handle_key, so the
+        # stash has to be burned here as it is on a typed submit.
+        self.composer.forget_stash()
         checked = [label for label, is_checked in self.choices.options if is_checked]
         if self.choices.multi and checked:
             return ", ".join(checked)

--- a/src/yeaboi/ui/session/chat/_screen.py
+++ b/src/yeaboi/ui/session/chat/_screen.py
@@ -108,9 +108,14 @@ def _fit_hint(pairs: list[tuple[str, str]], extras: str, avail: int) -> tuple[li
     the controls drawer (panel._hint_tab) still lists every one of them.
 
     Sacrifice order, cheapest first: the screenshot hint (also in the composer's
-    title chip and /help), then "/ commands" (typing "/" opens the menu by
-    itself), then "Ctrl+U clear" (in /help, and recoverable). Never dropped:
-    Enter send, the newline key, and the Esc tail the caller appends.
+    title chip and /help), "/ commands" (typing "/" opens the menu by itself),
+    "PgUp/PgDn scroll" (the wheel does it), "Ctrl+U clear" (in /help, and
+    recoverable), then the menu's own keys. Never dropped: Enter send, the
+    newline key, and the Esc tail the caller appends.
+
+    The list has to reach the menu pairs: with a choices menu up — the normal
+    intake state — dropping only the first three still overflows 80 columns,
+    and what gets amputated is the newline key this hint exists to teach.
     """
     budget = avail - _ESC_TAIL_CELLS
     if _hint_cells(pairs, extras) <= budget:
@@ -119,12 +124,10 @@ def _fit_hint(pairs: list[tuple[str, str]], extras: str, avail: int) -> tuple[li
         extras = ""
         if _hint_cells(pairs, extras) <= budget:
             return pairs, extras
-    for victim in ("/", "Ctrl+U"):
-        if len(pairs) <= 1:
-            break
-        pairs = [pair for pair in pairs if pair[0] != victim]
+    for victim in ("/", "PgUp/PgDn", "Ctrl+U", "Space", "↑/↓"):
         if _hint_cells(pairs, extras) <= budget:
             break
+        pairs = [pair for pair in pairs if pair[0] != victim]
     return pairs, extras
 
 

--- a/src/yeaboi/ui/session/chat/_screen.py
+++ b/src/yeaboi/ui/session/chat/_screen.py
@@ -44,7 +44,7 @@ from yeaboi.ui.shared._scroll import publish_geometry
 from yeaboi.ui.shared._voice_input import input_box_title
 
 from ._commands import SlashCommand
-from ._composer import ChatComposer
+from ._composer import NEWLINE_KEY, ChatComposer
 from ._transcript import ChatTranscript
 
 _COL_W_MAX = 110
@@ -68,7 +68,8 @@ _TIPS_PAIRS = [
     ("/small /large", "set plan size"),
     ("␣␣", "double-tap Space to speak"),
     ("/form", "fill it out as a form"),
-    ("alt+enter", "new line"),
+    (NEWLINE_KEY, "new line"),
+    ("Ctrl+U", "clear the box"),
     ("/finish", "answer the rest with defaults (Esc stops)"),
     ("/export", "save plan + chat"),
     ("/questions", "see what I'll ask"),
@@ -77,6 +78,54 @@ _TIPS_PAIRS = [
 
 # Rendered once per column width — static copy, never per-frame work.
 _tips_cache: dict[int, list[Text]] = {}
+
+
+# Page-panel border (2) + padding (4): the cells the hint row loses to chrome.
+_HINT_CHROME = 6
+# "   Esc Esc leave" — reserved out of the budget, never dropped.
+_ESC_TAIL_CELLS = 16
+
+
+def _hint_cells(pairs: list[tuple[str, str]], extras: str) -> int:
+    """Rendered width of a hint row, counted arithmetically.
+
+    Integer maths only: this runs inside every frame at 30fps, so measuring by
+    building Rich objects would be per-frame work for a static string.
+    """
+    total = sum(len(key) + 1 + len(label) for key, label in pairs) + 3 * max(0, len(pairs) - 1)
+    if extras:
+        total += 2 + Text(extras).cell_len
+    return total
+
+
+def _fit_hint(pairs: list[tuple[str, str]], extras: str, avail: int) -> tuple[list[tuple[str, str]], str]:
+    """Drop the lowest-value hint segments until the row fits ``avail`` cells.
+
+    Rich ellipsizes from the right, which amputates whichever hints happen to be
+    last — below 120 columns that was "Esc Esc leave", so the escape hatch was
+    invisible on a normal terminal while the row still ended mid-word. Dropping
+    whole segments keeps the row honest: what is shown is shown completely, and
+    the controls drawer (panel._hint_tab) still lists every one of them.
+
+    Sacrifice order, cheapest first: the screenshot hint (also in the composer's
+    title chip and /help), then "/ commands" (typing "/" opens the menu by
+    itself), then "Ctrl+U clear" (in /help, and recoverable). Never dropped:
+    Enter send, the newline key, and the Esc tail the caller appends.
+    """
+    budget = avail - _ESC_TAIL_CELLS
+    if _hint_cells(pairs, extras) <= budget:
+        return pairs, extras
+    if extras:
+        extras = ""
+        if _hint_cells(pairs, extras) <= budget:
+            return pairs, extras
+    for victim in ("/", "Ctrl+U"):
+        if len(pairs) <= 1:
+            break
+        pairs = [pair for pair in pairs if pair[0] != victim]
+        if _hint_cells(pairs, extras) <= budget:
+            break
+    return pairs, extras
 
 
 @dataclass
@@ -229,8 +278,11 @@ def _tips_card_lines(col_w: int, theme) -> list[Text]:
     grid = Table.grid(padding=(0, 3), pad_edge=False)
     grid.add_column()
     grid.add_column()
-    for left, right in zip(_TIPS_PAIRS[0::2], _TIPS_PAIRS[1::2]):
-        grid.add_row(build_key_hints([left]), build_key_hints([right]))
+    for i in range(0, len(_TIPS_PAIRS), 2):
+        row = _TIPS_PAIRS[i : i + 2]
+        # Pair up, but never silently drop a tip when the list is odd — zip()
+        # used to, which is a quiet way to lose the one you just added.
+        grid.add_row(build_key_hints([row[0]]), build_key_hints([row[1]]) if len(row) > 1 else Text(""))
     card = Panel(
         Group(Text(_EXAMPLE_TEXT, style="dim italic"), Text(""), grid),
         title=f"[bold {theme.accent}] Getting started [/]",
@@ -360,8 +412,9 @@ def build_chat_screen(
         pairs.append(("PgUp/PgDn", "scroll"))
         if choices.multi:
             pairs.append(("Space", "toggle"))
-    pairs += [("Enter", "send"), ("Alt+Enter", "newline"), ("/", "commands")]
+    pairs += [("Enter", "send"), (NEWLINE_KEY, "newline"), ("Ctrl+U", "clear"), ("/", "commands")]
     extras = (_voice_hint() + _image_hint()).strip()
+    # The drawer gets every pair whatever the width; only the inline row sheds.
     plain_hint = " · ".join(f"{k} {label}" for k, label in pairs)
     if extras:
         plain_hint += " " + extras
@@ -369,7 +422,8 @@ def build_chat_screen(
     if notice:
         hint = Text(indent + notice, style="bold white", justify="left", no_wrap=True, overflow="ellipsis")
     else:
-        hint = build_key_hints(pairs, pad=indent)
+        shown_pairs, extras = _fit_hint(pairs, extras, max(20, width - margin - _HINT_CHROME))
+        hint = build_key_hints(shown_pairs, pad=indent)
         if extras:
             hint.append("  " + extras.removeprefix("· "), style="rgb(110,110,125)")
         hint.append("   Esc Esc", style="bold rgb(210,210,220)")

--- a/src/yeaboi/ui/session/editor/_editor.py
+++ b/src/yeaboi/ui/session/editor/_editor.py
@@ -43,6 +43,7 @@ from yeaboi.ui.session.editor._editor_core import (
 )
 from yeaboi.ui.shared._animations import lerp_color
 from yeaboi.ui.shared._components import PAD, PLANNING_THEME, build_page_panel, planning_title
+from yeaboi.ui.shared._input import paste_payload
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -699,7 +700,7 @@ def edit_story(
         elif isinstance(key, str) and key.startswith("paste:"):
             min_col = _editable_start(buffer[cursor_row])
             if min_col is not None and cursor_col >= min_col:
-                pasted = key[6:].replace("\n", " ")
+                pasted = paste_payload(key)
                 buffer[cursor_row] = buffer[cursor_row][:cursor_col] + pasted + buffer[cursor_row][cursor_col:]
                 cursor_col += len(pasted)
         elif isinstance(key, str) and len(key) == 1 and key.isprintable():

--- a/src/yeaboi/ui/session/editor/_editor_core.py
+++ b/src/yeaboi/ui/session/editor/_editor_core.py
@@ -26,6 +26,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from yeaboi.ui.shared._components import PAD, PLANNING_THEME, build_page_panel, planning_title
+from yeaboi.ui.shared._input import paste_payload
 
 # ---------------------------------------------------------------------------
 # Shared field label pattern for all editors (story, task, sprint, etc.)
@@ -443,7 +444,7 @@ def edit_buffer_loop(
         elif isinstance(key, str) and key.startswith("paste:"):
             min_col = editable_start_fn(buffer[cursor_row])
             if min_col is not None and cursor_col >= min_col:
-                pasted = key[6:].replace("\n", " ")
+                pasted = paste_payload(key)
                 line = buffer[cursor_row]
                 buffer[cursor_row] = line[:cursor_col] + pasted + line[cursor_col:]
                 cursor_col += len(pasted)

--- a/src/yeaboi/ui/session/phases/_phases_intake.py
+++ b/src/yeaboi/ui/session/phases/_phases_intake.py
@@ -27,6 +27,7 @@ from yeaboi.ui.session.screens._screens_input import (
     _image_hint,
     _voice_hint,
 )
+from yeaboi.ui.shared._input import paste_payload
 
 logger = logging.getLogger(__name__)
 
@@ -215,7 +216,7 @@ def _phase_description_input(
             input_lines[cursor_row] = line[:word_start] + line[cursor_col:]
             cursor_col = word_start
         elif isinstance(key, str) and key.startswith("paste:"):
-            pasted = key[6:]
+            pasted = paste_payload(key, multiline=True)
             paste_lines = pasted.split("\n")
             if paste_lines:
                 # Insert first chunk at cursor
@@ -715,7 +716,7 @@ def _question_input_loop(
             input_value = input_value[:word_start] + input_value[cursor_pos:]
             cursor_pos = word_start
         elif isinstance(key, str) and key.startswith("paste:"):
-            pasted = key[6:]
+            pasted = paste_payload(key)
             input_value = input_value[:cursor_pos] + pasted + input_value[cursor_pos:]
             cursor_pos += len(pasted)
         elif key == "ctrl+v":

--- a/src/yeaboi/ui/session/phases/_phases_review.py
+++ b/src/yeaboi/ui/session/phases/_phases_review.py
@@ -16,6 +16,7 @@ from yeaboi.ui.session._utils import _invoke_with_animation, _render_to_lines, _
 from yeaboi.ui.session.screens._accordion import _build_accordion_question_screen
 from yeaboi.ui.session.screens._screens import _build_summary_screen
 from yeaboi.ui.session.screens._screens_pipeline import _build_edit_prompt_screen
+from yeaboi.ui.shared._input import paste_payload
 from yeaboi.ui.shared._scroll import SCROLL_KEYS, coalesce_scroll
 
 logger = logging.getLogger(__name__)
@@ -362,7 +363,7 @@ def _get_edit_input(
             word_start = _word_boundary_left(input_value, len(input_value))
             input_value = input_value[:word_start]
         elif isinstance(key, str) and key.startswith("paste:"):
-            input_value += key[6:]
+            input_value += paste_payload(key)
         elif key == "ctrl+v":
             if attachments is None:
                 unsupported_notice(_set_notice)

--- a/src/yeaboi/ui/shared/__init__.py
+++ b/src/yeaboi/ui/shared/__init__.py
@@ -39,7 +39,9 @@ from yeaboi.ui.shared._input import (  # noqa: F401
     disable_mouse_tracking,
     enable_bracketed_paste,
     enable_mouse_tracking,
+    paste_payload,
     read_key,
+    take_paste_dropped,
 )
 from yeaboi.ui.shared._scroll import (  # noqa: F401
     SCROLL_KEYS,

--- a/src/yeaboi/ui/shared/_input.py
+++ b/src/yeaboi/ui/shared/_input.py
@@ -24,6 +24,30 @@ _last_read_had_input = False
 # Set while a field is being typed into, so the app-wide single-letter shortcuts
 # (currently 'c' for the controls drawer) don't steal characters from the buffer.
 _text_entry = False
+# Raw bytes read ahead of the caller and not yet consumed: the tail of a chunked
+# bracketed-paste read that ran past the end marker. Popped before touching the fd
+# so the keystroke typed straight after a paste is never lost. Distinct from
+# _pushback, which holds already-decoded key NAMES and pops LIFO; these are bytes
+# and must come back in order. Single-threaded input, so a plain bytearray is safe.
+_pending_bytes = bytearray()
+# Characters the most recent bracketed paste dropped at _PASTE_KEEP_LIMIT, so the
+# caller can report what the terminal sent rather than only what survived. Read via
+# take_paste_dropped(); same "extra detail about the key just returned" pattern as
+# _last_read_had_input above.
+_last_paste_dropped = 0
+
+# Bracketed paste bounds. The keep limit is deliberately far above the app's own
+# message cap (input_guardrails.MAX_CHAT_INPUT_CHARS) so the *field* does the
+# truncating and can quote real numbers; the reader's job is only to stop a
+# runaway stream from eating memory. The drain limit and the two clocks bound a
+# paste whose end marker never arrives — a byte-at-a-time blocking read used to
+# hang the TUI outright in that case.
+_PASTE_KEEP_LIMIT = 100_000
+_PASTE_DRAIN_LIMIT = 4_000_000
+_PASTE_IDLE_SECONDS = 0.5
+_PASTE_DRAIN_SECONDS = 5.0
+_PASTE_END = b"\x1b[201~"
+_PASTE_CHUNK = 65536
 
 
 def set_text_entry(active: bool) -> None:
@@ -39,6 +63,34 @@ def set_text_entry(active: bool) -> None:
 def push_back_key(key: str) -> None:
     """Return a key to the front of the input stream (LIFO with the buffer)."""
     _pushback.append(key)
+
+
+def take_paste_dropped() -> int:
+    """Characters the most recent bracketed paste dropped at _PASTE_KEEP_LIMIT.
+
+    Read-and-reset: a "paste:" key and its drop count are consumed together, so a
+    stale count can never be attributed to the next paste. Kept off the key string
+    on purpose — "paste:<content>" is parsed by a dozen screens, and a wire-format
+    change would make every one of them silently swallow the paste instead of
+    failing loudly.
+    """
+    global _last_paste_dropped
+    dropped, _last_paste_dropped = _last_paste_dropped, 0
+    return dropped
+
+
+def paste_payload(key: str, *, multiline: bool = False) -> str:
+    """The text carried by a "paste:" key, shaped for the field receiving it.
+
+    Bracketed paste preserves newlines (a pasted brief keeps its paragraphs), so
+    single-line fields — the default — collapse them to spaces and strip the edges:
+    a copied API token almost always carries a trailing newline, and a literal "\n"
+    in a one-row box is invisible corruption.
+    """
+    text = key[len("paste:") :] if key.startswith("paste:") else ""
+    if multiline:
+        return text
+    return text.replace("\n", " ").strip()
 
 
 # True when the most recent "esc" event came from clicking the back tab rather
@@ -80,6 +132,78 @@ def _esc(*, from_tab: bool = False) -> str:
     return "esc"
 
 
+def _read_paste(fd: int) -> tuple[str, int]:
+    """Read a bracketed-paste payload through to its "\x1b[201~" end marker.
+
+    Returns (kept, total): the cleaned text, capped at _PASTE_KEEP_LIMIT, and how
+    many characters the terminal actually sent.
+
+    Three things here are load-bearing and were each a bug before:
+
+    1. It ALWAYS drains to the end marker, however much it keeps. Stopping early
+       leaves the rest of the paste in the tty, where the next reads decode it as
+       individual keystrokes — including the "\r" that means "enter", which sends
+       a half-pasted message and then types the remainder into the next one.
+    2. It reads in chunks and decodes ONCE. Byte-at-a-time decoding turned every
+       non-ASCII character (curly quotes, em dashes, emoji) into U+FFFD, and would
+       cost millions of syscalls at these sizes.
+    3. Every read is bounded. The old loop's blocking read hung the TUI forever if
+       a paste was aborted mid-stream.
+    """
+    import select as _select
+    import time as _time
+
+    # Seed from the read-ahead tail: two pastes in one burst leave the second
+    # one's opening bytes there, and reading the fd first would reorder them.
+    buf = bytearray(_pending_bytes)
+    _pending_bytes.clear()
+    deadline = _time.monotonic() + _PASTE_DRAIN_SECONDS
+    end = buf.find(_PASTE_END)
+    abandoned = False
+    while end == -1:
+        if _time.monotonic() > deadline or len(buf) > _PASTE_DRAIN_LIMIT:
+            abandoned = True
+            break
+        if not _select.select([fd], [], [], _PASTE_IDLE_SECONDS)[0]:
+            # Paste bytes stream continuously; a gap this long means the stream
+            # died without a terminator. Take what we have rather than block.
+            abandoned = True
+            break
+        chunk = os.read(fd, _PASTE_CHUNK)
+        if not chunk:
+            abandoned = True
+            break
+        # Search from just before the join so a marker split across two chunks
+        # is still found, without rescanning the whole buffer each time.
+        start = max(0, len(buf) - (len(_PASTE_END) - 1))
+        buf += chunk
+        end = buf.find(_PASTE_END, start)
+        if end != -1:
+            break
+
+    if end == -1:
+        payload, tail = bytes(buf), b""
+    else:
+        payload, tail = bytes(buf[:end]), bytes(buf[end + len(_PASTE_END) :])
+    if abandoned:
+        # Only here: the stream is malformed or absurd, so its remainder must be
+        # discarded rather than replayed as fake keystrokes. The normal path must
+        # never flush — per-call reads preserve type-ahead (see _read_key_impl).
+        try:
+            termios.tcflush(fd, termios.TCIFLUSH)
+        except Exception:  # noqa: BLE001 - a failed flush must not break input
+            pass
+    elif tail:
+        _pending_bytes.extend(tail)
+
+    text = payload.decode("utf-8", errors="replace")
+    # CRLF and lone CR both mean "new line" here; keeping \n is the whole point,
+    # since multi-line pastes used to arrive with their words glued together.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = "".join(c for c in text if c == "\n" or c.isprintable())
+    return text[:_PASTE_KEEP_LIMIT], len(text)
+
+
 def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
     """Read a single keypress from the terminal in raw mode.
 
@@ -104,8 +228,9 @@ def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
     """
     import select as _select
 
-    global _last_read_had_input
+    global _last_read_had_input, _last_paste_dropped
     _last_read_had_input = False
+    _last_paste_dropped = 0
 
     if _pushback:
         _last_read_had_input = True
@@ -129,11 +254,16 @@ def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
         #   - ISIG — signal generation, so every control char arrives as a keypress
         #     rather than a signal; read_key turns Ctrl+C back into KeyboardInterrupt
         #     itself, so quitting behaves exactly as it looks.
+        #   - ICRNL — CR-to-NL translation, so a pasted CRLF arrives as CRLF and
+        #     _read_paste can fold it into one newline. Left on, the line
+        #     discipline hands us "\n\n" and every Windows-line-ended paste
+        #     comes out double-spaced. Enter is unaffected: "\r" and "\n" both
+        #     already decode to "enter" below.
         new_settings = termios.tcgetattr(fd)
-        new_settings[0] &= ~termios.IXON  # input flags (c_iflag)
+        new_settings[0] &= ~(termios.IXON | termios.ICRNL)  # input flags (c_iflag)
         new_settings[3] &= ~(termios.IEXTEN | termios.ISIG)  # local flags (c_lflag)
         termios.tcsetattr(fd, termios.TCSANOW, new_settings)
-        if timeout is not None:
+        if timeout is not None and not _pending_bytes:
             try:
                 ready, _, _ = _select.select([fd], [], [], timeout)
             except KeyboardInterrupt:
@@ -142,7 +272,13 @@ def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
                 return ""
 
         def _read1() -> str:
-            """Read exactly 1 byte from fd, bypassing Python's buffer."""
+            """Read exactly 1 byte, from the paste read-ahead tail or the fd.
+
+            Bypasses Python's buffer (see the docstring above); the tail comes
+            first and in order, so a key typed straight after a paste survives.
+            """
+            if _pending_bytes:
+                return bytes([_pending_bytes.pop(0)]).decode("utf-8", errors="replace")
             return os.read(fd, 1).decode("utf-8", errors="replace")
 
         def _read_available(wait: float = 0.05) -> str:
@@ -333,27 +469,9 @@ def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
                     # Read remaining 3 chars of the start marker: "00~"
                     marker_rest = _read1() + _read1() + _read1()
                     if marker_rest == "00~":
-                        # Blocking reads until end marker \x1b[201~
-                        chars: list[str] = []
-                        max_len = 10000  # safety limit
-                        while len(chars) < max_len:
-                            c = _read1()
-                            if c == "\x1b":
-                                # Potential end marker: \x1b[201~
-                                m1 = _read1()
-                                if m1 == "[":
-                                    m2 = _read1() + _read1() + _read1() + _read1()
-                                    if m2 == "201~":
-                                        break  # end of paste
-                                    chars.append("\x1b[" + m2)
-                                else:
-                                    chars.append("\x1b" + m1)
-                            else:
-                                chars.append(c)
-                        content = "".join(chars)
-                        content = content.replace("\r", "").replace("\n", "")
-                        content = "".join(c for c in content if c.isprintable())
+                        content, total = _read_paste(fd)
                         if content:
+                            _last_paste_dropped = total - len(content)
                             return f"paste:{content}"
                     else:
                         _read_available()
@@ -481,9 +599,10 @@ def enter_raw_mode(stdin=None) -> None:
         _saved_term_settings = termios.tcgetattr(fd)
         tty.setcbreak(fd)  # disables ICANON + ECHO
         # Mirror read_key: drop IXON/IEXTEN/ISIG so Ctrl+S / Ctrl+O / Ctrl+C reach
-        # the app rather than the line discipline (read_key re-raises Ctrl+C).
+        # the app rather than the line discipline (read_key re-raises Ctrl+C),
+        # and ICRNL so a pasted CRLF stays CRLF (see read_key for why).
         m = termios.tcgetattr(fd)
-        m[0] &= ~termios.IXON
+        m[0] &= ~(termios.IXON | termios.ICRNL)
         m[3] &= ~(termios.IEXTEN | termios.ISIG)
         termios.tcsetattr(fd, termios.TCSANOW, m)
     except Exception:  # noqa: BLE001 - not a tty (pipe, redirect, CI); leave as-is

--- a/src/yeaboi/ui/shared/_input.py
+++ b/src/yeaboi/ui/shared/_input.py
@@ -42,15 +42,17 @@ _last_paste_dropped = 0
 # to the end marker.
 _paste_discarding = False
 
-# Bracketed paste bounds. The keep limit is deliberately far above the app's own
-# message cap (input_guardrails.MAX_CHAT_INPUT_CHARS) so the *field* does the
-# truncating and can quote real numbers; the reader's job is only to stop a
-# runaway stream from eating memory. The drain limit and the two clocks bound a
-# paste whose end marker never arrives — a byte-at-a-time blocking read used to
-# hang the TUI outright in that case.
-_PASTE_KEEP_LIMIT = 100_000
+# Bracketed paste bounds. The keep limit is the de-facto ceiling for every
+# single-line field in the app — most take a payload with no bound of their own,
+# and a six-figure paste into one builds a Text of that many cells and re-wraps
+# it every frame. Raising it does NOT buy the chat box better reporting: the
+# overflow is counted into take_paste_dropped() either way, so "Pasted 34,812
+# characters" survives a ceiling far below 34,812. The drain limit and the two
+# clocks bound a paste whose end marker never arrives — a byte-at-a-time
+# blocking read used to hang the TUI outright in that case.
+_PASTE_KEEP_LIMIT = 10_000
 _PASTE_DRAIN_LIMIT = 4_000_000
-_PASTE_IDLE_SECONDS = 0.5
+_PASTE_IDLE_SECONDS = 1.5
 _PASTE_DRAIN_SECONDS = 5.0
 _PASTE_END = b"\x1b[201~"
 _PASTE_CHUNK = 65536
@@ -178,6 +180,8 @@ def _read_paste(fd: int) -> tuple[str, int]:
         if not _select.select([fd], [], [], _PASTE_IDLE_SECONDS)[0]:
             # Paste bytes stream continuously; a gap this long means the stream
             # died without a terminator. Take what we have rather than block.
+            # Generous on purpose: a short gap is latency on a lossy link, and
+            # calling that death costs more than waiting does.
             abandoned = True
             break
         chunk = os.read(fd, _PASTE_CHUNK)

--- a/src/yeaboi/ui/shared/_input.py
+++ b/src/yeaboi/ui/shared/_input.py
@@ -35,6 +35,12 @@ _pending_bytes = bytearray()
 # take_paste_dropped(); same "extra detail about the key just returned" pattern as
 # _last_read_had_input above.
 _last_paste_dropped = 0
+# Set when a paste was abandoned mid-stream. A one-shot tcflush only discards
+# what is queued at that instant, and both abandon triggers mean "the stream is
+# still coming" — so the remainder would arrive as keystrokes, including the
+# "\r" that means enter. While this is set, every read first swallows input up
+# to the end marker.
+_paste_discarding = False
 
 # Bracketed paste bounds. The keep limit is deliberately far above the app's own
 # message cap (input_guardrails.MAX_CHAT_INPUT_CHARS) so the *field* does the
@@ -83,14 +89,17 @@ def paste_payload(key: str, *, multiline: bool = False) -> str:
     """The text carried by a "paste:" key, shaped for the field receiving it.
 
     Bracketed paste preserves newlines (a pasted brief keeps its paragraphs), so
-    single-line fields — the default — collapse them to spaces and strip the edges:
-    a copied API token almost always carries a trailing newline, and a literal "\n"
-    in a one-row box is invisible corruption.
+    single-line fields — the default — drop the edge newlines and collapse the
+    inner ones to spaces: a copied API token almost always carries a trailing
+    newline, and a literal "\n" in a one-row box is invisible corruption.
+
+    Only newlines are stripped, not whitespace generally — pasting mid-cell in
+    an editor must not silently lose a space the user meant to paste.
     """
     text = key[len("paste:") :] if key.startswith("paste:") else ""
     if multiline:
         return text
-    return text.replace("\n", " ").strip()
+    return text.strip("\r\n").replace("\n", " ")
 
 
 # True when the most recent "esc" event came from clicking the back tab rather
@@ -150,6 +159,7 @@ def _read_paste(fd: int) -> tuple[str, int]:
     3. Every read is bounded. The old loop's blocking read hung the TUI forever if
        a paste was aborted mid-stream.
     """
+    global _paste_discarding
     import select as _select
     import time as _time
 
@@ -159,10 +169,11 @@ def _read_paste(fd: int) -> tuple[str, int]:
     _pending_bytes.clear()
     deadline = _time.monotonic() + _PASTE_DRAIN_SECONDS
     end = buf.find(_PASTE_END)
-    abandoned = False
+    abandoned = overflowing = False
     while end == -1:
         if _time.monotonic() > deadline or len(buf) > _PASTE_DRAIN_LIMIT:
-            abandoned = True
+            # Still gushing when we gave up — the rest is on its way.
+            abandoned = overflowing = True
             break
         if not _select.select([fd], [], [], _PASTE_IDLE_SECONDS)[0]:
             # Paste bytes stream continuously; a gap this long means the stream
@@ -189,6 +200,11 @@ def _read_paste(fd: int) -> tuple[str, int]:
         # Only here: the stream is malformed or absurd, so its remainder must be
         # discarded rather than replayed as fake keystrokes. The normal path must
         # never flush — per-call reads preserve type-ahead (see _read_key_impl).
+        # The flush clears what is queued now; _paste_discarding covers whatever
+        # the terminal is still writing — armed only when we gave up on a stream
+        # that was still flowing. After a stall the stream is dead, and staying
+        # armed would swallow the user's next keypress instead.
+        _paste_discarding = overflowing
         try:
             termios.tcflush(fd, termios.TCIFLUSH)
         except Exception:  # noqa: BLE001 - a failed flush must not break input
@@ -202,6 +218,34 @@ def _read_paste(fd: int) -> tuple[str, int]:
     text = text.replace("\r\n", "\n").replace("\r", "\n")
     text = "".join(c for c in text if c == "\n" or c.isprintable())
     return text[:_PASTE_KEEP_LIMIT], len(text)
+
+
+def _discard_to_marker(fd: int) -> None:
+    """Swallow the remainder of an abandoned paste, up to its end marker.
+
+    Armed by _read_paste when it gives up on a stream. Disarms on the marker —
+    or on a long silence, which means the stream really did die and staying
+    armed would eat the user's next keypress instead.
+    """
+    global _paste_discarding
+    import select as _select
+    import time as _time
+
+    deadline = _time.monotonic() + _PASTE_DRAIN_SECONDS
+    window = b""
+    while _time.monotonic() < deadline:
+        if not _select.select([fd], [], [], _PASTE_IDLE_SECONDS)[0]:
+            break
+        chunk = os.read(fd, _PASTE_CHUNK)
+        if not chunk:
+            break
+        if _PASTE_END in window + chunk:
+            tail = (window + chunk).split(_PASTE_END, 1)[1]
+            if tail:
+                _pending_bytes.extend(tail)
+            break
+        window = (window + chunk)[-(len(_PASTE_END) - 1) :]
+    _paste_discarding = False
 
 
 def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
@@ -263,6 +307,10 @@ def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
         new_settings[0] &= ~(termios.IXON | termios.ICRNL)  # input flags (c_iflag)
         new_settings[3] &= ~(termios.IEXTEN | termios.ISIG)  # local flags (c_lflag)
         termios.tcsetattr(fd, termios.TCSANOW, new_settings)
+        # After the mode is set, never before: in the terminal's cooked mode a
+        # read stops at the line ending, so the marker would never be found.
+        if _paste_discarding:
+            _discard_to_marker(fd)
         if timeout is not None and not _pending_bytes:
             try:
                 ready, _, _ = _select.select([fd], [], [], timeout)
@@ -278,13 +326,33 @@ def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
             first and in order, so a key typed straight after a paste survives.
             """
             if _pending_bytes:
-                return bytes([_pending_bytes.pop(0)]).decode("utf-8", errors="replace")
+                # Take a whole UTF-8 sequence, not a byte: a curly quote typed
+                # straight after a paste would otherwise arrive as U+FFFD.
+                lead = _pending_bytes[0]
+                width = 4 if lead >= 0xF0 else 3 if lead >= 0xE0 else 2 if lead >= 0xC0 else 1
+                chunk = bytes(_pending_bytes[:width])
+                del _pending_bytes[:width]
+                return chunk.decode("utf-8", errors="replace")
             return os.read(fd, 1).decode("utf-8", errors="replace")
 
+        def _more_input(wait: float) -> bool:
+            """Is another byte available — from the read-ahead tail or the fd?
+
+            Every "is there more?" check must ask this rather than select() on
+            the fd alone. A tail holding an escape sequence (a second paste in
+            the same burst, or an arrow key typed straight after one) would
+            otherwise be read as a bare Esc followed by its literal characters
+            — and two of those inside the double-Esc window quit the chat and
+            throw the draft away.
+            """
+            if _pending_bytes:
+                return True
+            return bool(_select.select([fd], [], [], wait)[0])
+
         def _read_available(wait: float = 0.05) -> str:
-            """Read all immediately available bytes from fd."""
+            """Read all immediately available bytes (tail first, then the fd)."""
             buf = ""
-            while _select.select([fd], [], [], wait)[0]:
+            while _more_input(wait):
                 buf += _read1()
                 wait = 0.01  # shorter timeout for subsequent chars
             return buf
@@ -297,7 +365,7 @@ def _read_key_impl(stdin=None, timeout: float | None = None) -> str:
             # key or other escape sequence, which always sends \x1b[...
             # within microseconds). 100ms is imperceptible to a human
             # but safe for slow terminals / SSH connections.
-            if not _select.select([fd], [], [], 0.1)[0]:
+            if not _more_input(0.1):
                 return _esc()
             ch2 = _read1()
             if ch2 == "\x7f":

--- a/tests/unit/test_chat_commands.py
+++ b/tests/unit/test_chat_commands.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from yeaboi.ui.session.chat._commands import COMMANDS, ChatContext, dispatch, matching_commands
+from yeaboi.ui.session.chat._composer import NEWLINE_KEY, InsertResult
 
 
 def _ctx(**overrides) -> ChatContext:
@@ -11,7 +12,7 @@ def _ctx(**overrides) -> ChatContext:
         run_turn=MagicMock(),
         add_system=MagicMock(),
         add_artifact=MagicMock(),
-        insert_text=MagicMock(return_value=True),
+        insert_text=MagicMock(return_value=InsertResult(offered=0, kept=0, dropped=0)),
         trigger_voice=MagicMock(),
         trigger_image=MagicMock(),
         export=MagicMock(),
@@ -104,11 +105,27 @@ class TestDispatch:
         dispatch(ctx, "/summary")
         ctx.add_artifact.assert_called_with("intake_summary")
 
+    def test_help_names_the_keys_that_work(self):
+        ctx = _ctx()
+        dispatch(ctx, "/help")
+        text = ctx.add_system.call_args[0][0]
+        # The hint used to name Alt+Enter, which most terminals never deliver.
+        assert f"{NEWLINE_KEY} newline" in text
+        assert "Ctrl+U clear the box" in text
+        assert "Alt+Enter" not in text
+
     def test_paste_inserts_clipboard_text(self):
         ctx = _ctx()
         with patch("yeaboi.clipboard.read_clipboard_text", return_value="line1\nline2"):
             dispatch(ctx, "/paste")
         ctx.insert_text.assert_called_with("line1\nline2")
+
+    def test_paste_too_large_reports_the_numbers(self):
+        ctx = _ctx(insert_text=MagicMock(return_value=InsertResult(offered=34_812, kept=10_000, dropped=24_812)))
+        with patch("yeaboi.clipboard.read_clipboard_text", return_value="x" * 34_812):
+            dispatch(ctx, "/paste")
+        notice = ctx.add_system.call_args[0][0]
+        assert "34,812" in notice and "10,000" in notice and "24,812" in notice
 
     def test_paste_empty_clipboard_notices(self):
         ctx = _ctx()

--- a/tests/unit/test_chat_composer.py
+++ b/tests/unit/test_chat_composer.py
@@ -1,7 +1,18 @@
 """Tests for the chat composer — buffer editing, events, and wrapping."""
 
 from yeaboi.input_guardrails import MAX_CHAT_INPUT_CHARS
-from yeaboi.ui.session.chat._composer import ChatComposer, PasteImage, Submit, Truncated, Voice
+from yeaboi.ui.session.chat._composer import (
+    ChatComposer,
+    Cleared,
+    InsertResult,
+    PasteImage,
+    Restored,
+    Submit,
+    Truncated,
+    Voice,
+    clear_notice,
+    paste_notice,
+)
 
 
 def _type(composer: ChatComposer, text: str) -> None:
@@ -67,6 +78,15 @@ class TestEditing:
         assert c.text() == ""
         assert c.is_empty()
 
+    def test_reset_leaves_attachments_alone(self):
+        # Regression guard: _input_loop resets on submit and the caller reads
+        # attachments AFTERWARDS to resolve image chips.
+        c = ChatComposer()
+        _type(c, "look [image #1]")
+        c.attachments = ["/tmp/shot.png"]
+        c.reset()
+        assert c.attachments == ["/tmp/shot.png"]
+
 
 class TestEvents:
     def test_ctrl_v_signals_paste_image(self):
@@ -99,7 +119,7 @@ class TestPaste:
 
     def test_insert_text_preserves_newlines(self):
         c = ChatComposer()
-        assert c.insert_text("one\ntwo") is True
+        assert c.insert_text("one\ntwo").ok
         assert c.lines == ["one", "two"]
 
     def test_paste_truncated_at_chat_cap(self):
@@ -107,6 +127,45 @@ class TestPaste:
         event = c.handle_key("paste:" + "x" * (MAX_CHAT_INPUT_CHARS + 100))
         assert isinstance(event, Truncated)
         assert len(c.text()) == MAX_CHAT_INPUT_CHARS
+
+    def test_insert_text_reports_offered_kept_dropped(self):
+        c = ChatComposer()
+        result = c.insert_text("x" * (MAX_CHAT_INPUT_CHARS + 12))
+        assert (result.offered, result.kept, result.dropped) == (
+            MAX_CHAT_INPUT_CHARS + 12,
+            MAX_CHAT_INPUT_CHARS,
+            12,
+        )
+        assert not result.ok
+
+    def test_insert_text_counts_reader_drops_into_offered(self):
+        # The reader capped the paste before the composer ever saw it; those
+        # characters still belong in "what you pasted".
+        c = ChatComposer()
+        result = c.insert_text("x" * 100, already_dropped=24_000)
+        assert result.offered == 24_100
+        assert result.kept == 100
+        assert result.dropped == 24_000
+
+    def test_insert_text_of_empty_string_is_ok(self):
+        result = ChatComposer().insert_text("")
+        assert (result.offered, result.kept, result.dropped) == (0, 0, 0)
+        assert result.ok
+
+    def test_paste_into_a_full_box_keeps_nothing(self):
+        c = ChatComposer()
+        c.insert_text("x" * MAX_CHAT_INPUT_CHARS)
+        result = c.insert_text("more")
+        assert result.kept == 0
+        assert result.dropped == 4
+
+    def test_truncated_event_carries_the_numbers(self):
+        c = ChatComposer()
+        event = c.handle_key("paste:" + "x" * (MAX_CHAT_INPUT_CHARS + 100), dropped=5_000)
+        assert isinstance(event, Truncated)
+        assert event.offered == MAX_CHAT_INPUT_CHARS + 5_100
+        assert event.kept == MAX_CHAT_INPUT_CHARS
+        assert event.dropped == 5_100
 
     def test_set_text_prefill_puts_cursor_at_start(self):
         c = ChatComposer()
@@ -169,3 +228,114 @@ class TestCursorWord:
 
     def test_empty_buffer(self):
         assert ChatComposer().cursor_word() == ("", 0)
+
+
+class TestClearUndo:
+    def test_clear_stashes_text_and_chips(self):
+        c = ChatComposer()
+        _type(c, "abc")
+        c.attachments = ["/tmp/a.png", "/tmp/b.png"]
+        event = c.handle_key("clear")
+        assert isinstance(event, Cleared)
+        assert (event.chars, event.images) == (3, 2)
+        assert c.text() == ""
+        assert c.attachments == []
+
+    def test_second_clear_restores_text_cursor_and_chips(self):
+        c = ChatComposer()
+        _type(c, "hello")
+        c.handle_key("left")
+        c.attachments = ["/tmp/a.png"]
+        c.handle_key("clear")
+        event = c.handle_key("clear")
+        assert isinstance(event, Restored)
+        assert (event.chars, event.images) == (5, 1)
+        assert c.text() == "hello"
+        assert (c.row, c.col) == (0, 4)
+        assert c.attachments == ["/tmp/a.png"]
+
+    def test_clear_on_empty_box_with_no_stash_does_nothing(self):
+        c = ChatComposer()
+        assert c.handle_key("clear") is None
+        assert c.text() == ""
+
+    def test_whitespace_only_box_is_clearable(self):
+        # has_content(), not is_empty(): three spaces are something to destroy.
+        c = ChatComposer()
+        c.insert_text("   ")  # not _type: fast repeated spaces are the voice gesture
+        assert isinstance(c.handle_key("clear"), Cleared)
+        assert isinstance(c.handle_key("clear"), Restored)
+        assert c.text() == "   "
+
+    def test_attachments_alone_count_as_content(self):
+        c = ChatComposer()
+        c.attachments = ["/tmp/a.png"]
+        event = c.handle_key("clear")
+        assert isinstance(event, Cleared)
+        assert (event.chars, event.images) == (0, 1)
+
+    def test_undo_is_single_level(self):
+        c = ChatComposer()
+        _type(c, "first")
+        c.handle_key("clear")
+        c.handle_key("clear")
+        c.handle_key("clear")
+        _type(c, "second")
+        c.handle_key("clear")
+        c.handle_key("clear")
+        assert c.text() == "second"
+
+    def test_submit_burns_the_stash(self):
+        c = ChatComposer()
+        _type(c, "abc")
+        c.handle_key("clear")
+        _type(c, "sent")
+        assert isinstance(c.handle_key("enter"), Submit)
+        c.reset()
+        assert c.handle_key("clear") is None
+        assert not c.has_stash()
+
+    def test_has_stash_reports_recoverability(self):
+        c = ChatComposer()
+        assert not c.has_stash()
+        _type(c, "abc")
+        c.handle_key("clear")
+        assert c.has_stash()
+        c.handle_key("clear")
+        assert not c.has_stash()
+
+    def test_stash_is_immune_to_later_edits(self):
+        c = ChatComposer()
+        _type(c, "abc")
+        c.handle_key("clear")
+        _type(c, "zzz")
+        c.attachments.append("/tmp/late.png")
+        c.reset()
+        c.attachments = []
+        assert isinstance(c.handle_key("clear"), Restored)
+        assert c.text() == "abc"
+
+
+class TestNotices:
+    def test_clear_notice_counts_characters(self):
+        assert clear_notice(Cleared(chars=1240, images=0)) == (
+            "Cleared the message (1,240 characters) — Ctrl+U again to undo."
+        )
+
+    def test_clear_notice_pluralises_images(self):
+        assert "1 image)" in clear_notice(Cleared(chars=5, images=1))
+        assert "2 images)" in clear_notice(Cleared(chars=5, images=2))
+
+    def test_restore_notice(self):
+        assert clear_notice(Restored(chars=1240, images=0)) == "Restored your message (1,240 characters)."
+
+    def test_paste_notice_quotes_all_three_numbers(self):
+        notice = paste_notice(InsertResult(offered=34_812, kept=10_000, dropped=24_812))
+        assert "Pasted 34,812 characters" in notice
+        assert "kept 10,000" in notice
+        assert "dropped 24,812" in notice
+
+    def test_paste_notice_when_nothing_fits(self):
+        notice = paste_notice(InsertResult(offered=500, kept=0, dropped=500))
+        assert notice.startswith("Nothing pasted")
+        assert f"{MAX_CHAT_INPUT_CHARS:,}-character" in notice

--- a/tests/unit/test_chat_driver.py
+++ b/tests/unit/test_chat_driver.py
@@ -1824,6 +1824,23 @@ class TestClearUndo:
         driver._processing_key("clear", threading.Event())
         assert driver.composer.text() == "mid-turn draft"
 
+    def test_answering_a_menu_burns_the_stash(self):
+        """The choices answer leaves the loop without touching handle_key.
+
+        A stash surviving it blocks every later suggestion prefill (the guard
+        tests has_stash) and lets a Ctrl+U three questions on resurrect a draft
+        from a different question.
+        """
+        driver = self._drafted("a prefilled suggestion", ["clear", "enter", "esc", "esc"])
+        driver.choices = ChoiceRows(options=[("Greenfield", False), ("Existing", False)], highlight=0)
+        assert driver._input_loop() == "Greenfield"
+        assert not driver.composer.has_stash()
+
+    def test_an_inline_command_burns_the_stash(self):
+        driver = self._drafted("build an app /small", ["clear", "clear", "enter"])
+        assert driver._input_loop() == "/small"
+        assert not driver.composer.has_stash()
+
     def test_a_sent_message_is_not_recoverable(self):
         driver = self._drafted("send me", ["enter"])
         assert driver._input_loop() == "send me"

--- a/tests/unit/test_chat_driver.py
+++ b/tests/unit/test_chat_driver.py
@@ -1751,3 +1751,128 @@ class TestScrollingWithAMenuUp:
         driver._input_loop()
         assert driver.choices.highlight == 1
         assert driver.follow is True  # still pinned to the newest line
+
+
+def _shown_notices(driver: _ChatDriver) -> list[str]:
+    """Run the input loop, collecting the notice as each frame renders it.
+
+    Asserting driver.notice after the loop would always see "": the loop clears
+    it on the NEXT keypress, so what matters is what was on screen in between.
+    """
+    seen: list[str] = []
+    original = driver._render
+
+    def _record() -> None:
+        seen.append(driver.notice)
+        original()
+
+    driver._render = _record
+    driver._input_loop()
+    driver._render = original
+    return [notice for notice in seen if notice]
+
+
+class TestClearUndo:
+    """Ctrl+U empties the box and a second Ctrl+U puts it back — in both key
+    loops, since typing continues while the graph is working."""
+
+    def _drafted(self, text: str, keys: list[str]) -> _ChatDriver:
+        driver = _driver(FakeGraph([]), _keys(keys), {"messages": []})
+        driver.composer.set_text(text)
+        driver.composer.col = len(driver.composer.lines[0])
+        return driver
+
+    def test_ctrl_u_clears_and_says_how_to_undo(self):
+        driver = self._drafted("a long draft", ["clear", "esc", "esc"])
+        notices = _shown_notices(driver)
+        assert driver.composer.text() == ""
+        assert any("Ctrl+U again to undo" in notice for notice in notices)
+
+    def test_ctrl_u_twice_restores_the_draft(self):
+        driver = self._drafted("a long draft", ["clear", "clear", "esc", "esc"])
+        notices = _shown_notices(driver)
+        assert driver.composer.text() == "a long draft"
+        assert any(notice.startswith("Restored your message") for notice in notices)
+
+    def test_ctrl_u_on_an_empty_box_says_nothing(self):
+        driver = self._drafted("", ["clear", "esc", "esc"])
+        # Only the Esc prompt, never a clear/restore line.
+        assert not [n for n in _shown_notices(driver) if "message" in n]
+
+    def test_ctrl_u_clears_and_restores_image_chips(self):
+        driver = self._drafted("look [image #1]", ["clear", "clear", "esc", "esc"])
+        driver.composer.attachments = ["/tmp/shot.png"]
+        seen: list[list[str]] = []
+        original = driver._render
+
+        def _record() -> None:
+            seen.append(list(driver.composer.attachments))
+            original()
+
+        driver._render = _record
+        driver._input_loop()
+        assert [] in seen  # the chip went away with the text…
+        assert driver.composer.attachments == ["/tmp/shot.png"]  # …and came back with it
+
+    def test_clear_and_undo_work_during_a_turn(self):
+        import threading
+
+        driver = self._drafted("mid-turn draft", [])
+        driver._processing_key("clear", threading.Event())
+        assert driver.composer.text() == ""
+        assert "Ctrl+U again to undo" in driver.notice
+        driver._processing_key("clear", threading.Event())
+        assert driver.composer.text() == "mid-turn draft"
+
+    def test_a_sent_message_is_not_recoverable(self):
+        driver = self._drafted("send me", ["enter"])
+        assert driver._input_loop() == "send me"
+        driver._key = _keys(["clear", "esc", "esc"])
+        assert not [n for n in _shown_notices(driver) if "message" in n]
+        assert driver.composer.text() == ""
+
+
+class TestLargePaste:
+    """A paste bigger than the message cap has to say so — the old notice could
+    not fire at all, because the reader capped the text before the composer saw
+    it."""
+
+    def _driver_with(self, keys: list[str]) -> _ChatDriver:
+        return _driver(FakeGraph([]), _keys(keys), {"messages": []})
+
+    def test_notice_and_transcript_carry_the_numbers(self):
+        from yeaboi.input_guardrails import MAX_CHAT_INPUT_CHARS
+
+        over = 24_812
+        driver = self._driver_with(["paste:" + "x" * (MAX_CHAT_INPUT_CHARS + over), "esc", "esc"])
+        notices = _shown_notices(driver)
+        assert any(f"{MAX_CHAT_INPUT_CHARS + over:,}" in notice for notice in notices)
+        assert any(f"dropped {over:,}" in notice for notice in notices)
+        # Durable too: the hint line is gone on the next keypress.
+        assert any(f"dropped {over:,}" in message.text for message in driver.transcript.messages)
+
+    def test_reader_drops_are_counted_into_the_total(self, monkeypatch):
+        from yeaboi.input_guardrails import MAX_CHAT_INPUT_CHARS
+        from yeaboi.ui.session.chat import _driver as driver_mod
+
+        monkeypatch.setattr(driver_mod, "take_paste_dropped", lambda: 500_000)
+        driver = self._driver_with(["paste:" + "x" * (MAX_CHAT_INPUT_CHARS + 10), "esc", "esc"])
+        notices = _shown_notices(driver)
+        assert any(f"{MAX_CHAT_INPUT_CHARS + 500_010:,}" in notice for notice in notices)
+
+    def test_paste_into_a_full_box_says_nothing_fit(self):
+        from yeaboi.input_guardrails import MAX_CHAT_INPUT_CHARS
+
+        driver = self._driver_with(["paste:more", "esc", "esc"])
+        driver.composer.insert_text("x" * MAX_CHAT_INPUT_CHARS)
+        notices = _shown_notices(driver)
+        assert any(notice.startswith("Nothing pasted") for notice in notices)
+
+    def test_truncation_still_reported_during_a_turn(self):
+        import threading
+
+        from yeaboi.input_guardrails import MAX_CHAT_INPUT_CHARS
+
+        driver = self._driver_with([])
+        driver._processing_key("paste:" + "x" * (MAX_CHAT_INPUT_CHARS + 7), threading.Event())
+        assert "dropped 7" in driver.notice

--- a/tests/unit/test_chat_screen.py
+++ b/tests/unit/test_chat_screen.py
@@ -228,3 +228,56 @@ class TestStates:
         out = _render(_screen(composer=composer, command_menu=menu))
         assert "/export" in out
         assert "/edit" in out
+
+
+class TestHintRow:
+    """The hint row is the only place most people learn these keys, so it has to
+    name keys that work and finish its sentences."""
+
+    def _hint(self, width: int) -> str:
+        out = _ANSI.sub("", _render(_screen(width=width, console=_console(width)), width=width))
+        return next(line for line in out.splitlines() if "Enter" in line and "send" in line)
+
+    def test_names_ctrl_n_and_never_alt_enter(self):
+        # Alt+Enter needs Option-as-Meta, which iTerm2 and Terminal.app do not
+        # set by default — advertising it left users with no reachable newline.
+        out = _ANSI.sub("", _render(_screen(width=160, console=_console(160)), width=160))
+        assert "Ctrl+N newline" in out
+        assert "Alt+Enter" not in out
+
+    def test_offers_the_clear_key(self):
+        out = _ANSI.sub("", _render(_screen(width=160, console=_console(160)), width=160))
+        assert "Ctrl+U clear" in out
+
+    def test_row_never_ellipsizes(self):
+        for width in (80, 100, 120, 160):
+            assert "…" not in self._hint(width), f"hint clipped at {width} cols"
+
+    def test_narrow_row_keeps_send_newline_and_the_way_out(self):
+        line = self._hint(80)
+        assert "Enter send" in line
+        assert "Ctrl+N newline" in line
+        assert "Esc Esc" in line  # the escape hatch used to be the part cut off
+
+    def test_screenshot_hint_is_sacrificed_first(self):
+        assert "screenshot" in self._hint(160)
+        assert "screenshot" not in self._hint(80)
+
+    def test_drawer_keeps_every_pair_at_any_width(self):
+        panel = build_chat_screen(
+            ChatTranscript(), ChatComposer(), {}, width=80, height=40, scroll_offset=0, console=_console(80)
+        )
+        tab = panel._hint_tab.plain
+        for fragment in ("Enter send", "Ctrl+N newline", "Ctrl+U clear", "/ commands", "Esc leave"):
+            assert fragment in tab
+
+    def test_truncation_notice_numbers_survive_at_80_columns(self):
+        notice = "Pasted 34,812 characters — kept 10,000, dropped 24,812. The message limit is 10,000 characters."
+        out = _ANSI.sub("", _render(_screen(width=80, console=_console(80), notice=notice), width=80))
+        assert "Pasted 34,812 characters" in out
+        assert "dropped 24,812" in out
+
+    def test_tips_card_names_the_working_keys(self):
+        out = _ANSI.sub("", _render(_screen(width=120, console=_console(120)), width=120))
+        assert "Ctrl+N" in out and "new line" in out
+        assert "clear the box" in out

--- a/tests/unit/test_chat_screen.py
+++ b/tests/unit/test_chat_screen.py
@@ -253,6 +253,17 @@ class TestHintRow:
         for width in (80, 100, 120, 160):
             assert "…" not in self._hint(width), f"hint clipped at {width} cols"
 
+    def test_row_never_ellipsizes_with_a_menu_up(self):
+        # The normal intake state: a choices menu adds three more pairs, and
+        # the row has to shed those too rather than amputate the newline key.
+        choices = ChoiceRows(options=[("Greenfield", False), ("Existing", False)], highlight=0, multi=True)
+        for width in (80, 100, 120, 160):
+            out = _ANSI.sub("", _render(_screen(width=width, console=_console(width), choices=choices), width=width))
+            line = next(ln for ln in out.splitlines() if "Enter" in ln and "send" in ln)
+            assert "…" not in line, f"hint clipped at {width} cols with a menu up"
+            assert "Ctrl+N newline" in line
+            assert "Esc Esc" in line
+
     def test_narrow_row_keeps_send_newline_and_the_way_out(self):
         line = self._hint(80)
         assert "Enter send" in line

--- a/tests/unit/test_input_raw_mode.py
+++ b/tests/unit/test_input_raw_mode.py
@@ -364,17 +364,155 @@ class TestBracketedPaste:
                 t.cancel()
 
     def test_drop_count_is_cleared_by_the_next_key(self, pty_pair):
-        self._paste(pty_pair, b"small")
+        import threading
+
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        _input._last_paste_dropped = 999
+        t = threading.Timer(0.2, os.write, args=(master, b"k"))
+        t.start()
+        try:
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0) == "k"
+        finally:
+            t.cancel()
         assert _input.take_paste_dropped() == 0
+
+    def test_an_escape_sequence_in_the_read_ahead_tail_still_decodes(self, pty_pair):
+        """The tail is read ahead of the caller, so every "is there more input?"
+        check has to see it too.
+
+        Reading it a byte at a time against a select() on the fd alone turns an
+        arrow key typed after a paste into "esc" plus its literal characters —
+        and two of those inside the double-Esc window quit the chat.
+        """
+        import threading
+
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        t = threading.Timer(0.2, os.write, args=(master, b"\x1b[200~hi\x1b[201~\x1b[A"))
+        t.start()
+        try:
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0) == "paste:hi"
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=2.0) == "up"
+        finally:
+            t.cancel()
+
+    def test_two_pastes_in_one_burst_both_decode(self, pty_pair):
+        import threading
+
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        payload = b"\x1b[200~first\x1b[201~" + b"\x1b[200~second\x1b[201~"
+        t = threading.Timer(0.2, os.write, args=(master, payload))
+        t.start()
+        try:
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0) == "paste:first"
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=2.0) == "paste:second"
+        finally:
+            t.cancel()
+
+    def test_multibyte_char_after_a_paste_is_not_mangled(self, pty_pair):
+        import threading
+
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        t = threading.Timer(0.2, os.write, args=(master, "\x1b[200~hi\x1b[201~é".encode()))
+        t.start()
+        try:
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0) == "paste:hi"
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=2.0) == "é"
+        finally:
+            t.cancel()
+
+    def test_giving_up_on_a_flowing_stream_arms_the_discard(self, pty_pair, monkeypatch):
+        import threading
+
+        monkeypatch.setattr(_input, "_PASTE_DRAIN_LIMIT", 200)
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        t = threading.Timer(0.2, os.write, args=(master, b"\x1b[200~" + b"a" * 2_000))
+        t.start()
+        try:
+            # What arrived is still handed over; the rest is now disowned.
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0).startswith("paste:")
+            assert _input._paste_discarding is True
+        finally:
+            t.cancel()
+            _input._paste_discarding = False
+
+    def test_the_armed_discard_swallows_the_remainder(self, pty_pair):
+        """A one-shot tcflush cannot hold a stream that is still being written:
+        the remaining "\r" would decode as enter and send a half-pasted message."""
+        import threading
+
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        _input._paste_discarding = True
+        t = threading.Timer(0.2, os.write, args=(master, b"rest\rmore\x1b[201~Q"))
+        t.start()
+        try:
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0) == "Q"
+            assert _input._paste_discarding is False
+        finally:
+            t.cancel()
+            _input._paste_discarding = False
+
+    def test_a_stalled_paste_does_not_stay_armed(self, pty_pair, monkeypatch):
+        # The opposite case: the stream died, so the next thing typed is a key.
+        import threading
+
+        monkeypatch.setattr(_input, "_PASTE_IDLE_SECONDS", 0.2)
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        t = threading.Timer(0.1, os.write, args=(master, b"\x1b[200~abc"))
+        t.start()
+        try:
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0) == "paste:abc"
+            assert _input._paste_discarding is False
+        finally:
+            t.cancel()
 
 
 class TestPastePayload:
-    """paste_payload() shapes one payload for two kinds of field."""
+    """paste_payload() shapes one payload for the two kinds of field."""
 
-    def test_single_line_collapses_newlines_and_strips(self):
+    def test_single_line_collapses_newlines(self):
         # A copied token almost always carries a trailing newline.
         assert _input.paste_payload("paste:sk-abc\n") == "sk-abc"
         assert _input.paste_payload("paste:one\ntwo") == "one two"
+
+    def test_single_line_keeps_real_spaces(self):
+        # Only newlines are stripped: pasting mid-cell in an editor must not
+        # lose a space the user meant to paste.
+        assert _input.paste_payload("paste: padded ") == " padded "
 
     def test_multiline_preserves(self):
         assert _input.paste_payload("paste:one\ntwo", multiline=True) == "one\ntwo"

--- a/tests/unit/test_input_raw_mode.py
+++ b/tests/unit/test_input_raw_mode.py
@@ -254,3 +254,130 @@ class TestGlobalLetterShortcuts:
         push_back_key("ctrl+c")
         with pytest.raises(KeyboardInterrupt):
             read_key(timeout=0)
+
+
+class TestBracketedPaste:
+    """Bracketed paste: the reader must drain the whole payload, keep the line
+    breaks, and report what it dropped.
+
+    The old loop stopped at 10,000 characters *without* consuming the rest of
+    the paste or its end marker, so the overflow stayed in the tty and came back
+    as fake keystrokes — including the "\\r" that means "enter", which sent a
+    half-pasted message and typed the remainder into the next one.
+    """
+
+    def _paste(self, pty_pair, payload: bytes, *, trailer: bytes = b"", timeout: float = 5.0) -> str:
+        import threading
+
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        # Written from a timer, after the read is already waiting — see
+        # test_ctrl_v_decodes_to_paste_image_key for why.
+        t = threading.Timer(0.2, os.write, args=(master, b"\x1b[200~" + payload + b"\x1b[201~" + trailer))
+        t.start()
+        try:
+            return _input._read_key_impl(stdin=_Stdin(), timeout=timeout)
+        finally:
+            t.cancel()
+
+    def test_paste_decodes(self, pty_pair):
+        assert self._paste(pty_pair, b"hello") == "paste:hello"
+
+    def test_newlines_survive(self, pty_pair):
+        # Multi-line pastes used to arrive as "onetwothreefour".
+        key = self._paste(pty_pair, b"one\r\ntwo\rthree\nfour")
+        assert key == "paste:one\ntwo\nthree\nfour"
+
+    def test_control_chars_dropped_but_newlines_kept(self, pty_pair):
+        assert self._paste(pty_pair, b"a\x07b\nc") == "paste:ab\nc"
+
+    def test_utf8_is_not_mangled(self, pty_pair):
+        # Byte-at-a-time decoding turned every one of these into U+FFFD.
+        assert self._paste(pty_pair, "héllo — ✓".encode()) == "paste:héllo — ✓"
+
+    def test_oversized_paste_drains_fully_and_reports(self, pty_pair):
+        import threading
+
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        size = _input._PASTE_KEEP_LIMIT + 5_000
+        payload = b"\x1b[200~" + (b"a" * size) + b"\x1b[201~" + b"Z"
+        t = threading.Timer(0.2, os.write, args=(master, payload))
+        t.start()
+        try:
+            key = _input._read_key_impl(stdin=_Stdin(), timeout=5.0)
+            assert key.startswith("paste:")
+            assert len(key) - len("paste:") == _input._PASTE_KEEP_LIMIT
+            assert _input.take_paste_dropped() == 5_000
+            # The keystroke typed straight after the paste survives, and nothing
+            # of the overflow leaks in front of it.
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=2.0) == "Z"
+        finally:
+            t.cancel()
+
+    def test_unterminated_paste_does_not_hang(self, pty_pair, monkeypatch):
+        import threading
+
+        monkeypatch.setattr(_input, "_PASTE_IDLE_SECONDS", 0.2)
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        t = threading.Timer(0.1, os.write, args=(master, b"\x1b[200~abc"))
+        t.start()
+        try:
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=3.0) == "paste:abc"
+        finally:
+            t.cancel()
+
+    def test_marker_split_across_writes(self, pty_pair):
+        import threading
+
+        master, slave = pty_pair
+
+        class _Stdin:
+            def fileno(self):
+                return slave
+
+        timers = [
+            threading.Timer(0.2, os.write, args=(master, b"\x1b[2")),
+            threading.Timer(0.3, os.write, args=(master, b"00~hello")),
+            threading.Timer(0.4, os.write, args=(master, b"\x1b[20")),
+            threading.Timer(0.5, os.write, args=(master, b"1~")),
+        ]
+        for t in timers:
+            t.start()
+        try:
+            assert _input._read_key_impl(stdin=_Stdin(), timeout=5.0) == "paste:hello"
+        finally:
+            for t in timers:
+                t.cancel()
+
+    def test_drop_count_is_cleared_by_the_next_key(self, pty_pair):
+        self._paste(pty_pair, b"small")
+        assert _input.take_paste_dropped() == 0
+
+
+class TestPastePayload:
+    """paste_payload() shapes one payload for two kinds of field."""
+
+    def test_single_line_collapses_newlines_and_strips(self):
+        # A copied token almost always carries a trailing newline.
+        assert _input.paste_payload("paste:sk-abc\n") == "sk-abc"
+        assert _input.paste_payload("paste:one\ntwo") == "one two"
+
+    def test_multiline_preserves(self):
+        assert _input.paste_payload("paste:one\ntwo", multiline=True) == "one\ntwo"
+
+    def test_non_paste_key_yields_nothing(self):
+        assert _input.paste_payload("enter") == ""


### PR DESCRIPTION
## Summary

Three fixes to the planning chat's message box, all reported by a user who could not find a
newline key, could not empty the box, and hit an unexplained ceiling when pasting.

**The newline key we advertised could not be pressed.** The hint bar named `Alt+Enter`, which
needs Option-as-Meta — off by default in iTerm2 and Terminal.app. `Ctrl+N` has always worked and
was named nowhere. `NEWLINE_KEY` in `_composer.py` is now the single source for the hint row,
`/help` and the getting-started card. Deliberately *not* done: making `Shift+Enter` deliverable,
which needs a kitty/CSI-u protocol push that remaps Esc and every Ctrl+key and would mean
rewriting the shared key decoder for one key.

**The hint row was clipping.** Rich ellipsizes from the right, so below 120 columns the row ended
mid-word and `Esc Esc leave` — the escape hatch — was invisible. `_fit_hint()` drops whole
segments by priority (screenshot hint → `/ commands` → `Ctrl+U`) instead; `panel._hint_tab` still
carries every pair, so the controls drawer stays complete.

**Ctrl+U now says what it did, and can be taken back.** A second press restores the draft, the
cursor and any image chips. `reset()` deliberately still leaves `attachments` alone — `_input_loop`
resets on submit and the caller reads them *afterwards* to resolve chips — so only
`clear_with_stash()` empties both.

**Bracketed paste was corrupting the session, not capping it.** The reader stopped at 10,000
characters without consuming the rest of the payload or its `\x1b[201~` marker, so the overflow
stayed in the tty and later reads decoded it as individual keystrokes — including the `\r` that
maps to `enter`, which **sent a half-pasted message and typed the remainder into the next one**.
Four more defects in the same loop: newlines were deleted outright (`one\ntwo` → `onetwo`, words
glued across line breaks); byte-at-a-time decoding turned every em dash, curly quote and emoji into
U+FFFD; the blocking read hung the TUI if a paste was aborted mid-stream; and the terminal's
`ICRNL` translation turned a pasted CRLF into `\n\n` *before* the reader saw it, double-spacing
every Windows-line-ended paste. `_read_paste()` now drains to the marker, reads in chunks and
decodes once, bounds every read, and parks bytes read past the marker in a `_pending_bytes` FIFO so
the key typed straight after a paste survives. The cap stays at 10,000 and an oversized paste says
so with real numbers, in the hint line *and* the transcript (the hint line is gone on the next
keypress).

Newlines now reaching the app meant auditing every consumer of the `paste:` key: `paste_payload()`
shapes one payload for both kinds of field, and the 12 single-line sites collapse newlines to
spaces and strip the edges — a copied API token almost always carries a trailing newline. The key's
wire format is unchanged on purpose; a `paste:<n>:<content>` format would have made all 15 sites
silently swallow pastes instead of failing loudly.

## Review findings answered

An independent `code-reviewer` pass on the diff found one blocker and three should-fixes, all
fixed in the second commit:

- **blocker** — the `_pending_bytes` read-ahead tail was only consulted by `_read1`, not by the two
  "is there more input?" checks around it, so an escape sequence landing in the tail (a second
  paste in the same burst, or an arrow key typed straight after one) decoded as a bare Esc plus its
  literal characters. Two of those inside `_ESC_WINDOW_SECONDS` quit the chat and threw the draft
  away. One `_more_input()` helper now answers both checks; regression tests cover the arrow key,
  the second paste and a multi-byte character in the tail.
- **should-fix** — the abandon path's one-shot `tcflush` could not hold a stream that was still
  being written, so the remainder of an oversized paste still arrived as keystrokes. Giving up on a
  *flowing* stream now arms a sticky discard that swallows input up to the end marker; giving up on
  a *stalled* one deliberately does not, because there the stream is dead and staying armed would
  eat the user's next keypress.
- **should-fix** — `_fit_hint`'s sacrifice list stopped short of the menu pairs, so with a choices
  menu up (the normal intake state) the row ellipsized again and amputated the newline key. The
  list now reaches them, and `TestHintRow` asserts the invariant with a menu up too.
- **should-fix** — Ctrl+U was the one destructive action with no log line.
- **nits** — `paste_payload` stripped real leading/trailing spaces rather than only newlines (it
  would have silently eaten a deliberate space pasted mid-cell in an editor); the standup box still
  named `Alt+Enter` ahead of `Ctrl+N`; and two test gaps, both now covered.

## Test plan

- `make test` — 11,619 passed, 47 skipped
- `make lint` — clean
- `make security` — SAST clean, `pip-audit` clean
- New pty-backed reader tests (`tests/unit/test_input_raw_mode.py::TestBracketedPaste`): an
  oversized paste drains fully and the key typed after it arrives exactly once; newlines survive
  `\r\n`/`\r`/`\n`; UTF-8 round-trips; an unterminated paste returns instead of hanging; a marker
  split across four writes decodes once.
- New composer, screen, driver and command tests: the stash/undo state machine (including that a
  sent message is not recoverable and that `reset()` leaves attachments alone), the notice wording
  with thousands separators, and the hint row asserted at 80/100/120/160 columns to never ellipsize
  and always keep `Enter send`, the newline key and `Esc Esc leave`.
- End-to-end through a real pty into the real composer: 34,812 characters of prose with em dashes
  and curly quotes → no auto-submit, 10,000 kept, 322 line breaks preserved, 0 replacement
  characters, the trailing keystroke typed exactly once, and
  `Pasted 34,812 characters — kept 10,000, dropped 24,812.`

Closes YEA-84

DoD item 5 (surface parity) does not apply: this is keyboard ergonomics for one TUI textbox — no
new engine, MCP tool, mode card, CLI flag or plugin skill, so no `CAPABILITIES` row or `FeatureTip`.
DoD item 7 (web bundles) does not apply: nothing under `frontend/` was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
