### PR TITLE
skip the unreadable-directory scan test under a root euid

### DIFF
--- a/tests/unit/test_standup_transcripts.py
+++ b/tests/unit/test_standup_transcripts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import date
 from pathlib import Path
 
@@ -10,6 +11,12 @@ import pytest
 from yeaboi.standup import transcripts
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "transcripts"
+
+# A process with euid 0 bypasses DAC permission checks on Linux, so chmod(0o000)
+# hides nothing from it. Any test that proves a scan skips an unreadable
+# directory therefore reports a false failure under a root-run test environment
+# (containers, dev containers, some CI images) and says nothing about the code.
+RUNNING_AS_ROOT = hasattr(os, "geteuid") and os.geteuid() == 0
 
 
 @pytest.fixture
@@ -854,7 +861,9 @@ class TestScanBounds:
         found = transcripts._candidate_files(tmp_path, recurse=True)
         assert [p.name for p in found] == ["real.txt"]
 
+    @pytest.mark.skipif(RUNNING_AS_ROOT, reason="root bypasses DAC permission bits, so chmod(0o000) hides nothing")
     def test_unreadable_directory_is_skipped_not_fatal(self, tmp_path):
+        """Only meaningful for a non-root euid — see RUNNING_AS_ROOT above."""
         (tmp_path / "ok.txt").write_text("Alice: hi")
         locked = tmp_path / "locked"
         locked.mkdir()


### PR DESCRIPTION
## What

`tests/unit/test_standup_transcripts.py::TestScanBounds::test_unreadable_directory_is_skipped_not_fatal` asserts that `chmod(0o000)` on a directory hides its contents from the transcript scanner's `_candidate_files` walk. On Linux, a process running as root (euid 0) bypasses DAC permission checks entirely, so the chmod'd directory stays readable and the assertion fails — a false regression tied to the test runner's effective uid, not to the transcript scanner's actual behavior.

Fix: guard just that one test (the other four `TestScanBounds` tests are depth/entry/dotfile/flat bounds, uid-independent) with `@pytest.mark.skipif(RUNNING_AS_ROOT, reason=...)`, following the existing pattern in `test_config.py`/`test_paths.py`/`test_sessions.py`/`test_logging_setup.py`. Test-only, no production code touched.

Closes YEA-86

## Auto lane record

- Scout (standard tier) surveyed the `standup` workstream this week per the routine's focus (practice-signal automation traps, the relatedness suppress-only invariant, saved-setup applicability, the practice-feedback loop end to end). All of those held up under direct code reading and existing test coverage — this was the **only** finding, so 0 other `auto` finds were passed over.
- Type: `chore` (house-rules category 3 — a flaky/broken test — not category 2, so no regression-test admission ticket applies; nothing in this PR fixes product behavior).
- Impact: 2, Effort: S, Risk: low, Critical: false.
- Dedup: checked `workstream:standup` open/closed issues (#214 Jira-hang-in-suite, #147 crontab-spaces) — neither matches; not a duplicate.

## Test evidence

Before (this environment, euid 0):
```
tests/unit/test_standup_transcripts.py::TestScanBounds::test_unreadable_directory_is_skipped_not_fatal FAILED
AssertionError: assert ['ok.txt', 'inner.txt'] == ['ok.txt']
```

After:
```
tests/unit/test_standup_transcripts.py::TestScanBounds::test_unreadable_directory_is_skipped_not_fatal SKIPPED
SKIPPED [1] ...:864: root bypasses DAC permission bits, so chmod(0o000) hides nothing
```

Confirmed the guarded test still runs and passes for a non-root user (`setpriv --reuid=65534`): `5 passed`.

Scoped suite: `uv run pytest tests/unit/ -k standup` → `1742 passed, 1 skipped, 9300 deselected`.

Independent `code-reviewer` pass: clean, no blocker/should-fix findings (2 nits noted, not required by house-rules to fix for a category-3 auto-lane item — a missing `os.name == "nt"` companion guard, pre-existing pattern gap with no Windows CI job to regress against; and a note that a uid-independent `monkeypatch` twin of this test would additionally hold local root-sandbox coverage, which the merge-gate coverage doesn't need since GitHub's hosted runners run non-root and still execute this test).

## Gate

- `make lint`: clean
- `make test`: 11565 passed, 48 skipped, 2 pre-existing failures in `tests/unit/test_pr_feedback.py` (out of this workstream's charter — `scripts/`/`platform` — caused by a stub/transport mismatch from an earlier refactor (#237), confirmed unrelated to this diff since they fail identically in isolation on unmodified `origin/main`). Not filed as a new proposal: `platform`'s proposal queue is already full (0/2 slots, 11 open) and this finding fails loudly rather than silently, so it doesn't meet the `critical` bar to bypass the cap — per house-rules it's dropped silently rather than added to an already-overflowing queue.

## DoD exemptions

- Item 5 (surface parity / `CAPABILITIES` registry): no new capability, N/A.
- Item 6 (observability): test-only change, no new logging/metrics surface.
- Item 7 (web bundles): nothing under `frontend/`.

---

🤖 Cowork auto lane — `workstream:standup`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UbxwqfeNd4knsfVDuqLpCt)_