### PR TITLE
fix sed syntax error breaking every publish-beta.yml run

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -66,7 +66,7 @@ jobs:
           # the pipe and sed can exit 141, failing the step. Safe today only
           # because pyproject.toml has one `version = ` line — which is a fact
           # about the file, not about this function.
-          ver() { sed -nE 's/^version = "([^"]+)".*/\1/{p;q;}'; }
+          ver() { sed -nE '/^version = "/{s/^version = "([^"]+)".*/\1/;p;q;}'; }
           BASE=$(ver < pyproject.toml)
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- `publish-beta.yml`'s "Decide the pre-release version" step has failed on every run since PR #237: `sed -nE 's/.../\1/{p;q;}'` is missing a `;` before `{p;q;}`, so sed parses `{` as a substitution flag and errors with `unknown option to 's'`.
- Fixed by anchoring `{p;q;}` to the `/^version = "/` address rather than just inserting the semicolon — a semicolon-only fix would parse but silently print-and-quit on `pyproject.toml`'s first line (`[build-system]`) regardless of match, which would have published the wrong version.

## Test plan
- [x] Reproduced the exact CI error locally with the original sed command
- [x] Verified the fix extracts `3.8.1` correctly from the real `pyproject.toml`
- [x] `actionlint .github/workflows/publish-beta.yml` passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)