### PR TITLE
read claude-implement as a level, so an approval that produced nothing retries

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,18 @@ on:
     types: [opened, assigned, labeled]
   pull_request_review:
     types: [submitted]
+  # The level-triggered door into `implement`, below. `claude-implement` is a
+  # *level* — "this is approved and unbuilt" — but `issues: labeled` only observes
+  # its *edge*, so an approval that arrives twice, or whose run produced nothing,
+  # had no way to fire again. Issue #172 was ✅'d in Slack five times between
+  # 2026-08-09 and 08-11; only the first became a `labeled` event, and this
+  # workflow concluded `skipped` on 100 of its next 100 runs.
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "issue number to (re-)implement — must already carry claude-implement"
+        required: true
+        type: string
 
 jobs:
   claude:
@@ -55,10 +67,21 @@ jobs:
   # claude-review.yml, and auto-version.yml like any human-authored branch.
   implement:
     if: |
-      github.event_name == 'issues' &&
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'claude-implement'
+      (github.event_name == 'issues' &&
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'claude-implement') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       !github.event.issue.pull_request &&
+       contains(github.event.comment.body, '<!-- implement-retry -->') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
+    # Five ✅s on one issue could otherwise have started five 110-turn agents on
+    # it. There was no concurrency key on this job at all; the only thing that
+    # stopped it was the edge trigger being broken.
+    concurrency:
+      group: implement-${{ github.event.issue.number || inputs.issue }}
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write
@@ -66,6 +89,44 @@ jobs:
       id-token: write
       actions: read
     steps:
+      # The security boundary for every door above, and the reason none of them
+      # needs to be trusted: the trigger says which issue, and this step decides
+      # whether that issue may be built — by re-reading its live state and labels,
+      # not by believing the event payload. A forged `<!-- implement-retry -->`
+      # marker from a write-capable account can therefore only re-run something a
+      # human already approved.
+      #
+      # It is also strictly better than the label path for #172's own failure:
+      # that run read its labels from an event payload captured in the same second
+      # the relay stripped three of them, and built with no charter at all.
+      - name: Resolve the target issue
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          N: ${{ github.event.issue.number || inputs.issue }}
+        run: |
+          set -euo pipefail
+          case "$N" in ''|*[!0-9]*) echo "::error::not an issue number: $N"; exit 1 ;; esac
+          data=$(gh issue view "$N" --repo "$GITHUB_REPOSITORY" --json number,title,state,labels)
+          labels=$(jq -c '[.labels[].name]' <<< "$data")
+          if [ "$(jq -r .state <<< "$data")" != "OPEN" ] || ! jq -e 'index("claude-implement")' <<< "$labels" >/dev/null; then
+            echo "::error::#$N is not an open issue carrying claude-implement — refusing."
+            exit 1
+          fi
+          {
+            echo "number=$N"
+            echo "labels=$labels"
+            echo "title<<CLAUDE_EOF"
+            jq -r .title <<< "$data"
+            echo "CLAUDE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Captured before the action runs, so the ambiguous-exit check below can ask
+      # "did THIS run comment?" rather than "has any bot commented in two hours?".
+      - name: Stamp the run start
+        id: started
+        run: echo "at=$(date -u +%FT%TZ)" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
@@ -97,8 +158,12 @@ jobs:
       - name: Pick the model tier
         id: model
         env:
-          LABELS: ${{ toJSON(github.event.issue.labels.*.name) }}
-          TITLE: ${{ github.event.issue.title }}
+          # From the live read, not the event payload — see "Resolve the target
+          # issue" above. #172's run took its labels from a payload captured in
+          # the same second three of them were stripped, so it routed on a label
+          # set that no longer existed.
+          LABELS: ${{ steps.target.outputs.labels }}
+          TITLE: ${{ steps.target.outputs.title }}
         run: |
           if jq -e 'index("type:security") or index("workstream:security")' <<< "$LABELS" >/dev/null \
             || [[ "$TITLE" == *"[security]"* ]]; then
@@ -138,9 +203,9 @@ jobs:
             --model ${{ steps.model.outputs.id }} --max-turns 110
             --allowedTools "Read,Grep,Glob,Edit,Write,Task,Bash(make:*),Bash(uv run:*),Bash(git:*),Bash(gh issue:*),Bash(gh pr:*),Bash(gh api:*)"
           prompt: |
-            Implement GitHub issue #${{ github.event.issue.number }} in ${{ github.repository }}.
+            Implement GitHub issue #${{ steps.target.outputs.number }} in ${{ github.repository }}.
 
-            1. Read the issue with `gh issue view ${{ github.event.issue.number }}` (including comments).
+            1. Read the issue with `gh issue view ${{ steps.target.outputs.number }}` (including comments).
             2. Read `cowork/definition-of-done.md` — it is the contract this change must satisfy.
                If the issue carries a `workstream:<name>` label, also Read
                `cowork/workstreams/<name>.md` and stay inside the paths it declares.
@@ -156,7 +221,7 @@ jobs:
                write one line in the PR body saying DoD item 1 is deferred to merge, and carry on.
                `pr-merged-close-loop` runs as a Claude routine with the connectors attached, and
                already creates a missing ticket in Done rather than skipping it.
-            4. Create a branch named `feature/issue-${{ github.event.issue.number }}-<short-slug>` off main.
+            4. Create a branch named `feature/issue-${{ steps.target.outputs.number }}-<short-slug>` off main.
             5. Implement the change following CLAUDE.md conventions (observability pillars,
                TUI component standards, frozen-dataclass defaults, tests for every new function).
                Conventions are split across CLAUDE.md and `.claude/skills/*/SKILL.md` — Read
@@ -177,7 +242,7 @@ jobs:
                (the magic word is what makes the Linear GitHub integration attach the PR and move
                the ticket to Done on merge — a bare Linear URL does neither), notes any DoD item
                that genuinely does not apply, and closes the issue
-               (`Closes #${{ github.event.issue.number }}`). If step 3 could not create a ticket,
+               (`Closes #${{ steps.target.outputs.number }}`). If step 3 could not create a ticket,
                write the item-1-deferred-to-merge line instead of the `Closes YEA-NN` line.
             9. Pass the labels to `gh pr create` itself — `--label cowork` plus the issue's
                `workstream:<name>` and `type:<kind>` labels if it had them (the daily standup
@@ -194,7 +259,10 @@ jobs:
             items 8 and 9, and it runs on merge.
 
             If the issue is too ambiguous to implement safely, do NOT guess: comment on the
-            issue with the specific questions that need answering, and stop.
+            issue with the specific questions that need answering, and stop. **End that
+            comment with the literal line `<!-- implement: ambiguous -->`.** The guard below
+            treats it as the difference between this deliberate exit and a run that produced
+            nothing; without the marker your exit is reported as a broken run.
 
       # The failure this job is most prone to, and least able to report, is
       # succeeding at nothing: the run above can deny every write it needs and
@@ -209,26 +277,49 @@ jobs:
         # misleading "produced nothing" on top of a genuine `uv sync` failure.
         if: always() && (steps.implement.conclusion == 'success' || steps.implement.conclusion == 'failure')
         env:
-          ISSUE: ${{ github.event.issue.number }}
+          ISSUE: ${{ steps.target.outputs.number }}
+          STARTED_AT: ${{ steps.started.outputs.at }}
+          EXEC_FILE: ${{ steps.implement.outputs.execution_file }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # `permission_denials_count` is the field the action really writes — read
           # off run 31312744716, the 2026-08-09 no-op on #172, which reported
           # `"permission_denials_count": 17` beside `"num_turns": 31`.
-          log="${RUNNER_TEMP}/claude-execution-output.json"
+          log="${EXEC_FILE:-}"
+          [ -n "$log" ] && [ -f "$log" ] || log="${RUNNER_TEMP}/claude-execution-output.json"
           if [ ! -f "$log" ]; then
-            # A diagnostic that silently stops diagnosing is the failure class this
-            # step exists to remove, so say so rather than reading it as "no denials".
-            echo "::warning::no execution log at $log — denials were not checked"
-            denials=0
-          else
-            denials=$(jq '[.. | .permission_denials_count? // empty] | last // 0' "$log")
+            # This used to `::warning::` and set denials=0 — a guard that cannot
+            # check, passing. The path is hardcoded against one observed run of one
+            # pinned action version, so any change to the action's temp filename
+            # would silently disable the denial check and leave a green tick over
+            # exactly the 2026-08-09 failure it was written for.
+            echo "::error::no execution log at $log — denials could not be checked, so this run is not vouched for."
+            exit 1
           fi
+          denials=$(jq '[.. | .permission_denials_count? // empty] | last // 0' "$log")
           if [ "${denials:-0}" -gt 0 ]; then
             echo "::error::$denials tool call(s) denied — the --allowedTools grant above is wrong."
             exit 1
           fi
-          branch=$(git ls-remote --heads origin "refs/heads/feature/issue-$ISSUE-*" | head -1 | sed 's|.*refs/heads/||')
+          # A run that hit --max-turns left its work half-done by definition. Today
+          # that is only inferable from the branch-without-PR path below, which
+          # misses the case where it was truncated before pushing anything.
+          if [ "$(jq -r '[.. | .subtype? // empty] | last // ""' "$log")" = "error_max_turns" ]; then
+            echo "::error::the run hit --max-turns — whatever it did is half-finished."
+            exit 1
+          fi
+          # Ask the authoritative question first — the same one `digest.md`'s
+          # approved-with-no-PR section asks. A PR is the deliverable, and looking
+          # for it directly does not care what the branch was called.
+          if [ -n "$(gh pr list --search "$ISSUE in:body" --state all --json number --jq '.[0].number')" ]; then
+            echo "PR open for #$ISSUE."
+            exit 0
+          fi
+          # Both conventions: `claude-code-action` names branches `claude/issue-N-…`
+          # when it creates one itself, and a run that pushed under its own name
+          # used to read as "no branch" and fall through to the comment check.
+          branch=$(git ls-remote --heads origin "refs/heads/feature/issue-$ISSUE-*" "refs/heads/claude/issue-$ISSUE-*" \
+            | head -1 | sed 's|.*refs/heads/||')
           if [ -n "$branch" ]; then
             # A branch is not the deliverable; the PR is. A run truncated between
             # step 8's push and its `gh pr create` — the state the --max-turns note
@@ -255,12 +346,41 @@ jobs:
           # `.author.login? // ""` — a deleted account renders `author: null`, and a
           # raised jq under `bash -e` would abort the step with a traceback instead
           # of the message below.
+          # Two tightenings on what used to be "any [bot] comment in the last two
+          # hours". That counted `codeql-triage`, `flaky-test-hunter`,
+          # `feedback-remediation` and `pr-merged-close-loop` — all of which comment
+          # on issues as bots — and would count a reconciler's own attempt marker
+          # too. It now has to be a marker the prompt is told to write, posted after
+          # this job started.
           asked=$(gh issue view "$ISSUE" --json comments --jq \
             '[.comments[] | select((.author.login? // "") | endswith("[bot]"))
-              | select(.createdAt > "'"$(date -u -d '2 hours ago' +%FT%TZ)"'")] | length')
+              | select(.body | contains("<!-- implement: ambiguous -->"))
+              | select(.createdAt > "'"$STARTED_AT"'")] | length')
           if [ "${asked:-0}" -gt 0 ]; then
             echo "No branch, but the run commented on #$ISSUE — the documented ambiguous-issue exit."
             exit 0
           fi
           echo "::error::No branch and no comment on #$ISSUE — the run produced nothing."
           exit 1
+
+      # A red job used to be the end of it: the issue kept `claude-implement`,
+      # `digest.md` refuses to age out anything carrying that label, and nothing
+      # re-fired. So a broken implement run left an issue that no routine would
+      # ever touch again and no message anywhere. Record it on the issue, and give
+      # the reconciler a terminal state to stop at.
+      #
+      # `claude-implement` deliberately stays on: it is the key `digest.md`'s
+      # approved-with-no-PR section queries, and removing it would hide the failure
+      # rather than report it.
+      - name: Report a run that produced nothing
+        if: failure() && steps.target.outputs.number != ''
+        env:
+          ISSUE: ${{ steps.target.outputs.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue edit "$ISSUE" --add-label implement-blocked || true
+          gh issue comment "$ISSUE" --body "The implement job did not produce a PR — [run]($RUN_URL).
+
+          \`implement-blocked\` is on this issue now, so the reconciler will stop retrying it and the
+          daily digest reports it under **Approved, no PR yet**. Remove the label to let it retry." || true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -116,9 +116,13 @@ jobs:
           {
             echo "number=$N"
             echo "labels=$labels"
-            echo "title<<CLAUDE_EOF"
+            # Delimiter varied per run: it wraps an issue title, which is
+            # attacker-influenced text on a public repo. The human-approval gate in
+            # front of this is the real defence; this is the cheap half.
+            delim="CLAUDE_EOF_${GITHUB_RUN_ID}_${RANDOM}"
+            echo "title<<${delim}"
             jq -r .title <<< "$data"
-            echo "CLAUDE_EOF"
+            echo "${delim}"
           } >> "$GITHUB_OUTPUT"
 
       # Captured before the action runs, so the ambiguous-exit check below can ask
@@ -272,6 +276,7 @@ jobs:
       # no-op leaves the issue invisible to every routine. Assert the outcome
       # rather than the exit status.
       - name: Assert the run produced something
+        id: guard
         # Only when the action actually ran. `!= 'skipped'` also matches the empty
         # conclusion a step has when an earlier one failed, which would stack a
         # misleading "produced nothing" on top of a genuine `uv sync` failure.
@@ -311,8 +316,14 @@ jobs:
           # Ask the authoritative question first — the same one `digest.md`'s
           # approved-with-no-PR section asks. A PR is the deliverable, and looking
           # for it directly does not care what the branch was called.
-          if [ -n "$(gh pr list --search "$ISSUE in:body" --state all --json number --jq '.[0].number')" ]; then
-            echo "PR open for #$ISSUE."
+          # Open or merged only. `--state all` would let attempt 1's PR — including
+          # one CLOSED UNMERGED, which is among the likeliest reasons a re-fire is
+          # happening — answer for attempt 2, printing "PR open" without ever having
+          # checked that and bypassing this entire guard on precisely the path this
+          # workflow now makes normal.
+          if [ -n "$(gh pr list --search "$ISSUE in:body" --state all --json number,state,mergedAt \
+               --jq '[.[] | select(.state == "OPEN" or .mergedAt != null)][0].number')" ]; then
+            echo "An open or merged PR exists for #$ISSUE."
             exit 0
           fi
           # Both conventions: `claude-code-action` names branches `claude/issue-N-…`
@@ -373,7 +384,14 @@ jobs:
       # approved-with-no-PR section queries, and removing it would hide the failure
       # rather than report it.
       - name: Report a run that produced nothing
-        if: failure() && steps.target.outputs.number != ''
+        # Gated on the guard specifically, never on bare `failure()`. `failure()` is
+        # true if ANY earlier step failed, so a flaky checkout or a `uv sync` that
+        # 503s would land the terminal label: the reconciler then skips the issue,
+        # the age-out still refuses to touch it because it keeps `claude-implement`,
+        # and it needs a human. A transient infra blip becoming an unrecoverable
+        # state is the exact loss class this workflow exists to close — and the
+        # guard above already scopes itself for the same reason.
+        if: always() && steps.guard.conclusion == 'failure' && steps.target.outputs.number != ''
         env:
           ISSUE: ${{ steps.target.outputs.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/implement-reconcile.yml
+++ b/.github/workflows/implement-reconcile.yml
@@ -1,0 +1,101 @@
+name: Implement reconcile
+
+# `claude-implement` is a LEVEL — "this issue is approved and unbuilt" — but
+# `claude.yml`'s implement job only ever observed its EDGE (`issues: labeled`).
+# Everything that can go wrong between the two was therefore unrecoverable:
+#
+#   - a second ✅ is a no-op. `cowork_relay.py` emits `gh issue edit --add-label`,
+#     which does nothing when the label is already there. Issue #172 was approved
+#     five times between 2026-08-09 and 08-11 and built once.
+#   - a run that fired and produced nothing left no retry. #172's did exactly
+#     that: 231s, exit `success`, no branch, no PR, no comment.
+#   - a `labeled` event GitHub never delivered is simply lost.
+#
+# This job reads the level instead, so one mechanism covers all three. It runs no
+# model of its own — it is `gh` and `jq`, and its only power is to re-fire a job a
+# human already authorised.
+on:
+  schedule:
+    # :37 rather than the hour. GitHub queues scheduled workflows fleet-wide on
+    # the hour and delivers them late under load, which for a reconciler means
+    # drifting past the window it is reconciling.
+    - cron: "37 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+  actions: write # to dispatch claude.yml
+
+concurrency:
+  group: implement-reconcile
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Re-fire approved issues that produced no PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # Three attempts, then stop and say so. A level-triggered re-firer with a
+          # broken implement job would otherwise burn a 110-turn agent every six
+          # hours forever, which is the one way this job can be worse than the bug
+          # it fixes.
+          MAX_ATTEMPTS: "3"
+        run: |
+          set -euo pipefail
+
+          approved=$(gh issue list --repo "$REPO" --label claude-implement --state open \
+            --json number --jq '.[].number')
+          if [ -z "$approved" ]; then
+            echo "Nothing carries claude-implement. Exiting."
+            exit 0
+          fi
+
+          for n in $approved; do
+            labels=$(gh issue view "$n" --repo "$REPO" --json labels --jq '[.labels[].name]')
+            if jq -e 'index("implement-blocked")' <<< "$labels" >/dev/null; then
+              echo "#$n is implement-blocked — a human has to look. Skipping."
+              continue
+            fi
+
+            # The authoritative question, and the same one digest.md's
+            # approved-with-no-PR section asks.
+            if [ -n "$(gh pr list --repo "$REPO" --search "$n in:body" --state all --json number --jq '.[0].number')" ]; then
+              echo "#$n already has a PR. Nothing to do."
+              continue
+            fi
+            # Both branch conventions: claude-code-action names its own branches
+            # `claude/issue-N-…`, and a push that has not reached `gh pr create`
+            # yet is a run still in flight, not a run that failed.
+            if [ -n "$(git ls-remote --heads origin "refs/heads/feature/issue-$n-*" "refs/heads/claude/issue-$n-*")" ]; then
+              echo "#$n has a branch pushed but no PR — a run is mid-flight or truncated. Leaving it."
+              continue
+            fi
+            if gh run list --repo "$REPO" --workflow claude.yml --status in_progress \
+                 --json displayTitle --jq '.[].displayTitle' | grep -q "$n"; then
+              echo "#$n has a run in progress. Leaving it."
+              continue
+            fi
+
+            attempts=$(gh issue view "$n" --repo "$REPO" --json comments \
+              --jq '[.comments[] | select(.body | contains("<!-- implement-attempt -->"))] | length')
+            if [ "$attempts" -ge "$MAX_ATTEMPTS" ]; then
+              echo "::warning::#$n has had $attempts attempts and still has no PR — marking implement-blocked."
+              gh issue edit "$n" --repo "$REPO" --add-label implement-blocked
+              gh issue comment "$n" --repo "$REPO" --body "Re-fired $attempts times with no PR to show for it, so this is now \`implement-blocked\` and the reconciler will leave it alone. The daily digest reports it under **Approved, no PR yet**. Remove the label to let it retry."
+              continue
+            fi
+
+            next=$((attempts + 1))
+            echo "Re-firing #$n (attempt $next/$MAX_ATTEMPTS)."
+            gh workflow run claude.yml --repo "$REPO" --ref main -f issue="$n"
+            gh issue comment "$n" --repo "$REPO" --body "Approved but no PR — re-firing the implement job (attempt $next/$MAX_ATTEMPTS).
+
+          <!-- implement-attempt -->"
+          done

--- a/.github/workflows/implement-reconcile.yml
+++ b/.github/workflows/implement-reconcile.yml
@@ -64,10 +64,16 @@ jobs:
               continue
             fi
 
-            # The authoritative question, and the same one digest.md's
-            # approved-with-no-PR section asks.
-            if [ -n "$(gh pr list --repo "$REPO" --search "$n in:body" --state all --json number --jq '.[0].number')" ]; then
-              echo "#$n already has a PR. Nothing to do."
+            # Open or merged only. `--state all` would count a PR from a previous
+            # attempt that was CLOSED UNMERGED — which is among the likeliest
+            # reasons a re-fire is wanted at all. Counting it means such an issue is
+            # never re-fired *and* never blocked: it simply stops existing to the
+            # fleet, because `digest.md`'s approved-with-no-PR section asks this
+            # same question and would also see it.
+            if [ -n "$(gh pr list --repo "$REPO" --search "$n in:body" --state all \
+                 --json number,state,mergedAt \
+                 --jq '[.[] | select(.state == "OPEN" or .mergedAt != null)][0].number')" ]; then
+              echo "#$n already has an open or merged PR. Nothing to do."
               continue
             fi
             # Both branch conventions: claude-code-action names its own branches
@@ -83,12 +89,32 @@ jobs:
               continue
             fi
 
-            attempts=$(gh issue view "$n" --repo "$REPO" --json comments \
-              --jq '[.comments[] | select(.body | contains("<!-- implement-attempt -->"))] | length')
+            # Counted SINCE the last time `implement-blocked` was removed, not over
+            # all time. Nothing deletes the attempt markers, so a lifetime count
+            # made the documented recovery path — "remove the label to let it
+            # retry" — do the opposite: the next tick lands straight back in the
+            # cap branch, re-applies the label and posts the same notice, six hours
+            # apart, forever. Following the instructions was what generated the
+            # noise.
+            cleared=$(gh issue view "$n" --repo "$REPO" --json timelineItems \
+              --jq '[.timelineItems[]? | select(.__typename == "UnlabeledEvent")
+                     | select(.label.name == "implement-blocked") | .createdAt] | last // ""' 2>/dev/null || echo "")
+            if [ -n "$cleared" ]; then
+              # shellcheck disable=SC2016  # `$since` is a jq variable bound by --arg, not a shell one
+              attempts=$(gh issue view "$n" --repo "$REPO" --json comments \
+                --jq --arg since "$cleared" \
+                '[.comments[] | select(.body | contains("<!-- implement-attempt -->"))
+                  | select(.createdAt > $since)] | length')
+            else
+              attempts=$(gh issue view "$n" --repo "$REPO" --json comments \
+                --jq '[.comments[] | select(.body | contains("<!-- implement-attempt -->"))] | length')
+            fi
             if [ "$attempts" -ge "$MAX_ATTEMPTS" ]; then
               echo "::warning::#$n has had $attempts attempts and still has no PR — marking implement-blocked."
               gh issue edit "$n" --repo "$REPO" --add-label implement-blocked
-              gh issue comment "$n" --repo "$REPO" --body "Re-fired $attempts times with no PR to show for it, so this is now \`implement-blocked\` and the reconciler will leave it alone. The daily digest reports it under **Approved, no PR yet**. Remove the label to let it retry."
+              gh issue comment "$n" --repo "$REPO" --body "Re-fired $attempts times with no PR to show for it, so this is now \`implement-blocked\` and the reconciler will leave it alone. The daily digest reports it under **Approved, no PR yet**.
+
+          Removing the \`implement-blocked\` label resets the attempt count and lets it retry — attempts are counted from when that label was last removed, not over the issue's lifetime."
               continue
             fi
 

--- a/cowork/routines/cron/digest.md
+++ b/cowork/routines/cron/digest.md
@@ -389,6 +389,12 @@ The single decision point. It is the only routine that posts proposals to Slack.
      state from 2026-08-09 — the implement job it triggered exited green having written nothing —
      and the fleet's only report of it was the same three lines of Slack it had already posted.
      Anything listed here for more than a day is a broken lane, not a slow one.
+
+     **An issue also carrying `implement-blocked` is a lane that gave up**, not one that is slow:
+     the implement job produced no PR three times, or its outcome guard failed, and
+     `implement-reconcile.yml` has stopped retrying it. Say so — `— implement-blocked after <n>
+     attempts` — because nothing else will: the issue keeps `claude-implement`, so the age-out
+     still refuses to touch it, and this section is the only place it surfaces at all.
    - **Blocked** — line one is the workstream and its linked PR, `**<workstream>** [PR #123 —
      <title>](<pr url>)`; line two is `— ` and what is actually holding that PR up, from the
      `pr_feedback.py` run below (red CI, or *n* unanswered findings).

--- a/cowork/routines/cron/slack-relay.md
+++ b/cowork/routines/cron/slack-relay.md
@@ -146,6 +146,18 @@ announce who is unauthorized.
   `claude-implement` — the workstream label being the one `claude.yml` reads to find the charter
   that says which paths the build may touch. The grant no longer includes `gh api`, so the wrong
   call is now unavailable rather than merely forbidden.
+- **✅ on a reply whose issue is *already* labelled** → `gh issue comment <n>` carrying
+  `<!-- implement-retry -->`, which the helper emits for you in place of the label call. This is
+  not a second approval — it is a re-fire request, and `claude.yml` re-reads the live label before
+  it acts on the marker, so the comment asks and never authorises.
+
+  It exists because `--add-label` on a label that is already there is a **silent no-op**, and the
+  implement job fires on the `labeled` *event*, which GitHub does not emit for one. #172 was ✅'d
+  five times between 2026-08-09 and 08-11 and built once; this routine acked all five, so nothing
+  anywhere reported that four of them did nothing. A remove-then-add would have been the shorter
+  fix and the wrong one: it is two writes, and a crash between them leaves the issue carrying no
+  `claude-implement` at all — the label `digest.md` queries to report an approval the fleet never
+  acted on.
 - **❌ on a digest thread reply**, or on any message that references exactly one open issue or PR →
   `gh issue close <n>` / `gh pr close <n>`. A message referencing several is ambiguous — ask in
   thread, act on nothing.
@@ -179,9 +191,13 @@ No new state — GitHub issues are the queue, and this routine keeps it that way
   looking exactly like human input.
 - **A reply carrying 🤖 is done.** The marker sits on the message, never on a reaction — a reaction
   cannot carry one. Marked means handled, whatever the reaction under it says.
-- Before any GitHub write, check current state. Label already present, or issue already closed:
-  the verb already happened (here or on GitHub directly) — mark the message and say nothing at all,
-  in Slack or on the issue.
+- Before any GitHub write, check current state. Issue already closed: the verb already happened
+  (here or on GitHub directly) — mark the message and say nothing at all, in Slack or on the issue.
+- **"Label already present" is no longer "the verb already happened."** It means *already
+  approved*, and if no PR came of it the thing still owed is a re-fire, not silence — the helper
+  emits `refire` for exactly this case and it does get a one-line thread ack, because a second ✅
+  that produces nothing visible is indistinguishable from the bug it is working around. What
+  stays silent is an approval whose PR already exists; `scripts/cowork_relay.py` decides, not you.
 - Both ✅ and ❌ from allowlisted humans on one item: do nothing, reply asking for a single verb.
 - Once GitHub says decided, later reactions on the same item are ignored. GitHub is authoritative;
   Slack is how a decision arrives, not where it lives.

--- a/scripts/cowork_relay.py
+++ b/scripts/cowork_relay.py
@@ -229,6 +229,20 @@ def _has_open_label(issue: int, label: str, runner: Callable[[list[str]], str | 
     return None if str(data.get("state", "OPEN")).upper() == "CLOSED" else True
 
 
+def is_approved(issue: int, *, runner: Callable[[list[str]], str | None] | None = None) -> bool | None:
+    """Whether ``issue`` is already carrying `claude-implement`.
+
+    Tristate like its siblings, but read the other way round by its caller: a
+    ``None`` here means "could not tell", and the caller keeps the plain `approve`
+    verb rather than routing to `ask`. Applying a label that is already present is
+    a harmless no-op; refusing to act would strand the ordinary first approval
+    behind a `gh` call the routine sessions' egress proxy is known to refuse. The
+    asymmetry with `is_promotion` is deliberate — there, guessing wrong starts an
+    implementation run against a release ask, and here it does nothing at all.
+    """
+    return _has_open_label(issue, APPROVAL_LABEL, runner)
+
+
 def is_campaign_candidate(issue: int, *, runner: Callable[[list[str]], str | None] | None = None) -> bool | None:
     """Whether ``issue`` carries the `integration:candidate` label the campaign applies.
 
@@ -301,6 +315,27 @@ def _command(verb: str, issue: int) -> list[str]:
     """
     if verb == "approve":
         return ["gh", "issue", "edit", str(issue), "--add-label", APPROVAL_LABEL]
+    if verb == "refire":
+        # A repeat ✅ on an issue that is already approved. `--add-label` on a label
+        # that is already there is a *silent no-op*, and `claude.yml`'s implement
+        # job fires on the `labeled` event — so #172 was approved five times
+        # between 2026-08-09 and 08-11 and built once, with nothing anywhere
+        # reporting that the other four did nothing at all.
+        #
+        # A comment rather than a remove-then-add: that pair is lossy, and a crash
+        # between its two writes leaves the issue carrying no `claude-implement`,
+        # which is the exact label `digest.md` queries to report an approval the
+        # fleet never acted on. This marker is picked up by `claude.yml`, which
+        # then re-reads the label live before doing anything — so the comment
+        # requests, and never authorises.
+        return [
+            "gh",
+            "issue",
+            "comment",
+            str(issue),
+            "--body",
+            "re-approved via Slack ✅ — already labelled, so re-firing the implement job.\n\n<!-- implement-retry -->",
+        ]
     if verb == "promote":
         return ["gh", "issue", "edit", str(issue), "--add-label", PROMOTE_LABEL]
     if verb == "campaign":
@@ -316,6 +351,7 @@ def build_plan(
     *,
     promotion_check: Callable[[int], bool] | None = None,
     candidate_check: Callable[[int], bool] | None = None,
+    approved_check: Callable[[int], bool] | None = None,
 ) -> dict[str, Any]:
     """Turn a thread into the list of actions still owed, oldest first.
 
@@ -332,6 +368,7 @@ def build_plan(
     # pure. Tests pass a stub; nothing else should.
     is_promotion_issue = promotion_check or is_promotion
     is_candidate_issue = candidate_check or is_campaign_candidate
+    is_approved_issue = approved_check or is_approved
 
     plan: list[dict[str, Any]] = []
     item_replies = marked = ignored_markers = 0
@@ -393,7 +430,13 @@ def build_plan(
         if not approvers:
             verb = "reject"
         elif special is None:
-            verb = "approve"
+            # Already approved? Then this ✅ is a re-fire request, not an approval.
+            # `None` keeps the existing `approve` behaviour rather than routing to
+            # `ask`: applying a label that is already there is harmless, whereas
+            # refusing to act on an unreadable answer would strand the ordinary
+            # first-approval path behind a `gh` call that routine sessions' egress
+            # proxy is known to refuse.
+            verb = "refire" if is_approved_issue(issue) else "approve"
         else:
             label_verb, confirm = special
             confirmed = confirm(issue)

--- a/scripts/cowork_setup.py
+++ b/scripts/cowork_setup.py
@@ -273,6 +273,11 @@ DEPLOY_ROUTINE = "cd-deploy"
 KEEP_LABELS = frozenset(
     {
         "claude-implement",
+        # Applied by `claude.yml`'s outcome guard and by the reconciler, not by any
+        # cowork routine — so teardown must leave it, exactly as it leaves the
+        # approval label it sits beside. Deleting it would strip the one record
+        # that an implement run failed off every issue carrying it.
+        "implement-blocked",
         "feedback-override",
         "release:promotion",
         "release:promote",
@@ -598,6 +603,13 @@ def expected_labels() -> list[Label]:
         # backlog.
         Label(QUEUE_LABEL, "c2e0c6", "Approved by rule — an auto-lane item a sweep will build"),
         Label("claude-implement", "0e8a16", "Approved — the claude.yml implement job builds this"),
+        # Applied by `claude.yml` when its outcome guard fails, and by
+        # `implement-reconcile.yml` when three re-fires produced no PR. It is the
+        # terminal state that stops a level-triggered reconciler retrying a broken
+        # implement job every six hours forever. `claude-implement` deliberately
+        # stays on beside it — that is the label `digest.md` queries to report the
+        # issue at all, and removing it would hide the failure rather than name it.
+        Label("implement-blocked", "d93f0b", "The implement job produced no PR — a human has to look"),
         Label("feedback-override", "b60205", "Clears the pr-feedback merge gate — a human's call, recorded on the PR"),
         # The promotion pair. `release:promotion` marks the weekly ask issue and is
         # applied only by `cron/release-promote-ask.md`; `release:promote` is the

--- a/tests/unit/test_claude_workflow.py
+++ b/tests/unit/test_claude_workflow.py
@@ -153,6 +153,16 @@ class TestTheToolchain:
 
 
 class TestTheOutcomeGuard:
+    @staticmethod
+    def _guard(implement):
+        """The guard step, selected by name rather than by position.
+
+        It used to be `steps[-1]`, which was true only for as long as nothing ran
+        after it — and the fix for a guard that dies silently is precisely to add a
+        reporting step after it.
+        """
+        return next(step for step in implement["steps"] if step.get("name") == "Assert the run produced something")
+
     def test_the_job_asserts_it_produced_something(self, implement):
         """A green run that wrote no code is what hid all of the above.
 
@@ -160,7 +170,7 @@ class TestTheOutcomeGuard:
         refuses to age out an issue carrying `claude-implement`, so #172 became
         invisible to every routine in the fleet the moment it was approved.
         """
-        guard = implement["steps"][-1]
+        guard = self._guard(implement)
         assert "permission_denials_count" in guard["run"], "a denial in this job is always a misconfiguration"
         assert "feature/issue-" in guard["run"], "the branch prompt step 4 promises is the evidence of work"
         assert guard.get("if", "").startswith("always()")
@@ -174,5 +184,5 @@ class TestTheOutcomeGuard:
         comment as "the run asked a question and stopped" would therefore wave
         through a silent no-op on the single most common path into the job.
         """
-        guard = implement["steps"][-1]
+        guard = self._guard(implement)
         assert 'endswith("[bot]")' in guard["run"]

--- a/tests/unit/test_cowork_relay.py
+++ b/tests/unit/test_cowork_relay.py
@@ -90,13 +90,44 @@ class TestRecordedFailure:
             assert relay.ITEM_RE.match(ack["text"]) is None
         # and with every marker stripped, they are still not actionable
         bare = [{**r, "reactions": []} for r in thread]
-        assert relay.build_plan(bare, ALLOWLIST)["counts"]["item_replies"] == 12
+        counts = relay.build_plan(bare, ALLOWLIST, approved_check=lambda n: False)["counts"]
+        assert counts["item_replies"] == 12
 
     def test_stripping_the_marker_recovers_exactly_one_approval(self, thread):
+        """`approved_check` stubbed False — the state #172 was actually in when
+        this thread was recorded, before the label existed on it."""
         thread[0]["reactions"] = [r for r in thread[0]["reactions"] if r["name"] != relay.DONE]
-        plan = relay.build_plan(thread, ALLOWLIST)["plan"]
+        plan = relay.build_plan(thread, ALLOWLIST, approved_check=lambda n: False)["plan"]
         assert [(p["issue"], p["verb"]) for p in plan] == [(172, "approve")]
         assert plan[0]["who"] == ALLOWLIST[HUMAN]
+
+    def test_the_same_thread_re_fires_once_the_issue_is_already_labelled(self, thread):
+        """The bug this recording is of, stated as the fix.
+
+        #172 was ✅'d five times between 2026-08-09 and 08-11. Every one after the
+        first emitted `--add-label claude-implement` onto an issue that already had
+        it — a silent no-op, because `claude.yml`'s implement job fires on the
+        `labeled` *event* and GitHub emits none for a label that is already there.
+        The relay acked all five, so nothing anywhere reported that four of them
+        did nothing.
+        """
+        thread[0]["reactions"] = [r for r in thread[0]["reactions"] if r["name"] != relay.DONE]
+        plan = relay.build_plan(thread, ALLOWLIST, approved_check=lambda n: True)["plan"]
+        assert [(p["issue"], p["verb"]) for p in plan] == [(172, "refire")]
+        assert plan[0]["command"][:3] == ["gh", "issue", "comment"]
+        assert "<!-- implement-retry -->" in plan[0]["command"][-1]
+
+    def test_an_unreadable_approval_state_still_approves(self, thread):
+        """The asymmetry with `is_promotion`, which routes `None` to `ask`.
+
+        Guessing wrong there starts an implementation run against a release ask.
+        Guessing wrong here re-applies a label that is already present, which does
+        nothing — so refusing to act would only strand the ordinary first approval
+        behind a `gh` call the routine sessions' egress proxy is known to refuse.
+        """
+        thread[0]["reactions"] = [r for r in thread[0]["reactions"] if r["name"] != relay.DONE]
+        plan = relay.build_plan(thread, ALLOWLIST, approved_check=lambda n: None)["plan"]
+        assert [(p["issue"], p["verb"]) for p in plan] == [(172, "approve")]
 
 
 class TestVerbs:
@@ -108,16 +139,33 @@ class TestVerbs:
         lost `workstream:` label is what scopes which paths the implement job may
         touch, so this is a boundary, not bookkeeping.
         """
-        plan = relay.build_plan([item(172, white_check_mark=[HUMAN])], ALLOWLIST)["plan"]
+        fresh = [item(172, white_check_mark=[HUMAN])]
+        plan = relay.build_plan(fresh, ALLOWLIST, approved_check=lambda n: False)["plan"]
         assert plan[0]["command"] == ["gh", "issue", "edit", "172", "--add-label", "claude-implement"]
 
-    def test_no_emitted_command_can_replace_a_label_set(self):
-        thread = [item(1, ts="1", white_check_mark=[HUMAN]), item(2, ts="2", x=[HUMAN])]
-        for entry in relay.build_plan(thread, ALLOWLIST)["plan"]:
-            argv = entry["command"]
-            assert "api" not in argv
-            assert not {"PUT", "-X", "--method"} & set(argv)
-            assert "--remove-label" not in argv
+    @pytest.mark.parametrize("verb", ["approve", "refire", "promote", "campaign", "reject"])
+    def test_no_emitted_command_can_replace_a_label_set(self, verb):
+        """Over every verb by name, rather than over whichever ones a sample thread
+        happens to reach — `refire` needs a stubbed label read to be reached at all,
+        and a safety assertion that silently skips the newest verb is not one.
+
+        `gh issue edit --add-label` adds; `gh api -X PUT .../labels` replaces. On
+        2026-08-09 something ran the second, and #172 lost `cowork:proposal`,
+        `workstream:web-ux` and `type:security` in the same second it gained
+        `claude-implement` — leaving the implement job with no charter naming which
+        paths it was allowed to touch.
+        """
+        argv = relay._command(verb, 7)
+        assert "api" not in argv
+        assert not {"PUT", "-X", "--method"} & set(argv)
+        assert "--remove-label" not in argv
+
+    def test_every_verb_build_plan_can_choose_has_a_command(self):
+        """`_command` raises on an unknown verb, so a verb added to `build_plan`
+        without one turns a relay run into a crash mid-plan — after it has already
+        executed the entries before it."""
+        for verb in ("approve", "refire", "promote", "campaign", "reject"):
+            assert relay._command(verb, 1)[0] == "gh"
 
     def test_a_rejection_closes(self):
         plan = relay.build_plan([item(5, x=[HUMAN])], ALLOWLIST)["plan"]
@@ -125,7 +173,9 @@ class TestVerbs:
         assert plan[0]["command"] == ["gh", "issue", "close", "5"]
 
     def test_both_verbs_from_a_human_asks_and_acts_on_nothing(self):
-        plan = relay.build_plan([item(9, white_check_mark=[HUMAN], x=[HUMAN])], ALLOWLIST)["plan"]
+        plan = relay.build_plan(
+            [item(9, white_check_mark=[HUMAN], x=[HUMAN])], ALLOWLIST, approved_check=lambda n: False
+        )["plan"]
         assert plan[0]["verb"] == "ask"
         assert plan[0]["command"] is None
 
@@ -227,7 +277,8 @@ class TestPromotion:
         assert relay.is_promotion(231, runner=lambda a: payload) is False
 
     def test_an_ordinary_proposal_is_still_an_approval(self):
-        plan = relay.build_plan([item(172, white_check_mark=[HUMAN])], ALLOWLIST)["plan"]
+        fresh = [item(172, white_check_mark=[HUMAN])]
+        plan = relay.build_plan(fresh, ALLOWLIST, approved_check=lambda n: False)["plan"]
         assert plan[0]["verb"] == "approve"
         assert plan[0]["command"][-1] == "claude-implement"
 
@@ -339,9 +390,12 @@ class TestCampaignCandidate:
 
     def test_an_ordinary_proposal_is_still_an_approval(self):
         """The test that would have caught reusing `claude-implement` for the pick."""
-        plan = relay.build_plan([item(172, white_check_mark=[HUMAN])], ALLOWLIST, candidate_check=lambda n: True)[
-            "plan"
-        ]
+        plan = relay.build_plan(
+            [item(172, white_check_mark=[HUMAN])],
+            ALLOWLIST,
+            candidate_check=lambda n: True,
+            approved_check=lambda n: False,
+        )["plan"]
         assert plan[0]["verb"] == "approve"
         assert plan[0]["command"][-1] == "claude-implement"
 

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -811,6 +811,7 @@ class TestLabels:
                 "cowork:proposal",
                 "claude-implement",
                 "cowork:queued",
+                "implement-blocked",
                 "feedback-override",
                 "release:promotion",
                 "release:promote",
@@ -2216,12 +2217,16 @@ class TestTeardown:
         gate; the ``release:*`` pair is what ``publish.yml`` fires on, so deleting
         either disarms the only path that cuts an official release; and
         ``integration:approved`` is what the campaign routine reads to know which
-        provider it is building, so deleting it strands every ✅ on a shortlist.
+        provider it is building, so deleting it strands every ✅ on a shortlist;
+        and ``implement-blocked`` is the terminal state that stops a level-triggered
+        reconciler re-firing a broken implement job every six hours, so deleting it
+        both strips that record off every issue and restarts the loop.
         Removing any of them with the fleet would break a live gate, and the
         breakage is silent: applying a label that does not exist does nothing.
         """
         assert setup.KEEP_LABELS == {
             "claude-implement",
+            "implement-blocked",
             "feedback-override",
             "release:promotion",
             "release:promote",

--- a/tests/unit/test_implement_reconcile.py
+++ b/tests/unit/test_implement_reconcile.py
@@ -1,0 +1,136 @@
+"""Standing guards over `.github/workflows/implement-reconcile.yml`.
+
+`claude-implement` is a level — "this issue is approved and unbuilt" — and
+`claude.yml`'s implement job only ever observed its edge. This workflow reads the
+level, which is what makes a lost `labeled` event, a repeated ✅ and a run that
+produced nothing all recoverable by one mechanism.
+
+Reading a level means looping, and a loop over an unattended 110-turn agent is
+the one way this can be worse than the bug it fixes. So most of what is pinned
+here is about **stopping**: the attempt cap, the terminal label, and the two
+queries that decide whether there is anything to do. Each fails silently — a
+reconciler that re-fires forever and one that never re-fires at all both look
+exactly like a quiet workflow from the outside.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "implement-reconcile.yml"
+CLAUDE = REPO_ROOT / ".github" / "workflows" / "claude.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+@pytest.fixture(scope="module")
+def script(workflow) -> str:
+    """The one `run:` block that does the reconciling."""
+    steps = workflow["jobs"]["reconcile"]["steps"]
+    return next(step["run"] for step in steps if "run" in step and "claude-implement" in step["run"])
+
+
+class TestItCanStop:
+    def test_there_is_an_attempt_cap(self, script, workflow):
+        """Without one, a broken implement job burns a 110-turn agent every six
+        hours forever. The cap is the difference between a reconciler and a loop."""
+        env = next(s for s in workflow["jobs"]["reconcile"]["steps"] if "run" in s and "MAX_ATTEMPTS" in str(s))["env"]
+        assert int(env["MAX_ATTEMPTS"]) >= 1
+        assert "-ge" in script and "MAX_ATTEMPTS" in script
+
+    def test_reaching_the_cap_applies_the_terminal_label(self, script):
+        assert "--add-label implement-blocked" in script
+
+    def test_a_blocked_issue_is_skipped_before_anything_else(self, script):
+        """Ordering is the invariant, not just presence. The blocked check must come
+        before the attempt count, or a capped issue is re-counted and re-notified
+        on every tick — which is the noise the cap exists to prevent."""
+        assert script.index('index("implement-blocked")') < script.index("MAX_ATTEMPTS")
+
+    def test_clearing_the_label_actually_lets_it_retry(self, script):
+        """The documented recovery path has to work, and once did the opposite.
+
+        Nothing deletes the `<!-- implement-attempt -->` markers, so a lifetime
+        count meant removing `implement-blocked` put the issue straight back into
+        the cap branch on the next tick: label re-applied, same notice posted, six
+        hours apart, forever. Following the instructions was what generated the
+        noise. Attempts are counted from the last time that label was removed.
+        """
+        assert "UnlabeledEvent" in script
+        assert "timelineItems" in script
+        assert "$since" in script, "the attempt count is not scoped to anything"
+
+
+class TestItKnowsWhenThereIsNothingToDo:
+    @pytest.mark.parametrize("path", [WORKFLOW, CLAUDE])
+    def test_a_closed_unmerged_pr_does_not_count_as_a_pr(self, path):
+        """Asked of both files, because they ask the same question and a fix in one
+        is not a fix in the other.
+
+        `--state all` alone would let a previous attempt's PR — including one closed
+        unmerged, which is among the likeliest reasons a re-fire is wanted — answer
+        for this attempt. In `claude.yml` that bypasses the whole outcome guard; here
+        it means the issue is never re-fired *and* never blocked, so it stops
+        existing to the fleet entirely, since `digest.md`'s approved-with-no-PR
+        section asks the identical question.
+        """
+        text = path.read_text()
+        assert "in:body" in text
+        assert ".mergedAt != null" in text, f"{path.name} counts a closed-unmerged PR as a PR"
+        assert '.state == "OPEN"' in text
+
+    def test_both_branch_conventions_are_checked(self, script):
+        """`claude-code-action` names its own branches `claude/issue-N-…`. Knowing
+        only `feature/issue-N-*` reads a mid-flight run as a failed one and re-fires
+        on top of it."""
+        assert "feature/issue-$n-*" in script
+        assert "claude/issue-$n-*" in script
+
+    def test_it_leaves_a_run_in_flight_alone(self, script):
+        assert "in_progress" in script
+
+
+class TestItCannotDoMoreThanReFire:
+    def test_it_never_applies_the_approval_label(self, script):
+        """`claude-implement` is a human's verb. A machine that could apply it could
+        approve its own work; `house-rules.md` forbids it and this is the one file
+        with both the motive and the token."""
+        assert "--add-label claude-implement" not in script
+
+    def test_it_never_closes_or_merges_anything(self, script):
+        for forbidden in ("gh issue close", "gh pr merge", "gh pr close"):
+            assert forbidden not in script
+
+    def test_it_dispatches_rather_than_implementing(self, script):
+        """It runs no model of its own — `gh` and `jq`. The job it starts is the one
+        that carries the tool grant, the turn cap and the outcome guard."""
+        assert "gh workflow run claude.yml" in script
+
+    def test_the_dispatch_target_accepts_being_dispatched(self):
+        """The two halves of one contract, in different files: this workflow passes
+        `-f issue=<n>`, and `claude.yml` has to declare that input and fire on it."""
+        claude = yaml.safe_load(CLAUDE.read_text())
+        triggers = claude[True] if True in claude else claude["on"]
+        assert "issue" in triggers["workflow_dispatch"]["inputs"]
+        assert "workflow_dispatch" in claude["jobs"]["implement"]["if"]
+
+
+class TestTheLabelIsRealEverywhereItIsUsed:
+    def test_cowork_setup_creates_it(self):
+        """A label a workflow applies but `make cowork-setup` never creates does
+        nothing at all, silently — and the thing it silently fails to do here is
+        stop the loop."""
+        import sys
+
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        import cowork_setup as setup
+
+        assert "implement-blocked" in {label.name for label in setup.expected_labels()}
+        assert "implement-blocked" in setup.KEEP_LABELS, "teardown would strip the record off every issue"


### PR DESCRIPTION
## Summary

`claude-implement` is a **level** — "this issue is approved and unbuilt" — but `claude.yml`'s
implement job only ever observed its **edge** (`issues: labeled`). Everything that can come between
the two was unrecoverable:

- **a second ✅ is a silent no-op.** `gh issue edit --add-label` on a label that is already there
  emits no `labeled` event. Issue #172 was ✅'d in Slack five times between 2026-08-09 and 08-11 and
  built **once**; the relay acked all five, so nothing anywhere reported that four did nothing.
- **the one run that did fire produced nothing** — 231s, exit `success`, no branch, no PR, no
  comment — and nothing retried it.
- `claude.yml` has concluded `skipped` on **100 of its last 100 runs**.

## Three doors, none of them trusted

`workflow_dispatch` with an issue number, the existing label event, and a `<!-- implement-retry -->`
marker gated on `author_association`. A new **"Resolve the target issue"** first step re-reads the
issue's live state and labels and refuses anything not open and carrying `claude-implement` — so the
trigger says *which* issue and this step decides *whether*. A forged marker from a write-capable
account can only re-run something a human already approved.

It is also strictly better than the label path for #172's own failure: that run read its labels from
an event payload captured in the same second the relay stripped three of them, and built with **no
charter at all**. The tier step, the prompt and the guard now all read from the live values.

Plus a job-level `concurrency` group, which did not exist — five ✅s could in principle have started
five 110-turn agents on one issue.

## The reconciler

`implement-reconcile.yml`, every six hours, no model — `gh` and `jq`. For each open
`claude-implement` issue with no PR, no branch and no run in flight, dispatch the job. **Three
attempts**, counted from `<!-- implement-attempt -->` comments, then `implement-blocked` and stop: a
level-triggered re-firer with a broken implement job would otherwise burn a 110-turn agent every six
hours forever, which is the one way this can be worse than the bug it fixes. The digest reports that
state, since the issue keeps `claude-implement` and the age-out still refuses to touch it.

## Four holes in the outcome guard

Each one turned it back into a green tick:

1. **a missing execution log `::warning::`d and set denials to 0** — a guard that cannot check,
   passing. The path is hardcoded against one observed run of one pinned action version. Now an
   error, and it reads `steps.implement.outputs.execution_file` first. An `error_max_turns` subtype
   fails too — today that is only inferable from the branch-without-PR path.
2. **"a bot commented in the last two hours"** counted `codeql-triage`, `flaky-test-hunter`,
   `feedback-remediation` and `pr-merged-close-loop`, and would have counted the reconciler's own
   attempt marker. Now it requires `<!-- implement: ambiguous -->` — a marker the prompt is told to
   write — posted after this job started.
3. **the branch probe knew one convention.** `claude-code-action` names its own branches
   `claude/issue-N-…`, which read as "no branch". It asks `gh pr list --search "$N in:body"` first
   now — the authoritative question, and the same one `digest.md` asks.
4. **a failed guard went nowhere.** The job turned red, the issue kept its label, the age-out
   refused to touch it, and nothing re-fired. It now comments the run URL and applies
   `implement-blocked`.

## Test plan

- `make test` — 11691 passed, 47 skipped · `make lint` clean · `actionlint` clean on both workflows
- `test_claude_workflow.py` selected the guard by **position**, which held only while nothing ran
  after it — and the fix for a guard that dies silently is exactly to add a step after it. By name now.
- New relay tests replay the recorded 2026-08-09 thread both ways: `approved_check` False → the
  `approve` it was, True → the `refire` it should have been, None → still `approve` (the asymmetry
  with `is_promotion` is deliberate, and the docstring says why).
- The label-safety assertion was parametrised over every verb by name — it sampled a thread before,
  so it could not reach `refire` at all, and a safety check that silently skips the newest verb is
  not one.

## Note

Four approval tests were reaching the **real** `gh issue view` and passing only because they never
hit that seam. They stub it now — which is what `build_plan`'s docstring already said they must.

🤖 Generated with [Claude Code](https://claude.com/claude-code)