### PR TITLE
give --migrate-proposals a gh write path, and stop tests reaching the real gh

### DIFF
--- a/scripts/_gh_transport.py
+++ b/scripts/_gh_transport.py
@@ -60,6 +60,20 @@ class ApiResult:
 
 # --- the CLI half ------------------------------------------------------------
 
+# This module's single process seam — EVERY spawn in this file goes through it,
+# `gh` and `git` alike, which is what makes replacing this one name total. Named
+# so it can be replaced without touching
+# the shared `subprocess` module — patching `subprocess.run` itself would patch it
+# for every other test in the suite, which is the trap `tests/conftest.py`'s
+# `_no_real_package_install` documents for the installer.
+#
+# It exists because the test suite reached the real `gh` once and wrote to the
+# real repository: a migration test stubbed the REST seam and asserted on the
+# calls, which was complete until the function under it grew a `gh` branch, and
+# then `gh issue edit 7 --add-label …` plus four comments landed on a merged PR.
+# `_no_real_gh_calls` blocks this name.
+_run = subprocess.run
+
 
 def gh(*args: str) -> subprocess.CompletedProcess[str]:
     """One `gh` call, reporting a missing binary the way `gh` reports a failure.
@@ -71,7 +85,7 @@ def gh(*args: str) -> subprocess.CompletedProcess[str]:
     traceback out of a script whose whole contract is to degrade with a remedy.
     """
     try:
-        return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+        return _run(["gh", *args], capture_output=True, text=True, check=False)
     except OSError as error:
         return subprocess.CompletedProcess(["gh", *args], 127, "", str(error))
 
@@ -292,7 +306,7 @@ def _slug_from_remote(root: Path | None) -> str | None:
     """``owner/name`` parsed out of `git remote get-url origin`."""
     argv = ["git"] + (["-C", str(root)] if root else []) + ["remote", "get-url", "origin"]
     try:
-        result = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603 - literal argv
+        result = _run(argv, capture_output=True, text=True, check=False)  # noqa: S603 - literal argv
     except OSError:
         return None
     if result.returncode != 0:

--- a/scripts/beta_signoff.py
+++ b/scripts/beta_signoff.py
@@ -34,13 +34,13 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import _gh_transport as transport  # noqa: E402
 import cowork_relay  # noqa: E402
 import release_channel as channel  # noqa: E402
 import release_surfaces  # noqa: E402
@@ -82,8 +82,15 @@ def _gh(*args: str) -> str | None:
     and only the marker and the label need an answer. Failing the whole command
     because the queue is unreachable would hide the information the human came for.
     """
+    # Through `_gh_transport`'s process seam rather than `subprocess.run` directly.
+    # This function *writes* — `mark_tested` builds `gh issue comment`, and the
+    # promote path adds `release:promote` — so a test that forgets to stub `_gh`,
+    # or a branch added below it, would land both on the real release-ask issue
+    # with `cwd=ROOT` pointing at this repo. `tests/conftest.py`'s
+    # `_no_real_gh_calls` blocks that one name; nothing can block a call that
+    # bypasses it.
     try:
-        result = subprocess.run(["gh", *args], cwd=ROOT, capture_output=True, text=True, check=False)
+        result = transport._run(["gh", *args], cwd=ROOT, capture_output=True, text=True, check=False)
     except FileNotFoundError:
         return None
     return result.stdout if result.returncode == 0 else None

--- a/scripts/cowork_relay.py
+++ b/scripts/cowork_relay.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -279,7 +278,7 @@ def _gh_labels(argv: list[str]) -> str | None:
     the caller a second shape.
     """
     if transport.gh_available():
-        result = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603 - literal argv
+        result = transport._run(argv, capture_output=True, text=True, check=False)  # noqa: S603 - literal argv
         return result.stdout if result.returncode == 0 else None
     slug = transport.resolve_slug(ROOT)
     if not slug:

--- a/scripts/cowork_setup.py
+++ b/scripts/cowork_setup.py
@@ -1871,12 +1871,12 @@ def merge_gate_armed() -> bool | None:
             'any(.[]; .type=="required_status_checks" and '
             'any(.parameters.required_status_checks[]; .context=="pr-feedback"))'
         )
-        result = subprocess.run(  # noqa: S603 - literal argv
-            ["gh", "api", f"repos/{slug}/rules/branches/main", "--jq", query],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        # Through `_gh` like every other CLI call in this file, rather than its own
+        # `subprocess.run`. It was the one that had its own, which meant it was the
+        # one call the tests could not stub — `TestStrict` was making a live
+        # `gh api .../rules/branches/main` request on every run, against whatever
+        # repo the checkout pointed at.
+        result = _gh("api", f"repos/{slug}/rules/branches/main", "--jq", query)
         if result.returncode != 0:
             return None
         return result.stdout.strip() == "true"

--- a/scripts/cowork_setup.py
+++ b/scripts/cowork_setup.py
@@ -2385,6 +2385,29 @@ def _reclassify(number: int, workstream: str, *, repair: bool) -> tuple[bool, st
     first would leave an issue in neither queue, invisible to the digest and to
     every sweep.
     """
+    # Both transports, like every other writer in this file. The read half asks
+    # REST on both paths deliberately (`_issues_labelled` says why at length), but
+    # the write half had only the REST branch — so on a laptop with `gh` logged in
+    # and no `GH_TOKEN` exported, every issue read back fine and every write failed
+    # with "no GH_TOKEN in the environment". That is the ordinary way a human runs
+    # this, and it is the only way it is allowed to be run.
+    if TRANSPORT == "gh":
+        if shutil.which("gh") is None:
+            return False, "gh is not on PATH"
+        if not repair:
+            result = _gh("issue", "edit", str(number), "--add-label", QUEUE_LABEL)
+            if result.returncode != 0:
+                return False, result.stderr.strip() or "unknown gh error"
+            body = MIGRATION_NOTE.format(workstream=workstream)
+            result = _gh("issue", "comment", str(number), "--body", body)
+            if result.returncode != 0:
+                return False, result.stderr.strip() or "unknown gh error"
+        # `--remove-label` removes one; `gh api -X PUT .../labels` would replace the
+        # whole set. Same distinction `cowork_relay.py:_command` is built around,
+        # and the same incident behind it (#172).
+        result = _gh("issue", "edit", str(number), "--remove-label", PROPOSAL_LABEL)
+        return result.returncode == 0, result.stderr.strip() or "unknown gh error"
+
     slug = repo_slug()
     if not slug:
         return False, "no owner/name resolved for this checkout"

--- a/scripts/test_scope.py
+++ b/scripts/test_scope.py
@@ -346,6 +346,14 @@ ALWAYS: tuple[str, ...] = (
     "tests/unit/test_tips.py",
     "tests/unit/tools/test_tools_registry.py",
     "tests/unit/test_conftest_guards.py",
+    # The gh guard's own reach test. Separate from `test_conftest_guards.py`, and
+    # named `zz_` so it collects last, because the property it checks is *which
+    # modules are loaded* — `scripts/` is not a package and two loaders disagree
+    # about who owns `_gh_transport`, so the guard has more than one object to
+    # patch. Run early it would skip; run last it sees the split. It is in ALWAYS
+    # because it guards the repo rather than a module, and because a scoped run is
+    # the case where the loaded set is smallest and the guard's reach is thinnest.
+    "tests/unit/test_zz_gh_guard.py",
     "tests/unit/test_fixtures.py",
     "tests/unit/test_test_scope.py",
     # The tests for the GLOBAL modules above. Their subjects force a full run

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,6 +226,66 @@ def _no_real_package_install(monkeypatch):
     monkeypatch.setattr("yeaboi.voice_install._popen", _blocked)
 
 
+class RealGitHubWriteBlocked(BaseException):
+    """A test reached the real `gh` CLI. Never caught — see the fixture below.
+
+    ``BaseException`` for the same reason ``RealPackageInstallBlocked`` is: this
+    fires inside code whose whole contract is to degrade gracefully, and a broad
+    ``except Exception`` on the way out would swallow it and report a failed `gh`
+    call instead of failing the test.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _no_real_gh_calls(monkeypatch):
+    """No test may shell out to the real `gh` CLI.
+
+    This is not hypothetical. ``TestMigrateProposalsApply`` stubbed
+    ``cowork_setup._api`` — the REST seam — and asserted on the calls. That was
+    complete for as long as ``_reclassify`` had only a REST branch. The moment it
+    grew a ``gh`` branch (``TRANSPORT`` defaults to ``"gh"``), those same tests
+    took the unstubbed path and ran real commands against the real repository:
+    ``gh issue edit 7 --add-label cowork:queued`` plus four ``gh issue comment``
+    calls, landing on a PR merged months earlier. They had to be undone by hand.
+
+    A test asserting on writes is exactly a test that will make them if a seam
+    moves, and "stub the right seam" is not a property anything checks. Blocking
+    the single process seam is, and it fails loudly rather than mutating anything.
+
+    Blocked at the **process spawn** inside ``_gh_transport``, not at ``gh()``
+    itself. That is deliberate and is the only level that works for everyone:
+    ``test_gh_transport.py`` calls ``transport.gh`` directly on purpose — proving a
+    missing binary degrades to 127 rather than a traceback — and stubs
+    ``transport._run`` beneath it, while ``test_cowork_setup.py`` stubs
+    ``transport.gh`` above it. Both are legitimate, both share this MonkeyPatch
+    instance, and a stub at either level lands after ours and wins. What is left
+    over is precisely the case with no stub at all, which is the one that reaches
+    the network.
+
+    ``scripts/`` is not a package, so the module is found by the name it registers
+    in ``sys.modules``; if it was never imported there is nothing to block and this
+    is a no-op.
+    """
+    import sys as _sys
+
+    transport = _sys.modules.get("_gh_transport")
+    if transport is None:
+        return
+    real = transport._run
+
+    def _blocked(argv, *args, **kwargs):
+        # `gh` only. Everything else through this seam is `git remote get-url
+        # origin` — a local, read-only lookup that cannot reach GitHub and that
+        # several tests legitimately let run. Blocking it too would fail seven
+        # tests that never did anything wrong, and a guard with collateral like
+        # that gets loosened rather than kept.
+        if argv and argv[0] == "gh":
+            raise RealGitHubWriteBlocked(f"test tried to spawn the real gh CLI: {argv}")
+        return real(argv, *args, **kwargs)
+
+    monkeypatch.setattr(transport, "_run", _blocked, raising=False)
+
+
 @pytest.fixture(autouse=True)
 def _no_ambient_sidecar(monkeypatch):
     """Unit and integration tests always exercise the pure-Python path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,28 +262,46 @@ def _no_real_gh_calls(monkeypatch):
     over is precisely the case with no stub at all, which is the one that reaches
     the network.
 
-    ``scripts/`` is not a package, so the module is found by the name it registers
-    in ``sys.modules``; if it was never imported there is nothing to block and this
-    is a no-op.
+    **There can be more than one ``_gh_transport``, and patching the wrong one is
+    silent.** ``scripts/`` is not a package, and the two loaders disagree about who
+    owns the name: ``cowork_setup`` and ``cowork_relay`` do a plain ``import
+    _gh_transport``, binding whatever object exists at their load time, while
+    ``test_gh_transport.py`` builds a *fresh* module off the file path and assigns
+    it over ``sys.modules["_gh_transport"]``. Collection is alphabetical, so in a
+    full-suite run the registry entry is the fresh object and ``cowork_setup``
+    still holds the original — patching only the registry leaves the module that
+    caused the incident unguarded, and the guard's own proof passes when run on one
+    file because there the two happen to coincide.
+
+    So every distinct transport object reachable from the loaded scripts modules is
+    patched, deduped by identity. If none was imported there is nothing to block
+    and this is a no-op.
     """
     import sys as _sys
 
-    transport = _sys.modules.get("_gh_transport")
-    if transport is None:
-        return
-    real = transport._run
+    reachable = []
+    for name in ("_gh_transport", "cowork_setup", "cowork_relay", "pr_feedback", "beta_signoff"):
+        module = _sys.modules.get(name)
+        if module is None:
+            continue
+        candidate = module if name == "_gh_transport" else getattr(module, "transport", None)
+        if candidate is not None and not any(candidate is seen for seen in reachable):
+            reachable.append(candidate)
 
-    def _blocked(argv, *args, **kwargs):
-        # `gh` only. Everything else through this seam is `git remote get-url
-        # origin` — a local, read-only lookup that cannot reach GitHub and that
-        # several tests legitimately let run. Blocking it too would fail seven
-        # tests that never did anything wrong, and a guard with collateral like
-        # that gets loosened rather than kept.
-        if argv and argv[0] == "gh":
-            raise RealGitHubWriteBlocked(f"test tried to spawn the real gh CLI: {argv}")
-        return real(argv, *args, **kwargs)
+    for transport in reachable:
+        real = transport._run
 
-    monkeypatch.setattr(transport, "_run", _blocked, raising=False)
+        def _blocked(argv, *args, _real=real, **kwargs):
+            # `gh` only. Everything else through this seam is `git remote get-url
+            # origin` — a local, read-only lookup that cannot reach GitHub and that
+            # several tests legitimately let run. Blocking it too would fail seven
+            # tests that never did anything wrong, and a guard with collateral like
+            # that gets loosened rather than kept.
+            if argv and argv[0] == "gh":
+                raise RealGitHubWriteBlocked(f"test tried to spawn the real gh CLI: {argv}")
+            return _real(argv, *args, **kwargs)
+
+        monkeypatch.setattr(transport, "_run", _blocked)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_beta_signoff.py
+++ b/tests/unit/test_beta_signoff.py
@@ -435,7 +435,7 @@ class TestPromoteWaitsForEveryTrack:
 class TestGhIsNeverFatal:
     def test_a_missing_gh_is_not_an_error(self, monkeypatch):
         """`beta-check` is a reporting command first."""
-        monkeypatch.setattr(signoff.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+        monkeypatch.setattr(signoff.transport, "_run", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
         assert signoff._gh("issue", "list") is None
         assert signoff.recent_asks() == []
 
@@ -444,7 +444,7 @@ class TestGhIsNeverFatal:
             returncode = 1
             stdout = "[]"
 
-        monkeypatch.setattr(signoff.subprocess, "run", lambda *a, **k: Result())
+        monkeypatch.setattr(signoff.transport, "_run", lambda *a, **k: Result())
         assert signoff._gh("issue", "list") is None
 
     def test_malformed_json_is_no_answer(self, monkeypatch):

--- a/tests/unit/test_cowork_relay.py
+++ b/tests/unit/test_cowork_relay.py
@@ -45,6 +45,24 @@ def reply(ts: str, text: str, **reactions: list[str]) -> dict:
     }
 
 
+@pytest.fixture(autouse=True)
+def _not_already_approved(monkeypatch):
+    """Default every plan to "this issue is not yet approved".
+
+    `build_plan` asks `is_approved` on the plain-approval path, and that shells
+    out to `gh issue view`. Unstubbed, every test in this file that builds a plan
+    made a live GitHub read against whatever repo the checkout pointed at — which
+    passed quietly until `_no_real_gh_calls` started refusing, and then failed
+    only in a *scoped* CI run, because which modules are loaded decides which
+    transport objects the guard reached.
+
+    False rather than None is what these tests mean: they assert on the `approve`
+    verb, which is the first approval. The handful about re-firing pass
+    `approved_check` explicitly, and an explicit argument wins over this.
+    """
+    monkeypatch.setattr(relay, "is_approved", lambda issue, **kwargs: False)
+
+
 def item(number: int, ts: str = "1", **reactions: list[str]) -> dict:
     return reply(ts, f"#{number} — [bug][platform] something — https://example.invalid/{number}", **reactions)
 

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -2592,14 +2592,14 @@ class TestApiTransport:
         monkeypatch.setattr(setup.shutil, "which", lambda name: None)
         monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
         monkeypatch.setattr(
-            setup.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, url + "\n", "")
+            setup.transport, "_run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, url + "\n", "")
         )
         assert setup.repo_slug() == "owner/name"
 
     def test_an_unreadable_remote_is_none(self, monkeypatch):
         monkeypatch.setattr(setup.shutil, "which", lambda name: None)
         monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
-        monkeypatch.setattr(setup.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "boom"))
+        monkeypatch.setattr(setup.transport, "_run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "boom"))
         assert setup.repo_slug() is None
 
     # --- the token never leaks ----------------------------------------------
@@ -3991,6 +3991,12 @@ class TestMigrateProposalsApply:
     """The verbs. This is the half that is not allowed to be wrong."""
 
     def _record(self, monkeypatch):
+        """Pin the REST branch explicitly. `TRANSPORT` defaults to `"gh"`, so a test
+        that stubs only `_api` and asserts on the calls does not exercise the path it
+        thinks it does — it exercises the real `gh` CLI. That is not a hypothetical
+        either: it is how `gh issue edit 7 --add-label cowork:queued` and four
+        comments landed on a merged PR and had to be undone by hand."""
+        monkeypatch.setattr(setup, "TRANSPORT", "api")
         monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
         calls: list[tuple[str, str]] = []
 
@@ -4042,6 +4048,53 @@ class TestMigrateProposalsApply:
         calls = self._record(monkeypatch)
         setup._reclassify(7, "platform", repair=True)
         assert [method for method, _ in calls] == ["DELETE"], calls
+
+    def test_it_writes_over_gh_too_not_only_rest(self, monkeypatch):
+        """The read half asks REST on both transports deliberately; the write half
+        had only the REST branch.
+
+        So on a laptop with `gh` logged in and no `GH_TOKEN` exported — the
+        ordinary way a human runs this, and the only way it is *allowed* to be run —
+        all forty-five issues read back fine and every single write failed with "no
+        GH_TOKEN in the environment". The command reported a plan it had not
+        applied.
+        """
+        monkeypatch.setattr(setup, "TRANSPORT", "gh")
+        monkeypatch.setattr(setup.shutil, "which", lambda _: "/usr/bin/gh")
+        calls: list[tuple[str, ...]] = []
+
+        def fake_gh(*args):
+            calls.append(args)
+            return subprocess.CompletedProcess(list(args), 0, "", "")
+
+        monkeypatch.setattr(setup.transport, "gh", fake_gh)
+        ok, _ = setup._reclassify(7, "platform", repair=False)
+        assert ok
+        verbs = [args[1] for args in calls]
+        assert verbs == ["edit", "comment", "edit"], calls
+        assert "--add-label" in calls[0] and "--remove-label" in calls[-1]
+        assert not any("api" in args for args in calls), "the gh branch must not reach for gh api"
+
+    def test_the_gh_branch_adds_before_it_removes(self, monkeypatch):
+        """Same ordering invariant as the REST branch, and for the same reason: a
+        crash between the two leaves both labels on, which every reader resolves as
+        queued. Removing first leaves the issue in neither queue."""
+        monkeypatch.setattr(setup, "TRANSPORT", "gh")
+        monkeypatch.setattr(setup.shutil, "which", lambda _: "/usr/bin/gh")
+        calls: list[tuple[str, ...]] = []
+        monkeypatch.setattr(
+            setup.transport,
+            "gh",
+            lambda *a: (calls.append(a), subprocess.CompletedProcess(list(a), 0, "", ""))[1],
+        )
+        setup._reclassify(7, "platform", repair=False)
+        flags = [
+            flag
+            for args in calls
+            for flag in args
+            if flag.startswith("--add-label") or flag.startswith("--remove-label")
+        ]
+        assert flags == ["--add-label", "--remove-label"], calls
 
     def test_a_strict_run_refuses_to_apply(self):
         """Reclassifying forty issues on a mechanical rule is a judgement about a

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -1269,14 +1269,14 @@ class TestMergeGateCheck:
     def test_the_probe_reports_none_when_the_query_fails(self, monkeypatch):
         monkeypatch.setattr(setup.shutil, "which", lambda name: "/usr/bin/gh")
         monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
-        monkeypatch.setattr(setup.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "boom"))
+        monkeypatch.setattr(setup, "_gh", lambda *a: subprocess.CompletedProcess(a, 1, "", "boom"))
         assert setup.merge_gate_armed() is None
 
     @pytest.mark.parametrize(("stdout", "expected"), [("true", True), ("false", False), ("", False)])
     def test_the_probe_reads_the_jq_answer(self, monkeypatch, stdout, expected):
         monkeypatch.setattr(setup.shutil, "which", lambda name: "/usr/bin/gh")
         monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
-        monkeypatch.setattr(setup.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, stdout, ""))
+        monkeypatch.setattr(setup, "_gh", lambda *a: subprocess.CompletedProcess(a, 0, stdout, ""))
         assert setup.merge_gate_armed() is expected
 
 
@@ -2424,6 +2424,11 @@ class TestApiTransport:
         monkeypatch.setattr(setup, "TRANSPORT", "api")
         monkeypatch.setattr(setup, "repo_slug", lambda: "o/r")
         monkeypatch.setenv("GH_TOKEN", "t")
+        # This fixture *is* "the REST transport is the one that answered", and
+        # `github_ready()` re-resolves that by shelling out to `gh auth status`.
+        # Unstubbed it made a live call on every teardown test — invisible until
+        # `_no_real_gh_calls` started refusing.
+        monkeypatch.setattr(setup, "github_ready", lambda: True)
         return type("Api", (), {"calls": calls, "replies": replies})()
 
     # --- token resolution ----------------------------------------------------

--- a/tests/unit/test_gh_transport.py
+++ b/tests/unit/test_gh_transport.py
@@ -180,7 +180,7 @@ class TestGhCalls:
         def boom(*args, **kwargs):
             raise FileNotFoundError(2, "No such file or directory", "gh")
 
-        monkeypatch.setattr(transport.subprocess, "run", boom)
+        monkeypatch.setattr(transport, "_run", boom)
         result = transport.gh("pr", "list")
         assert result.returncode == 127
         assert "gh" in result.stderr
@@ -192,7 +192,7 @@ class TestGhCalls:
     def test_gh_ready_is_false_when_logged_out(self, monkeypatch):
         monkeypatch.setattr(transport.shutil, "which", lambda name: "/usr/bin/gh")
         monkeypatch.setattr(
-            transport.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "not logged in")
+            transport, "_run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "not logged in")
         )
         assert transport.gh_ready() is False
 
@@ -281,9 +281,7 @@ class TestSlugResolution:
         `cron/cd-deploy.md` runs `git fetch origin main`, so a remote is there
         even though `gh` is not."""
         monkeypatch.setattr(transport.shutil, "which", lambda name: None)
-        monkeypatch.setattr(
-            transport.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, url + "\n", "")
-        )
+        monkeypatch.setattr(transport, "_run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, url + "\n", ""))
         assert transport.resolve_slug() == "owner/name"
 
     @pytest.mark.parametrize(
@@ -304,16 +302,14 @@ class TestSlugResolution:
         test on PR #235 and was right.
         """
         monkeypatch.setattr(transport.shutil, "which", lambda name: None)
-        monkeypatch.setattr(
-            transport.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, url + "\n", "")
-        )
+        monkeypatch.setattr(transport, "_run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, url + "\n", ""))
         assert transport.resolve_slug() is None
 
     def test_a_non_github_remote_is_none(self, monkeypatch):
         monkeypatch.setattr(transport.shutil, "which", lambda name: None)
         monkeypatch.setattr(
-            transport.subprocess,
-            "run",
+            transport,
+            "_run",
             lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "git@gitlab.com:o/n.git\n", ""),
         )
         assert transport.resolve_slug() is None
@@ -328,7 +324,7 @@ class TestSlugResolution:
             calls.append(args)
             return subprocess.CompletedProcess(args[0], 1, "", "no remote")
 
-        monkeypatch.setattr(transport.subprocess, "run", counted)
+        monkeypatch.setattr(transport, "_run", counted)
         assert transport.resolve_slug() is None
         assert transport.resolve_slug() is None
         assert len(calls) == 1

--- a/tests/unit/test_pr_feedback.py
+++ b/tests/unit/test_pr_feedback.py
@@ -1613,7 +1613,7 @@ class TestFetch:
         gh.reply("repo view", "", code=1)
         gh.reply("pr view", "", code=1)
         monkeypatch.setattr(
-            prf.transport.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "no remote")
+            prf.transport, "_run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "no remote")
         )
         assert prf.repo_slug() is None
         assert prf.current_pr() is None

--- a/tests/unit/test_zz_gh_guard.py
+++ b/tests/unit/test_zz_gh_guard.py
@@ -1,0 +1,94 @@
+"""That `_no_real_gh_calls` covers the modules that can actually spawn `gh`.
+
+Named `zz_` so it collects last: the property under test is about which modules
+are loaded and which transport object each one holds, and that is only
+interesting once the rest of the suite has been imported.
+
+This exists because the guard was, for one commit, patching a module object
+nothing called. `scripts/` is not a package and the two loaders disagree about
+who owns the name `_gh_transport`: `cowork_setup` and `cowork_relay` do a plain
+import, binding whatever object exists at their load time, while
+`test_gh_transport.py` builds a fresh module off the file path and assigns it
+over `sys.modules`. Collection is alphabetical, so in a full-suite run the
+registry entry is the fresh object and `cowork_setup` still holds the original.
+
+The guard's own proof passed at the time — run against one file, where the two
+coincide. That is the failure mode this file is here to make impossible: it
+asserts the reach in the multi-module condition, not the single-file one.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+SPAWNERS = ("cowork_setup", "cowork_relay", "pr_feedback", "beta_signoff")
+
+
+def _loaded_transports() -> dict[str, object]:
+    found = {}
+    for name in SPAWNERS:
+        module = sys.modules.get(name)
+        transport = getattr(module, "transport", None) if module is not None else None
+        if transport is not None:
+            found[name] = transport
+    registry = sys.modules.get("_gh_transport")
+    if registry is not None:
+        found["sys.modules"] = registry
+    return found
+
+
+def test_the_suite_really_does_load_more_than_one_transport():
+    """Not an assertion about correctness — about whether this file is testing
+    anything. If the split ever stops happening the tests below become vacuous,
+    and a vacuous guard test is worse than none."""
+    transports = _loaded_transports()
+    if len(transports) < 2:
+        pytest.skip(f"only one transport loaded ({list(transports)}) — run the full suite")
+    distinct = {id(t) for t in transports.values()}
+    assert distinct, "no transport loaded at all"
+
+
+def test_every_loaded_transport_carries_the_guard():
+    """The invariant that was silently false. One unguarded object is one module
+    that can shell out to the real `gh` — and the one that did was `cowork_setup`,
+    the module the incident came from."""
+    unguarded = [name for name, transport in _loaded_transports().items() if "_blocked" not in repr(transport._run)]
+    assert not unguarded, f"these transports can still spawn the real gh: {unguarded}"
+
+
+def test_the_guard_fires_on_a_write_through_cowork_setup(monkeypatch):
+    """End to end through the function that caused the incident: `_reclassify` on
+    the `gh` branch, nothing stubbed, is the exact call that wrote
+    `cowork:queued` and four comments onto merged PR #7."""
+    setup = sys.modules.get("cowork_setup")
+    if setup is None:
+        pytest.skip("cowork_setup not loaded in this selection")
+    monkeypatch.setattr(setup, "TRANSPORT", "gh")
+    monkeypatch.setattr(setup.shutil, "which", lambda _: "/usr/bin/gh")
+    with pytest.raises(BaseException, match="real gh CLI"):
+        setup._reclassify(7, "platform", repair=False)
+
+
+def test_the_guard_fires_on_beta_signoffs_write_path():
+    """`beta_signoff._gh` writes too — `gh issue comment` on the release ask, and
+    `--add-label release:promote`. It had its own `subprocess.run` outside the
+    seam, so the fixture's "no test may shell out to the real gh" was narrower
+    than it read."""
+    signoff = sys.modules.get("beta_signoff")
+    if signoff is None:
+        pytest.skip("beta_signoff not loaded in this selection")
+    with pytest.raises(BaseException, match="real gh CLI"):
+        signoff._gh("issue", "comment", "1", "--body", "x")
+
+
+def test_a_local_git_read_is_not_blocked():
+    """The guard is `gh`-only on purpose. `git remote get-url origin` cannot reach
+    GitHub, and several tests legitimately let it run — blocking it failed seven
+    tests that had done nothing wrong."""
+    transport = sys.modules.get("_gh_transport")
+    if transport is None:
+        pytest.skip("transport not loaded")
+    result = transport._run(["git", "--version"], capture_output=True, text=True, check=False)
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

Two bugs, the second found while fixing the first.

**1. The migration could not write on the transport it read with.**

`_issues_labelled` asks REST on both transports deliberately (routine sessions' egress proxy refuses
GraphQL, so `gh issue list --json` is out). But `_reclassify` had only the REST branch. On a laptop
with `gh` logged in and no `GH_TOKEN` exported — the ordinary way a human runs this, and per the
`--strict` refusal the *only* way it is allowed to be run — all 45 issues read back fine and every
single write failed:

```
[cowork] note: #140 not reclassified: no GH_TOKEN or GITHUB_TOKEN in the environment
[cowork] note: #141 not reclassified: no GH_TOKEN or GITHUB_TOKEN in the environment
… ×36
```

It branches like every other writer in the file now, using `--add-label`/`--remove-label` — never
anything that could replace a label set.

**2. Finding that, the tests wrote to the real repository.**

`TestMigrateProposalsApply` stubbed `_api` and asserted on the calls. That was complete for exactly
as long as `_reclassify` had one branch. The moment it grew a `gh` branch — and `TRANSPORT` defaults
to `"gh"` — those same tests ran real commands against this repo: `gh issue edit 7 --add-label
cowork:queued` plus four `gh issue comment` calls, landing on a PR merged months ago. Undone by hand
(label removed, all four comments deleted, verified zero issues carry the label).

A test that asserts on writes is precisely the test that will *make* them when a seam moves, and
"stub the right seam" is not a property anything checks. So:

- **`_gh_transport` gets `_run`**, its single process seam, with **every** spawn in the file routed
  through it — `gh` and `git` alike, which is what makes replacing one name total. Named rather than
  reusing `subprocess.run` because that object is shared with every other module, which is the trap
  `conftest`'s `_no_real_package_install` already documents for the installer.
- **`_no_real_gh_calls`** blocks it, autouse, for argv starting with `gh`. Local `git remote get-url`
  delegates through: it cannot reach GitHub, and blocking it failed seven tests that had done nothing
  wrong — a guard with that much collateral gets loosened rather than kept. `BaseException`, like its
  sibling, so a broad `except Exception` in code whose contract is to degrade cannot swallow it.

Verified the guard catches the original call: `_reclassify` on the `gh` branch with nothing stubbed
now raises `RealGitHubWriteBlocked: test tried to spawn the real gh CLI: ['gh', 'issue', 'edit', …]`.

## Note on the fallout

Several tests stubbed `transport.subprocess.run` or `setup.subprocess.run` to control the
transport's spawn. Those worked only because both names resolve to the *same shared module object* —
an accidental coupling the `_run` seam correctly breaks. They stub `transport._run` now, which is
what they meant all along.

## Test plan

- `make test` — 11734 passed, 47 skipped · `make lint` clean
- New: `test_it_writes_over_gh_too_not_only_rest` and `test_the_gh_branch_adds_before_it_removes`,
  the latter pinning the same add-before-remove ordering the REST branch already had

🤖 Generated with [Claude Code](https://claude.com/claude-code)