### PR TITLE
close the codeql triage loop: record the accepts, and scope a rejection to the paths it was argued about

### DIFF
--- a/.github/codeql/triage-policy.yml
+++ b/.github/codeql/triage-policy.yml
@@ -35,6 +35,12 @@ auto:
 # as part of recording it — `codeql-triage.yml` may not dismiss one itself, so an
 # entry here without a dismissal leaves the tab reading red on something already
 # settled, which is how a real alert gets lost in the noise.
+#
+# `accepted:` is the scope of that decision — the paths it was made about, and
+# only those. `codeql-triage.yml` suppresses an alert on a listed path and files
+# one on any other path, so answering a rule here retires it where it was argued
+# rather than everywhere it could ever fire. Leave the key off and the rule still
+# proposes: writing down a reason and accepting a location are separate acts.
 propose:
   - id: actions/untrusted-checkout/medium
     why: >-
@@ -53,6 +59,9 @@ propose:
       must resolve to a real refs/tags/beta/X.Y.ZrcN that only publish-beta.yml
       pushes. Any change at either site is a redesign of the release path, not an
       alert fix.
+    accepted:
+      - .github/workflows/auto-version.yml
+      - .github/workflows/publish.yml
   - id: actions/cache-poisoning/poisonable-step
     why: >-
       Decided in #249 — alerts #63 and #64, dismissed as accepted risk once
@@ -67,6 +76,8 @@ propose:
       to PyPI — so it is a decision about both jobs or neither. Revisit by moving
       the rc's test run out of the privileged context, which is a release-path
       redesign rather than an alert fix.
+    accepted:
+      - .github/workflows/publish.yml
 
 # Cap on how many alerts one run may fix. Past this the run fixes the first N,
 # reports the rest by number, and leaves them for the following week — a large

--- a/.github/codeql/triage-policy.yml
+++ b/.github/codeql/triage-policy.yml
@@ -30,15 +30,43 @@ auto:
       host.endswith("." + known)`. See `tools/local_git._known_git_host`.
 
 # Always proposed, with the reason recorded so nobody re-litigates it from
-# scratch each quarter. An entry here is a decision, not a backlog item.
+# scratch each quarter. An entry here is a decision, not a backlog item. When
+# that decision is accept-the-risk, the alerts get dismissed in the Security tab
+# as part of recording it — `codeql-triage.yml` may not dismiss one itself, so an
+# entry here without a dismissal leaves the tab reading red on something already
+# settled, which is how a real alert gets lost in the noise.
 propose:
   - id: actions/untrusted-checkout/medium
     why: >-
-      auto-version.yml checks out the PR head on purpose, and the file already
-      carries the reasoning plus the fine-grained-PAT requirement that bounds
-      it. Removing the checkout breaks the workflow_run chain that Claude
-      Review and Dependabot verify both depend on. Any change here is a
-      redesign of the release path, not an alert fix.
+      Two locations, both deliberate, both decided in #248 — alerts #26 and #65,
+      dismissed as accepted risk once that decision was recorded here.
+      auto-version.yml:60 checks out the PR head on purpose, and the file already
+      carries the reasoning plus the fine-grained-PAT requirement that bounds it.
+      Removing the checkout breaks the workflow_run chain that Claude Review and
+      Dependabot verify both depend on. publish.yml's `test` job checks out
+      `needs.check.outputs.sha` rather than main for the guarantee the whole file
+      exists for — the tested rc and the published final must be the same tree —
+      so the non-constant ref is the feature, not the defect. What bounds it:
+      reaching that job needs both `release:promote` and `release:promotion` on
+      the ask issue (repo write for either), the `<!-- tested: -->` marker is
+      filtered to an authorAssociation of OWNER/MEMBER/COLLABORATOR, and the ref
+      must resolve to a real refs/tags/beta/X.Y.ZrcN that only publish-beta.yml
+      pushes. Any change at either site is a redesign of the release path, not an
+      alert fix.
+  - id: actions/cache-poisoning/poisonable-step
+    why: >-
+      Decided in #249 — alerts #63 and #64, dismissed as accepted risk once
+      recorded here. publish.yml's `test` job runs `make lint` and `make test` out
+      of the same non-constant-ref checkout as the entry above, in the
+      default-branch cache scope, with astral-sh/setup-uv v9 caching on its `auto`
+      default — so the query is describing a real chain, bounded by the same
+      two-label gate and author-association filter. It fails this file's admission
+      test ("can a wrong fix be caught by CI") in both directions: nothing under
+      test exercises the cache scope, and `enable-cache: false` would apply
+      verbatim to the `publish` job's setup-uv, which builds the artifact uploaded
+      to PyPI — so it is a decision about both jobs or neither. Revisit by moving
+      the rc's test run out of the privileged context, which is a release-path
+      redesign rather than an alert fix.
 
 # Cap on how many alerts one run may fix. Past this the run fixes the first N,
 # reports the rest by number, and leaves them for the following week — a large

--- a/.github/workflows/codeql-triage.yml
+++ b/.github/workflows/codeql-triage.yml
@@ -97,67 +97,22 @@ jobs:
           gh api "repos/$REPO/code-scanning/alerts?state=open&per_page=100" \
             --paginate --slurp > alerts-raw.json
 
-          uv run python - <<'PY'
-          import json
-          import os
-          import pathlib
+          # Every cowork-labelled issue, so the classifier can tell a rule
+          # nobody has ruled on from one that was answered — and, since 2026-08,
+          # from one answered about a DIFFERENT file. `--state all` because a
+          # closed issue is still a record; what it is no longer is a reason to
+          # stay quiet. `--label cowork` rather than `cowork:proposal`: that pair
+          # is mutually exclusive with `cowork:queued` (cowork/house-rules.md,
+          # **The queue**), and the narrow label would miss a reclassified issue.
+          gh issue list --label cowork --state all --limit 500 \
+            --json number,title,state > issues-raw.json
 
-          import yaml
-
-          policy = yaml.safe_load(pathlib.Path(".github/codeql/triage-policy.yml").read_text())
-          auto_rules = {e["id"] for e in policy["auto"]}
-          fixes = {e["id"]: e["fix"] for e in policy["auto"]}
-          max_batch = int(policy["max_batch"])
-
-          pages = json.loads(pathlib.Path("alerts-raw.json").read_text() or "[]")
-          alerts = [a for page in pages for a in page]
-
-          # Worst first, so a capped batch keeps the alerts that matter rather
-          # than whichever rule sorts earliest in the alphabet.
-          SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "error": 2, "warning": 3, "note": 4}
-
-          def slim(a):
-              inst = a.get("most_recent_instance") or {}
-              loc = inst.get("location") or {}
-              return {
-                  "number": a["number"],
-                  "rule": a["rule"]["id"],
-                  "severity": a["rule"].get("security_severity_level") or a["rule"].get("severity"),
-                  "path": loc.get("path"),
-                  "line": loc.get("start_line"),
-                  "message": (inst.get("message") or {}).get("text", ""),
-                  "url": a.get("html_url"),
-              }
-
-          auto = [slim(a) for a in alerts if a["rule"]["id"] in auto_rules]
-          propose = [slim(a) for a in alerts if a["rule"]["id"] not in auto_rules]
-
-          auto.sort(key=lambda x: (SEVERITY_ORDER.get(x["severity"], 9), x["rule"], x["path"] or "", x["line"] or 0))
-          dropped = []
-          if len(auto) > max_batch:
-              auto, dropped = auto[:max_batch], auto[max_batch:]
-
-          pathlib.Path("codeql-auto.json").write_text(json.dumps({"fixes": fixes, "alerts": auto}, indent=2))
-          pathlib.Path("codeql-propose.json").write_text(json.dumps(propose, indent=2))
-
-          print(f"open={len(alerts)} auto={len(auto)} propose={len(propose)} dropped={len(dropped)}")
-          for a in auto:
-              print(f"  AUTO    #{a['number']:>4} {a['rule']:<45} {a['path']}:{a['line']}")
-          for a in propose:
-              print(f"  PROPOSE #{a['number']:>4} {a['rule']:<45} {a['path']}:{a['line']}")
-
-          # Never let a cap read as full coverage.
-          if dropped:
-              nums = ", ".join(f"#{a['number']}" for a in dropped)
-              print(f"::warning::Batch capped at {max_batch}. Deferred to next week: {nums}")
-
-          with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as fh:
-              fh.write(f"found={'true' if (auto or propose) else 'false'}\n")
-              fh.write(f"auto_count={len(auto)}\n")
-              fh.write(f"propose_count={len(propose)}\n")
-          if not auto and not propose:
-              print("::notice::No open code-scanning alerts. Nothing to triage.")
-          PY
+          # The classifier is scripts/codeql_triage.py, not a heredoc: it decides
+          # what is already accepted, what is a new location on a decided rule,
+          # and what nobody has dismissed — three comparisons that must be
+          # unit-tested, which a shell heredoc cannot be.
+          uv run python scripts/codeql_triage.py \
+            --alerts alerts-raw.json --issues issues-raw.json
 
           # `--auto` is only a gate if the ruleset actually requires the check we
           # are leaning on. `pr-feedback` is the one carrying DoD item 10 — Claude
@@ -199,8 +154,12 @@ jobs:
             - `codeql-auto.json` — `{"fixes": {<rule id>: <how to fix it>}, "alerts": [...]}`.
               Every alert here is on the auto allowlist in
               `.github/codeql/triage-policy.yml`. Fix ALL of them.
-            - `codeql-propose.json` — alerts whose rules are NOT on that
-              allowlist. File issues, never code.
+            - `codeql-propose.json` — a list of `{"rule", "action",
+              "existing_issue", "alerts"}` groups, one per rule NOT on that
+              allowlist and not already accepted for that path. File issues,
+              never code. Anything absent from both files was suppressed
+              deliberately and reported in the survey log; do not go looking for
+              it.
 
             Read `.github/codeql/triage-policy.yml` first. Its `fix` text for each
             rule is the prescribed remedy — follow it rather than inventing one,
@@ -251,26 +210,38 @@ jobs:
 
             ## The propose lane (for `codeql-propose.json`)
 
-            For each alert, one deduped issue per RULE — not per alert, or a
-            repeated rule floods the queue:
+            Already grouped and already deduped — one entry per rule, each with
+            an `action` the classifier chose and an `existing_issue`. Do NOT
+            re-search the issue list to second-guess it: whether a rule counts as
+            answered is a comparison against `triage-policy.yml`'s `accepted:`
+            paths, and doing it here by eye is what let a rejected rule go quiet
+            at a file nobody had ruled on. Act on the `action`:
 
-            1. `gh issue list --label cowork --search "<rule id>" --state all`.
-               `--state all` so a rule someone already rejected is not re-filed.
-               `--label cowork` rather than `cowork:proposal`: those two are
-               mutually exclusive with `cowork:queued` (`cowork/house-rules.md`,
-               **The queue**), so searching the narrower label would miss a rule
-               whose issue had been reclassified and open a second public issue
-               re-asking a decision `triage-policy.yml` already records. Both
-               labels sit beside `cowork`, so this sees either.
-               If an open issue covers the rule, add a short comment listing this
-               week's alert numbers instead of opening a duplicate.
-            2. Otherwise open `[security][security] codeql: <rule id>` labelled
-               `cowork:proposal`, `workstream:security`, `type:security`, with the
-               affected locations, why it is not auto-fixable, and what a fix
-               would have to decide. If `triage-policy.yml`'s `propose` section
-               already records a `why` for that rule, quote it and do not
-               re-argue it. End with:
-               `Approve by adding the ``claude-implement`` label. Reject by closing this issue.`
+            - `open` — no issue has ever covered this rule. Open
+              `[security][security] codeql: <rule id>` labelled `cowork:proposal`,
+              `workstream:security`, `type:security`, with the affected locations,
+              why it is not auto-fixable, and what a fix would have to decide.
+            - `comment` — `existing_issue` is open and covers the rule. Add a
+              short comment listing this week's alert numbers. Open nothing.
+            - `new-location` — `existing_issue` is CLOSED, so this rule was
+              answered once, but these alerts are at paths its `accepted:` list
+              does not cover. Open a NEW issue titled
+              `[security][security] codeql: <rule id> at <path>`. Name ONLY the
+              new locations, link the closed issue, and quote its decision rather
+              than re-arguing it — the question is whether that reasoning extends
+              here, which is a different question from the one it answered. Say
+              so in one line at the top.
+
+            If `triage-policy.yml`'s `propose` section records a `why` for the
+            rule, quote it and do not re-argue it. End every issue you open with:
+            `Approve by adding the ``claude-implement`` label. Reject by closing this issue.`
+
+            **Closing an issue is not the end of the loop.** A rejection is only
+            recorded once the rule's `accepted:` list in `triage-policy.yml` names
+            the paths it was made about and the alerts themselves are dismissed in
+            the Security tab. Say that in the issue, because you may do neither:
+            the `accepted:` edit is a human's (it is an approval gate in a file),
+            and dismissing an alert is forbidden to you outright.
 
             DISCLOSURE STOP: if an alert describes a path an outside attacker could
             actually exploit in a released version, do NOT open a public issue — a

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ SCRUM.md
 # `git add` of a file listing every open security alert is not a mistake worth
 # leaving available.
 /alerts-raw.json
+/issues-raw.json
 /codeql-auto.json
 /codeql-propose.json
 /bin/

--- a/scripts/codeql_triage.py
+++ b/scripts/codeql_triage.py
@@ -1,0 +1,258 @@
+"""Classify this repo's open code-scanning alerts for `codeql-triage.yml`.
+
+This is the deterministic, zero-token half of the weekly triage job. It reads the
+raw alerts and `.github/codeql/triage-policy.yml` and decides, for every alert,
+which of three lanes it belongs in — and it decides *in Python*, because the one
+thing the model must never do here is fail silently.
+
+It used to live as a heredoc inside the workflow, where nothing could test it.
+It moved out when it grew the two rules below, both of which are exactly the kind
+of comparison `cowork/README.md` insists Python owns rather than a prompt:
+
+**A rejection is scoped to a location, not to a rule.** The propose lane used to
+dedupe on `gh issue list --search "<rule id>" --state all`, so closing one issue
+retired that rule *everywhere*, forever. `actions/untrusted-checkout/medium` was
+answered for `auto-version.yml` and `publish.yml` in #248; under the old key the
+same rule firing on a genuinely unsafe checkout in a workflow that does not exist
+yet would have been swallowed with nothing printed. So the record of what was
+accepted is the `accepted:` path list on a `propose` entry — reviewed, in a file,
+in the diff — and an alert on a decided rule at an *unlisted* path is a finding,
+not a duplicate.
+
+**An accept without a dismissal is reported every week.** `codeql-triage.yml` may
+not dismiss an alert (`cowork/house-rules.md`: closing one by declaring it
+uninteresting is a human's call), so a recorded accept can sit open in the
+Security tab indefinitely — which is how four alerts sat there from 2026-08-12
+looking unexamined when they had been decided the same day. Because the survey
+only ever fetches `state=open`, every alert that lands in the `accepted` lane is
+by definition one nobody dismissed, and each one gets a `::warning::`.
+
+Both rules share a design bias: silence means "nothing found", so anything this
+script declines to act on it says out loud instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+from dataclasses import dataclass, field
+
+import yaml
+
+# Worst first, so a capped batch keeps the alerts that matter rather than
+# whichever rule sorts earliest in the alphabet.
+SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "error": 2, "warning": 3, "note": 4}
+
+# What the model should do with a rule's remaining alerts. Named rather than
+# inferred, so the prompt branches on a value instead of re-deriving the reason.
+ACTION_OPEN = "open"  # no issue has ever covered this rule
+ACTION_COMMENT = "comment"  # an open issue covers it — add this week's numbers
+ACTION_NEW_LOCATION = "new-location"  # a rejected rule, at a path nobody accepted
+
+
+@dataclass(frozen=True)
+class Group:
+    """One rule's proposable alerts, plus what to do about them."""
+
+    rule: str
+    action: str
+    alerts: list[dict]
+    existing_issue: int | None = None
+
+    def as_dict(self) -> dict:
+        return {
+            "rule": self.rule,
+            "action": self.action,
+            "existing_issue": self.existing_issue,
+            "alerts": self.alerts,
+        }
+
+
+@dataclass
+class Classification:
+    auto: list[dict] = field(default_factory=list)
+    accepted: list[dict] = field(default_factory=list)
+    propose: list[dict] = field(default_factory=list)
+    dropped: list[dict] = field(default_factory=list)
+
+
+def slim(alert: dict) -> dict:
+    """Keep only what the prompt needs. The rest is noise in a token budget."""
+    inst = alert.get("most_recent_instance") or {}
+    loc = inst.get("location") or {}
+    return {
+        "number": alert["number"],
+        "rule": alert["rule"]["id"],
+        "severity": alert["rule"].get("security_severity_level") or alert["rule"].get("severity"),
+        "path": loc.get("path"),
+        "line": loc.get("start_line"),
+        "message": (inst.get("message") or {}).get("text", ""),
+        "url": alert.get("html_url"),
+    }
+
+
+def _sort_key(alert: dict) -> tuple:
+    return (SEVERITY_ORDER.get(alert["severity"], 9), alert["rule"], alert["path"] or "", alert["line"] or 0)
+
+
+def accepted_paths(policy: dict) -> dict[str, set[str]]:
+    """rule id -> the paths a human recorded as accepted risk for that rule.
+
+    Absent or empty means "decided nowhere yet": a `propose` entry with no
+    `accepted:` list still proposes, which is what keeps adding the list a
+    deliberate act rather than a side effect of writing down a reason.
+    """
+    return {entry["id"]: set(entry.get("accepted") or ()) for entry in policy.get("propose") or ()}
+
+
+def classify(alerts: list[dict], policy: dict) -> Classification:
+    """Split open alerts into auto-fixable, already-accepted, and proposable."""
+    auto_rules = {entry["id"] for entry in policy["auto"]}
+    accepted = accepted_paths(policy)
+    out = Classification()
+
+    for alert in (slim(a) for a in alerts):
+        if alert["rule"] in auto_rules:
+            out.auto.append(alert)
+        elif alert["path"] in accepted.get(alert["rule"], set()):
+            out.accepted.append(alert)
+        else:
+            out.propose.append(alert)
+
+    out.auto.sort(key=_sort_key)
+    out.accepted.sort(key=_sort_key)
+    out.propose.sort(key=_sort_key)
+
+    max_batch = int(policy["max_batch"])
+    if len(out.auto) > max_batch:
+        out.auto, out.dropped = out.auto[:max_batch], out.auto[max_batch:]
+    return out
+
+
+def _issue_for_rule(rule: str, issues: list[dict]) -> dict | None:
+    """The issue covering a rule, preferring an open one.
+
+    Matched on the title, which `codeql-triage.yml` writes as
+    `[security][security] codeql: <rule id>`. Title rather than body because a
+    body may merely *mention* a rule — a sweep quoting one, another issue linking
+    to it — and a loose match here suppresses a real finding.
+    """
+    hits = [i for i in issues if rule in (i.get("title") or "")]
+    if not hits:
+        return None
+    open_hits = [i for i in hits if (i.get("state") or "").upper() == "OPEN"]
+    pool = open_hits or hits
+    return max(pool, key=lambda i: i["number"])
+
+
+def group_proposals(propose: list[dict], issues: list[dict]) -> list[Group]:
+    """One group per rule, carrying the action the prompt should take.
+
+    Dedup is per rule, as it always was — a repeated rule would otherwise flood
+    the queue. What changed is that a *closed* issue no longer ends the matter:
+    every alert reaching here already survived the `accepted` filter, so a
+    rejected rule turning up again means a location nobody has ruled on.
+    """
+    by_rule: dict[str, list[dict]] = {}
+    for alert in propose:
+        by_rule.setdefault(alert["rule"], []).append(alert)
+
+    groups = []
+    for rule, alerts in by_rule.items():
+        issue = _issue_for_rule(rule, issues)
+        if issue is None:
+            action, number = ACTION_OPEN, None
+        elif (issue.get("state") or "").upper() == "OPEN":
+            action, number = ACTION_COMMENT, issue["number"]
+        else:
+            action, number = ACTION_NEW_LOCATION, issue["number"]
+        groups.append(Group(rule=rule, action=action, alerts=alerts, existing_issue=number))
+
+    groups.sort(key=lambda g: _sort_key(g.alerts[0]))
+    return groups
+
+
+def report(found: Classification, groups: list[Group]) -> list[str]:
+    """Every line the job prints, including the warnings. Returned rather than
+    printed so a test can assert on them."""
+    lines = [
+        f"open={len(found.auto) + len(found.accepted) + len(found.propose) + len(found.dropped)} "
+        f"auto={len(found.auto)} accepted={len(found.accepted)} "
+        f"propose={len(found.propose)} dropped={len(found.dropped)}"
+    ]
+    for a in found.auto:
+        lines.append(f"  AUTO     #{a['number']:>4} {a['rule']:<45} {a['path']}:{a['line']}")
+    for a in found.accepted:
+        lines.append(f"  ACCEPTED #{a['number']:>4} {a['rule']:<45} {a['path']}:{a['line']}")
+    for g in groups:
+        for a in g.alerts:
+            lines.append(f"  PROPOSE  #{a['number']:>4} {a['rule']:<45} {a['path']}:{a['line']} [{g.action}]")
+
+    # An accept is recorded in the policy file; dismissing the alert is a
+    # separate, human-only act. Anything in this lane came back from a
+    # `state=open` query, so it is an accept whose dismissal never happened.
+    for a in found.accepted:
+        lines.append(
+            f"::warning::Alert #{a['number']} ({a['rule']} at {a['path']}) is recorded as accepted "
+            "in .github/codeql/triage-policy.yml but is still open. Dismiss it in the Security tab "
+            "so the tab means what it says; this job may not dismiss it."
+        )
+
+    # The case the old rule-scoped dedup swallowed in silence.
+    for g in groups:
+        if g.action != ACTION_NEW_LOCATION:
+            continue
+        paths = ", ".join(sorted({a["path"] or "?" for a in g.alerts}))
+        lines.append(
+            f"::warning::{g.rule} was answered in #{g.existing_issue}, but is now firing at {paths}, "
+            "which no `accepted:` entry covers. Filing it as new rather than treating it as decided."
+        )
+
+    # Never let a cap read as full coverage.
+    if found.dropped:
+        nums = ", ".join(f"#{a['number']}" for a in found.dropped)
+        lines.append(f"::warning::Batch capped. Deferred to next week: {nums}")
+
+    if not found.auto and not groups:
+        lines.append("::notice::No open code-scanning alerts to act on. Nothing to triage.")
+    return lines
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--alerts", required=True, help="`gh api … --slurp` output: a list of pages")
+    parser.add_argument("--issues", required=True, help="`gh issue list --json number,title,state` output")
+    parser.add_argument("--policy", default=".github/codeql/triage-policy.yml")
+    parser.add_argument("--auto-out", default="codeql-auto.json")
+    parser.add_argument("--propose-out", default="codeql-propose.json")
+    args = parser.parse_args(argv)
+
+    policy = yaml.safe_load(pathlib.Path(args.policy).read_text())
+    pages = json.loads(pathlib.Path(args.alerts).read_text() or "[]")
+    alerts = [a for page in pages for a in page]
+    issues = json.loads(pathlib.Path(args.issues).read_text() or "[]")
+
+    found = classify(alerts, policy)
+    groups = group_proposals(found.propose, issues)
+
+    fixes = {entry["id"]: entry["fix"] for entry in policy["auto"]}
+    pathlib.Path(args.auto_out).write_text(json.dumps({"fixes": fixes, "alerts": found.auto}, indent=2))
+    pathlib.Path(args.propose_out).write_text(json.dumps([g.as_dict() for g in groups], indent=2))
+
+    for line in report(found, groups):
+        print(line)
+
+    if output := os.environ.get("GITHUB_OUTPUT"):
+        with pathlib.Path(output).open("a") as fh:
+            fh.write(f"found={'true' if (found.auto or groups) else 'false'}\n")
+            fh.write(f"auto_count={len(found.auto)}\n")
+            fh.write(f"propose_count={len(found.propose)}\n")
+            fh.write(f"accepted_count={len(found.accepted)}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_codeql_triage.py
+++ b/tests/unit/test_codeql_triage.py
@@ -21,10 +21,15 @@ has carried cannot silently come back one `uses:` line at a time.
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
 import pytest
 import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import codeql_triage  # noqa: E402  — scripts/ is not a package
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
@@ -159,8 +164,31 @@ class TestTriageWorkflow:
         """The job commits, so a stray `git add` must not be able to sweep in a
         file listing every open security alert."""
         ignored = (REPO_ROOT / ".gitignore").read_text()
-        for name in ("alerts-raw.json", "codeql-auto.json", "codeql-propose.json"):
+        for name in ("alerts-raw.json", "issues-raw.json", "codeql-auto.json", "codeql-propose.json"):
             assert f"/{name}" in ignored
+
+    def test_classification_runs_from_the_script_not_a_heredoc(self):
+        """The survey's three comparisons live in `scripts/codeql_triage.py`.
+
+        Inlining them back into the shell step would put the accepted-path check,
+        the new-location check and the undismissed-accept warning somewhere no
+        unit test can reach — and each one's failure mode is a finding that never
+        gets printed, which is precisely what nobody notices.
+        """
+        text = TRIAGE_WORKFLOW.read_text()
+        assert "scripts/codeql_triage.py" in text
+        assert "--alerts alerts-raw.json --issues issues-raw.json" in text, (
+            "the classifier needs the issue list too, or a closed issue cannot be told from no issue"
+        )
+        assert "uv run python - <<" not in text, "the classifier must not move back into an untestable heredoc"
+
+    def test_the_prompt_defers_to_the_classifier_action(self):
+        """A prompt that re-derives "is this rule answered?" by searching issues
+        reintroduces the rule-scoped dedup this change removed."""
+        text = TRIAGE_WORKFLOW.read_text()
+        for action in (codeql_triage.ACTION_OPEN, codeql_triage.ACTION_COMMENT, codeql_triage.ACTION_NEW_LOCATION):
+            assert f"`{action}`" in text, f"the prompt must say what to do on action={action}"
+        assert "--state all`. " not in text, "the old rule-scoped dedup instruction must be gone"
 
 
 class TestCodeqlConfig:
@@ -178,6 +206,190 @@ class TestCodeqlConfig:
         none was a vulnerability; ruff-bandit still covers tests/ via
         `make security`."""
         assert "tests/**" in yaml.safe_load(CONFIG.read_text())["paths-ignore"]
+
+
+class TestAcceptedPaths:
+    """`accepted:` scopes a rejection to the locations it was argued about.
+
+    Before it existed, the propose lane deduped on the rule id alone against
+    `--state all`, so closing one issue retired that rule at every file forever.
+    The list is the fix, and it is only worth anything while it stays true.
+    """
+
+    def test_accepted_is_only_ever_a_list_of_repo_paths(self):
+        for entry in _policy()["propose"]:
+            for path in entry.get("accepted") or ():
+                assert not path.startswith("/") and ".." not in path, f"{path} is not a repo-relative path"
+
+    def test_every_accepted_path_still_exists(self):
+        """A renamed or deleted file leaves an accept pointing at nothing.
+
+        That is worse than no accept: the rule keeps firing at the new path and
+        the stale entry makes the policy read as though somebody looked.
+        """
+        for entry in _policy()["propose"]:
+            for path in entry.get("accepted") or ():
+                assert (REPO_ROOT / path).exists(), (
+                    f"{entry['id']} accepts {path}, which no longer exists — re-point the entry "
+                    "at the file that replaced it, or drop it so the rule proposes again"
+                )
+
+    def test_auto_rules_cannot_carry_accepted(self):
+        """The two lanes answer different questions. A rule that is auto-fixed is
+        never accepted at a path; conflating them would silently stop a fix."""
+        for entry in _policy()["auto"]:
+            assert "accepted" not in entry, f"{entry['id']} is auto-fixed — `accepted:` has no meaning there"
+
+
+class TestClassifier:
+    """`scripts/codeql_triage.py` — the comparisons the prompt must not make."""
+
+    POLICY = {
+        "auto": [{"id": "actions/unpinned-tag", "fix": "pin it"}],
+        "propose": [
+            {"id": "actions/untrusted-checkout/medium", "why": "decided", "accepted": ["a.yml"]},
+            {"id": "py/some-rule", "why": "decided nowhere yet"},
+        ],
+        "max_batch": 2,
+    }
+
+    @staticmethod
+    def _alert(number: int, rule: str, path: str, severity: str = "medium") -> dict:
+        return {
+            "number": number,
+            "rule": {"id": rule, "security_severity_level": severity},
+            "html_url": f"https://example.invalid/{number}",
+            "most_recent_instance": {
+                "location": {"path": path, "start_line": 1},
+                "message": {"text": "msg"},
+            },
+        }
+
+    def test_auto_accepted_and_propose_are_three_distinct_lanes(self):
+        found = codeql_triage.classify(
+            [
+                self._alert(1, "actions/unpinned-tag", "w.yml"),
+                self._alert(2, "actions/untrusted-checkout/medium", "a.yml"),
+                self._alert(3, "actions/untrusted-checkout/medium", "b.yml"),
+            ],
+            self.POLICY,
+        )
+        assert [a["number"] for a in found.auto] == [1]
+        assert [a["number"] for a in found.accepted] == [2]
+        assert [a["number"] for a in found.propose] == [3], (
+            "b.yml is not on the rule's accepted list, so the decision about a.yml does not cover it"
+        )
+
+    def test_a_propose_entry_without_accepted_suppresses_nothing(self):
+        """Writing down a reason and accepting a location are separate acts."""
+        found = codeql_triage.classify([self._alert(9, "py/some-rule", "x.py")], self.POLICY)
+        assert not found.accepted and [a["number"] for a in found.propose] == [9]
+
+    def test_batch_cap_defers_rather_than_drops(self):
+        found = codeql_triage.classify(
+            [self._alert(n, "actions/unpinned-tag", f"w{n}.yml") for n in range(1, 5)], self.POLICY
+        )
+        assert len(found.auto) == 2 and len(found.dropped) == 2
+        assert any("Deferred to next week" in line for line in codeql_triage.report(found, []))
+
+    def test_worst_severity_survives_the_cap(self):
+        found = codeql_triage.classify(
+            [
+                self._alert(1, "actions/unpinned-tag", "a.yml", "low"),
+                self._alert(2, "actions/unpinned-tag", "b.yml", "critical"),
+                self._alert(3, "actions/unpinned-tag", "c.yml", "high"),
+            ],
+            self.POLICY,
+        )
+        assert [a["number"] for a in found.auto] == [2, 3]
+
+
+class TestProposalGrouping:
+    """A closed issue is a record, not a reason to stay quiet."""
+
+    @staticmethod
+    def _slim(number: int, rule: str, path: str) -> dict:
+        return {"number": number, "rule": rule, "severity": "medium", "path": path, "line": 1, "message": "", "url": ""}
+
+    def test_a_rule_nobody_has_filed_opens_an_issue(self):
+        groups = codeql_triage.group_proposals([self._slim(1, "r/one", "a.yml")], [])
+        assert groups[0].action == codeql_triage.ACTION_OPEN and groups[0].existing_issue is None
+
+    def test_an_open_issue_gets_a_comment_not_a_duplicate(self):
+        issues = [{"number": 7, "title": "[security][security] codeql: r/one", "state": "OPEN"}]
+        groups = codeql_triage.group_proposals([self._slim(1, "r/one", "a.yml")], issues)
+        assert groups[0].action == codeql_triage.ACTION_COMMENT and groups[0].existing_issue == 7
+
+    def test_a_closed_issue_no_longer_silences_a_new_location(self):
+        """The regression this whole change exists for.
+
+        #248 answered `actions/untrusted-checkout/medium` for two workflows and
+        was closed. Under the old rule-scoped `--state all` dedup the same rule
+        firing on a third file was treated as a duplicate and never surfaced.
+        """
+        issues = [{"number": 248, "title": "[security][security] codeql: r/one", "state": "CLOSED"}]
+        groups = codeql_triage.group_proposals([self._slim(1, "r/one", "brand-new.yml")], issues)
+        assert groups[0].action == codeql_triage.ACTION_NEW_LOCATION
+        assert groups[0].existing_issue == 248
+
+    def test_one_group_per_rule_so_a_repeated_rule_cannot_flood_the_queue(self):
+        alerts = [self._slim(1, "r/one", "a.yml"), self._slim(2, "r/one", "b.yml"), self._slim(3, "r/two", "c.yml")]
+        groups = codeql_triage.group_proposals(alerts, [])
+        assert len(groups) == 2
+        assert sorted(len(g.alerts) for g in groups) == [1, 2]
+
+    def test_a_title_match_is_required_rather_than_a_body_mention(self):
+        """A loose match against prose suppresses a real finding."""
+        issues = [{"number": 5, "title": "some sweep find", "state": "CLOSED", "body": "mentions r/one"}]
+        groups = codeql_triage.group_proposals([self._slim(1, "r/one", "a.yml")], issues)
+        assert groups[0].action == codeql_triage.ACTION_OPEN
+
+
+class TestSurveyReport:
+    """Silence means "nothing found", so every suppression says so out loud."""
+
+    def test_an_accepted_alert_still_open_is_warned_about_every_run(self):
+        """The survey only fetches `state=open`, so reaching this lane at all
+        means the accept was recorded and the alert never dismissed — the exact
+        state four alerts sat in from 2026-08-12 with nothing reporting it."""
+        found = codeql_triage.Classification(
+            accepted=[{"number": 26, "rule": "r/one", "path": "a.yml", "line": 1, "severity": "medium"}]
+        )
+        warnings = [line for line in codeql_triage.report(found, []) if line.startswith("::warning::")]
+        assert len(warnings) == 1
+        assert "#26" in warnings[0] and "Dismiss it in the Security tab" in warnings[0]
+
+    def test_a_new_location_on_a_decided_rule_is_warned_about(self):
+        group = codeql_triage.Group(
+            rule="r/one",
+            action=codeql_triage.ACTION_NEW_LOCATION,
+            existing_issue=248,
+            alerts=[{"number": 9, "rule": "r/one", "path": "new.yml", "line": 1, "severity": "high"}],
+        )
+        warnings = [
+            line for line in codeql_triage.report(codeql_triage.Classification(), [group]) if "::warning::" in line
+        ]
+        assert len(warnings) == 1 and "#248" in warnings[0] and "new.yml" in warnings[0]
+
+    def test_nothing_to_do_is_a_notice_not_a_silence(self):
+        lines = codeql_triage.report(codeql_triage.Classification(), [])
+        assert any(line.startswith("::notice::") for line in lines)
+
+    def test_accepted_alone_does_not_wake_claude(self):
+        """A run whose only finding is an undismissed accept has no code to
+        write and no issue to file. It reports and stops."""
+        found = codeql_triage.classify(
+            [
+                {
+                    "number": 26,
+                    "rule": {"id": "actions/untrusted-checkout/medium", "security_severity_level": "medium"},
+                    "most_recent_instance": {"location": {"path": "a.yml", "start_line": 1}},
+                }
+            ],
+            TestClassifier.POLICY,
+        )
+        assert found.accepted and not found.auto
+        assert not codeql_triage.group_proposals(found.propose, [])
 
 
 class TestActionsArePinned:

--- a/tests/unit/test_cowork_setup.py
+++ b/tests/unit/test_cowork_setup.py
@@ -3922,11 +3922,18 @@ class TestMigrateProposals:
         step 4 reclassifies in place on every run, and a carve-out that exists in
         one and not the other is a hole that opens a week later rather than never.
 
-        `codeql-triage.yml` dedupes by searching for the rule id, and once its
-        issue carries `cowork:queued` that search does not find it: next week's run
-        opens a second **public** issue re-asking a decision `triage-policy.yml`
-        already records. This is the one consumer for which the two labels being
-        mutually exclusive is a hazard rather than a convenience.
+        `codeql-triage.yml` dedupes per rule against the issues it fetches, and
+        once an issue carries `cowork:queued` a narrower label does not return it:
+        next week's run opens a second **public** issue re-asking a decision
+        `triage-policy.yml` already records. This is the one consumer for which
+        the two labels being mutually exclusive is a hazard rather than a
+        convenience.
+
+        The matching itself moved into `scripts/codeql_triage.py` when a
+        rejection stopped being rule-scoped, so what is asserted here is the
+        *fetch*: the broad label, and every state. Getting either wrong puts the
+        issue outside the classifier's reach, where no test of the classifier can
+        see the gap.
         """
         sweep = (setup.COWORK / "sweep-procedure.md").read_text(encoding="utf-8")
         rules = (setup.COWORK / "house-rules.md").read_text(encoding="utf-8")
@@ -3934,8 +3941,9 @@ class TestMigrateProposals:
         assert "codeql" in rules.lower()
         workflow = setup.REPO_ROOT / ".github" / "workflows" / "codeql-triage.yml"
         dedupe = workflow.read_text(encoding="utf-8")
-        assert "--label cowork --search" in dedupe, (
-            "the workflow still dedupes on cowork:proposal alone, which a reclassified issue escapes"
+        assert "gh issue list --label cowork --state all" in dedupe, (
+            "the workflow must fetch by the broad `cowork` label and every state — narrowing to "
+            "`cowork:proposal` loses a reclassified issue, and dropping `--state all` loses a decided one"
         )
 
     def test_a_codeql_proposal_is_held(self):


### PR DESCRIPTION
Four CodeQL alerts sat open in the Security tab looking unexamined. They had been
decided on 2026-08-12 the same day they appeared — `codeql-triage.yml` filed #248
(`actions/untrusted-checkout/medium`) and #249 (`actions/cache-poisoning/poisonable-step`),
both closed `NOT_PLANNED` as accept-the-risk. Pulling on that turned up a second, larger
problem behind it.

## 1. The decisions were never recorded, and the alerts never dismissed

Both issue bodies said the outcome belonged in `triage-policy.yml` (#248 item 3, #249 item 4).
It never landed: the `untrusted-checkout` `why` argued `auto-version.yml` only — #248 itself
flags `publish.yml` as *"not in scope when the `why` above was written"* — and
`cache-poisoning/poisonable-step` was on neither list. And nothing dismissed the alerts,
because `codeql-triage.yml` may not (*"closing an alert by declaring it uninteresting is not
[its business]"*) and no human did.

Both `why` blocks are now written, naming their deciding issue and alert numbers. Alerts 26,
63, 64 and 65 are dismissed as `won't fix` with comments pointing here;
`code-scanning/alerts?state=open` returns nothing.

## 2. Closing an issue retired its rule *everywhere*, permanently

The propose lane deduped on `gh issue list --search "<rule id>" --state all` — keyed on the
rule, not the location. So closing #248 meant `actions/untrusted-checkout/medium` firing on a
genuinely unsafe checkout in a workflow that does not exist yet would have been dropped as a
duplicate, with nothing printed. A selector's failure mode is silence, and this one had no
floor under it.

- **`accepted:`** on a `propose` entry lists the paths the decision was made about. An alert
  on a listed path is suppressed; one anywhere else is filed as `new-location` against the
  closed issue, quoting its reasoning rather than re-arguing it — because whether that
  reasoning *extends* is a different question from the one it answered. Leaving the key off
  still proposes: recording a reason and accepting a location are separate acts.
- **An accept without a dismissal is now reported every week.** The survey only ever fetches
  `state=open`, so anything reaching the accepted lane is by definition undismissed. Each gets
  a `::warning::`. That is precisely the state the four alerts sat in with nothing watching.

Replaying the real 2026-08-12 alert set plus one hypothetical new location:

```
open=4 auto=0 accepted=3 propose=1 dropped=0
  ACCEPTED #  64 actions/cache-poisoning/poisonable-step   .github/workflows/publish.yml:381
  ACCEPTED #  26 actions/untrusted-checkout/medium         .github/workflows/auto-version.yml:60
  ACCEPTED #  65 actions/untrusted-checkout/medium         .github/workflows/publish.yml:372
  PROPOSE  #  99 actions/untrusted-checkout/medium         .github/workflows/brand-new.yml:12 [new-location]
::warning::Alert #64 … is recorded as accepted … but is still open. Dismiss it in the Security tab
::warning::Alert #26 … ::warning::Alert #65 …
::warning::actions/untrusted-checkout/medium was answered in #248, but is now firing at
           .github/workflows/brand-new.yml, which no `accepted:` entry covers.
```

The old code printed nothing for any of those four.

## Why the classifier moved out of the workflow

It was a heredoc inside the YAML, where no test could reach it. The three comparisons it now
makes each fail by *not printing something*, which is the one failure mode nothing notices, so
they belong in `scripts/codeql_triage.py` alongside `pr_feedback.py` and `release_lane.py` —
`cowork/README.md`'s "Python owns every comparison" applies exactly here. The prompt branches
on the `action` the classifier chose instead of re-deriving "is this rule answered?" by
searching issues, which is the re-derivation this change removes.

## Files

- `scripts/codeql_triage.py` — new; `classify` / `group_proposals` / `report`
- `.github/codeql/triage-policy.yml` — both `why` blocks, both `accepted:` lists, and what the new key means
- `.github/workflows/codeql-triage.yml` — heredoc → script call, `gh issue list` fetch, rewritten propose lane
- `tests/unit/test_codeql_triage.py` — 18 new tests over the classifier, the policy shape, and the wiring
- `tests/unit/test_cowork_setup.py` — the carve-out guard follows the mechanism; the invariant (broad `cowork` label, every state) is unchanged

`make test-fast` (12,781 tests), `make lint`, `make cowork-check` all pass locally. Integration
and contract lanes run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)