### PR TITLE
record the trigger ids for day-ahead and retune

### DIFF
--- a/cowork/README.md
+++ b/cowork/README.md
@@ -234,7 +234,7 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 
 | Routine | Trigger | Workstream | Tier | URL |
 |---|---|---|---|---|
-| `cron/day-ahead.md` | `45 5 * * *` daily | — | `fast` | — |
+| `cron/day-ahead.md` | `45 5 * * *` daily | — | `fast` | https://claude.ai/code/routines/trig_01EPy41L2yD7YLKzuRXVfxw1 |
 | `cron/integrations-campaign.md` | `20 7 * * 1-5` weekdays | integrations | `deep` | https://claude.ai/code/routines/trig_019w6RJqz8aWJ13TkXmPUgtX |
 | `cron/agents-standup.md` | `15 6 * * 1-5` weekdays | agents | `fast` | https://claude.ai/code/routines/trig_013tsooGjdnEMLRQcm7ZKU57 |
 | `cron/shipped-standup.md` | `0 18 * * *` daily | — | `standard` | https://claude.ai/code/routines/trig_0118jEhPuaKrCaUWCYQtVgEv |
@@ -242,7 +242,7 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 | `cron/slack-relay.md` | `0 7-23 * * *` hourly | — | `fast` | https://claude.ai/code/routines/trig_01X18LBBBZ1FWEtx2Cmffyow |
 | `cron/release-promote-ask.md` | `0 9 * * 1` Mon | — | `fast` | https://claude.ai/code/routines/trig_01G4TuU1wYY7GXJ1cEXZUNSu |
 | `cron/cd-deploy.md` | `0 4 * * *` daily + push (any branch) | — | `standard` | https://claude.ai/code/routines/trig_01AkW6ojpjKcra8H64R3Astr |
-| `cron/retune.md` | `0 8 * * 0` Sun | fleet | `standard` | — |
+| `cron/retune.md` | `0 8 * * 0` Sun | fleet | `standard` | https://claude.ai/code/routines/trig_01KYYfRyy1kKCYXq8EFn6ac6 |
 | `events/pr-opened-dod-audit.md` | PR opened / synchronized | — | `standard` | https://claude.ai/code/routines/trig_01Egz2NXy4GwzJzRRC7Z4Zm3 |
 | `events/pr-merged-close-loop.md` | PR closed (merged) | — | `fast` | https://claude.ai/code/routines/trig_019gLyX5qWx7g5rXZkUKaDAo |
 | `events/release-published-announce.md` | Release published | — | `standard` | https://claude.ai/code/routines/trig_01VXdR2FbPJUsMqVWghA7C5T |


### PR DESCRIPTION
## Summary

Two cells in `cowork/README.md`'s URL column, written by `scripts/cowork_setup.py --urls` after today's `/cowork deploy` registered the two routines that had no id yet:

| routine | trigger |
|---|---|
| `cron/day-ahead.md` | `trig_01EPy41L2yD7YLKzuRXVfxw1` |
| `cron/retune.md` | `trig_01KYYfRyy1kKCYXq8EFn6ac6` |

That column is the ledger a deploy reads to decide whether a routine already exists — a create is blocked unless the README records no id for it, which is what stops a partial page read from registering a second copy of a routine already firing. Without these two cells the next deploy would try to create both again, and the routines API has no delete.

`retune` is the fleet's sixteenth workstream, merged in #265. `day-ahead` was already on `main` but had never been registered.

## Test plan

- `make cowork-check` — the doctor that fails when the README table, a routine file and the tier table disagree.
- Read back from the API: both routines exist, `enabled: true`, `next_run_at` 2026-08-16 05:45 UTC and 2026-08-16 08:04 UTC respectively.
- Re-running the deploy plan against a snapshot including both now reports `create: 0`.

## Definition of Done

- **Items 2–7** — no code change; the diff is two table cells. No tests, capability, bundle or observability implication.
- **Item 1 (Linear)** — this is the mechanical record of a deploy, not tracked work; the deploy itself was part of YEA-97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)