### PR TITLE
record the go-migration routine urls from the first deploy

### DIFF
--- a/cowork/README.md
+++ b/cowork/README.md
@@ -245,12 +245,12 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 | `cron/release-promote-ask.md` | `0 9 * * 1` Mon | — | `fast` | https://claude.ai/code/routines/trig_01G4TuU1wYY7GXJ1cEXZUNSu |
 | `cron/cd-deploy.md` | `0 4 * * *` daily + push (any branch) | — | `standard` | https://claude.ai/code/routines/trig_01AkW6ojpjKcra8H64R3Astr |
 | `cron/retune.md` | `0 8 * * 0` Sun | fleet | `standard` | https://claude.ai/code/routines/trig_01KYYfRyy1kKCYXq8EFn6ac6 |
-| `cron/go-migration-campaign.md` | `40 7 * * 1-5` weekdays | go-migration | `heavy` | |
-| `cron/go-migration-progress.md` | `30 8 * * 2` Tue | go-migration | `fast` | |
+| `cron/go-migration-campaign.md` | `40 7 * * 1-5` weekdays | go-migration | `heavy` | https://claude.ai/code/routines/trig_01M9VRz8rvNTusXLuxBwzwSB |
+| `cron/go-migration-progress.md` | `30 8 * * 2` Tue | go-migration | `fast` | https://claude.ai/code/routines/trig_01A9NbWuCDoS137MH3u3scsn |
 | `events/pr-opened-dod-audit.md` | PR opened / synchronized | — | `standard` | https://claude.ai/code/routines/trig_01Egz2NXy4GwzJzRRC7Z4Zm3 |
 | `events/pr-merged-close-loop.md` | PR closed (merged) | — | `fast` | https://claude.ai/code/routines/trig_019gLyX5qWx7g5rXZkUKaDAo |
 | `events/release-published-announce.md` | Release published | — | `standard` | https://claude.ai/code/routines/trig_01VXdR2FbPJUsMqVWghA7C5T |
-| `events/go-migration-wave-merged.md` | PR closed (merged wave) | go-migration | `fast` | |
+| `events/go-migration-wave-merged.md` | PR closed (merged wave) | go-migration | `fast` | https://claude.ai/code/routines/trig_0158sWhFEhPhZy28nfMFu3iK |
 
 > **Cron trap.** The fortnightly and monthly slots restrict **day-of-month only**. Standard cron
 > *ORs* day-of-month with day-of-week when both are restricted, so `30 7 1-7,15-21 * 2` fires every


### PR DESCRIPTION
## Summary
/cowork deploy registered the three go-migration routines and wired the wave-merged webhook; this records their claude.ai URLs in the README's registered-routines table — written by `scripts/cowork_setup.py --urls`, never by hand.

## Test plan
- `make cowork-check` clean on the repo half (table ↔ file ↔ tier agreement unchanged; only URL cells filled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)