### PR TITLE
prior art: batch multi-select carousel replaces the per-repo loop

### DIFF
--- a/docs/docs/scrum-standards.html
+++ b/docs/docs/scrum-standards.html
@@ -165,14 +165,14 @@ gtag('config','G-K9HLPT5ZMP',{client_storage:'none',ads_data_redaction:true});
       </ul>
 
       <h3 id="prior-art">Prior Art (greenfield only)</h3>
-      <p>A greenfield project is rarely built from nothing — the team usually already owns the auth service, the deployment pattern, the design system. When Q2 is answered <strong>greenfield</strong>, the agent inserts one more step between the PTO questions and the intake summary: it ranks the team's own repositories against everything gathered so far and asks about each shortlisted one, with a concrete pitch rather than a bare name.</p>
+      <p>A greenfield project is rarely built from nothing — the team usually already owns the auth service, the deployment pattern, the design system. When Q2 is answered <strong>greenfield</strong>, the agent inserts one more step between the PTO questions and the intake summary: it ranks the team's own repositories against everything gathered so far and offers the whole shortlist at once, each with a concrete pitch rather than a bare name — browse the list and tick the relevant ones in a single answer.</p>
       <ul>
         <li><strong>The repositories come from Team Analysis</strong>, which walks GitHub and Azure DevOps each run and now persists that inventory. Planning reads it offline; a profile captured before this existed says so rather than going quiet.</li>
         <li><strong>Ranking is deterministic</strong> — stack overlap, keyword overlap against Q1/Q3/Q4, recency — and only the top five are enriched with live API calls, so an estate of hundreds costs five reads rather than hundreds.</li>
         <li><strong>The model may only subtract.</strong> It writes the pitch bullets and may drop a candidate it judges irrelevant; it is never given a shape in which to nominate a repository that did not rank.</li>
         <li><strong>Accepted repositories</strong> feed plan generation and appear in the intake summary and every export.</li>
-        <li><strong>Rejections are remembered globally, with the reason</strong>, and that repository is never offered again on any project. The memory is suppress-only: it can remove a candidate, never add one.</li>
-        <li>Candidates are asked about one at a time, and answering is what brings up the next. "Skip the rest" ends the step without recording a verdict on what is left.</li>
+        <li><strong>Leaving a repository unticked is a pass for this project only</strong> — nothing is recorded, and it may be offered again next time. Banning one (the <strong>X</strong> key in the TUI, or a <code>!N</code> token in a typed answer) is the explicit, permanent verdict: that repository is never offered again on any project. The memory is suppress-only: it can remove a candidate, never add one.</li>
+        <li>All candidates appear in one batch, in the TUI as a browsable multi-select (the detail card follows the highlighted row) and on text surfaces as a numbered list answered with the same grammar everywhere: the relevant numbers (<code>1 3</code>), <code>all</code>, or <code>none</code>, with <code>!N</code> to ban.</li>
       </ul>
 
       <h3 id="adaptive-behavior">Adaptive Behavior</h3>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.15.0"
+version = "3.16.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/agent/headless.py
+++ b/src/yeaboi/agent/headless.py
@@ -141,14 +141,16 @@ def _next_auto_input(graph_state: dict) -> str | None:
 
     if isinstance(qs, QuestionnaireState) and qs.awaiting_confirmation:
         # Prior-art sub-loop — the intake is asking which existing repositories
-        # are relevant. Headless has nobody to ask, so it bails out of the whole
-        # list ("3") rather than answering for the user: accepting on their
-        # behalf would put repositories into a plan nobody vetted, and rejecting
-        # would write verdicts to a ledger that suppresses them forever. Callers
+        # are relevant. Headless has nobody to ask, so it answers "none":
+        # accepting on the user's behalf would put repositories into a plan
+        # nobody vetted, and "none" writes nothing to the ledger — an unpicked
+        # batch is passed over for this run only, never suppressed. Callers
         # that DO know pass them in via run_planning_pipeline(prior_art=...).
+        # A legacy "reason" stage (resumed old session) gets "none" too: the
+        # node re-asks the batch on that input and the next pass answers it.
         if qs._prior_art_stage in ("ask", "reason"):
             logger.info("Headless: skipping the prior-art step (no user to ask)")
-            return "3" if qs._prior_art_stage == "ask" else ""
+            return "none"
 
         # Intake summary shown — confirm it. Skipped/defaulted questions were
         # already resolved by build_questionnaire_from_answers().

--- a/src/yeaboi/agent/nodes.py
+++ b/src/yeaboi/agent/nodes.py
@@ -3929,9 +3929,13 @@ def _show_summary_or_pto(questionnaire: QuestionnaireState, prefix: str = "") ->
 # ---------------------------------------------------------------------------
 # See docs: "Project Intake Questionnaire" — prior art
 
-_PRIOR_ART_ACCEPT = "Yes, relevant"
-_PRIOR_ART_REJECT = "Not relevant"
-_PRIOR_ART_SKIP = "Skip the rest"
+# The one grammar every surface answers in — the chat widget submits it, and
+# REPL / form / headless / typed-chat users type it against the numbered list
+# the prompt shows. Documented in _prior_art_prompt and _PRIOR_ART_GRAMMAR_HINT.
+_PRIOR_ART_GRAMMAR_HINT = (
+    'Reply with the numbers that are relevant (e.g. "1 3"), "all", or "none". '
+    'Prefix ! to never suggest a repo again (e.g. "1 !2").'
+)
 
 
 def _prior_art_applies(questionnaire: QuestionnaireState) -> bool:
@@ -3944,7 +3948,7 @@ def _prior_art_applies(questionnaire: QuestionnaireState) -> bool:
 def _start_prior_art(questionnaire: QuestionnaireState) -> str | None:
     """Run the scan and open the sub-loop. None means "nothing to ask".
 
-    Returns the first candidate's prompt when there is a shortlist. When there
+    Returns the one batch prompt when there is a shortlist. When there
     is not, the stage is closed out and the reason recorded so the card can say
     which of "no profile" / "profile too old" / "nothing matched" happened —
     going quiet would leave the user unable to tell a gap from a verdict.
@@ -4003,65 +4007,76 @@ def _accepted_prior_art(questionnaire: QuestionnaireState) -> tuple:
     return tuple(refs)
 
 
-def _prior_art_current(questionnaire: QuestionnaireState) -> dict | None:
-    """The candidate currently on screen, or None when the list is exhausted."""
-    index = questionnaire._prior_art_index
-    candidates = questionnaire._prior_art_candidates
-    return candidates[index] if 0 <= index < len(candidates) else None
-
-
 def _prior_art_prompt(questionnaire: QuestionnaireState) -> str:
-    """The question for the current candidate, pitch and all."""
-    candidate = _prior_art_current(questionnaire)
-    if candidate is None:
+    """The one batch question listing every shortlisted repository.
+
+    All candidates appear numbered with condensed pitches, because this same
+    markdown is the whole interface on the text surfaces (REPL, form intake,
+    typed chat) — the answer grammar it documents is what
+    _parse_prior_art_answer accepts, so nothing depends on the chat widget.
+    """
+    candidates = questionnaire._prior_art_candidates
+    if not candidates:
         return ""
-    total = len(questionnaire._prior_art_candidates)
-    position = questionnaire._prior_art_index + 1
+    plural = "repository" if len(candidates) == 1 else "repositories"
     lines = [
-        f"**Prior art {position} of {total}** — you already have **{candidate.get('name', '')}**.",
+        f"**Prior art** — you already have {len(candidates)} {plural} that might be relevant.",
         "",
     ]
-    for bullet in candidate.get("pitch") or ():
-        lines.append(f"- {bullet}")
-    stack = candidate.get("stack") or candidate.get("languages") or ()
-    if stack:
-        lines.append("")
-        lines.append(f"_{', '.join(stack)}_")
-    lines += [
-        "",
-        "Is it relevant to this project?",
-        "",
-        f"[1] {_PRIOR_ART_ACCEPT}",
-        f"[2] {_PRIOR_ART_REJECT}",
-        f"[3] {_PRIOR_ART_SKIP}",
-    ]
-    # Say that answering is what reaches the rest. The candidates are asked
-    # about one at a time on every surface, so "1 of 3" on its own reads as a
-    # pager offering no way to reach 2 and 3.
-    remaining = total - position
-    if remaining:
-        lines += ["", f"_Answering brings up the next — {remaining} more after this._"]
+    for position, candidate in enumerate(candidates, start=1):
+        stack = candidate.get("stack") or candidate.get("languages") or ()
+        title = f"**{position}. {candidate.get('name', '')}**"
+        if stack:
+            title += f" _({', '.join(stack)})_"
+        lines.append(title)
+        for bullet in (candidate.get("pitch") or ())[:2]:
+            lines.append(f"   - {bullet}")
+    lines += ["", _PRIOR_ART_GRAMMAR_HINT]
     return "\n".join(lines)
 
 
-def _prior_art_advance(questionnaire: QuestionnaireState) -> dict:
-    """Move to the next candidate, or finish the sub-loop.
+def _parse_prior_art_answer(text: str, count: int) -> tuple[set[int], set[int]] | None:
+    """Parse a batch verdict into 0-based (relevant, banned) index sets.
 
-    Finishing writes the rejections to the global ledger and hands back to the
-    funnel, which shows the summary the accepted references now appear in.
+    Grammar (case-insensitive, tokens split on commas/whitespace):
+      - ``N``            → relevant (1-based against the prompt's numbering)
+      - ``!N``           → banned — never suggest again (permanent ledger write)
+      - ``all``          → every candidate relevant
+      - ``none``/``skip``/empty → nothing relevant, nothing banned
+    A ban wins over a select of the same index. Any out-of-range digit or
+    unrecognised token returns None so the caller can re-prompt — silently
+    dropping half an answer would record a verdict the user never gave.
     """
-    questionnaire._prior_art_index += 1
-    questionnaire._prior_art_stage = "ask"
-    if _prior_art_current(questionnaire) is not None:
-        return {
-            "questionnaire": questionnaire,
-            "messages": [AIMessage(content=_prior_art_prompt(questionnaire))],
-        }
-    return _finish_prior_art(questionnaire)
+    words = [w for w in re.split(r"[,\s]+", text.strip().lower()) if w]
+    relevant: set[int] = set()
+    banned: set[int] = set()
+    for word in words:
+        if word in ("none", "skip"):
+            # An explicit "nothing" — inert beside other tokens rather than an
+            # error, so "none" typed after second thoughts still parses.
+            continue
+        if word == "all":
+            relevant.update(range(count))
+            continue
+        is_ban = word.startswith("!")
+        digits = word[1:] if is_ban else word
+        if not digits.isdigit():
+            return None
+        index = int(digits) - 1
+        if not 0 <= index < count:
+            return None
+        (banned if is_ban else relevant).add(index)
+    return relevant - banned, banned
 
 
 def _finish_prior_art(questionnaire: QuestionnaireState) -> dict:
-    """Close the sub-loop: persist rejections, then show the summary."""
+    """Close the sub-loop: persist verdicts, then show the summary.
+
+    Only explicit verdicts reach the permanent ledger: accepted → up, banned
+    (``!N``) → down. A candidate the user simply did not tick is passed over
+    for this project only and appears in neither list — writing it down would
+    make one quick Enter silently blacklist the whole shortlist forever.
+    """
     from yeaboi.agent import prior_art_feedback
 
     questionnaire._prior_art_stage = "done"
@@ -4081,7 +4096,7 @@ def _finish_prior_art(questionnaire: QuestionnaireState) -> dict:
             project=str(questionnaire.answers.get(1, ""))[:120],
         )
     logger.info(
-        "prior_art: %d accepted, %d rejected",
+        "prior_art: %d accepted, %d banned",
         len(questionnaire._prior_art_accepted),
         len(questionnaire._prior_art_rejected),
     )
@@ -5277,57 +5292,46 @@ def project_intake(state: ScrumState) -> dict:
             return _show_summary_or_pto(questionnaire)
 
         if questionnaire._prior_art_stage in ("ask", "reason"):
-            user_text = last_msg.content.strip()
-            candidate = _prior_art_current(questionnaire)
-            if candidate is None:
+            candidates = questionnaire._prior_art_candidates
+            if not candidates:
                 # Defensive: the list emptied underneath us (a resumed session
                 # drops the transients). Close out rather than loop.
                 return _finish_prior_art(questionnaire)
 
             if questionnaire._prior_art_stage == "reason":
-                # Empty is a legitimate answer — "no" without a "why" is still
-                # a rejection, and demanding a reason would train people to
-                # accept things to get past the prompt.
-                questionnaire._prior_art_rejected.append(
-                    {
-                        "key": candidate.get("key", ""),
-                        "name": candidate.get("name", ""),
-                        "reason": "" if user_text.lower() in ("skip", "-") else user_text,
-                    }
-                )
-                return _prior_art_advance(questionnaire)
-
-            choice = user_text.lower()
-            if choice in ("1", "y", "yes", _PRIOR_ART_ACCEPT.lower()):
-                questionnaire._prior_art_accepted.append(candidate)
-                return _prior_art_advance(questionnaire)
-            if choice in ("2", "n", "no", _PRIOR_ART_REJECT.lower()):
-                questionnaire._prior_art_stage = "reason"
+                # Legacy tolerance: "reason" was the per-repo "why isn't it
+                # relevant?" free-text stage, which only a session serialized
+                # by an older build can still be in. The user's text answers a
+                # question this build no longer asks, so re-ask the whole
+                # batch rather than guess what the words meant.
+                questionnaire._prior_art_stage = "ask"
                 return {
                     "questionnaire": questionnaire,
-                    "messages": [
-                        AIMessage(
-                            content=(
-                                f"Why isn't **{candidate.get('name', '')}** relevant? "
-                                "I'll stop suggesting it. (Enter to skip)"
-                            )
-                        )
-                    ],
+                    "messages": [AIMessage(content=_prior_art_prompt(questionnaire))],
                 }
-            if choice in ("3", "skip", "skip the rest", _PRIOR_ART_SKIP.lower()):
-                # Bailing out is not a rejection — nothing is written to the
-                # ledger for the candidates never seen.
-                return _finish_prior_art(questionnaire)
-            return {
-                "questionnaire": questionnaire,
-                "messages": [
-                    AIMessage(
-                        content=(
-                            f"Please choose [1] {_PRIOR_ART_ACCEPT}, [2] {_PRIOR_ART_REJECT} or [3] {_PRIOR_ART_SKIP}:"
-                        )
-                    )
-                ],
-            }
+
+            parsed = _parse_prior_art_answer(last_msg.content, len(candidates))
+            if parsed is None:
+                return {
+                    "questionnaire": questionnaire,
+                    "messages": [AIMessage(content=_PRIOR_ART_GRAMMAR_HINT)],
+                }
+            relevant, banned = parsed
+            # The submission is the whole verdict: both lists are re-derived
+            # from it, so a half-answered legacy loop carried in by a resumed
+            # session cannot double-write its earlier per-repo answers.
+            questionnaire._prior_art_accepted = [candidates[i] for i in sorted(relevant)]
+            questionnaire._prior_art_rejected = [
+                {"key": candidates[i].get("key", ""), "name": candidates[i].get("name", ""), "reason": ""}
+                for i in sorted(banned)
+            ]
+            logger.info(
+                "prior_art: batch verdict — %d relevant, %d banned, %d passed over",
+                len(relevant),
+                len(banned),
+                len(candidates) - len(relevant) - len(banned),
+            )
+            return _finish_prior_art(questionnaire)
 
         # ── Velocity choice menu handler ─────────────────────────────
         # "1" or "accept" → accept computed/overridden velocity

--- a/src/yeaboi/agent/nodes.py
+++ b/src/yeaboi/agent/nodes.py
@@ -4060,7 +4060,9 @@ def _parse_prior_art_answer(text: str, count: int) -> tuple[set[int], set[int]] 
             continue
         is_ban = word.startswith("!")
         digits = word[1:] if is_ban else word
-        if not digits.isdigit():
+        # isdecimal, not isdigit: isdigit accepts superscripts ("²") that
+        # int() then refuses, turning a typo into a raised turn error.
+        if not digits.isdecimal():
             return None
         index = int(digits) - 1
         if not 0 <= index < count:

--- a/src/yeaboi/agent/state.py
+++ b/src/yeaboi/agent/state.py
@@ -1752,18 +1752,23 @@ class QuestionnaireState:
     # Transient prior-art sub-loop, modelled on the PTO sub-loop above. After
     # the questionnaire and before the confirmation summary, a greenfield
     # project is offered the team's own repositories as reference material and
-    # the user accepts or rejects each in turn.
-    # Stages: "" (not started), "ask", "reason", "done".
+    # the user picks the relevant ones in one batched answer.
+    # Stages: "" (not started), "ask", "empty", "done". ("reason" was the old
+    # per-repo rejection-reason stage — read-tolerated from sessions serialized
+    # by older builds; the handler converts it back to "ask".)
     # See docs: "Project Intake Questionnaire" — prior art
     _prior_art_stage: str = ""
-    # Transient: the shortlist being walked, each a RepoCandidate as a dict.
+    # Transient: the shortlist on offer, each a RepoCandidate as a dict.
     _prior_art_candidates: list[dict] = field(default_factory=list)
-    # Transient: which candidate is currently on screen.
+    # Transient: kept for serialization compatibility with the old one-at-a-time
+    # loop; no longer advanced (the whole shortlist shows at once).
     _prior_art_index: int = 0
     # Transient: accepted candidates, promoted to ScrumState.prior_art on confirm.
     _prior_art_accepted: list[dict] = field(default_factory=list)
-    # Transient: rejections as {"key", "name", "reason"}, written to the global
-    # feedback ledger when the sub-loop ends.
+    # Transient: banned candidates ("never suggest again") as {"key", "name",
+    # "reason"}, written to the global feedback ledger when the sub-loop ends.
+    # Reason is always "" now — the free-text "why?" stage is gone; a candidate
+    # merely left unticked lands in neither list and is never written down.
     _prior_art_rejected: list[dict] = field(default_factory=list)
     # Transient: why the shortlist was empty, so the card can say which of
     # "no profile" / "profile too old" / "nothing matched" happened. Going

--- a/src/yeaboi/agent/state.py
+++ b/src/yeaboi/agent/state.py
@@ -1897,6 +1897,11 @@ class ScrumState(_RequiredState, total=False):
     # field, not a driver attribute, because the end-to-end chat path
     # (stop_after_intake=False) still auto-accepts reviews while it is set.
     _chat_fast_forward: bool
+    # Which prior-art candidate the chat's carousel is previewing (0-based).
+    # Presentation-only and driver-owned: the card renderer reads it, no graph
+    # node ever does, and the driver pops it when the batch submits or a size
+    # switch resets the sub-loop. Serializes harmlessly mid-browse.
+    _prior_art_preview: int
 
     # Project analysis — structured synthesis of intake answers.
     # Set once by project_analyzer node; no reducer needed (single value).

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,37 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "3.16.0",
+      "date": "2026-08-16",
+      "summary": "Planning mode's prior-art intake flow now batches all candidate repos into a single multi-select carousel instead of asking about each one individually. Select multiple repos at once with Space, navigate with arrow keys, and use X to permanently dismiss a candidate. Rejections no longer blacklist repos globally — unchecking just skips them for this project, while X explicitly bans them forever. The new batch grammar works everywhere: TUI carousel, CLI flags, headless APIs, and REPL forms all use the same syntax (numbers, ranges, all, none, or !N bans). Resume now correctly replays the batch prompt instead of stale hints.",
+      "highlights": [
+        {
+          "text": "Batch multi-select carousel for prior-art intake: select all relevant repos at once instead of one-by-one confirmation",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Kinder rejection semantics: unchecked repos are skipped for this project only; explicit X bans them permanently",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Unified batch grammar works on all surfaces: TUI, CLI, headless, and REPL use consistent 1/3, all, none, !N syntax",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Fixed resume flow to replay the batch prompt correctly instead of stale hints",
+          "areas": [
+            "planning"
+          ]
+        }
+      ]
+    },
+    {
       "version": "3.15.0",
       "date": "2026-08-16",
       "summary": "Deterministic signals now carry a tamper-evident, auditable decision chain that tracks the evidence behind every verdict. Provenance adds a new run_provenance_audit engine and command-line tools to verify chain integrity and trace any signal to the data that produced it. Standup surfaces conflicts as explicit cards when sources disagree (board says Done but a PR is open), and every standup decision (practice signals, confidence verdicts, LLM-adjudication drops) chains its evidence. Performance mode's 1:1 preps, completions, and reviews record their source ticket keys so every assessment is traceable. Payloads carry severity as a word, resolution strategies default to manual review, and failed chain writes become report warnings instead of blocking runs. New provenance audit|trace CLI commands and MCP tools bring full parity to headless and agent-driven workflows.",

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -1701,10 +1701,26 @@ class _ChatDriver:
         # Only the "ask" stage gets the card; "empty" went out as prose, and a
         # legacy "reason" reply has no card to rebuild (the node re-asks the
         # batch on the next input, which posts a fresh one).
+        # The card belongs to the newest reply that is NOT the grammar hint:
+        # a rejected typed answer leaves [..., AI(batch prompt), Human, AI(hint)],
+        # and pinning to the newest reply outright would card the one-liner
+        # while the batch-prompt wall above it replayed raw.
         prior_art_at = -1
         qs = self._qs()
         if qs is not None and getattr(qs, "_prior_art_stage", "") == "ask" and qs._prior_art_candidates:
-            prior_art_at = newest_reply_at
+            from yeaboi.agent.nodes import _PRIOR_ART_GRAMMAR_HINT
+
+            prior_art_at = max(
+                (
+                    i
+                    for i, m in enumerate(messages)
+                    if isinstance(m, AIMessage)
+                    and isinstance(m.content, str)
+                    and m.content
+                    and m.content.strip() != _PRIOR_ART_GRAMMAR_HINT
+                ),
+                default=-1,
+            )
         for i, message in enumerate(messages):
             if isinstance(message, HumanMessage) and isinstance(message.content, str):
                 self.transcript.add_user(message.content)

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -106,26 +106,15 @@ _CONFIRM_VERDICT_PROMPT = (
     "Here's everything I've got. Pick an option below — or type **accept**, **edit N**, or just tell me what's off."
 )
 
-_PRIOR_ART_VERDICT_PROMPT = "You already own this one. Pick an option below — or type **yes**, **no**, or **skip**."
+_PRIOR_ART_VERDICT_PROMPT = (
+    "You already own these. **Space** picks the relevant ones, **←/→** browses the details, "
+    "**X** hides a repo forever, **Enter** confirms — or type e.g. **1 3**, **all**, or **none**."
+)
 
 
 def _prior_art_verdict_prompt(qs) -> str:
-    """The verdict line, ending in what happens after the pick.
-
-    The card replaces itself each time the loop advances, so a bare prompt
-    leaves someone looking at "1 of 3" with no way to know that answering is
-    the thing that reaches 2 and 3 — the one question the card cannot answer
-    about itself.
-    """
-    candidates = getattr(qs, "_prior_art_candidates", None) or []
-    remaining = len(candidates) - (getattr(qs, "_prior_art_index", 0) + 1)
-    if remaining == 1:
-        tail = " Answering brings up the last one."
-    elif remaining > 1:
-        tail = f" Answering brings up the next of {remaining} more."
-    else:
-        tail = " This is the last one."
-    return _PRIOR_ART_VERDICT_PROMPT + tail
+    """The one bubble under the prior-art card — the whole batch, one line."""
+    return _PRIOR_ART_VERDICT_PROMPT
 
 
 _FORM_CHOICE_LABEL = "Fill it out as a form instead"
@@ -563,6 +552,7 @@ class _ChatDriver:
         # render from any more and would show as "(… unavailable)". The step
         # re-runs under the new mode and posts a fresh one.
         self.transcript.drop_artifact("prior_art")
+        self.state.pop("_prior_art_preview", None)
         self._note(f"Switched to {label} — I kept all your answers.")
         # One no-LLM invoke so project_intake produces the first gap question
         # (mirrors the old _switch_to_epic_pending re-entry).
@@ -835,8 +825,8 @@ class _ChatDriver:
             return
 
         # Prior-art verdict → card + one line. The node's prompt already
-        # contains the pitch and a [1]/[2]/[3] block; the card renders both
-        # properly and the choice rows carry the keys.
+        # contains the numbered shortlist and the answer grammar; the card
+        # renders the same data properly and the choice rows carry the keys.
         if qs is not None and getattr(qs, "_prior_art_stage", "") == "ask":
             self.transcript.add_artifact("prior_art")
             self._say(_prior_art_verdict_prompt(qs))
@@ -1330,14 +1320,50 @@ class _ChatDriver:
                 # through to the scroll handler below.
                 if key == "up":
                     self.choices.highlight = (self.choices.highlight - 1) % len(self.choices.options)
+                    self._carousel_moved()
                     continue
                 if key == "down":
                     self.choices.highlight = (self.choices.highlight + 1) % len(self.choices.options)
+                    self._carousel_moved()
+                    continue
+                if key in ("left", "right") and self.choices.carousel:
+                    # A carousel browses sideways too. Safe to claim here: the
+                    # composer is empty (outer gate), so there is no cursor for
+                    # ←/→ to move, and ordinary menus fall through untouched.
+                    step = -1 if key == "left" else 1
+                    self.choices.highlight = (self.choices.highlight + step) % len(self.choices.options)
+                    self._carousel_moved()
                     continue
                 if key == " " and self.choices.multi:
                     i = self.choices.highlight
                     label, checked = self.choices.options[i]
+                    if i in self.choices.banned:
+                        # Space on a banned row un-bans and picks it — the two
+                        # marks are mutually exclusive, and reaching for Space
+                        # says "actually I want this one".
+                        self.choices.banned.discard(i)
+                        self.choices.options[i] = (label, True)
+                        logger.info("Chat prior-art ban toggle: row %d -> unbanned (picked)", i + 1)
+                        continue
                     self.choices.options[i] = (label, not checked)
+                    continue
+                if key in ("x", "X") and self.choices.carousel:
+                    # Permanent "never suggest again" — kept off Space so a
+                    # quick multi-pick can't blacklist a repo by accident.
+                    # Claiming a letter is safe only because the composer is
+                    # empty; prose starting with "x" needs another char first.
+                    i = self.choices.highlight
+                    label, _checked = self.choices.options[i]
+                    if i in self.choices.banned:
+                        self.choices.banned.discard(i)
+                    else:
+                        self.choices.banned.add(i)
+                        self.choices.options[i] = (label, False)
+                    logger.info(
+                        "Chat prior-art ban toggle: row %d -> %s",
+                        i + 1,
+                        "banned" if i in self.choices.banned else "unbanned",
+                    )
                     continue
                 if key == "enter":
                     return self._choice_answer()
@@ -1424,11 +1450,37 @@ class _ChatDriver:
         self.composer.col = len(before)
         return word
 
+    def _carousel_moved(self) -> None:
+        """Sync the prior-art preview card to the highlighted row.
+
+        Presentation-only: the preview index lives on graph_state under a
+        driver-owned key (precedent: _intake_mode) and never reaches the node.
+        Fires in key branches only — never per frame — and invalidates just
+        the one card rather than the whole transcript cache.
+        """
+        if self.choices is None or not self.choices.carousel:
+            return
+        self.state["_prior_art_preview"] = self.choices.highlight
+        self.transcript.invalidate_artifact("prior_art")
+
     def _choice_answer(self) -> str:
         assert self.choices is not None
         # This return leaves the input loop without touching handle_key, so the
         # stash has to be burned here as it is on a typed submit.
         self.composer.forget_stash()
+        if self.choices.carousel:
+            # The batch verdict goes to the node as its index grammar, never as
+            # joined labels — a repo named "a, b" would shatter on the comma
+            # join below and then re-parse as nonsense.
+            picked = [
+                str(i + 1)
+                for i, (_label, is_checked) in enumerate(self.choices.options)
+                if is_checked and i not in self.choices.banned
+            ]
+            banned = [f"!{i + 1}" for i in sorted(self.choices.banned)]
+            answer = " ".join(picked + banned) or "none"
+            logger.info("Chat prior-art batch submit: %s", answer)
+            return answer
         checked = [label for label, is_checked in self.choices.options if is_checked]
         if self.choices.multi and checked:
             return ", ".join(checked)
@@ -1623,15 +1675,27 @@ class _ChatDriver:
         # exists to replace. It is the newest assistant reply whenever the
         # questionnaire is parked on the verdict gate.
         summary_at = -1
+        newest_reply_at = max(
+            (
+                i
+                for i, m in enumerate(messages)
+                if isinstance(m, AIMessage) and isinstance(m.content, str) and m.content
+            ),
+            default=-1,
+        )
         if self._at_intake_summary():
-            summary_at = max(
-                (
-                    i
-                    for i, m in enumerate(messages)
-                    if isinstance(m, AIMessage) and isinstance(m.content, str) and m.content
-                ),
-                default=-1,
-            )
+            summary_at = newest_reply_at
+        # Same replacement for a session parked mid prior-art: the live turn
+        # rendered a card + one line (_append_reply), so replaying the node's
+        # markdown here would resurrect the wall the card replaced. Mutually
+        # exclusive with summary_at — _at_intake_summary excludes prior art.
+        # Only the "ask" stage gets the card; "empty" went out as prose, and a
+        # legacy "reason" reply has no card to rebuild (the node re-asks the
+        # batch on the next input, which posts a fresh one).
+        prior_art_at = -1
+        qs = self._qs()
+        if qs is not None and getattr(qs, "_prior_art_stage", "") == "ask" and qs._prior_art_candidates:
+            prior_art_at = newest_reply_at
         for i, message in enumerate(messages):
             if isinstance(message, HumanMessage) and isinstance(message.content, str):
                 self.transcript.add_user(message.content)
@@ -1639,6 +1703,9 @@ class _ChatDriver:
                 if i == summary_at:
                     self.transcript.add_artifact("intake_summary")
                     self.transcript.add_assistant(_CONFIRM_VERDICT_PROMPT)
+                elif i == prior_art_at:
+                    self.transcript.add_artifact("prior_art")
+                    self.transcript.add_assistant(_prior_art_verdict_prompt(qs))
                 else:
                     self.transcript.add_assistant(message.content)
         for kind, key in (
@@ -1805,11 +1872,26 @@ class _ChatDriver:
                     view.choices = None
                 if view.choices:
                     highlight = next((i for i, (_o, sel) in enumerate(view.choices) if sel), 0)
+                    banned: set[int] = set()
+                    if view.prior_art:
+                        # Pre-bans mirror the pre-checks: populated only when a
+                        # legacy mid-loop session resumed with per-repo verdicts
+                        # already recorded, so they stay visible and reversible.
+                        qs = self._qs()
+                        rejected_keys = {r.get("key", "") for r in getattr(qs, "_prior_art_rejected", [])}
+                        banned = {
+                            i
+                            for i, c in enumerate(getattr(qs, "_prior_art_candidates", []))
+                            if c.get("key", "") and c.get("key", "") in rejected_keys
+                        }
+                        self.state["_prior_art_preview"] = highlight
                     self.choices = ChoiceRows(
                         options=list(view.choices),
                         highlight=highlight,
                         multi=view.multi_select,
                         auto_submit=view.auto_submit,
+                        carousel=view.prior_art,
+                        banned=banned,
                     )
                 else:
                     self.choices = None
@@ -1918,22 +2000,22 @@ class _ChatDriver:
         return submit
 
     def _prior_art_pick(self, submit: str) -> str:
-        """Map a prior-art verdict pick to the digit the node understands.
+        """Map a prior-art submission to what the node understands.
 
-        The "reason" stage has no menu, so free text passes straight through —
-        including text that starts with a digit, which is why this maps only
-        exact labels and never parses the reply.
+        The "ask" stage needs no mapping any more: both the widget
+        (:meth:`_choice_answer`'s carousel branch) and a typed reply already
+        speak the node's index grammar, so they pass straight through. Only
+        the empty card's "Continue" row is a label to translate — it is an
+        acknowledgement, not a verdict, and just needs to not be mistaken for
+        a confirmation-gate pick on the way through.
         """
-        from ._question_view import PRIOR_ART_CONTINUE, PRIOR_ART_NO, PRIOR_ART_SKIP, PRIOR_ART_YES
+        from ._question_view import PRIOR_ART_CONTINUE
 
-        # "Continue" is an acknowledgement of the empty card, not a verdict —
-        # the node takes any input there, so it only needs to not be mistaken
-        # for a confirmation-gate pick on the way through.
-        mapping = {PRIOR_ART_YES: "1", PRIOR_ART_NO: "2", PRIOR_ART_SKIP: "3", PRIOR_ART_CONTINUE: "ok"}
-        mapped = mapping.get(submit)
-        if mapped is not None:
+        self.state.pop("_prior_art_preview", None)  # the preview dies with the menu
+        if submit == PRIOR_ART_CONTINUE:
             logger.info("Chat: prior-art pick -> %s", submit)
-        return mapped or submit
+            return "ok"
+        return submit
 
     def _entertain_duck(self, tick: float) -> None:
         """Rotate working quips (plus the odd gag) through a long wait.

--- a/src/yeaboi/ui/session/chat/_driver.py
+++ b/src/yeaboi/ui/session/chat/_driver.py
@@ -828,6 +828,15 @@ class _ChatDriver:
         # contains the numbered shortlist and the answer grammar; the card
         # renders the same data properly and the choice rows carry the keys.
         if qs is not None and getattr(qs, "_prior_art_stage", "") == "ask":
+            # Lazy for the same reason as apply_size_switch: nodes is heavy.
+            from yeaboi.agent.nodes import _PRIOR_ART_GRAMMAR_HINT
+
+            if reply.strip() == _PRIOR_ART_GRAMMAR_HINT:
+                # The node rejected a typed answer. Swallowing this and
+                # re-posting the same card would read as a no-op — the one
+                # chat turn where the node's own words must go out as prose.
+                self._say(reply)
+                return
             self.transcript.add_artifact("prior_art")
             self._say(_prior_art_verdict_prompt(qs))
             return

--- a/src/yeaboi/ui/session/chat/_question_view.py
+++ b/src/yeaboi/ui/session/chat/_question_view.py
@@ -54,13 +54,10 @@ CONFIRM_EDIT = "Edit an answer…"
 CONFIRM_OVERRIDE_VELOCITY = "Override the velocity…"
 CONFIRM_FREETEXT = "Tell me what's off…"
 
-# Prior-art sub-loop labels. Same rule as the CONFIRM_* set above: the raw
-# label must never reach the graph — the driver maps a pick to the node's
-# literal ("1"/"2"/"3"), because _parse_edit_intent reads a bare digit as
-# "edit QN" and the node's handler does not know these strings.
-PRIOR_ART_YES = "Yes, relevant"
-PRIOR_ART_NO = "Not relevant…"
-PRIOR_ART_SKIP = "Skip the rest"
+# Prior-art empty-state label. Same rule as the CONFIRM_* set above: the raw
+# label must never reach the graph — the driver maps it to the node's literal.
+# The "ask" stage has no labels at all any more: its rows are the candidate
+# names themselves, and the driver submits the node's index grammar directly.
 PRIOR_ART_CONTINUE = "Continue"
 
 
@@ -132,6 +129,7 @@ class QuestionView:
     choices: list[tuple[str, bool]] | None = None  # (label, pre_selected)
     multi_select: bool = False
     auto_submit: bool = False  # bare digit picks + submits (command menus only)
+    prior_art: bool = False  # the prior-art carousel menu (ban key + index-grammar submit)
     suggestion: str | None = None  # free-text prefill (chip suggestions become prefill)
     progress: str = ""  # "Question 2 of 6" over the planned set (chat shows it for every mode)
     phase_label: str = ""
@@ -165,18 +163,22 @@ def derive_question_view(graph_state: dict) -> QuestionView:
     # Guard mirrors _append_reply's card condition exactly — the choices must
     # appear iff the card+prompt did, and never during the PTO sub-loop,
     # velocity number entry, or an edit re-ask.
-    # Prior-art sub-loop: a per-candidate verdict, offered exactly where the
-    # node is waiting for one. Checked BEFORE the confirmation gate because
-    # both run with awaiting_confirmation set and cur_q past the last question
-    # — without this the Accept/Edit menu would render over the prior-art card.
+    # Prior-art sub-loop: one multi-select row per candidate, offered exactly
+    # where the node is waiting for the batch verdict. Checked BEFORE the
+    # confirmation gate because both run with awaiting_confirmation set and
+    # cur_q past the last question — without this the Accept/Edit menu would
+    # render over the prior-art card. Pre-checks come from _prior_art_accepted:
+    # empty on a fresh run, populated when a legacy mid-loop session resumes,
+    # which makes earlier per-repo verdicts visible and re-editable.
     if qs.awaiting_confirmation and getattr(qs, "_prior_art_stage", "") == "ask":
+        accepted_keys = {c.get("key", "") for c in getattr(qs, "_prior_art_accepted", [])}
         view.choices = [
-            (PRIOR_ART_YES, True),
-            (PRIOR_ART_NO, False),
-            (PRIOR_ART_SKIP, False),
+            (str(c.get("name", "")), bool(c.get("key", "")) and c.get("key", "") in accepted_keys)
+            for c in getattr(qs, "_prior_art_candidates", [])
         ]
-        view.multi_select = False
-        view.auto_submit = True
+        view.multi_select = True
+        view.auto_submit = False
+        view.prior_art = True
         return view
     # Nothing was found, and the card says why. There is no verdict to give,
     # so the only affordance is an acknowledgement — but it still has to be a

--- a/src/yeaboi/ui/session/chat/_screen.py
+++ b/src/yeaboi/ui/session/chat/_screen.py
@@ -124,7 +124,7 @@ def _fit_hint(pairs: list[tuple[str, str]], extras: str, avail: int) -> tuple[li
         extras = ""
         if _hint_cells(pairs, extras) <= budget:
             return pairs, extras
-    for victim in ("/", "PgUp/PgDn", "Ctrl+U", "Space", "↑/↓"):
+    for victim in ("/", "PgUp/PgDn", "Ctrl+U", "X", "←/→", "Space", "↑/↓ ←/→", "↑/↓"):
         if _hint_cells(pairs, extras) <= budget:
             break
         pairs = [pair for pair in pairs if pair[0] != victim]
@@ -143,12 +143,20 @@ class ChoiceRows:
     stroke. Only for menus whose labels are commands (the size question, the
     review verdict) — never for data-entry questions, where a typed "12"
     must stay free text.
+
+    carousel: the prior-art browse menu — ←/→ also move the highlight (the
+    detail card above follows it), X toggles a permanent "never suggest"
+    ban on the highlighted row, and the driver submits the node's index
+    grammar instead of the joined labels. banned holds those row indices;
+    a banned row draws ✗ and is always unchecked.
     """
 
     options: list[tuple[str, bool]] = field(default_factory=list)
     highlight: int = 0
     multi: bool = False
     auto_submit: bool = False
+    carousel: bool = False
+    banned: set[int] = field(default_factory=set)
 
 
 @dataclass
@@ -249,6 +257,8 @@ def _stage_dot(stage: str, graph_state: dict) -> int:
 def _placeholder(stage: str, graph_state: dict, choices: ChoiceRows | None) -> str:
     """Ghost text for the empty composer — tells the user what fits here now."""
     if choices is not None and choices.options:
+        if choices.carousel:
+            return "Space picks · X hides forever · Enter confirms — or type e.g. 1 3, all, none…"
         if stage == "intake" and not graph_state.get("messages"):
             if len(choices.options) >= 3:
                 # The greeting's third row is the form preference.
@@ -257,11 +267,6 @@ def _placeholder(stage: str, graph_state: dict, choices: ChoiceRows | None) -> s
         return "Pick with ↑/↓ — or just type your answer…"
     if stage == "intake" and not graph_state.get("messages"):
         return "Describe your project — a few sentences is enough…"
-    # The prior-art "why isn't it relevant" reply has no menu, so the ghost
-    # text is the only thing telling the user Enter alone is a valid answer.
-    qs = graph_state.get("questionnaire")
-    if stage == "intake" and getattr(qs, "_prior_art_stage", "") == "reason":
-        return "Why isn't it relevant? I'll stop suggesting it — or Enter to skip…"
     if stage == "intake":
         return "Type an answer — /skip /defaults /form /finish all work…"
     if stage in ("review", "epic"):
@@ -413,13 +418,20 @@ def build_chat_screen(
     if command_menu:
         pairs.append(("Tab", "complete"))
     if choices is not None and choices.options:
-        pairs.append(("↑/↓", "choose"))
+        if choices.carousel:
+            # ←/→ browse too, and the card above follows — one combined
+            # keycap keeps the row short enough to survive 80 columns.
+            pairs.append(("↑/↓ ←/→", "browse"))
+        else:
+            pairs.append(("↑/↓", "choose"))
         # Arrows belong to the menu while one is up, so name the keys that
         # still reach the transcript — a menu usually sits under something
         # the answer depends on (the intake summary is 30 rows of it).
         pairs.append(("PgUp/PgDn", "scroll"))
         if choices.multi:
             pairs.append(("Space", "toggle"))
+        if choices.carousel:
+            pairs.append(("X", "never suggest"))
     pairs += [("Enter", "send"), (NEWLINE_KEY, "newline"), ("Ctrl+U", "clear"), ("/", "commands")]
     extras = (_voice_hint() + _image_hint()).strip()
     # The drawer gets every pair whatever the width; only the inline row sheds.
@@ -454,6 +466,14 @@ def build_chat_screen(
         for i, (label, checked) in enumerate(choices.options):
             row = Text("  ")
             row.append("❯ " if i == choices.highlight else "  ", style=f"bold {theme.accent_bright}")
+            if i in choices.banned:
+                # A banned row is out of the running: ✗ replaces the checkbox
+                # (it is always unchecked) and the label dims. X un-bans it.
+                row.append("✗   ", style=theme.muted)
+                row.append(f"{i + 1}. {label}", style="dim")
+                row.append("  never suggest", style="dim")
+                lines.append(row)
+                continue
             if choices.multi:
                 row.append("[x] " if checked else "[ ] ", style=theme.accent if checked else "dim")
             row.append(f"{i + 1}. {label}", style="bold white" if i == choices.highlight else "white")

--- a/src/yeaboi/ui/session/chat/_screen.py
+++ b/src/yeaboi/ui/session/chat/_screen.py
@@ -124,7 +124,10 @@ def _fit_hint(pairs: list[tuple[str, str]], extras: str, avail: int) -> tuple[li
         extras = ""
         if _hint_cells(pairs, extras) <= budget:
             return pairs, extras
-    for victim in ("/", "PgUp/PgDn", "Ctrl+U", "X", "←/→", "Space", "↑/↓ ←/→", "↑/↓"):
+    # "↑/↓ ←/→" is the carousel's combined browse pair (there is no separate
+    # "←/→" key); it outlives Space because once Space is gone it is the only
+    # navigation hint left on the row.
+    for victim in ("/", "PgUp/PgDn", "Ctrl+U", "X", "Space", "↑/↓ ←/→", "↑/↓"):
         if _hint_cells(pairs, extras) <= budget:
             break
         pairs = [pair for pair in pairs if pair[0] != victim]

--- a/src/yeaboi/ui/session/chat/_transcript.py
+++ b/src/yeaboi/ui/session/chat/_transcript.py
@@ -63,7 +63,12 @@ def _artifact_renderable(kind: str, graph_state: dict, render_w: int):
         return _render_tui_intake_summary(qs, render_w) if qs is not None else None
     if kind == "prior_art":
         qs = graph_state.get("questionnaire")
-        return _render_prior_art(qs, render_w) if qs is not None else None
+        if qs is None:
+            return None
+        # _prior_art_preview is the chat driver's presentation-only cursor —
+        # which row the carousel is highlighting right now. It never reaches
+        # the node; surfaces without the widget just preview the first repo.
+        return _render_prior_art(qs, render_w, preview=graph_state.get("_prior_art_preview", 0))
     if kind == "epic" and graph_state.get("project_analysis"):
         return _render_tui_epic(graph_state["project_analysis"], render_w=render_w)
     if kind == "analysis" and graph_state.get("project_analysis"):
@@ -130,39 +135,38 @@ def _render_prior_art_closed(qs, candidates: list) -> object:
         elif key and key in rejected:
             line.append("  ✗ ", style="dim")
             line.append(name, style="dim")
-            line.append("   not relevant", style="dim")
+            line.append("   never suggest", style="dim")
         else:
-            # Reached by "Skip the rest", which ends the loop without a verdict
-            # on what is left. Saying "not reviewed" rather than nothing keeps
-            # a skip distinguishable from a rejection.
+            # Left unticked: passed over for this project only, nothing
+            # written down. "Not this time" keeps that distinguishable from
+            # the permanent ✗ ban above.
             line.append("  · ", style="dim")
             line.append(name, style="dim")
-            line.append("   not reviewed", style="dim")
+            line.append("   not this time", style="dim")
         rows.append(line)
     return Group(*rows)
 
 
-def _render_prior_art(qs, render_w: int):
-    """The prior-art candidate currently awaiting a verdict.
+def _render_prior_art(qs, render_w: int, *, preview: int = 0):
+    """The prior-art card: a preview of one repo, browsable over the batch.
 
     Rendered from the questionnaire's transient sub-loop state, like every
-    other card renders from live graph_state — the card holds no data of its
-    own, so a re-render after an answer always shows the right candidate.
+    other card renders from live graph_state — plus ``preview``, the chat
+    driver's highlight cursor: as the carousel moves through the choice rows
+    the card re-renders to show that row's pitch and stack. The card is a
+    pure preview — selection state lives in the checkboxes below it, bans in
+    their ✗ rows — so it stays a function of (graph_state, preview) only.
     Once the loop closes it becomes the record of the verdicts given.
     """
     from rich.console import Group
     from rich.text import Text
 
     candidates = getattr(qs, "_prior_art_candidates", None) or []
-    index = getattr(qs, "_prior_art_index", 0)
     if not candidates:
         return None
-    # "Skip the rest" ends the loop without moving the index, so the stage is
-    # the authority on whether anything is still being asked — keying off the
-    # index alone would leave the card frozen on the skipped candidate,
-    # still marked as the one being decided.
-    if getattr(qs, "_prior_art_stage", "") == "done" or not (0 <= index < len(candidates)):
+    if getattr(qs, "_prior_art_stage", "") == "done":
         return _render_prior_art_closed(qs, candidates)
+    index = max(0, min(int(preview or 0), len(candidates) - 1))
     candidate = candidates[index]
 
     rows: list = []
@@ -187,35 +191,23 @@ def _render_prior_art(qs, render_w: int):
         rows.append(Text(""))
         rows.append(Text("  " + " · ".join(str(s) for s in stack), style="dim"))
 
-    rows.append(Text(""))
-    rows.append(Text(f"  {index + 1} of {len(candidates)}", style="dim"))
-    # The roster. One card per kind means this card *replaces itself* as the
-    # loop advances, so without the full list there is no evidence the other
-    # candidates exist — "1 of 3" reads as a pager with no pager keys. Listing
-    # every one, with what was already decided, makes the sequence visible
-    # without adding navigation the rest of intake does not have.
+    # The browse roster: which repo the card is detailing, among what else is
+    # on offer. No verdicts here — a ✓ on the card would duplicate (and race)
+    # the checkbox that actually holds the selection.
     if len(candidates) > 1:
-        accepted, rejected = _prior_art_verdicts(qs)
+        rows.append(Text(""))
         for position, other in enumerate(candidates):
             name = str(other.get("name", ""))
-            key = str(other.get("key", ""))
             line = Text(overflow="ellipsis", no_wrap=True)
             if position == index:
                 line.append("  ▶ ", style="bold")
                 line.append(name, style="bold white")
-                line.append("   deciding now", style="dim")
-            elif key and key in accepted:
-                line.append("  ✓ ", style="bold")
-                line.append(name, style="dim")
-                line.append("   kept", style="dim")
-            elif key and key in rejected:
-                line.append("  ✗ ", style="dim")
-                line.append(name, style="dim")
-                line.append("   not relevant", style="dim")
             else:
                 line.append("  · ", style="dim")
                 line.append(name, style="dim")
             rows.append(line)
+        rows.append(Text(""))
+        rows.append(Text(f"  {len(candidates)} repositories — ←/→ to browse, pick below", style="dim"))
     return Group(*rows)
 
 
@@ -320,6 +312,13 @@ class ChatTranscript:
         """Drop artifact caches after a graph turn — their data may have changed."""
         for message in self.messages:
             if message.role == "artifact":
+                message.invalidate()
+
+    def invalidate_artifact(self, kind: str) -> None:
+        """Drop one card's cache — for a presentation change (the prior-art
+        preview following the highlight) that touches no other card's data."""
+        for message in self.messages:
+            if message.role == "artifact" and message.artifact_kind == kind:
                 message.invalidate()
 
     # -- rendering ---------------------------------------------------------

--- a/tests/unit/nodes/test_prior_art_subloop.py
+++ b/tests/unit/nodes/test_prior_art_subloop.py
@@ -183,6 +183,12 @@ class TestParseGrammar:
         assert _parse_prior_art_answer("what?", 3) is None
         assert _parse_prior_art_answer("!x", 3) is None
 
+    def test_unicode_digits_reprompt_rather_than_raise(self):
+        # "²".isdigit() is True but int("²") raises — the parser must treat
+        # it as an unknown token, not blow up the turn.
+        assert _parse_prior_art_answer("²", 3) is None
+        assert _parse_prior_art_answer("!²", 3) is None
+
 
 class TestBatchVerdicts:
     def _state(self, reply, qs):

--- a/tests/unit/nodes/test_prior_art_subloop.py
+++ b/tests/unit/nodes/test_prior_art_subloop.py
@@ -3,7 +3,8 @@
 Sits between the PTO sub-loop and the confirmation summary. The properties
 worth defending: it only fires for greenfield, it never blocks the summary
 when there is nothing to ask, every exit routes back through the funnel, and
-rejections reach the global ledger while a bail-out does not.
+only explicit verdicts reach the global ledger — a candidate merely left
+unpicked in the batch answer is passed over for this project only.
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ from langchain_core.messages import HumanMessage
 from yeaboi.agent import prior_art
 from yeaboi.agent.nodes import (
     _finish_prior_art,
-    _prior_art_advance,
+    _parse_prior_art_answer,
     _prior_art_applies,
     _prior_art_prompt,
     _show_summary_or_pto,
@@ -153,66 +154,127 @@ class TestPtoExitsReachTheGuard:
         assert result["pending_review"] == "project_intake"
 
 
-class TestVerdicts:
+class TestParseGrammar:
+    """_parse_prior_art_answer — the one grammar every surface speaks."""
+
+    def test_indices_commas_and_whitespace(self):
+        assert _parse_prior_art_answer("1 3", 3) == ({0, 2}, set())
+        assert _parse_prior_art_answer("1,3", 3) == ({0, 2}, set())
+        assert _parse_prior_art_answer(" 2 ", 3) == ({1}, set())
+
+    def test_all_none_skip_and_empty(self):
+        assert _parse_prior_art_answer("all", 2) == ({0, 1}, set())
+        assert _parse_prior_art_answer("none", 2) == (set(), set())
+        assert _parse_prior_art_answer("skip", 2) == (set(), set())
+        assert _parse_prior_art_answer("", 2) == (set(), set())
+
+    def test_bang_bans(self):
+        assert _parse_prior_art_answer("1 !2", 3) == ({0}, {1})
+        assert _parse_prior_art_answer("!3", 3) == (set(), {2})
+
+    def test_ban_wins_over_select_of_the_same_index(self):
+        assert _parse_prior_art_answer("1 !1", 2) == (set(), {0})
+        assert _parse_prior_art_answer("all !2", 2) == ({0}, {1})
+
+    def test_out_of_range_and_unknown_tokens_fail_whole(self):
+        # Half an answer must not be recorded as a verdict.
+        assert _parse_prior_art_answer("1 9", 3) is None
+        assert _parse_prior_art_answer("0", 3) is None
+        assert _parse_prior_art_answer("what?", 3) is None
+        assert _parse_prior_art_answer("!x", 3) is None
+
+
+class TestBatchVerdicts:
     def _state(self, reply, qs):
         return {"messages": [HumanMessage(content=reply)], "questionnaire": qs}
 
-    def test_accept_advances_and_records_the_candidate(self):
-        qs = _qs(stage="ask", candidates=[_candidate(), _candidate("github:acme/pay", "acme/pay")])
-        result = project_intake(self._state("1", qs))
-        assert [c["key"] for c in qs._prior_art_accepted] == ["github:acme/auth"]
-        assert qs._prior_art_index == 1
-        assert "acme/pay" in result["messages"][0].content
-
-    def test_reject_asks_why_before_advancing(self):
-        qs = _qs(stage="ask", candidates=[_candidate()])
-        result = project_intake(self._state("2", qs))
-        assert qs._prior_art_stage == "reason"
-        assert qs._prior_art_index == 0
-        assert "Why isn't" in result["messages"][0].content
-
-    def test_the_reason_is_recorded_then_the_loop_advances(self, _no_ledger_writes):
-        qs = _qs(stage="reason", candidates=[_candidate()])
-        project_intake(self._state("it's the service we're retiring", qs))
-        assert qs._prior_art_rejected == [
-            {"key": "github:acme/auth", "name": "acme/auth", "reason": "it's the service we're retiring"}
+    def _three(self):
+        return [
+            _candidate(),
+            _candidate("github:acme/pay", "acme/pay"),
+            _candidate("github:acme/web", "acme/web"),
         ]
-        assert qs._prior_art_stage == "done"
 
-    def test_an_empty_reason_is_still_a_rejection(self, _no_ledger_writes):
-        # Demanding a reason would train people to accept things to get past
-        # the prompt.
-        qs = _qs(stage="reason", candidates=[_candidate()])
-        project_intake(self._state("", qs))
-        assert qs._prior_art_rejected[0]["reason"] == ""
-        assert any(w["verdict"] == "down" for w in _no_ledger_writes)
-
-    def test_skip_the_rest_ends_the_loop_without_rejecting_anything(self, _no_ledger_writes):
-        qs = _qs(stage="ask", candidates=[_candidate(), _candidate("github:acme/pay", "acme/pay")])
-        result = project_intake(self._state("3", qs))
+    def test_indices_select_relevant_and_finish_in_one_turn(self):
+        qs = _qs(stage="ask", candidates=self._three())
+        result = project_intake(self._state("1 3", qs))
+        assert [c["key"] for c in qs._prior_art_accepted] == ["github:acme/auth", "github:acme/web"]
         assert qs._prior_art_stage == "done"
+        # The whole batch is one graph turn — the summary follows immediately.
+        assert result["pending_review"] == "project_intake"
+
+    def test_all_selects_everything(self):
+        qs = _qs(stage="ask", candidates=self._three())
+        project_intake(self._state("all", qs))
+        assert len(qs._prior_art_accepted) == 3
+
+    def test_none_selects_nothing_and_writes_nothing(self, _no_ledger_writes):
+        qs = _qs(stage="ask", candidates=self._three())
+        result = project_intake(self._state("none", qs))
+        assert qs._prior_art_accepted == []
         assert qs._prior_art_rejected == []
-        # Bailing out is not a verdict — nothing reaches the ledger.
+        # Passing over the batch is not a verdict — nothing reaches the ledger.
         assert _no_ledger_writes == []
         assert result["pending_review"] == "project_intake"
 
-    def test_unrecognised_reply_reprompts_without_advancing(self):
-        qs = _qs(stage="ask", candidates=[_candidate()])
-        result = project_intake(self._state("what?", qs))
-        assert qs._prior_art_index == 0
-        assert qs._prior_art_stage == "ask"
-        assert "Please choose" in result["messages"][0].content
+    def test_skip_still_means_none(self, _no_ledger_writes):
+        qs = _qs(stage="ask", candidates=self._three())
+        result = project_intake(self._state("skip", qs))
+        assert qs._prior_art_stage == "done"
+        assert _no_ledger_writes == []
+        assert result["pending_review"] == "project_intake"
 
-    def test_word_forms_work_as_well_as_digits(self):
-        qs = _qs(stage="ask", candidates=[_candidate()])
-        project_intake(self._state("yes", qs))
-        assert len(qs._prior_art_accepted) == 1
+    def test_bang_bans_with_an_empty_reason(self, _no_ledger_writes):
+        qs = _qs(stage="ask", candidates=self._three())
+        project_intake(self._state("1 !2", qs))
+        assert qs._prior_art_rejected == [{"key": "github:acme/pay", "name": "acme/pay", "reason": ""}]
+        verdicts = {w["repo_key"]: w["verdict"] for w in _no_ledger_writes}
+        assert verdicts == {"github:acme/auth": "up", "github:acme/pay": "down"}
+
+    def test_a_ban_beats_a_select_of_the_same_repo(self):
+        qs = _qs(stage="ask", candidates=self._three())
+        project_intake(self._state("1 !1", qs))
+        assert qs._prior_art_accepted == []
+        assert [r["key"] for r in qs._prior_art_rejected] == ["github:acme/auth"]
+
+    def test_invalid_token_reprompts_without_finishing(self):
+        qs = _qs(stage="ask", candidates=self._three())
+        result = project_intake(self._state("what?", qs))
+        assert qs._prior_art_stage == "ask"
+        assert qs._prior_art_accepted == []
+        assert "Reply with the numbers" in result["messages"][0].content
+
+    def test_a_resubmission_replaces_rather_than_appends(self):
+        # The submission is the whole verdict: pre-filled lists (a legacy
+        # half-loop carried in by a resumed session) are re-derived, never
+        # added to — the double-write guard.
+        qs = _qs(stage="ask", candidates=self._three())
+        qs._prior_art_accepted = [_candidate("github:acme/pay", "acme/pay")]
+        qs._prior_art_rejected = [{"key": "github:acme/web", "name": "acme/web", "reason": "old"}]
+        project_intake(self._state("1", qs))
+        assert [c["key"] for c in qs._prior_art_accepted] == ["github:acme/auth"]
+        assert qs._prior_art_rejected == []
 
     def test_an_emptied_candidate_list_closes_out_instead_of_looping(self):
         qs = _qs(stage="ask", candidates=[])
         result = project_intake(self._state("1", qs))
         assert qs._prior_art_stage == "done"
         assert result["pending_review"] == "project_intake"
+
+
+class TestLegacyReasonStage:
+    """Sessions serialized mid-"reason" by the old per-repo loop."""
+
+    def test_a_resumed_reason_stage_reasks_the_batch(self, _no_ledger_writes):
+        qs = _qs(stage="reason", candidates=[_candidate(), _candidate("github:acme/pay", "acme/pay")])
+        result = project_intake({"messages": [HumanMessage(content="it is being retired")], "questionnaire": qs})
+        # The text answered a question this build no longer asks — nothing is
+        # recorded from it; the batch prompt goes out instead.
+        assert qs._prior_art_stage == "ask"
+        assert qs._prior_art_rejected == []
+        assert _no_ledger_writes == []
+        body = result["messages"][0].content
+        assert "acme/auth" in body and "acme/pay" in body
 
 
 class TestLedger:
@@ -289,33 +351,33 @@ class TestSummaryAndPromotion:
 
 
 class TestPrompt:
-    def test_shows_position_pitch_and_stack(self):
+    def test_lists_every_candidate_numbered(self):
         qs = _qs(stage="ask", candidates=[_candidate(), _candidate("github:acme/pay", "acme/pay")])
         text = _prior_art_prompt(qs)
-        assert "1 of 2" in text
-        assert "acme/auth" in text
+        assert "**1. acme/auth**" in text
+        assert "**2. acme/pay**" in text
         assert "does OIDC login" in text
         assert "Python, FastAPI" in text
 
+    def test_explains_the_answer_grammar(self):
+        """The markdown is the whole interface on the text surfaces (REPL,
+        form, headless), so the grammar has to be in the prompt itself."""
+        qs = _qs(stage="ask", candidates=[_candidate()])
+        text = _prior_art_prompt(qs)
+        assert '"all"' in text
+        assert '"none"' in text
+        assert "never suggest" in text
+
+    def test_pitches_are_condensed_to_two_bullets(self):
+        candidate = _candidate()
+        candidate["pitch"] = ["one", "two", "three", "four"]
+        qs = _qs(stage="ask", candidates=[candidate])
+        text = _prior_art_prompt(qs)
+        assert "one" in text and "two" in text
+        assert "three" not in text
+
     def test_exhausted_list_renders_nothing(self):
         assert _prior_art_prompt(_qs(stage="ask", candidates=[], index=5)) == ""
-
-    def test_says_that_answering_reaches_the_rest(self):
-        """One candidate is on screen at a time on every surface, so the prompt
-        has to say what the position indicator cannot: that a verdict is the
-        way to the others."""
-        qs = _qs(stage="ask", candidates=[_candidate(), _candidate("github:acme/pay", "acme/pay")])
-        assert "1 more after this" in _prior_art_prompt(qs)
-
-    def test_the_last_candidate_promises_nothing_further(self):
-        qs = _qs(stage="ask", candidates=[_candidate(), _candidate("github:acme/pay", "acme/pay")], index=1)
-        assert "after this" not in _prior_art_prompt(qs)
-
-    def test_advance_past_the_end_finishes(self, _no_ledger_writes):
-        qs = _qs(stage="ask", candidates=[_candidate()], index=0)
-        result = _prior_art_advance(qs)
-        assert qs._prior_art_stage == "done"
-        assert result["pending_review"] == "project_intake"
 
 
 class TestEmptyCard:

--- a/tests/unit/test_chat_driver.py
+++ b/tests/unit/test_chat_driver.py
@@ -1891,6 +1891,22 @@ class TestPriorArtCarousel:
         driver.choices.banned = {0}
         assert driver._input_loop() == "2 !1"
 
+    def test_a_rejected_answer_surfaces_the_grammar_hint_as_prose(self):
+        # The node re-prompts with the grammar on a parse failure; swallowing
+        # it behind the static card+prompt would make a rejected "yes" read
+        # as a no-op.
+        from yeaboi.agent.nodes import _PRIOR_ART_GRAMMAR_HINT
+
+        state = {
+            "messages": [HumanMessage(content="yes"), AIMessage(content=_PRIOR_ART_GRAMMAR_HINT)],
+            "_chat_greeting_done": True,
+            "questionnaire": self._qs(),
+        }
+        driver = _driver(FakeGraph([]), _keys([]), state)
+        driver._append_reply(streamed="")
+        bubble = next(m for m in reversed(driver.transcript.messages) if m.role == "assistant")
+        assert "Reply with the numbers" in bubble.text
+
     def test_rebuild_readds_the_card_mid_batch(self):
         state = {
             "messages": [

--- a/tests/unit/test_chat_driver.py
+++ b/tests/unit/test_chat_driver.py
@@ -1907,6 +1907,33 @@ class TestPriorArtCarousel:
         bubble = next(m for m in reversed(driver.transcript.messages) if m.role == "assistant")
         assert "Reply with the numbers" in bubble.text
 
+    def test_rebuild_after_a_rejected_answer_cards_the_prompt_not_the_hint(self):
+        # A rejected typed answer leaves the transcript ending
+        # [AI(batch prompt), Human("auth"), AI(grammar hint)]. The card must
+        # replace the batch prompt — carding the newest reply outright would
+        # attach it to the one-line hint and replay the markdown wall raw.
+        from yeaboi.agent.nodes import _PRIOR_ART_GRAMMAR_HINT
+
+        batch_prompt = "**Prior art** — you already have 2 repositories that might be relevant."
+        state = {
+            "messages": [
+                HumanMessage(content="desc"),
+                AIMessage(content=batch_prompt),
+                HumanMessage(content="auth"),
+                AIMessage(content=_PRIOR_ART_GRAMMAR_HINT),
+            ],
+            "_chat_greeting_done": True,
+            "questionnaire": self._qs(),
+        }
+        driver = _driver(FakeGraph([]), _keys([]), state)
+        driver._rebuild_transcript()
+        roles = [(m.role, m.artifact_kind) for m in driver.transcript.messages]
+        assert ("artifact", "prior_art") in roles
+        texts = [m.text for m in driver.transcript.messages]
+        assert not any("already have 2 repositories" in t for t in texts)
+        # The hint replays as prose, mirroring the live turn.
+        assert any("Reply with the numbers" in t for t in texts)
+
     def test_rebuild_readds_the_card_mid_batch(self):
         state = {
             "messages": [

--- a/tests/unit/test_chat_driver.py
+++ b/tests/unit/test_chat_driver.py
@@ -1807,6 +1807,108 @@ class TestScrollingWithAMenuUp:
         assert driver.follow is True  # still pinned to the newest line
 
 
+class TestPriorArtCarousel:
+    """The prior-art batch menu: browse with all four arrows (the card above
+    follows the highlight), Space picks, X bans permanently, and the
+    submission is the node's index grammar — never the labels."""
+
+    def _qs(self):
+        qs = QuestionnaireState(current_question=TOTAL_QUESTIONS + 1)
+        qs.awaiting_confirmation = True
+        qs._prior_art_stage = "ask"
+        qs._prior_art_candidates = [
+            {"key": "github:acme/a", "name": "a, b", "pitch": ["oidc login"], "stack": ["Py"]},
+            {"key": "github:acme/c", "name": "acme/c", "pitch": ["card payments"], "stack": ["Go"]},
+        ]
+        return qs
+
+    def _carousel_driver(self, keys, *, checked=(False, False)):
+        driver = _driver(FakeGraph([]), keys, {"messages": [], "questionnaire": self._qs()})
+        driver.transcript.add_artifact("prior_art")
+        driver.choices = ChoiceRows(
+            options=[("a, b", checked[0]), ("acme/c", checked[1])],
+            multi=True,
+            carousel=True,
+        )
+        return driver
+
+    def test_left_right_move_the_highlight_and_the_preview(self):
+        driver = self._carousel_driver(_keys(["right", "esc", "esc"]))
+        driver._input_loop()
+        assert driver.choices.highlight == 1
+        assert driver.state["_prior_art_preview"] == 1
+        # The stale cache was invalidated and the card re-rendered for the
+        # new preview — its cached lines now show the second repo's pitch.
+        card = next(m for m in driver.transcript.messages if m.role == "artifact")
+        cached = " ".join(line.plain for line in card._cache[1])
+        assert "card payments" in cached
+        assert "oidc login" not in cached
+
+    def test_up_down_also_sync_the_preview(self):
+        driver = self._carousel_driver(_keys(["down", "esc", "esc"]))
+        driver._input_loop()
+        assert driver.state["_prior_art_preview"] == 1
+
+    def test_left_right_fall_through_on_ordinary_menus(self):
+        driver = _driver(FakeGraph([]), _keys(["left", "esc", "esc"]))
+        driver.choices = ChoiceRows(options=[("Accept", False), ("Edit", False)], auto_submit=True)
+        driver._input_loop()
+        assert driver.choices.highlight == 0
+
+    def test_x_bans_and_unchecks_the_highlighted_row(self):
+        driver = self._carousel_driver(_keys(["x", "esc", "esc"]), checked=(True, False))
+        driver._input_loop()
+        assert driver.choices.banned == {0}
+        assert driver.choices.options[0][1] is False
+
+    def test_x_again_lifts_the_ban(self):
+        driver = self._carousel_driver(_keys(["x", "x", "esc", "esc"]))
+        driver._input_loop()
+        assert driver.choices.banned == set()
+
+    def test_space_on_a_banned_row_unbans_and_picks(self):
+        driver = self._carousel_driver(_keys([" ", "esc", "esc"]))
+        driver.choices.banned = {0}
+        driver._input_loop()
+        assert driver.choices.banned == set()
+        assert driver.choices.options[0][1] is True
+
+    def test_enter_submits_the_index_grammar_not_the_labels(self):
+        # The first repo is literally named "a, b" — the generic label join
+        # would shatter it on the comma and the node would re-parse noise.
+        driver = self._carousel_driver(_keys(["enter"]), checked=(True, False))
+        driver.choices.banned = {1}
+        assert driver._input_loop() == "1 !2"
+
+    def test_an_empty_selection_submits_none(self):
+        driver = self._carousel_driver(_keys(["enter"]))
+        assert driver._input_loop() == "none"
+
+    def test_a_banned_row_is_never_also_picked(self):
+        # Ban wins over a leftover check: the checked flag survives in the
+        # options list, but the grammar must not claim the repo both ways.
+        driver = self._carousel_driver(_keys(["enter"]), checked=(True, True))
+        driver.choices.banned = {0}
+        assert driver._input_loop() == "2 !1"
+
+    def test_rebuild_readds_the_card_mid_batch(self):
+        state = {
+            "messages": [
+                HumanMessage(content="desc"),
+                AIMessage(content="**Prior art** — you already have 2 repositories that might be relevant."),
+            ],
+            "_chat_greeting_done": True,
+            "questionnaire": self._qs(),
+        }
+        driver = _driver(FakeGraph([]), _keys([]), state)
+        driver._rebuild_transcript()
+        roles = [(m.role, m.artifact_kind) for m in driver.transcript.messages]
+        assert ("artifact", "prior_art") in roles
+        # The node's markdown wall must not replay next to the card.
+        texts = [m.text for m in driver.transcript.messages]
+        assert not any("already have 2 repositories" in t for t in texts)
+
+
 def _shown_notices(driver: _ChatDriver) -> list[str]:
     """Run the input loop, collecting the notice as each frame renders it.
 

--- a/tests/unit/test_chat_screen.py
+++ b/tests/unit/test_chat_screen.py
@@ -219,6 +219,20 @@ class TestStates:
         assert "[x] " in out
         assert "[ ] " in out
 
+    def test_banned_carousel_rows_show_the_cross_and_stay_unchecked(self):
+        choices = ChoiceRows(
+            options=[("acme/auth", True), ("acme/pay", False)],
+            highlight=0,
+            multi=True,
+            carousel=True,
+            banned={1},
+        )
+        out = _ANSI.sub("", _render(_screen(choices=choices)))
+        assert "✗" in out
+        assert "never suggest" in out
+        # The banned row draws no checkbox — one mark per row, never both.
+        assert "[ ] 2." not in out and "[x] 2." not in out
+
     def test_command_menu_lists_matches(self):
         from yeaboi.ui.session.chat._commands import COMMANDS
 
@@ -261,6 +275,23 @@ class TestHintRow:
             out = _ANSI.sub("", _render(_screen(width=width, console=_console(width), choices=choices), width=width))
             line = next(ln for ln in out.splitlines() if "Enter" in ln and "send" in ln)
             assert "…" not in line, f"hint clipped at {width} cols with a menu up"
+            assert "Ctrl+N newline" in line
+            assert "Esc Esc" in line
+
+    def test_carousel_hint_names_its_keys_when_there_is_room(self):
+        choices = ChoiceRows(options=[("acme/auth", False)], highlight=0, multi=True, carousel=True)
+        out = _ANSI.sub("", _render(_screen(width=160, console=_console(160), choices=choices), width=160))
+        assert "X never suggest" in out
+        assert "←/→" in out and "browse" in out
+
+    def test_carousel_row_never_ellipsizes(self):
+        # X and the browse keys are sacrificed before Space — the core toggle
+        # — and the row must still finish its sentences at 80 columns.
+        choices = ChoiceRows(options=[("acme/auth", False)], highlight=0, multi=True, carousel=True)
+        for width in (80, 100, 120, 160):
+            out = _ANSI.sub("", _render(_screen(width=width, console=_console(width), choices=choices), width=width))
+            line = next(ln for ln in out.splitlines() if "Enter" in ln and "send" in ln)
+            assert "…" not in line, f"hint clipped at {width} cols with the carousel up"
             assert "Ctrl+N newline" in line
             assert "Esc Esc" in line
 

--- a/tests/unit/test_chat_screen.py
+++ b/tests/unit/test_chat_screen.py
@@ -285,8 +285,8 @@ class TestHintRow:
         assert "←/→" in out and "browse" in out
 
     def test_carousel_row_never_ellipsizes(self):
-        # X and the browse keys are sacrificed before Space — the core toggle
-        # — and the row must still finish its sentences at 80 columns.
+        # X is sacrificed before Space (the core toggle), and the combined
+        # browse pair last — the row must still finish its sentences at 80.
         choices = ChoiceRows(options=[("acme/auth", False)], highlight=0, multi=True, carousel=True)
         for width in (80, 100, 120, 160):
             out = _ANSI.sub("", _render(_screen(width=width, console=_console(width), choices=choices), width=width))

--- a/tests/unit/test_chat_transcript.py
+++ b/tests/unit/test_chat_transcript.py
@@ -87,6 +87,25 @@ class TestCaching:
         assert user_msg._cache is not None
         assert artifact_msg._cache is None
 
+    def test_invalidate_one_artifact_leaves_the_others_cached(self):
+        # The carousel invalidates only the prior-art card per keypress —
+        # dropping every card's cache would re-render five panels per arrow.
+        t = ChatTranscript()
+        t.add_artifact("analysis")
+        t.add_artifact("prior_art")
+        t.lines(80, {}, _console(), theme=PLANNING_THEME)
+        t.invalidate_artifact("prior_art")
+        analysis_msg, prior_art_msg = t.messages
+        assert analysis_msg._cache is not None
+        assert prior_art_msg._cache is None
+
+    def test_invalidate_a_kind_that_matches_nothing_is_a_no_op(self):
+        t = ChatTranscript()
+        t.add_artifact("analysis")
+        t.lines(80, {}, _console(), theme=PLANNING_THEME)
+        t.invalidate_artifact("prior_art")
+        assert t.messages[0]._cache is not None
+
 
 class TestArtifacts:
     def test_unavailable_artifact_shows_placeholder(self):

--- a/tests/unit/test_prior_art_chat.py
+++ b/tests/unit/test_prior_art_chat.py
@@ -3,7 +3,9 @@
 The two guards are the point: both the prior-art sub-loop and the confirmation
 gate run with awaiting_confirmation set and current_question past the last
 question, so without an explicit ordering the Accept/Edit menu renders over the
-prior-art card and the summary card is posted mid-loop.
+prior-art card and the summary card is posted mid-loop. The step is one batch
+now: a multi-select row per candidate, a card that previews whichever row the
+carousel highlights, and a submission in the node's index grammar.
 """
 
 from __future__ import annotations
@@ -11,12 +13,10 @@ from __future__ import annotations
 from yeaboi.agent.state import TOTAL_QUESTIONS, QuestionnaireState
 from yeaboi.ui.session.chat._question_view import (
     CONFIRM_ACCEPT,
-    PRIOR_ART_NO,
-    PRIOR_ART_SKIP,
-    PRIOR_ART_YES,
+    PRIOR_ART_CONTINUE,
     derive_question_view,
 )
-from yeaboi.ui.session.chat._screen import _placeholder
+from yeaboi.ui.session.chat._screen import ChoiceRows, _placeholder
 from yeaboi.ui.session.chat._transcript import _ARTIFACT_TITLES, _artifact_renderable
 
 
@@ -40,15 +40,23 @@ def _qs(stage=""):
 
 
 class TestChoiceRows:
-    def test_ask_stage_offers_the_three_verdicts(self):
+    def test_ask_stage_offers_one_multi_row_per_candidate(self):
         view = derive_question_view({"questionnaire": _qs("ask")})
-        assert [label for label, _ in view.choices] == [PRIOR_ART_YES, PRIOR_ART_NO, PRIOR_ART_SKIP]
-        assert view.auto_submit is True
-        assert view.multi_select is False
+        assert [label for label, _ in view.choices] == ["acme/auth", "acme/pay"]
+        assert view.multi_select is True
+        assert view.auto_submit is False
+        assert view.prior_art is True
 
-    def test_yes_is_preselected(self):
+    def test_nothing_starts_checked_on_a_fresh_run(self):
+        # Relevance is opt-in — a quick Enter must accept nothing by accident.
         view = derive_question_view({"questionnaire": _qs("ask")})
-        assert view.choices[0][1] is True
+        assert all(checked is False for _, checked in view.choices)
+
+    def test_a_legacy_half_loop_resumes_with_its_verdicts_pre_checked(self):
+        qs = _qs("ask")
+        qs._prior_art_accepted = [dict(qs._prior_art_candidates[1])]
+        view = derive_question_view({"questionnaire": qs})
+        assert [checked for _, checked in view.choices] == [False, True]
 
     def test_the_confirm_menu_does_not_render_over_the_card(self):
         # The guard this test exists for.
@@ -56,65 +64,66 @@ class TestChoiceRows:
         assert CONFIRM_ACCEPT not in [label for label, _ in view.choices]
 
     def test_reason_stage_has_no_menu_so_the_composer_owns_it(self):
+        # Legacy tolerance: only a session serialized by an older build can
+        # still be in "reason"; its first input triggers the node's re-ask.
         assert derive_question_view({"questionnaire": _qs("reason")}).choices is None
 
     def test_the_confirm_menu_returns_once_prior_art_is_done(self):
         view = derive_question_view({"questionnaire": _qs("done")})
         assert CONFIRM_ACCEPT in [label for label, _ in view.choices]
+        assert view.prior_art is False
 
     def test_untouched_when_prior_art_never_ran(self):
         view = derive_question_view({"questionnaire": _qs("")})
         assert CONFIRM_ACCEPT in [label for label, _ in view.choices]
 
+    def test_empty_stage_offers_continue(self):
+        view = derive_question_view({"questionnaire": _qs("empty")})
+        assert [label for label, _ in view.choices] == [PRIOR_ART_CONTINUE]
+
 
 class TestPlaceholder:
-    def test_reason_stage_says_enter_skips(self):
-        text = _placeholder("intake", {"questionnaire": _qs("reason"), "messages": ["x"]}, None)
-        assert "Enter to skip" in text
+    def test_the_carousel_ghost_teaches_the_keys_and_the_grammar(self):
+        rows = ChoiceRows(options=[("acme/auth", False)], multi=True, carousel=True)
+        text = _placeholder("intake", {"questionnaire": _qs("ask"), "messages": ["x"]}, rows)
+        assert "Space" in text and "X" in text
+        assert "all" in text
 
-    def test_other_stages_are_unaffected(self):
-        text = _placeholder("intake", {"questionnaire": _qs("done"), "messages": ["x"]}, None)
-        assert "Enter to skip" not in text
+    def test_ordinary_menus_keep_their_ghost(self):
+        rows = ChoiceRows(options=[("Accept", True)])
+        text = _placeholder("intake", {"questionnaire": _qs("done"), "messages": ["x"]}, rows)
+        assert "↑/↓" in text
 
 
 class TestCard:
+    def _out(self, qs, preview=None, width=70):
+        from rich.console import Console
+
+        graph_state = {"questionnaire": qs}
+        if preview is not None:
+            graph_state["_prior_art_preview"] = preview
+        console = Console(width=width, record=True)
+        console.print(_artifact_renderable("prior_art", graph_state, width - 2))
+        return console.export_text()
+
     def test_registered_with_a_title(self):
         assert _ARTIFACT_TITLES["prior_art"] == "You already have this"
 
-    def test_renders_the_current_candidate_with_position(self):
-        from rich.console import Console
-
-        console = Console(width=70, record=True)
-        console.print(_artifact_renderable("prior_art", {"questionnaire": _qs("ask")}, 68))
-        out = console.export_text()
+    def test_renders_the_first_candidate_by_default(self):
+        out = self._out(_qs("ask"))
         assert "acme/auth" in out
         assert "does OIDC" in out
-        assert "1 of 2" in out
 
-    def test_follows_the_index(self):
-        from rich.console import Console
+    def test_the_preview_index_drives_the_card(self):
+        # The carousel: the driver publishes the highlight and the card
+        # follows it — node state never moves.
+        out = self._out(_qs("ask"), preview=1)
+        assert "takes cards" in out
+        assert "does OIDC" not in out
 
-        qs = _qs("ask")
-        qs._prior_art_index = 1
-        console = Console(width=70, record=True)
-        console.print(_artifact_renderable("prior_art", {"questionnaire": qs}, 68))
-        out = console.export_text()
-        assert "acme/pay" in out and "2 of 2" in out
-
-    def test_exhausted_index_shows_the_verdicts_rather_than_vanishing(self):
-        """A renderer that returns None prints "(<title> unavailable)" in the
-        card's place, so the card the user just worked through would decay into
-        an error string. It becomes the record of what was decided instead."""
-        from rich.console import Console
-
-        qs = _qs("ask")
-        qs._prior_art_accepted = [dict(qs._prior_art_candidates[0])]
-        qs._prior_art_index = 99
-        console = Console(width=70, record=True)
-        console.print(_artifact_renderable("prior_art", {"questionnaire": qs}, 68))
-        out = console.export_text()
-        assert "Reviewed 2" in out
-        assert "kept" in out
+    def test_an_out_of_range_preview_clamps_instead_of_crashing(self):
+        out = self._out(_qs("ask"), preview=99)
+        assert "takes cards" in out
 
     def test_a_card_with_no_candidates_still_renders_nothing(self):
         qs = _qs("ask")
@@ -126,47 +135,41 @@ class TestCard:
 
 
 class TestRoster:
-    """The card replaces itself as the loop advances, so the roster is the only
-    evidence the other candidates exist — without it "1 of 3" reads as a pager
-    with no pager keys."""
+    """The card details one repo at a time, so the roster is the evidence the
+    others exist — and the footer names the browse keys."""
 
-    def _out(self, qs, width=70):
+    def _out(self, qs, preview=0, width=70):
         from rich.console import Console
 
         console = Console(width=width, record=True)
-        console.print(_artifact_renderable("prior_art", {"questionnaire": qs}, width - 2))
+        console.print(
+            _artifact_renderable("prior_art", {"questionnaire": qs, "_prior_art_preview": preview}, width - 2)
+        )
         return console.export_text()
 
-    def test_every_candidate_is_listed_not_just_the_current_one(self):
+    def test_every_candidate_is_listed_not_just_the_previewed_one(self):
         out = self._out(_qs("ask"))
         assert "acme/auth" in out
         assert "acme/pay" in out
 
-    def test_the_current_one_is_marked_as_being_decided(self):
-        assert "deciding now" in self._out(_qs("ask"))
+    def test_the_footer_names_the_browse_keys(self):
+        out = self._out(_qs("ask"))
+        assert "2 repositories" in out
+        assert "browse" in out
 
-    def test_a_decided_candidate_carries_its_verdict(self):
+    def test_no_verdicts_on_the_card(self):
+        # Selection lives in the checkboxes below, bans in their ✗ rows — a ✓
+        # here would duplicate (and race) the widget state.
         qs = _qs("ask")
         qs._prior_art_accepted = [dict(qs._prior_art_candidates[0])]
-        qs._prior_art_index = 1
-        out = self._out(qs)
-        assert "kept" in out
-
-    def test_a_rejected_candidate_says_so(self):
-        qs = _qs("ask")
-        qs._prior_art_rejected = [{"key": "github:acme/auth", "name": "acme/auth", "reason": "too old"}]
-        qs._prior_art_index = 1
-        out = self._out(qs)
-        assert "not relevant" in out
+        out = self._out(qs, preview=1)
+        assert "kept" not in out
 
     def test_a_lone_candidate_gets_no_roster(self):
-        """One row that says "deciding now" under a card about that one repo is
-        noise, not orientation."""
         qs = _qs("ask")
         qs._prior_art_candidates = qs._prior_art_candidates[:1]
         out = self._out(qs)
-        assert "1 of 1" in out
-        assert "deciding now" not in out
+        assert "browse" not in out
 
 
 class TestClosedCard:
@@ -184,22 +187,19 @@ class TestClosedCard:
     def test_a_done_stage_shows_the_verdicts(self):
         qs = _qs("done")
         qs._prior_art_accepted = [dict(qs._prior_art_candidates[0])]
-        qs._prior_art_rejected = [{"key": "github:acme/pay", "name": "acme/pay", "reason": "retiring it"}]
+        qs._prior_art_rejected = [{"key": "github:acme/pay", "name": "acme/pay", "reason": ""}]
         out = self._out(qs)
         assert "Reviewed 2" in out
         assert "kept" in out
-        assert "not relevant" in out
-        assert "deciding now" not in out
+        assert "never suggest" in out
 
-    def test_skip_the_rest_leaves_the_untouched_ones_marked_not_reviewed(self):
-        """ "Skip the rest" ends the loop without moving the index, so keying off
-        the index alone would freeze the card on the skipped candidate, still
-        marked as the one being decided."""
+    def test_an_unpicked_candidate_reads_not_this_time(self):
+        # Unchecked is a pass for this project only — distinguishable from
+        # the permanent ✗ ban.
         qs = _qs("done")
         qs._prior_art_accepted = [dict(qs._prior_art_candidates[0])]
         out = self._out(qs)
-        assert "not reviewed" in out
-        assert "deciding now" not in out
+        assert "not this time" in out
 
 
 class TestSizeSwitchDropsTheCard:
@@ -223,6 +223,7 @@ class TestSizeSwitchDropsTheCard:
             "apply_size_switch clears the prior-art transients, so the card has "
             "nothing left to render from and would show as '(… unavailable)'"
         )
+        assert "_prior_art_preview" in source, "the stale preview index must not outlive the reset loop"
 
 
 class TestSummaryCard:
@@ -251,25 +252,13 @@ class TestSummaryCard:
 
 
 class TestVerdictPrompt:
-    def _prompt(self, index, total):
+    def test_one_static_line_names_the_keys_and_the_grammar(self):
         from yeaboi.ui.session.chat._driver import _prior_art_verdict_prompt
 
-        qs = _qs("ask")
-        qs._prior_art_candidates = [{"key": f"k{i}", "name": f"r{i}"} for i in range(total)]
-        qs._prior_art_index = index
-        return _prior_art_verdict_prompt(qs)
-
-    def test_more_than_one_left_names_the_count(self):
-        assert "next of 2 more" in self._prompt(0, 3)
-
-    def test_exactly_one_left_says_last(self):
-        assert "the last one" in self._prompt(1, 3)
-
-    def test_the_final_candidate_promises_nothing_further(self):
-        assert "This is the last one." in self._prompt(2, 3)
-
-    def test_the_pick_instructions_survive(self):
-        assert "**yes**" in self._prompt(0, 3)
+        prompt = _prior_art_verdict_prompt(_qs("ask"))
+        assert "**Space**" in prompt
+        assert "**X**" in prompt
+        assert "**all**" in prompt
 
 
 class TestDriverGuards:
@@ -289,7 +278,7 @@ class TestDriverGuards:
     def test_summary_card_returns_once_the_subloop_is_done(self):
         assert self._driver(_qs("done"))._at_intake_summary() is True
 
-    def test_at_prior_art_tracks_the_two_live_stages(self):
+    def test_at_prior_art_tracks_the_live_stages(self):
         assert self._driver(_qs("ask"))._at_prior_art() is True
         assert self._driver(_qs("reason"))._at_prior_art() is True
         assert self._driver(_qs("done"))._at_prior_art() is False
@@ -299,34 +288,40 @@ class TestPickMapping:
     def _driver(self):
         from yeaboi.ui.session.chat._driver import _ChatDriver
 
-        return object.__new__(_ChatDriver)
+        driver = object.__new__(_ChatDriver)
+        driver.state = {"_prior_art_preview": 1}
+        return driver
 
-    def test_labels_map_to_the_digits_the_node_reads(self):
-        driver = self._driver()
-        assert driver._prior_art_pick(PRIOR_ART_YES) == "1"
-        assert driver._prior_art_pick(PRIOR_ART_NO) == "2"
-        assert driver._prior_art_pick(PRIOR_ART_SKIP) == "3"
+    def test_continue_maps_to_the_nodes_ok(self):
+        assert self._driver()._prior_art_pick(PRIOR_ART_CONTINUE) == "ok"
 
-    def test_free_text_passes_through_untouched(self):
-        # Including text that starts with a digit — a reason is prose, and
-        # parsing it would turn "3 years old and unmaintained" into a skip.
+    def test_grammar_strings_pass_through_untouched(self):
+        # The widget already submits the node's index grammar, and a typed
+        # answer is the same grammar — there is nothing left to map.
         driver = self._driver()
-        assert driver._prior_art_pick("3 years old and unmaintained") == "3 years old and unmaintained"
+        assert driver._prior_art_pick("1 3 !2") == "1 3 !2"
+        assert driver._prior_art_pick("none") == "none"
         assert driver._prior_art_pick("") == ""
+
+    def test_the_preview_dies_with_the_menu(self):
+        driver = self._driver()
+        driver._prior_art_pick("none")
+        assert "_prior_art_preview" not in driver.state
 
 
 class TestHeadless:
-    def test_the_subloop_is_skipped_rather_than_answered(self):
+    def test_the_batch_is_answered_none(self):
         from yeaboi.agent.headless import _next_auto_input
 
         # Accepting on the user's behalf would put unvetted repos in a plan;
-        # rejecting would write a permanent suppression. Bailing does neither.
-        assert _next_auto_input({"questionnaire": _qs("ask")}) == "3"
+        # "none" writes nothing to the ledger, so nothing is suppressed either.
+        assert _next_auto_input({"questionnaire": _qs("ask")}) == "none"
 
-    def test_a_reason_prompt_is_answered_with_silence(self):
+    def test_a_legacy_reason_stage_gets_none_too(self):
         from yeaboi.agent.headless import _next_auto_input
 
-        assert _next_auto_input({"questionnaire": _qs("reason")}) == ""
+        # The node turns that into a batch re-ask; the next pass answers it.
+        assert _next_auto_input({"questionnaire": _qs("reason")}) == "none"
 
     def test_confirm_still_works_once_prior_art_is_done(self):
         from yeaboi.agent.headless import _next_auto_input

--- a/tests/unit/test_prior_art_persistence.py
+++ b/tests/unit/test_prior_art_persistence.py
@@ -72,6 +72,18 @@ class TestSessionStoreRoundTrip:
             loaded = store.load_state("sess-2")
         assert not loaded.get("prior_art")
 
+    def test_a_stray_preview_index_round_trips_harmlessly(self, tmp_path):
+        # _prior_art_preview is the chat driver's presentation-only carousel
+        # cursor. It is popped on submit, but a session saved mid-browse still
+        # carries it — loading must neither crash nor lose it.
+        from yeaboi.sessions import SessionStore
+
+        with SessionStore(tmp_path / "s.db") as store:
+            store.create_session("sess-3", "mid-browse save")
+            store.save_state("sess-3", {"messages": [], "_prior_art_preview": 2})
+            loaded = store.load_state("sess-3")
+        assert loaded["_prior_art_preview"] == 2
+
 
 class TestExports:
     def test_markdown_carries_prior_art(self):


### PR DESCRIPTION
## Summary

Planning's prior-art repo-relevance step (greenfield intake) asked about each shortlisted repo one at a time — up to 10 graph turns, a card that replaced itself, and every "Not relevant" opening a free-text "why?" turn whose answer permanently blacklisted the repo. It is now one batch:

- **One multi-select carousel in the chat**: a `ChoiceRows(multi=True, carousel=True)` row per candidate (all unchecked), the "You already have this" card re-rendering to preview whichever row is highlighted (↑/↓ and ←/→ while the composer is empty), Space picks, Enter confirms the whole batch in a single graph turn.
- **Kinder rejection semantics**: unchecked = passed over for this project only, nothing written to the suppression ledger. Permanent dismissal is the explicit `X` key (✗ *never suggest*), written as `VERDICT_DOWN` with an empty reason; the free-text reason stage is removed (legacy `"reason"` sessions are read-tolerated and re-asked the batch).
- **One text grammar on every surface** (`_parse_prior_art_answer`): `1 3`, `all`, `none`/`skip`/empty, `!N` bans; ban beats select; any invalid token re-prompts. The node's markdown prompt lists every candidate numbered and documents the grammar, so REPL/form/typed/headless answers work without the widget. The widget submits indices, never labels (a repo named `a, b` would shatter on the old label join). Headless answers `none`.
- **Resume fix**: `_rebuild_transcript` now replays the prior-art card mid-loop instead of the node's raw markdown.
- State field names/shapes unchanged — no migration. `_prior_art_preview` (driver-owned presentation cursor) declared in `ScrumState`, popped on submit and size switch.

Independent review findings all addressed: `isdecimal()` guards the parser against Unicode digits that `int()` refuses; the node's invalid-answer re-prompt now surfaces in chat as prose instead of being swallowed by the static card; `scrum-standards.html` updated to the batch flow; hint sacrifice order fixed (dead entry removed, X shed before Space); direct unit tests for `invalidate_artifact`.

## Test plan

- `make ship-gate` (lint → format-check → full test suite → security → preflight incl. golden evaluators + docs site) — green.
- New/updated tests: grammar parser (incl. `²` re-prompt), batch verdicts + ledger semantics (unchecked writes nothing), legacy reason re-ask, prompt shape, carousel keys (←/→ preview sync, X ban toggle, Space unban, comma-name grammar submit), banned-row rendering, hint overflow at 80 cols, resume card rebuild, re-prompt pass-through, `invalidate_artifact`, stray-preview round-trip.
- DoD: web bundles untouched (no `frontend/` changes); Go parity untouched (off the mirrored surfaces); Notion/Slack fire on merge via `pr-merged-close-loop`.

Closes YEA-104

🤖 Generated with [Claude Code](https://claude.com/claude-code)