### PR TITLE
add the ship mode: supervised story → PR pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,8 +194,9 @@ src/yeaboi/
   standup/ retro/ poker/ performance/ reporting/ roadmap/ analysis/  — standalone modes (shared blueprint)
   agentwatch/                        — the Agents family: usage/standup/security engines over local agent-session telemetry
   provenance/                        — tamper-evident decision chain + conflicts vocabulary (recorded by standup/performance)
+  ship/                              — supervised story → PR pipeline: budget fuse, worktree isolation, agent driver, approval gate
   pricing.py                         — the per-model LLM rate table (cache-aware); every cost estimate goes through it
-  mcp/                               — stdio MCP server (yeaboi-mcp; 51 tools over the engines)
+  mcp/                               — stdio MCP server (yeaboi-mcp; 53 tools over the engines)
   repl/                              — legacy REPL for CLI-flag-driven flows
   ui/                                — full-screen TUI (mode_select, provider_select, session, shared)
   input_guardrails.py / output_guardrails.py / formatters.py / *_exporter.py / *_sync.py

--- a/claude-plugin/yeaboi/skills/ship/SKILL.md
+++ b/claude-plugin/yeaboi/skills/ship/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: ship
+description: "Read the user's supervised story → PR runs (yeaboi ship): which stories from the sprint plan were handed to a coding agent, what each run's diff/validation/cost looked like, whether the human approved it at the gate, and which PR it opened. Use when the user asks what ship ran, why a launch was denied (budget), or what a run cost. Launching a run is done by the user in the TUI or with `yeaboi ship run` — never from here."
+---
+
+# Ship run history with yeaboi
+
+Ship is yeaboi's supervised story → PR pipeline: a story from the sprint plan
+is implemented by a coding agent (Claude Code headless) in an isolated
+worktree, validated deterministically, and pushed as a PR only after the human
+approves the diff at the gate. This skill READS that history; it never starts
+a run.
+
+1. **List runs** with `ship_history` (newest first, `limit` 1–100). Each run
+   carries: `story_id`, `status` (`approved` = shipped with a PR; `rejected`,
+   `failed`, `cancelled` are terminal without one; `awaiting_approval` means a
+   human is being asked right now), the branch, `diff_stat`, the validation
+   verdict, `cost_usd`, and `pr_url`.
+
+2. **Answer "what's happening / why was I denied"** with `ship_status`: the
+   latest run plus the user-global launch budget (active permits, hourly and
+   daily counts, and the circuit breaker that opens for an hour after a
+   provider quota error). A denial reason like `hourly-budget (2/2 in last
+   hour)` names the exact fuse; relay it and when it resets, don't suggest
+   retry loops.
+
+3. **Be honest about what a status means.** `failed` with "the agent produced
+   no changes" is the deterministic bridge speaking: the agent exited cleanly
+   but produced no diff, so nothing proceeded — that is the system working.
+   Validation `configured: false` means nothing was proven, not that checks
+   passed. `cost_usd` is an estimate from local transcripts priced at public
+   rates, not a bill.
+
+4. **To start a run**, point the user at the Ship card in the TUI or
+   `yeaboi ship run <STORY> --repo <path> --check "make test"`. Both end at a
+   human approval gate; there is deliberately no MCP launch — a run holds a
+   live subprocess for many minutes and its gate is a terminal decision.
+
+## Error handling
+
+Both tools return `{ok, llm_mode, warnings, data}`. If `ok` is false, relay
+`error.message` and its `hint`. An empty history is normal before the first
+run — say so rather than treating it as an error.

--- a/cowork/workstreams/planning.md
+++ b/cowork/workstreams/planning.md
@@ -10,7 +10,10 @@ lives outside a `<mode>/engine.py` (`agent/headless.py:run_planning_pipeline`).
 `json_exporter.py`, `prd_exporter.py` (the Product Requirements Document builder),
 `ollama_control.py` (a provider's lifecycle, like `llm.py`), `mcp/tools_planning.py`,
 `mcp/tools_sessions.py` (its `usage_get` is a read-only view over **tui-ux**'s page),
-`claude-plugin/yeaboi/skills/plan-sprint/`, `tests/unit/nodes/`, `tests/unit/prompts/`,
+`src/yeaboi/ship/` (the plan's back half: a story driven through a supervised coding agent to a
+PR — budget fuse, worktree isolation, driver, approval gate), `mcp/tools_ship.py`,
+`ui/mode_select/_ship.py`, `claude-plugin/yeaboi/skills/plan-sprint/`,
+`claude-plugin/yeaboi/skills/ship/`, `tests/unit/nodes/`, `tests/unit/prompts/`,
 `tests/integration/`, `tests/golden/`
 
 **Skills** — `.claude/skills/agent-and-state/SKILL.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.16.0"
+version = "3.17.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/test_scope.py
+++ b/scripts/test_scope.py
@@ -161,6 +161,9 @@ AREAS: tuple[Area, ...] = (
             "src/yeaboi/agent/",
             "src/yeaboi/prompts/",
             "src/yeaboi/ui/session/",
+            # The plan's back half: a story from the sprint plan driven through
+            # a supervised coding agent to a PR.
+            "src/yeaboi/ship/",
             "src/yeaboi/questionnaire_io.py",
             "src/yeaboi/transcript.py",
             "src/yeaboi/json_exporter.py",
@@ -191,6 +194,9 @@ AREAS: tuple[Area, ...] = (
             "tests/unit/test_ollama_control.py",
             "tests/unit/test_duck_*.py",
             "tests/unit/test_session_handoff.py",
+            # test_ship_gate.py (the /ship command guard) also matches this
+            # glob; it lives in ALWAYS, and a double claim is harmless.
+            "tests/unit/test_ship_*.py",
         ),
     ),
     Area(

--- a/src/yeaboi/agent/state.py
+++ b/src/yeaboi/agent/state.py
@@ -1630,6 +1630,83 @@ def prior_art_from_dicts(rows) -> tuple[PriorArtRef, ...]:
 
 
 # ---------------------------------------------------------------------------
+# Ship artifacts (the supervised story → PR pipeline)
+# ---------------------------------------------------------------------------
+
+
+# Run lifecycle. `awaiting_approval` is the pause the human gate owns; the
+# resolve and resume transitions are independent CAS updates in ship/store.py.
+SHIP_STATUSES = (
+    "planned",
+    "running",
+    "awaiting_approval",
+    "approved",
+    "rejected",
+    "failed",
+    "cancelled",
+)
+
+
+@dataclass(frozen=True)
+class ShipPhase:
+    """One pipeline phase's outcome, for the progress screen and the record."""
+
+    name: str = ""  # setup | implement | validate | gate | finalize
+    status: str = ""  # completed | failed | skipped
+    detail: str = ""
+    duration_s: float = 0.0
+
+
+@dataclass(frozen=True)
+class ShipValidation:
+    """What the deterministic validation step ran and what it said.
+
+    ``configured`` False means no command was available — a visible state the
+    approval screen must show, never a silent pass.
+    """
+
+    configured: bool = False
+    command: str = ""
+    passed: bool = False
+    exit_code: int = -1
+    output_tail: str = ""
+
+
+@dataclass(frozen=True)
+class ShipRun:
+    """One supervised story → PR run, end to end.
+
+    Frozen like every artifact: the store persists status transitions, and the
+    engine returns a fresh copy per phase. The gate fields mirror archon's
+    protocol — ``gate_resolution`` is independent of ``status`` so resolve and
+    resume cannot race each other.
+    """
+
+    run_id: str = ""
+    story_id: str = ""
+    session_id: str = ""  # the *planning* session the story came from
+    agent_session_id: str = ""  # the coding agent's own session (transcript key)
+    repo: str = ""
+    branch: str = ""
+    worktree: str = ""
+    base_sha: str = ""
+    status: str = "planned"  # one of SHIP_STATUSES
+    phases: tuple[ShipPhase, ...] = ()
+    validation: ShipValidation = ShipValidation()
+    diff_stat: str = ""  # `git diff --stat` summary shown at the gate
+    cost_usd: float = 0.0
+    transcript_findings: tuple[tuple[str, str, str], ...] = ()  # (kind, severity, label)
+    transcript_path: str = ""
+    pr_url: str = ""
+    gate_resolution: str = ""  # "" (open) | approved | rejected
+    gate_comment: str = ""  # the approver's words; lands in the PR body
+    rejection_count: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+    warnings: tuple[str, ...] = ()
+
+
+# ---------------------------------------------------------------------------
 # Questionnaire state (mutable — updated incrementally by intake node)
 # ---------------------------------------------------------------------------
 

--- a/src/yeaboi/beta.py
+++ b/src/yeaboi/beta.py
@@ -58,6 +58,16 @@ AGENTWATCH_BETA_NOTICE = (
     "number as an estimate to verify, not an invoice."
 )
 
+# Ship's pair: the claim is about what it DOES (spends quota, writes branches),
+# not about output quality — the approval gate is the mitigation, so the
+# instruction names it.
+SHIP_BETA_PHRASE = "drives a real coding agent against your repository"
+SHIP_BETA_NOTICE = (
+    "Ship mode is in beta — it drives a real coding agent against your repository "
+    "and spends real API quota. Nothing is pushed without your approval at the "
+    "gate; review the diff like a stranger wrote it."
+)
+
 # Amber caution. Deliberately *not* the warm gold (226,186,96) used by the NEW
 # badge: beta is a warning, new is a freshness cue, and the two appear side by
 # side in the tips gallery where they must not read as the same thing. The docs

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,43 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "3.17.0",
+      "date": "2026-08-17",
+      "summary": "The Ship mode closes yeaboi's feedback loop: a user story from your saved sprint plan is handed to a supervised Claude Code headless agent in an isolated git worktree, its diff is validated deterministically, a human approves it at a gate, and only then is the branch pushed and a PR opened. Features include a global budget fuse with quota tracking and fail-closed safety, a worktree coordinator that handles repo setup and cleanup, a mechanical driver that strips agent permissions (no git push, no command execution), and a pipeline with precondition validation and 3-attempt reviewer gates.",
+      "highlights": [
+        {
+          "text": "Ship mode: deliver user stories directly from sprint plan via supervised coding agent in isolated worktree",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Budget fuse: user-global quota (1 concurrent / 2 per hour / 12 per day) with fail-closed safety and circuit breaker on quota errors",
+          "areas": [
+            "usage"
+          ]
+        },
+        {
+          "text": "Deterministic gate: validation runs in its own process, precondition checks for empty diffs, and reviewer can request rework with feedback",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Mechanical safety: agent cannot run git or shell commands; only yeaboi commits and pushes after approval",
+          "areas": [
+            "general"
+          ]
+        },
+        {
+          "text": "Full surfaces: TUI beta card with picker/progress/gate/result screens, CLI commands (run/status/history), MCP tools, and plugin skill",
+          "areas": [
+            "planning"
+          ]
+        }
+      ]
+    },
+    {
       "version": "3.16.0",
       "date": "2026-08-16",
       "summary": "Planning mode's prior-art intake flow now batches all candidate repos into a single multi-select carousel instead of asking about each one individually. Select multiple repos at once with Space, navigate with arrow keys, and use X to permanently dismiss a candidate. Rejections no longer blacklist repos globally — unchecking just skips them for this project, while X explicitly bans them forever. The new batch grammar works everywhere: TUI carousel, CLI flags, headless APIs, and REPL forms all use the same syntax (numbers, ranges, all, none, or !N bans). Resume now correctly replays the batch prompt instead of stale hints.",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -1959,6 +1959,11 @@ def _ship_run(args: argparse.Namespace, console: Console) -> int:
             cancel_event=cancel,
         )
 
+    with ShipStore() as preexisting:
+        # Runs that already exist belong to OTHER sessions (a TUI in another
+        # terminal, a stale process). Prompting for those would let this user
+        # approve a diff they are not looking at — and push it.
+        known = {r.run_id for r in preexisting.list_runs(limit=100)}
     worker = threading.Thread(target=_work, daemon=True)
     worker.start()
     try:
@@ -1971,7 +1976,7 @@ def _ship_run(args: argparse.Namespace, console: Console) -> int:
                 # stamps gate_resolution, and a rework clears it again — so the
                 # reopened gate prompts again by construction.
                 for run in store.list_runs(limit=3):
-                    if run.status != "awaiting_approval" or run.gate_resolution:
+                    if run.run_id in known or run.status != "awaiting_approval" or run.gate_resolution:
                         continue
                     console.print(format_run_rich(run))
                     try:

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -940,6 +940,34 @@ def build_parser() -> argparse.ArgumentParser:
     ptrace_p.add_argument("--depth", type=int, default=2, metavar="N", help="Evidence hops to follow (default 2)")
     ptrace_p.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
 
+    ship_desc = (
+        "Hand a story from your saved sprint plan to a supervised coding agent (Claude Code headless): "
+        "isolated worktree and branch, deterministic validation, a human approval gate at the terminal, "
+        "and a PR only after approval. A user-global launch budget caps runs."
+    )
+    ship_p = subparsers.add_parser(
+        "ship",
+        help="Implement a story from your plan via a supervised coding agent",
+        description=ship_desc,
+    )
+    ship_sub = ship_p.add_subparsers(dest="ship_command", metavar="{run,status,history}", required=True)
+    srun_p = ship_sub.add_parser("run", help="Run one story through the pipeline", description=ship_desc)
+    srun_p.add_argument("story_id", metavar="STORY", help="Story id from the plan (e.g. US-001)")
+    srun_p.add_argument("--repo", default=".", metavar="PATH", help="Target git repository (default: current dir)")
+    srun_p.add_argument("--session", default="", metavar="ID", help="Planning session id (default: latest)")
+    srun_p.add_argument(
+        "--check", default="", metavar="CMD", help="Validation command run in the worktree (e.g. 'make test')"
+    )
+    srun_p.add_argument("--timeout-minutes", type=int, default=30, metavar="N", help="Agent run timeout (default 30)")
+    srun_p.add_argument("--dry-run", action="store_true", help="Canned run — no agent, no git, no network")
+    srun_p.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
+    srun_p.add_argument("--strict", action="store_true", help="Exit 3 when the run did not end approved")
+    sstatus_p = ship_sub.add_parser("status", help="The latest run and the launch budget", description=ship_desc)
+    sstatus_p.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
+    shistory_p = ship_sub.add_parser("history", help="Recent runs, newest first", description=ship_desc)
+    shistory_p.add_argument("--limit", type=int, default=10, metavar="N", help="Runs to show (default 10)")
+    shistory_p.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
+
     analyze_p = subparsers.add_parser("analyze", help="Analyse team board history into a calibration profile")
     analyze_p.add_argument(
         "--source",
@@ -1390,6 +1418,7 @@ def _run_subcommand(args: argparse.Namespace) -> int:
         "analyze": _cmd_analyze,
         "agents": _cmd_agents,
         "provenance": _cmd_provenance,
+        "ship": _cmd_ship,
     }
     try:
         return handlers[args.command](args, console)
@@ -1843,6 +1872,143 @@ def _cmd_provenance(args: argparse.Namespace, console: Console) -> int:
     else:
         console.print(format_trace_rich(trace))
     return 0 if trace.found else 1
+
+
+def _cmd_ship(args: argparse.Namespace, console: Console) -> int:
+    """The ship pipeline headless: same engine the TUI page uses
+    (CLAUDE.md "REQUIRED: Surface Parity"). The approval gate prompts on the
+    terminal and resolves through the same ShipStore CAS as the TUI screen."""
+    import json
+    from dataclasses import asdict
+
+    from yeaboi.beta import SHIP_BETA_NOTICE
+
+    logging.getLogger(__name__).info("ship %s (beta)", args.ship_command)
+    _print_beta_notice(SHIP_BETA_NOTICE)
+
+    if args.ship_command == "history":
+        from yeaboi.ship.render import format_history_rich
+        from yeaboi.ship.store import ShipStore
+
+        with ShipStore() as store:
+            runs = store.list_runs(limit=args.limit)
+        if args.format == "json":
+            print(json.dumps([asdict(r) for r in runs], indent=2))
+        else:
+            console.print(format_history_rich(runs))
+        return 0
+
+    if args.ship_command == "status":
+        from yeaboi.ship import budget
+        from yeaboi.ship.render import format_budget_rich, format_run_rich
+        from yeaboi.ship.store import ShipStore
+
+        with ShipStore() as store:
+            runs = store.list_runs(limit=1)
+        posture = budget.status()
+        if args.format == "json":
+            print(json.dumps({"latest": asdict(runs[0]) if runs else None, "budget": asdict(posture)}, indent=2))
+        else:
+            if runs:
+                console.print(format_run_rich(runs[0]))
+            else:
+                console.print("No ship runs yet.")
+            console.print(format_budget_rich(posture))
+        return 0
+
+    # run
+    return _ship_run(args, console)
+
+
+def _ship_run(args: argparse.Namespace, console: Console) -> int:
+    """`yeaboi ship run` — engine on a worker thread, the gate answered here."""
+    import json
+    import threading
+    import time
+    from dataclasses import asdict
+
+    from yeaboi import fs_policy
+    from yeaboi.ship import engine
+    from yeaboi.ship.render import format_run_rich
+    from yeaboi.ship.store import ShipStore
+
+    repo = str(Path(args.repo).expanduser().resolve())
+    if not args.dry_run:
+        try:
+            fs_policy.resolve_and_check(repo, mode="write", context="ship: run a coding agent against this repository")
+        except PermissionError as exc:
+            print(f"✗ {exc}", file=sys.stderr)
+            return 2
+        if not sys.stdin.isatty():
+            # The gate is a human decision made at a terminal; without one the
+            # run would hang forever awaiting an approval nobody can give.
+            print("✗ ship run needs an interactive terminal — the approval gate prompts here.", file=sys.stderr)
+            return 2
+
+    result_box: list = [None]
+    cancel = threading.Event()
+
+    def _work() -> None:
+        result_box[0] = engine.run_ship(
+            args.story_id,
+            repo,
+            session_id=args.session,
+            check_command=args.check,
+            timeout_minutes=args.timeout_minutes,
+            dry_run=args.dry_run,
+            cancel_event=cancel,
+        )
+
+    worker = threading.Thread(target=_work, daemon=True)
+    worker.start()
+    try:
+        with ShipStore() as store:
+            while worker.is_alive():
+                worker.join(timeout=0.5)
+                if not worker.is_alive() or cancel.is_set():
+                    continue  # a cancelled run winds down on its own; stop prompting
+                # An open gate is one this loop has not answered yet: resolving
+                # stamps gate_resolution, and a rework clears it again — so the
+                # reopened gate prompts again by construction.
+                for run in store.list_runs(limit=3):
+                    if run.status != "awaiting_approval" or run.gate_resolution:
+                        continue
+                    console.print(format_run_rich(run))
+                    try:
+                        answer = input("Approve and open a PR? [y]es / [n]o with feedback / [c]ancel run: ")
+                    except EOFError:
+                        answer = "c"
+                    answer = answer.strip().lower()
+                    if answer in ("y", "yes"):
+                        store.resolve_gate(run.run_id, "approved")
+                    elif answer in ("n", "no"):
+                        try:
+                            comment = input("Feedback for the agent's rework: ").strip()
+                        except EOFError:
+                            comment = ""
+                        store.resolve_gate(run.run_id, "rejected", comment)
+                    else:
+                        cancel.set()
+                time.sleep(0.5)
+    except KeyboardInterrupt:
+        cancel.set()
+        print("Cancelling the run — the agent is stopped and nothing is pushed…", file=sys.stderr)
+        worker.join(timeout=60)
+    worker.join(timeout=5)
+    run = result_box[0]
+    if run is None:
+        print("✗ the run did not report a result — see logs", file=sys.stderr)
+        return 1
+    for warning in run.warnings:
+        print(f"⚠ {warning}", file=sys.stderr)
+    if args.format == "json":
+        print(json.dumps(asdict(run), indent=2))
+    else:
+        console.print(format_run_rich(run))
+    if args.strict and run.status != "approved":
+        print(f"strict: run ended {run.status} — exit 3", file=sys.stderr)
+        return 3
+    return 0
 
 
 def _cmd_agents(args: argparse.Namespace, console: Console) -> int:

--- a/src/yeaboi/mcp/server.py
+++ b/src/yeaboi/mcp/server.py
@@ -67,6 +67,7 @@ def create_app():
         tools_reporting,
         tools_retro,
         tools_sessions,
+        tools_ship,
         tools_standup,
         tools_team,
     )
@@ -85,6 +86,7 @@ def create_app():
         tools_anonymize,
         tools_agentwatch,
         tools_provenance,
+        tools_ship,
     )
     for module in modules:
         module.register(app)

--- a/src/yeaboi/mcp/tools_ship.py
+++ b/src/yeaboi/mcp/tools_ship.py
@@ -1,0 +1,60 @@
+"""MCP tools: ship — read the supervised story → PR runs and the launch budget.
+
+Read-only by design. Launching a run is deliberately NOT an MCP tool: a run
+holds a live subprocess for many minutes behind the server's single engine
+lock (blocking every other tool), and its approval gate is a human decision
+made at a terminal — the same reasoning that keeps output-sharing off this
+surface. Runs start from the TUI's Ship card or `yeaboi ship run`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from yeaboi.mcp.runtime import run_readonly
+
+logger = logging.getLogger(__name__)
+
+
+def _history(limit: int):
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100.")
+    from dataclasses import asdict
+
+    from yeaboi.ship.store import ShipStore
+
+    # asdict per run: to_jsonable only unpacks a TOP-LEVEL dataclass, and a
+    # nested one would degrade to its repr via json's default=str.
+    with ShipStore() as store:
+        return {"runs": [asdict(run) for run in store.list_runs(limit=limit)]}
+
+
+def _status():
+    from dataclasses import asdict
+
+    from yeaboi.ship import budget
+    from yeaboi.ship.store import ShipStore
+
+    with ShipStore() as store:
+        runs = store.list_runs(limit=1)
+    return {"latest": asdict(runs[0]) if runs else None, "budget": asdict(budget.status())}
+
+
+def register(app) -> None:
+    """Attach the ship tools to the FastMCP app."""
+
+    @app.tool()
+    async def ship_history(limit: int = 10) -> dict:
+        """BETA — List the user's supervised coding-agent runs (yeaboi ship), newest first:
+        story, status, validation verdict, cost, and the PR each approved run opened.
+
+        Runs are launched from the TUI or `yeaboi ship run`, never from here — the
+        approval gate is a human decision made at a terminal."""
+        return await run_readonly(_history, limit)
+
+    @app.tool()
+    async def ship_status() -> dict:
+        """BETA — The latest ship run plus the user-global launch budget posture
+        (active permits, hourly/daily counts, circuit-breaker state). Use to answer
+        "is a run in flight / why was a launch denied" without starting anything."""
+        return await run_readonly(_status)

--- a/src/yeaboi/paths.py
+++ b/src/yeaboi/paths.py
@@ -109,7 +109,6 @@ REPORTING_EXPORTS_DIR = EXPORTS_DIR / "reporting"
 ROADMAP_EXPORTS_DIR = EXPORTS_DIR / "roadmap"
 ANONYMIZE_EXPORTS_DIR = EXPORTS_DIR / "anonymize"  # privacy-masked, shareable copies of any mode's output
 AGENTWATCH_EXPORTS_DIR = EXPORTS_DIR / "agentwatch"  # the Agents family: usage / standup / security reports
-SHIP_EXPORTS_DIR = EXPORTS_DIR / "ship"  # supervised coding-agent run summaries
 
 # ---------------------------------------------------------------------------
 # Ship (supervised coding-agent runs)
@@ -483,13 +482,6 @@ def get_ship_dir() -> Path:
     SHIP_DIR.mkdir(parents=True, exist_ok=True)
     restrict_permissions(SHIP_DIR, mode=0o700)
     return SHIP_DIR
-
-
-def get_ship_export_dir(run_key: str) -> Path:
-    """Return the ship export directory for a run, creating it if needed."""
-    d = SHIP_EXPORTS_DIR / _safe_key(run_key, "run")
-    d.mkdir(parents=True, exist_ok=True)
-    return d
 
 
 def get_bin_dir() -> Path:

--- a/src/yeaboi/paths.py
+++ b/src/yeaboi/paths.py
@@ -109,6 +109,24 @@ REPORTING_EXPORTS_DIR = EXPORTS_DIR / "reporting"
 ROADMAP_EXPORTS_DIR = EXPORTS_DIR / "roadmap"
 ANONYMIZE_EXPORTS_DIR = EXPORTS_DIR / "anonymize"  # privacy-masked, shareable copies of any mode's output
 AGENTWATCH_EXPORTS_DIR = EXPORTS_DIR / "agentwatch"  # the Agents family: usage / standup / security reports
+SHIP_EXPORTS_DIR = EXPORTS_DIR / "ship"  # supervised coding-agent run summaries
+
+# ---------------------------------------------------------------------------
+# Ship (supervised coding-agent runs)
+# ---------------------------------------------------------------------------
+
+# Everything the ship mode owns on disk lives under ROOT_DIR on purpose: the
+# fs sandbox already allows this tree read-write, so budget checks, worktree
+# registries and the agent's checkout itself need no extra path consent — only
+# the *target repository* does (its .git gains a worktree entry).
+SHIP_DIR = ROOT_DIR / "ship"
+SHIP_WORKTREES_DIR = SHIP_DIR / "worktrees"  # the agent's checkouts: <repo-slug>/<run-id>/
+SHIP_WORKTREE_REGISTRY = SHIP_DIR / "worktrees.json"
+# The user-global launch budget: one ledger per human, shared by every run,
+# so N concurrent yeaboi instances cannot multiply the spend.
+SHIP_BUDGET_FILE = SHIP_DIR / "ai-budget.json"
+SHIP_BUDGET_LOCK = SHIP_DIR / "ai-budget.lock"
+SHIP_BUDGET_RECEIPTS = SHIP_DIR / "ai-budget-receipts.jsonl"
 
 # ---------------------------------------------------------------------------
 # Logs
@@ -126,6 +144,7 @@ ANALYSIS_LOGS_DIR = LOGS_DIR / "analysis"
 PLANNING_LOGS_DIR = LOGS_DIR / "planning"
 MCP_LOGS_DIR = LOGS_DIR / "mcp"
 AGENTWATCH_LOGS_DIR = LOGS_DIR / "agentwatch"
+SHIP_LOGS_DIR = LOGS_DIR / "ship"
 
 # Legacy log paths
 LEGACY_TUI_LOG = ROOT_DIR / "scrum-agent.log"
@@ -445,6 +464,32 @@ def get_agentwatch_log_dir() -> Path:
     """Return the agentwatch (Agents family) logs directory, creating it if needed."""
     AGENTWATCH_LOGS_DIR.mkdir(parents=True, exist_ok=True)
     return AGENTWATCH_LOGS_DIR
+
+
+def get_ship_log_dir() -> Path:
+    """Return the Ship (supervised coding-agent) logs directory, creating it if needed."""
+    SHIP_LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    return SHIP_LOGS_DIR
+
+
+def get_ship_dir() -> Path:
+    """Return the ship data directory (budget ledger, worktree registry), creating it if needed.
+
+    Hardened like the sessions DB dir: the budget ledger decides whether an
+    agent launch is allowed, so it must not be writable by another local user.
+    """
+    from yeaboi.config import restrict_permissions
+
+    SHIP_DIR.mkdir(parents=True, exist_ok=True)
+    restrict_permissions(SHIP_DIR, mode=0o700)
+    return SHIP_DIR
+
+
+def get_ship_export_dir(run_key: str) -> Path:
+    """Return the ship export directory for a run, creating it if needed."""
+    d = SHIP_EXPORTS_DIR / _safe_key(run_key, "run")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 def get_bin_dir() -> Path:

--- a/src/yeaboi/ship/__init__.py
+++ b/src/yeaboi/ship/__init__.py
@@ -1,0 +1,26 @@
+"""Ship — yeaboi ships code from its own sprint plan.
+
+The back half of planning: a user story from a saved plan is handed to a
+supervised coding agent (Claude Code headless) in an isolated git worktree,
+its output is validated deterministically, and a human approval gate stands
+between the diff and the pull request. Story → worktree → implement →
+validate → approve → PR, natively in Python — the pipeline shape follows
+archon's plan-to-PR workflow and the ops rails (budget fuse, worktree
+coordinator, headless supervision) port ruflo's hard-won lessons; see each
+module's docstring for what was kept and why.
+
+Public API is re-exported here; submodules keep heavy/optional work inside
+functions so importing this package is always cheap — mirrors the standup /
+retro / roadmap packages.
+"""
+
+from __future__ import annotations
+
+from yeaboi.ship.budget import BudgetDecision, BudgetStatus, release, reserve
+
+__all__ = [
+    "BudgetDecision",
+    "BudgetStatus",
+    "release",
+    "reserve",
+]

--- a/src/yeaboi/ship/budget.py
+++ b/src/yeaboi/ship/budget.py
@@ -1,0 +1,356 @@
+"""User-global launch budget for supervised coding-agent runs.
+
+Design ported from ruflo's ``global-ai-budget.ts`` (MIT), re-implemented for
+yeaboi: the ledger lives under the user's home — never the workspace — so every
+yeaboi instance on the machine shares one budget. The failure it prevents is
+multiplicative spend: N worktrees each launching "just a couple" of agent runs
+silently exhausting the user's hourly Claude quota.
+
+Three files under ``paths.get_ship_dir()`` (0700):
+
+- ``ai-budget.json``          — the enforcement ledger (launches + active permits)
+- ``ai-budget.lock``          — O_EXCL mutation lock with stale takeover
+- ``ai-budget-receipts.jsonl``— append-only telemetry, never read for enforcement
+
+Rules, all deliberate:
+
+- ``reserve()`` checks circuit → concurrency → hourly → daily, in that order,
+  and **a reservation counts as a launch immediately** — the hourly/daily
+  invariant is on launches, not completions, so a run that dies early still
+  spent its slot. ``release()`` frees only the concurrency slot.
+- **Fails closed**: an unreadable ledger or an unobtainable lock denies the
+  launch. An unaccountable launch is exactly what this fuse exists to prevent.
+  The one escape hatch is ``YEABOI_AI_BUDGET_DISABLE=1``, which returns a
+  ``bypass_…`` permit that release() ignores.
+- A quota/429 error output from a *failed* launch opens a circuit breaker for
+  60 minutes, user-wide. The pattern is never applied to successful output,
+  which may legitimately discuss rate limiting in the user's own code.
+- Stale state self-heals on read: launches older than 24 h are pruned, and an
+  active permit is dropped once its process is dead or it is older than
+  30 minutes (the cutoff tolerates PID reuse). A corrupt ledger starts fresh
+  rather than blocking forever — worst case is one over-budget launch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from yeaboi.paths import SHIP_BUDGET_FILE, SHIP_BUDGET_LOCK, SHIP_BUDGET_RECEIPTS, get_ship_dir
+
+logger = logging.getLogger(__name__)
+
+# Defaults chosen to be deliberately tight — a human raises them consciously
+# via env, they never silently widen.
+DEFAULT_MAX_CONCURRENT = 1  # YEABOI_AI_MAX_CONCURRENT
+DEFAULT_MAX_PER_HOUR = 2  # YEABOI_AI_MAX_PER_HOUR
+DEFAULT_MAX_PER_DAY = 12  # YEABOI_AI_MAX_PER_DAY
+DEFAULT_QUOTA_PAUSE_MINUTES = 60  # YEABOI_AI_QUOTA_PAUSE_MINUTES
+
+HOUR_S = 60 * 60
+DAY_S = 24 * HOUR_S
+# Abandoned-reservation cutoff. Must exceed the longest supervised run timeout
+# so a live run is never reaped mid-flight; also the PID-reuse tolerance.
+ACTIVE_STALE_S = 30 * 60
+# A lock older than this belongs to a crashed process — take it over.
+LOCK_STALE_S = 10.0
+_LOCK_DEADLINE_S = 2.0
+_LOCK_POLL_S = 0.025
+
+_RECEIPTS_MAX_BYTES = 512 * 1024
+_RECEIPTS_KEEP_LINES = 200
+
+# Matched ONLY against the error output of a failed launch.
+_QUOTA_ERROR_RE = re.compile(
+    r"\b429\b|rate[\s_-]?limit|usage[\s_-]?limit|quota|too many requests|overloaded_error",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    """The answer to "may I launch an agent right now?".
+
+    ``reason`` is machine-readable-ish prose naming the limit that denied
+    (e.g. ``"hourly-budget (2/2 in last hour)"``) so the TUI can show the
+    user exactly which fuse blew and when it resets.
+    """
+
+    allowed: bool = False
+    permit_id: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class BudgetStatus:
+    """A read-only snapshot for status screens. Never used for enforcement."""
+
+    active: int = 0
+    launched_last_hour: int = 0
+    launched_last_day: int = 0
+    max_concurrent: int = DEFAULT_MAX_CONCURRENT
+    max_per_hour: int = DEFAULT_MAX_PER_HOUR
+    max_per_day: int = DEFAULT_MAX_PER_DAY
+    paused_until: float = 0.0
+    paused_reason: str = ""
+
+
+def _now() -> float:
+    """Wall-clock seconds; a seam for tests (the ledger persists across runs)."""
+    return time.time()
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def limits() -> tuple[int, int, int, int]:
+    """(max_concurrent, per_hour, per_day, quota_pause_minutes), env-resolved."""
+    return (
+        _int_env("YEABOI_AI_MAX_CONCURRENT", DEFAULT_MAX_CONCURRENT),
+        _int_env("YEABOI_AI_MAX_PER_HOUR", DEFAULT_MAX_PER_HOUR),
+        _int_env("YEABOI_AI_MAX_PER_DAY", DEFAULT_MAX_PER_DAY),
+        _int_env("YEABOI_AI_QUOTA_PAUSE_MINUTES", DEFAULT_QUOTA_PAUSE_MINUTES),
+    )
+
+
+def is_disabled() -> bool:
+    """True when the human explicitly disabled the fuse for this environment."""
+    return os.getenv("YEABOI_AI_BUDGET_DISABLE", "").strip() in ("1", "true", "yes")
+
+
+def looks_like_quota_error(error_output: str) -> bool:
+    """Whether a failed launch's error output names a quota/rate-limit problem."""
+    return bool(_QUOTA_ERROR_RE.search(error_output or ""))
+
+
+def _is_process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by someone else
+    except OSError:
+        return False
+    return True
+
+
+def _refuse_symlink(path: Path) -> None:
+    """A symlinked ledger would let another local user redirect our writes."""
+    try:
+        if path.is_symlink():
+            raise PermissionError(f"refusing symlinked budget file: {path}")
+    except OSError as exc:  # lstat failed for some other reason
+        raise PermissionError(f"cannot inspect budget file: {path}: {exc}") from exc
+
+
+class _Lock:
+    """O_EXCL lockfile with stale takeover; guards every ledger mutation."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._held = False
+
+    def __enter__(self) -> _Lock:
+        deadline = time.monotonic() + _LOCK_DEADLINE_S
+        while True:
+            try:
+                fd = os.open(self._path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                os.write(fd, str(os.getpid()).encode("ascii"))
+                os.close(fd)
+                self._held = True
+                return self
+            except FileExistsError:
+                try:
+                    age = time.time() - self._path.stat().st_mtime
+                except OSError:
+                    age = 0.0  # vanished between attempts — retry immediately
+                if age > LOCK_STALE_S:
+                    # The holder crashed; take the lock over.
+                    logger.warning("Taking over stale budget lock (age %.1fs)", age)
+                    self._path.unlink(missing_ok=True)
+                    continue
+                if time.monotonic() > deadline:
+                    raise TimeoutError("budget lock is held") from None
+                time.sleep(_LOCK_POLL_S)
+
+    def __exit__(self, *exc: object) -> None:
+        if self._held:
+            self._path.unlink(missing_ok=True)
+            self._held = False
+
+
+def _read_ledger(path: Path) -> dict:
+    _refuse_symlink(path)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        # A corrupt ledger starts fresh rather than blocking forever; worst
+        # case is one over-budget launch, and the receipt trail still exists.
+        logger.warning("Budget ledger is corrupt; starting fresh")
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_ledger(path: Path, data: dict) -> None:
+    _refuse_symlink(path)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(data, indent=1), encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    tmp.replace(path)
+
+
+def _prune(data: dict, now: float) -> dict:
+    launches = [e for e in data.get("launches", []) if isinstance(e, dict) and now - float(e.get("at", 0)) < DAY_S]
+    active = []
+    for entry in data.get("active", []):
+        if not isinstance(entry, dict):
+            continue
+        age = now - float(entry.get("at", 0))
+        if age >= ACTIVE_STALE_S:
+            continue
+        if not _is_process_alive(int(entry.get("pid", 0))):
+            continue
+        active.append(entry)
+    pruned = dict(data)
+    pruned["launches"] = launches
+    pruned["active"] = active
+    return pruned
+
+
+def _receipt(event: str, **fields: object) -> None:
+    """Append one telemetry line; a receipt failure never affects enforcement."""
+    try:
+        get_ship_dir()
+        _refuse_symlink(SHIP_BUDGET_RECEIPTS)
+        line = json.dumps({"event": event, "at": _now(), **fields}, ensure_ascii=False)
+        with open(SHIP_BUDGET_RECEIPTS, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+        if SHIP_BUDGET_RECEIPTS.stat().st_size > _RECEIPTS_MAX_BYTES:
+            lines = SHIP_BUDGET_RECEIPTS.read_text(encoding="utf-8").splitlines()
+            SHIP_BUDGET_RECEIPTS.write_text("\n".join(lines[-_RECEIPTS_KEEP_LINES:]) + "\n", encoding="utf-8")
+    except Exception as exc:
+        logger.warning("Could not write budget receipt: %s", exc)
+
+
+def reserve(*, kind: str = "ship") -> BudgetDecision:
+    """Try to reserve a launch slot. Denies with a named reason, never raises."""
+    now = _now()
+    if is_disabled():
+        permit = f"bypass_{int(now)}_{os.getpid()}"
+        logger.info("Budget fuse disabled via YEABOI_AI_BUDGET_DISABLE; issuing %s", permit)
+        return BudgetDecision(allowed=True, permit_id=permit, reason="budget disabled by env")
+    max_concurrent, per_hour, per_day, _pause_minutes = limits()
+    try:
+        get_ship_dir()
+        with _Lock(SHIP_BUDGET_LOCK):
+            data = _prune(_read_ledger(SHIP_BUDGET_FILE), now)
+            paused_until = float(data.get("paused_until", 0) or 0)
+            if paused_until > now:
+                until = time.strftime("%H:%M", time.localtime(paused_until))
+                reason = f"circuit-open until {until} ({data.get('paused_reason', 'quota error')})"
+                _receipt("deny", kind=kind, reason=reason)
+                return BudgetDecision(reason=reason)
+            active = data.get("active", [])
+            if len(active) >= max_concurrent:
+                reason = f"global-concurrency ({len(active)}/{max_concurrent} active)"
+                _receipt("deny", kind=kind, reason=reason)
+                return BudgetDecision(reason=reason)
+            launches = data.get("launches", [])
+            hour_count = sum(1 for e in launches if now - float(e.get("at", 0)) < HOUR_S)
+            if hour_count >= per_hour:
+                reason = f"hourly-budget ({hour_count}/{per_hour} in last hour)"
+                _receipt("deny", kind=kind, reason=reason)
+                return BudgetDecision(reason=reason)
+            if len(launches) >= per_day:
+                reason = f"daily-budget ({len(launches)}/{per_day} in last 24h)"
+                _receipt("deny", kind=kind, reason=reason)
+                return BudgetDecision(reason=reason)
+            permit = f"permit_{int(now)}_{os.getpid()}_{os.urandom(3).hex()}"
+            launches.append({"at": now, "permit": permit, "kind": kind})
+            active.append({"at": now, "permit": permit, "pid": os.getpid()})
+            data["launches"] = launches
+            data["active"] = active
+            _write_ledger(SHIP_BUDGET_FILE, data)
+    except Exception as exc:
+        # Fail CLOSED: an unaccountable launch is what this fuse prevents.
+        reason = f"budget-unavailable ({exc})"
+        logger.error("Budget reserve failed closed: %s", exc)
+        _receipt("deny", kind=kind, reason=reason)
+        return BudgetDecision(reason=reason)
+    logger.info("Budget reserved %s (%d/%d this hour)", permit, hour_count + 1, per_hour)
+    _receipt("launch", kind=kind, permit=permit)
+    return BudgetDecision(allowed=True, permit_id=permit)
+
+
+def release(permit_id: str) -> None:
+    """Free the concurrency slot. The launch itself stays counted. Never raises."""
+    if not permit_id or permit_id.startswith("bypass_"):
+        return
+    try:
+        with _Lock(SHIP_BUDGET_LOCK):
+            data = _prune(_read_ledger(SHIP_BUDGET_FILE), _now())
+            before = len(data.get("active", []))
+            data["active"] = [e for e in data.get("active", []) if e.get("permit") != permit_id]
+            if len(data["active"]) != before:
+                _write_ledger(SHIP_BUDGET_FILE, data)
+    except Exception as exc:
+        logger.warning("Budget release failed (slot will expire on its own): %s", exc)
+    _receipt("release", permit=permit_id)
+
+
+def record_quota_error(detail: str) -> None:
+    """Open the circuit breaker after a failed launch's quota error. Never raises."""
+    now = _now()
+    _minutes = limits()[3]
+    try:
+        with _Lock(SHIP_BUDGET_LOCK):
+            data = _read_ledger(SHIP_BUDGET_FILE)
+            data["paused_until"] = now + _minutes * 60
+            data["paused_reason"] = (detail or "quota error")[:200]
+            _write_ledger(SHIP_BUDGET_FILE, data)
+    except Exception as exc:
+        logger.error("Could not open budget circuit breaker: %s", exc)
+        return
+    logger.warning("Budget circuit open for %d minutes: %s", _minutes, detail[:200])
+    _receipt("quota_pause", minutes=_minutes, detail=(detail or "")[:200])
+
+
+def status() -> BudgetStatus:
+    """A lock-free snapshot for the TUI/CLI. Empty on any read problem."""
+    max_concurrent, per_hour, per_day, _pause = limits()
+    now = _now()
+    try:
+        data = _prune(_read_ledger(SHIP_BUDGET_FILE), now)
+    except Exception:
+        data = {}
+    launches = data.get("launches", [])
+    return BudgetStatus(
+        active=len(data.get("active", [])),
+        launched_last_hour=sum(1 for e in launches if now - float(e.get("at", 0)) < HOUR_S),
+        launched_last_day=len(launches),
+        max_concurrent=max_concurrent,
+        max_per_hour=per_hour,
+        max_per_day=per_day,
+        paused_until=float(data.get("paused_until", 0) or 0) if float(data.get("paused_until", 0) or 0) > now else 0.0,
+        paused_reason=str(data.get("paused_reason", "")) if float(data.get("paused_until", 0) or 0) > now else "",
+    )

--- a/src/yeaboi/ship/budget.py
+++ b/src/yeaboi/ship/budget.py
@@ -65,9 +65,15 @@ _LOCK_POLL_S = 0.025
 _RECEIPTS_MAX_BYTES = 512 * 1024
 _RECEIPTS_KEEP_LINES = 200
 
-# Matched ONLY against the error output of a failed launch.
+# Matched ONLY against the error output of a failed launch — but that output
+# is the agent's own stdout tail, which can echo the user's code. So every
+# alternative here requires an error *shape*, never a bare topic word: an
+# agent that failed while WORKING ON rate-limiting code must not trip a
+# user-global hour-long pause.
 _QUOTA_ERROR_RE = re.compile(
-    r"\b429\b|rate[\s_-]?limit|usage[\s_-]?limit|quota|too many requests|overloaded_error",
+    r"\b429\b|rate[\s_-]?limit(?:ed|_error|s? (?:hit|reached|exceeded))"
+    r"|usage[\s_-]?limit|quota[\s_-]?(?:exceeded|reached|exhausted)"
+    r"|too many requests|overloaded_error",
     re.IGNORECASE,
 )
 
@@ -113,7 +119,10 @@ def _int_env(name: str, default: int) -> int:
         value = int(raw)
     except ValueError:
         return default
-    return value if value > 0 else default
+    # Zero is honoured, not "corrected": setting a limit to 0 is the user
+    # saying deny everything, which is the one direction a fail-closed fuse
+    # must always respect. Only nonsense (negatives) falls back.
+    return value if value >= 0 else default
 
 
 def limits() -> tuple[int, int, int, int]:
@@ -300,6 +309,32 @@ def reserve(*, kind: str = "ship") -> BudgetDecision:
     logger.info("Budget reserved %s (%d/%d this hour)", permit, hour_count + 1, per_hour)
     _receipt("launch", kind=kind, permit=permit)
     return BudgetDecision(allowed=True, permit_id=permit)
+
+
+def heartbeat(permit_id: str) -> None:
+    """Refresh a live permit's timestamp so the stale-reaper leaves it alone.
+
+    A whole ship run — agent, validation, an unbounded human gate wait — can
+    outlive ``ACTIVE_STALE_S``; without this the concurrency slot would be
+    reaped mid-run and a second launch allowed, silently breaking the
+    "1 concurrent" invariant. One permit also deliberately covers a run's
+    rework attempts: the budget counts *runs started*, not agent invocations.
+    Never raises.
+    """
+    if not permit_id or permit_id.startswith("bypass_"):
+        return
+    try:
+        with _Lock(SHIP_BUDGET_LOCK):
+            data = _read_ledger(SHIP_BUDGET_FILE)
+            touched = False
+            for entry in data.get("active", []):
+                if isinstance(entry, dict) and entry.get("permit") == permit_id:
+                    entry["at"] = _now()
+                    touched = True
+            if touched:
+                _write_ledger(SHIP_BUDGET_FILE, data)
+    except Exception as exc:
+        logger.warning("Budget heartbeat failed (slot may expire early): %s", exc)
 
 
 def release(permit_id: str) -> None:

--- a/src/yeaboi/ship/costing.py
+++ b/src/yeaboi/ship/costing.py
@@ -1,0 +1,91 @@
+"""Cost and security posture of one finished agent run, from its transcript.
+
+agentwatch already knows how to stream a Claude Code transcript into per-model
+token usage (deduped by requestId), price it through ``pricing.py``, and flag
+secrets / risky bash along the way. This module reuses that machinery for a
+single known file instead of a full-tree sweep.
+
+It deliberately lives here rather than as new public API on
+``agentwatch/collector.py``: the agentwatch family is mirrored line-for-line
+in the Go sidecar under the byte-parity contract, so the mirrored files stay
+untouched and this thin adapter imports their internals instead. If the
+sidecar ever needs this seam, promoting it is a deliberate dual-maintenance
+change — not a side effect of the ship mode.
+
+Reading ``~/.claude/projects`` is already permitted (and read-only) under
+``fs_policy``'s built-in rules; the transcript filename is the session id, so
+``locate_transcript`` is a glob, not a database.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from yeaboi.agentwatch.collector import IngestStats, _parse_file, _source_roots
+from yeaboi.agentwatch.engine import _session_cost
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TranscriptFinding:
+    """One security finding from the run's transcript (pattern + location only)."""
+
+    kind: str = ""  # "secret" | "risky_tool"
+    severity: str = ""
+    label: str = ""
+    line_no: int = 0
+
+
+@dataclass(frozen=True)
+class RunCost:
+    """What one agent run cost, and what its transcript showed."""
+
+    usd: float = 0.0
+    known_models: bool = True  # False when a model priced at the fallback tier
+    session_id: str = ""
+    turns: int = 0
+    findings: tuple[TranscriptFinding, ...] = ()
+
+
+def locate_transcript(session_id: str) -> Path | None:
+    """Find the transcript for *session_id* under the agent-session roots.
+
+    The filename is the session id — Claude Code writes one
+    ``<session-id>.jsonl`` per session under ``~/.claude/projects/<project>/``.
+    """
+    if not session_id or "/" in session_id or "\\" in session_id:
+        return None
+    for _source, root in _source_roots():
+        if not root.is_dir():
+            continue
+        for candidate in root.rglob(f"{session_id}.jsonl"):
+            return candidate
+    return None
+
+
+def cost_transcript(path: Path) -> RunCost | None:
+    """Price one transcript file; None when it cannot be read at all."""
+    findings: list[TranscriptFinding] = []
+
+    def _on_finding(kind: str, severity: str, label: str, line_no: int, _session_id: str) -> None:
+        findings.append(TranscriptFinding(kind=kind, severity=severity, label=label, line_no=line_no))
+
+    stats = IngestStats()
+    try:
+        rollup = _parse_file(path, stats=stats, on_finding=_on_finding)
+    except OSError as exc:
+        logger.warning("Could not read transcript %s: %s", path, exc)
+        return None
+    usd, all_known = _session_cost(rollup.model_usage)
+    if stats.malformed_lines:
+        logger.info("Transcript %s had %d malformed lines", path.name, stats.malformed_lines)
+    return RunCost(
+        usd=usd,
+        known_models=all_known,
+        session_id=rollup.session_id,
+        turns=rollup.turns,
+        findings=tuple(findings),
+    )

--- a/src/yeaboi/ship/driver.py
+++ b/src/yeaboi/ship/driver.py
@@ -54,6 +54,22 @@ _TAIL_LINES = 400
 # knows. yeaboi is routinely launched from one, so the child must not inherit.
 _SESSION_ENV_VARS = ("CLAUDE_SESSION_ID", "CLAUDE_PARENT_SESSION_ID", "CLAUDECODE")
 
+# The agent's capability envelope, and it is MECHANICAL, not prose:
+# `acceptEdits` lets file edits land without a prompt (a headless --print run
+# cannot answer one, so the default mode would leave the agent unable to edit
+# at all), while Bash and every other gated tool stay denied — the agent
+# cannot run git, so it physically cannot push, commit, or open a PR; the
+# pipeline commits its work and pushes only after the human gate. The
+# disallow list is belt and braces on top: an explicit deny outranks every
+# permission mode if one is ever passed.
+_PERMISSION_ARGS = (
+    "--permission-mode",
+    "acceptEdits",
+    "--disallowedTools",
+    "Bash(git push:*)",
+    "Bash(gh:*)",
+)
+
 
 @dataclass(frozen=True)
 class DriverResult:
@@ -185,7 +201,7 @@ class ClaudeCodeDriver:
         warnings: list[str] = []
         try:
             proc = subprocess.Popen(  # noqa: S603 — fixed binary + flags; prompt over stdin
-                [self._binary, "--print", "--output-format", "json"],
+                [self._binary, "--print", "--output-format", "json", *_PERMISSION_ARGS],
                 cwd=str(cwd),
                 env=self._child_env(),
                 stdin=subprocess.PIPE,
@@ -202,12 +218,18 @@ class ClaudeCodeDriver:
         logger.info("Agent run started (pid %s, cwd %s)", proc.pid, cwd)
 
         tail: deque[str] = deque(maxlen=_TAIL_LINES)
+        # The pump may still be appending when the supervisor snapshots (a
+        # grandchild that inherited stdout can hold the pipe open after claude
+        # exits), and iterating a mutating deque raises — so every touch of
+        # ``tail`` happens under this lock.
+        tail_lock = threading.Lock()
 
         def _pump() -> None:
             assert proc.stdout is not None
             for raw_line in proc.stdout:
                 line = raw_line.rstrip("\n")
-                tail.append(line)
+                with tail_lock:
+                    tail.append(line)
                 if on_line is not None:
                     try:
                         on_line(line)
@@ -237,10 +259,16 @@ class ClaudeCodeDriver:
                 _terminate_group(proc)
                 break
             time.sleep(_POLL_S)
-        proc.wait()
+        try:
+            # Bounded: after a kill ladder that logged "would not die" an
+            # unbounded wait would hang the supervisor thread forever.
+            proc.wait(timeout=_KILL_GRACE_S)
+        except subprocess.TimeoutExpired:
+            logger.error("Agent process %s survived the kill ladder; abandoning it", proc.pid)
         pump.join(timeout=_KILL_GRACE_S)
         duration = time.monotonic() - started
-        raw = "\n".join(tail)
+        with tail_lock:
+            raw = "\n".join(tail)
         envelope = _parse_envelope(raw)
         if not envelope and raw.strip():
             warnings.append("agent output was not the expected JSON envelope; using raw text")

--- a/src/yeaboi/ship/driver.py
+++ b/src/yeaboi/ship/driver.py
@@ -1,0 +1,280 @@
+"""The coding-agent driver: spawn and supervise a headless Claude Code run.
+
+The provider seam is archon's three-method shape (``run`` / ``get_type`` /
+``get_capabilities``) so a second agent CLI can slot in later; the Claude Code
+implementation is ruflo's hard-won recipe, every detail of which was a
+production failure upstream:
+
+- **The prompt goes over stdin, never argv** — write then close; the EOF is
+  what unblocks ``--print``. (Upstream scar: Windows re-tokenizes argv through
+  ``cmd.exe`` and a prompt containing ``>`` created files.)
+- **Session env vars are stripped** (``CLAUDE_SESSION_ID``,
+  ``CLAUDE_PARENT_SESSION_ID``, ``CLAUDECODE``): Claude Code detects a nested
+  session and exits immediately, and yeaboi is very often launched from inside
+  one.
+- **The child gets its own process group** (``start_new_session=True``) and
+  the kill ladder targets the whole group: ``claude`` spawns grandchildren
+  (MCP bridges, tools), and a plain ``kill()`` orphans them to init.
+- **The JSON envelope is parsed leniently**: a schema surprise from an older
+  or newer CLI degrades to raw text with a warning, never an exception —
+  downstream, the deterministic bridge judges the run by the diff on disk,
+  not by what the agent said.
+
+Supervision follows ``voice_install._run_installer``: a daemon pump thread
+reads stdout for the process's whole life (so the pipe can never fill and
+block the child), and the supervisor loop polls a cancel event and a
+monotonic deadline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_S = 30 * 60  # one run implements one story; longer means stuck
+_KILL_GRACE_S = 5.0
+_POLL_S = 0.2
+_PROBE_TIMEOUT_S = 5.0
+_TAIL_LINES = 400
+
+# Claude Code refuses to start inside another Claude session; these are how it
+# knows. yeaboi is routinely launched from one, so the child must not inherit.
+_SESSION_ENV_VARS = ("CLAUDE_SESSION_ID", "CLAUDE_PARENT_SESSION_ID", "CLAUDECODE")
+
+
+@dataclass(frozen=True)
+class DriverResult:
+    """What one supervised run produced. ``ok`` means the process exited 0 —
+    whether it actually *did* anything is the pipeline bridge's question."""
+
+    ok: bool = False
+    output: str = ""  # the agent's final text (envelope `result`, else raw tail)
+    session_id: str = ""
+    returncode: int = -1
+    timed_out: bool = False
+    cancelled: bool = False
+    error: str = ""  # tail of output when the run failed
+    duration_s: float = 0.0
+    cost_usd: float = 0.0  # the envelope's own figure; 0.0 when absent
+    num_turns: int = 0
+    warnings: tuple[str, ...] = ()
+
+
+class AgentDriver(Protocol):
+    """The provider seam: anything that can run one prompt in one directory."""
+
+    def run(
+        self,
+        prompt: str,
+        cwd: Path,
+        *,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        cancel_event: threading.Event | None = None,
+        on_line: Callable[[str], None] | None = None,
+    ) -> DriverResult: ...
+
+    def get_type(self) -> str: ...
+
+    def get_capabilities(self) -> dict[str, object]: ...
+
+
+def _terminate_group(proc: subprocess.Popen) -> None:
+    """SIGTERM the child's whole group, escalate to SIGKILL after a grace."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=_KILL_GRACE_S)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        proc.kill()
+    try:
+        proc.wait(timeout=_KILL_GRACE_S)
+    except subprocess.TimeoutExpired:
+        logger.error("Agent process %s would not die", proc.pid)
+
+
+def _parse_envelope(raw: str) -> dict:
+    """The ``--output-format json`` envelope, or {} — never an exception."""
+    text = raw.strip()
+    if not text:
+        return {}
+    try:
+        data = json.loads(text)
+        return data if isinstance(data, dict) else {}
+    except ValueError:
+        pass
+    # Some CLI versions print progress lines before the envelope; try the tail.
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                data = json.loads(line)
+                return data if isinstance(data, dict) else {}
+            except ValueError:
+                continue
+    return {}
+
+
+class ClaudeCodeDriver:
+    """Run Claude Code headless: ``claude --print --output-format json``."""
+
+    def __init__(self, binary: str = "claude") -> None:
+        self._binary = binary
+
+    def get_type(self) -> str:
+        return "claude_code"
+
+    def get_capabilities(self) -> dict[str, object]:
+        return {"session_resume": True, "structured_output": "best-effort", "cost_visibility": True}
+
+    def available(self) -> tuple[bool, str]:
+        """(usable, detail). Probed with a hard timeout; never raises."""
+        path = shutil.which(self._binary)
+        if not path:
+            return False, f"{self._binary} not found on PATH"
+        try:
+            proc = subprocess.run(  # noqa: S603 — fixed binary, fixed args
+                [path, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=_PROBE_TIMEOUT_S,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return False, f"{self._binary} --version failed: {exc}"
+        if proc.returncode != 0:
+            return False, f"{self._binary} --version exited {proc.returncode}"
+        return True, (proc.stdout or "").strip()
+
+    def _child_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        for var in _SESSION_ENV_VARS:
+            env.pop(var, None)
+        return env
+
+    def run(
+        self,
+        prompt: str,
+        cwd: Path,
+        *,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        cancel_event: threading.Event | None = None,
+        on_line: Callable[[str], None] | None = None,
+    ) -> DriverResult:
+        """Supervise one run to completion, cancellation, or timeout. Never raises."""
+        started = time.monotonic()
+        warnings: list[str] = []
+        try:
+            proc = subprocess.Popen(  # noqa: S603 — fixed binary + flags; prompt over stdin
+                [self._binary, "--print", "--output-format", "json"],
+                cwd=str(cwd),
+                env=self._child_env(),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                encoding="utf-8",
+                errors="replace",
+                start_new_session=True,
+            )
+        except OSError as exc:
+            return DriverResult(error=f"could not launch {self._binary}: {exc}")
+        logger.info("Agent run started (pid %s, cwd %s)", proc.pid, cwd)
+
+        tail: deque[str] = deque(maxlen=_TAIL_LINES)
+
+        def _pump() -> None:
+            assert proc.stdout is not None
+            for raw_line in proc.stdout:
+                line = raw_line.rstrip("\n")
+                tail.append(line)
+                if on_line is not None:
+                    try:
+                        on_line(line)
+                    except Exception:  # a UI callback must never kill the pump
+                        pass
+
+        pump = threading.Thread(target=_pump, name="ship-agent-pump", daemon=True)
+        pump.start()
+        try:
+            assert proc.stdin is not None
+            proc.stdin.write(prompt)
+            proc.stdin.close()
+        except (BrokenPipeError, OSError) as exc:
+            warnings.append(f"agent closed stdin early: {exc}")
+
+        timed_out = cancelled = False
+        deadline = started + timeout_s
+        while proc.poll() is None:
+            if cancel_event is not None and cancel_event.is_set():
+                cancelled = True
+                logger.info("Agent run cancelled; terminating pid %s", proc.pid)
+                _terminate_group(proc)
+                break
+            if time.monotonic() > deadline:
+                timed_out = True
+                logger.warning("Agent run exceeded %.0fs; terminating pid %s", timeout_s, proc.pid)
+                _terminate_group(proc)
+                break
+            time.sleep(_POLL_S)
+        proc.wait()
+        pump.join(timeout=_KILL_GRACE_S)
+        duration = time.monotonic() - started
+        raw = "\n".join(tail)
+        envelope = _parse_envelope(raw)
+        if not envelope and raw.strip():
+            warnings.append("agent output was not the expected JSON envelope; using raw text")
+        output = str(envelope.get("result") or "") or raw
+        ok = proc.returncode == 0 and not timed_out and not cancelled and not bool(envelope.get("is_error"))
+        error = ""
+        if not ok:
+            error = raw[-2000:] if raw else (f"exit {proc.returncode}" if not timed_out else "timed out")
+        logger.info(
+            "Agent run finished: exit=%s ok=%s timed_out=%s cancelled=%s %.1fs",
+            proc.returncode,
+            ok,
+            timed_out,
+            cancelled,
+            duration,
+        )
+        try:
+            cost = float(envelope.get("total_cost_usd") or 0.0)
+        except (TypeError, ValueError):
+            cost = 0.0
+        try:
+            turns = int(envelope.get("num_turns") or 0)
+        except (TypeError, ValueError):
+            turns = 0
+        return DriverResult(
+            ok=ok,
+            output=output,
+            session_id=str(envelope.get("session_id") or ""),
+            returncode=proc.returncode if proc.returncode is not None else -1,
+            timed_out=timed_out,
+            cancelled=cancelled,
+            error=error,
+            duration_s=duration,
+            cost_usd=cost,
+            num_turns=turns,
+            warnings=tuple(warnings),
+        )

--- a/src/yeaboi/ship/engine.py
+++ b/src/yeaboi/ship/engine.py
@@ -1,0 +1,418 @@
+"""Ship engine — one supervised story → PR run, as a standalone pipeline.
+
+NOT a LangGraph node: like every mode engine this is a plain function the TUI,
+CLI and MCP adapt thinly (# See docs: "Architecture" — four layers). There is
+no LLM call anywhere in *this* process — the model runs inside the spawned
+Claude Code subprocess; yeaboi's job is the deterministic frame around it:
+budget, isolation, evidence bridges, validation, the human gate, and the PR.
+
+Engine conventions (# See docs: "Agentic Blueprint Reference"):
+- never raises — every failure is a ``ShipRun(status="failed")`` with the
+  reason in ``warnings``;
+- ``on_progress`` receives ``analysis_component`` lifecycle events so every
+  existing progress screen renders it unchanged;
+- ``cancel_event`` is polled between units of work, never mid-subprocess-kill.
+
+The gate wait is a poll of the store, not an in-memory flag: resolution
+arrives via ``ShipStore.resolve_gate`` from whichever surface the approver
+used (TUI screen, CLI prompt — one seam, the practice-feedback pattern), and
+the database CAS is the arbiter, so two surfaces racing resolve exactly once.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+from yeaboi.agent.state import ShipPhase, ShipRun, ShipValidation
+from yeaboi.analysis.progress import send_component_progress
+from yeaboi.ship import budget, costing, pipeline, worktree
+from yeaboi.ship.driver import ClaudeCodeDriver, DriverResult
+from yeaboi.ship.store import ShipStore
+
+logger = logging.getLogger(__name__)
+
+MAX_REJECTION_ATTEMPTS = 3  # after this many gate rejections the run is terminal
+_GATE_POLL_S = 1.0
+
+
+class _RunAbortError(Exception):
+    """Internal control flow: carries the terminal artifact out of a phase."""
+
+    def __init__(self, run: ShipRun) -> None:
+        super().__init__(run.status)
+        self.run = run
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _report(on_progress, component_id: str, label: str, status: str, **kwargs) -> None:
+    try:
+        send_component_progress(on_progress, component_id=component_id, label=label, status=status, **kwargs)
+    except Exception:  # a progress consumer must never kill the run
+        logger.debug("progress callback failed", exc_info=True)
+
+
+def _new_run_id(story_id: str) -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    safe = "".join(c if c.isalnum() or c in "._-" else "-" for c in story_id.lower()).strip("-.")[:40]
+    return f"{safe or 'story'}-{stamp}"
+
+
+def _failed(run: ShipRun, reason: str, *, phase: str = "") -> ShipRun:
+    phases = run.phases
+    if phase:
+        phases = (*phases, ShipPhase(name=phase, status="failed", detail=reason[:300]))
+    return replace(run, status="failed", phases=phases, warnings=(*run.warnings, reason), updated_at=_now_iso())
+
+
+def _load_story(session_id: str, story_id: str, db_path: Path | None):
+    """(story, tasks, resolved_session_id) — raises ValueError with a plain reason."""
+    from yeaboi.paths import get_db_path
+    from yeaboi.sessions import SessionStore
+
+    with SessionStore(db_path or get_db_path()) as sessions:
+        resolved = session_id or sessions.get_latest_session_id()
+        if not resolved:
+            raise ValueError("no saved planning sessions — generate a plan first")
+        state = sessions.load_state(resolved)
+    if state is None:
+        raise ValueError(f"session {resolved} has no saved state")
+    story, tasks = pipeline.find_story(state, story_id)
+    return story, tasks, resolved
+
+
+def _dry_run_artifact(story_id: str, repo: str) -> ShipRun:
+    """A canned, fully-shaped run: no subprocess, no git, no network."""
+    phases = tuple(
+        ShipPhase(name=name, status="completed", detail="dry run")
+        for name in ("setup", "implement", "validate", "gate", "finalize")
+    )
+    return ShipRun(
+        run_id="dry-run",
+        story_id=story_id,
+        repo=repo,
+        branch="ship/dry-run",
+        status="approved",
+        phases=phases,
+        validation=ShipValidation(configured=True, command="(dry run)", passed=True, exit_code=0),
+        diff_stat="(dry run — nothing was executed)",
+        gate_resolution="approved",
+        created_at=_now_iso(),
+        updated_at=_now_iso(),
+        warnings=("dry run — no agent was launched and nothing was written",),
+    )
+
+
+def _save(store: ShipStore, run: ShipRun, *, expect_status: str | None = None) -> ShipRun:
+    """Persist a transition; on a lost CAS adopt the stored truth."""
+    if store.save_run(run, expect_status=expect_status):
+        return run
+    stored = store.get_run(run.run_id)
+    logger.warning("Lost a status race for %s; adopting stored state %s", run.run_id, getattr(stored, "status", "?"))
+    return stored or run
+
+
+def _await_gate(
+    store: ShipStore,
+    run: ShipRun,
+    *,
+    cancel_event: threading.Event | None,
+) -> ShipRun:
+    """Poll until the gate is resolved or the run is cancelled."""
+    while True:
+        if cancel_event is not None and cancel_event.is_set():
+            cancelled = replace(run, status="cancelled", updated_at=_now_iso())
+            return _save(store, cancelled, expect_status="awaiting_approval")
+        current = store.get_run(run.run_id) or run
+        if current.gate_resolution:
+            return current
+        time.sleep(_GATE_POLL_S)
+
+
+def run_ship(
+    story_id: str,
+    repo: str,
+    *,
+    session_id: str = "",
+    check_command: str = "",
+    timeout_minutes: int = 30,
+    db_path: Path | None = None,
+    dry_run: bool = False,
+    on_progress: Callable | None = None,
+    cancel_event: threading.Event | None = None,
+    driver: object | None = None,
+) -> ShipRun:
+    """Drive one story from the saved plan to an approved PR. Never raises.
+
+    ``driver`` is an injection seam (an ``AgentDriver``); the default is
+    Claude Code headless. The human gate always resolves through
+    ``ShipStore.resolve_gate`` — this function only waits for it.
+    """
+    if dry_run:
+        return _dry_run_artifact(story_id, repo)
+    agent = driver if driver is not None else ClaudeCodeDriver()
+
+    # -- resolve inputs before spending anything ---------------------------
+    try:
+        story, tasks, resolved_session = _load_story(session_id, story_id, db_path)
+    except Exception as exc:  # noqa: BLE001 — a broken DB is a failed run, not a crash
+        return _failed(ShipRun(story_id=story_id, repo=repo, created_at=_now_iso()), f"could not load story: {exc}")
+
+    available, detail = True, ""
+    probe = getattr(agent, "available", None)
+    if callable(probe):
+        available, detail = probe()
+    if not available:
+        return _failed(
+            ShipRun(story_id=story_id, repo=repo, session_id=resolved_session, created_at=_now_iso()),
+            f"coding agent unavailable: {detail}",
+        )
+
+    run_id = _new_run_id(story_id)
+    run = ShipRun(
+        run_id=run_id,
+        story_id=story_id,
+        session_id=resolved_session,
+        repo=repo,
+        status="planned",
+        created_at=_now_iso(),
+    )
+
+    # -- budget ------------------------------------------------------------
+    decision = budget.reserve()
+    if not decision.allowed:
+        return _failed(run, f"launch budget denied: {decision.reason}")
+    permit = decision.permit_id
+    store = ShipStore(db_path)
+    try:
+        return _run_phases(
+            store,
+            run,
+            story,
+            tasks,
+            agent,
+            check_command=check_command,
+            timeout_minutes=timeout_minutes,
+            on_progress=on_progress,
+            cancel_event=cancel_event,
+        )
+    except _RunAbortError as aborted:
+        return aborted.run
+    except Exception as exc:  # noqa: BLE001 — the engine contract: never raise
+        logger.exception("Ship run %s crashed", run_id)
+        failed = _failed(run, f"unexpected failure: {exc}")
+        try:
+            store.save_run(failed)
+        except Exception:
+            pass
+        return failed
+    finally:
+        budget.release(permit)
+        store.close()
+
+
+def _run_phases(
+    store: ShipStore,
+    run: ShipRun,
+    story,
+    tasks,
+    agent,
+    *,
+    check_command: str,
+    timeout_minutes: int,
+    on_progress,
+    cancel_event,
+) -> ShipRun:
+    """The phase sequence. Raises _RunAbortError with the terminal artifact."""
+
+    def _abort(terminal: ShipRun) -> None:
+        try:
+            store.save_run(terminal)
+        except Exception:
+            logger.warning("Could not persist terminal state for %s", terminal.run_id)
+        raise _RunAbortError(terminal)
+
+    def _phase_done(name: str, detail: str, started: float) -> None:
+        nonlocal run
+        phase = ShipPhase(name=name, status="completed", detail=detail[:300], duration_s=time.monotonic() - started)
+        run = replace(run, phases=(*run.phases, phase), updated_at=_now_iso())
+
+    # -- setup -------------------------------------------------------------
+    started = time.monotonic()
+    _report(on_progress, "ship-setup", "Preparing isolated worktree", "running")
+    try:
+        record = worktree.prepare(run.run_id, run.repo)
+    except worktree.WorktreeError as exc:
+        _report(on_progress, "ship-setup", "Preparing isolated worktree", "failed", detail=str(exc))
+        _abort(_failed(run, str(exc), phase="setup"))
+    run = replace(run, repo=record.repo, branch=record.branch, worktree=record.path, base_sha=record.base_sha)
+    _phase_done("setup", f"worktree at {record.path}", started)
+    run = store.record_run(replace(run, status="running"))
+    _report(on_progress, "ship-setup", "Preparing isolated worktree", "completed")
+
+    # -- implement ---------------------------------------------------------
+    prompt = pipeline.build_prompt(story, tasks)
+    result = _implement(agent, prompt, record, run, timeout_minutes, on_progress, cancel_event, label="Implementing")
+    if result is None:  # cancelled
+        _abort(_save(store, replace(run, status="cancelled", updated_at=_now_iso())))
+
+    # -- bridge + validate + gate loop ------------------------------------
+    while True:
+        started = time.monotonic()
+        _report(on_progress, "ship-validate", "Validating the diff", "running")
+        try:
+            has_work, diff_stat = pipeline.diff_bridge(record)
+        except worktree.WorktreeError as exc:
+            _abort(_failed(run, f"could not inspect the worktree: {exc}", phase="validate"))
+        if not has_work:
+            # The bridge: an agent that declined still exited 0. The diff is
+            # the evidence, and there is none.
+            detail = "the agent produced no changes"
+            if result is not None and result.output:
+                detail += f" — it said: {result.output[:400]}"
+            _report(on_progress, "ship-validate", "Validating the diff", "failed", detail="no changes")
+            _abort(_failed(run, detail, phase="implement"))
+        validation = pipeline.run_validation(record, check_command)
+        run = replace(run, diff_stat=diff_stat, validation=validation, updated_at=_now_iso())
+        _phase_done("validate", "passed" if validation.passed else "see gate screen", started)
+        _report(
+            on_progress,
+            "ship-validate",
+            "Validating the diff",
+            "completed" if (not validation.configured or validation.passed) else "partial",
+        )
+        run = _attach_cost(run, result)
+
+        # -- gate ----------------------------------------------------------
+        _report(on_progress, "ship-gate", "Awaiting human approval", "running")
+        run = replace(run, status="awaiting_approval", gate_resolution="", gate_comment="", updated_at=_now_iso())
+        run = _save(store, run, expect_status="running")
+        if run.status != "awaiting_approval":
+            _abort(run)  # someone else moved the run; their state wins
+        run = _await_gate(store, run, cancel_event=cancel_event)
+        if run.status == "cancelled":
+            _report(on_progress, "ship-gate", "Awaiting human approval", "failed", detail="cancelled")
+            raise _RunAbortError(run)
+        if run.gate_resolution == "approved":
+            _report(on_progress, "ship-gate", "Awaiting human approval", "completed")
+            break
+        # rejected
+        if run.rejection_count >= MAX_REJECTION_ATTEMPTS:
+            _report(on_progress, "ship-gate", "Awaiting human approval", "failed", detail="rejected")
+            terminal = replace(
+                run,
+                status="rejected",
+                phases=(*run.phases, ShipPhase(name="gate", status="failed", detail="rejected at attempts cap")),
+                updated_at=_now_iso(),
+            )
+            _abort(_save(store, terminal, expect_status="awaiting_approval"))
+        _report(on_progress, "ship-gate", "Awaiting human approval", "partial", detail="rejected — reworking")
+        rework = pipeline.rework_prompt(run.gate_comment, run.validation)
+        run = _save(store, replace(run, status="running", updated_at=_now_iso()), expect_status="awaiting_approval")
+        if run.status != "running":
+            _abort(run)
+        result = _implement(
+            agent, rework, record, run, timeout_minutes, on_progress, cancel_event, label="Reworking after rejection"
+        )
+        if result is None:
+            _abort(_save(store, replace(run, status="cancelled", updated_at=_now_iso())))
+
+    # -- finalize ----------------------------------------------------------
+    started = time.monotonic()
+    _report(on_progress, "ship-finalize", "Pushing branch and opening PR", "running")
+    title = f"{story.title or story.id} (via yeaboi ship)"
+    summary = _pr_summary(run, story)
+    outcome = pipeline.push_and_open_pr(record, title=title, body=pipeline.build_pr_body(summary, run.gate_comment))
+    if not outcome.pushed:
+        _report(on_progress, "ship-finalize", "Pushing branch and opening PR", "failed", detail=outcome.detail)
+        _abort(_failed(run, outcome.detail, phase="finalize"))
+    _phase_done("finalize", outcome.detail, started)
+    run = replace(run, status="approved", pr_url=outcome.pr_url, updated_at=_now_iso())
+    run = _save(store, run, expect_status="awaiting_approval")
+    _report(on_progress, "ship-finalize", "Pushing branch and opening PR", "completed", detail=outcome.pr_url)
+    logger.info("Ship run %s finished: %s", run.run_id, outcome.detail)
+    return run
+
+
+def _implement(
+    agent,
+    prompt: str,
+    record,
+    run: ShipRun,
+    timeout_minutes: int,
+    on_progress,
+    cancel_event,
+    *,
+    label: str,
+) -> DriverResult | None:
+    """One driver invocation. None means cancelled; a failed run aborts here
+    only on launch/quota problems — 'it ran but did nothing' is the bridge's
+    call, not ours."""
+    _report(on_progress, "ship-implement", label, "running")
+    result = agent.run(
+        prompt,
+        Path(record.path),
+        timeout_s=max(1, timeout_minutes) * 60,
+        cancel_event=cancel_event,
+        on_line=None,
+    )
+    if result.cancelled:
+        _report(on_progress, "ship-implement", label, "failed", detail="cancelled")
+        return None
+    if not result.ok and budget.looks_like_quota_error(result.error):
+        budget.record_quota_error(result.error[-300:])
+    _report(on_progress, "ship-implement", label, "completed" if result.ok else "partial")
+    return result
+
+
+def _attach_cost(run: ShipRun, result: DriverResult | None) -> ShipRun:
+    """Fold the transcript's cost + security findings into the artifact."""
+    if result is None or not result.session_id:
+        return run
+    transcript = costing.locate_transcript(result.session_id)
+    if transcript is None:
+        return replace(run, agent_session_id=result.session_id, cost_usd=run.cost_usd + result.cost_usd)
+    cost = costing.cost_transcript(transcript)
+    if cost is None:
+        return replace(run, agent_session_id=result.session_id, transcript_path=str(transcript))
+    findings = tuple((f.kind, f.severity, f.label) for f in cost.findings)
+    return replace(
+        run,
+        agent_session_id=result.session_id,
+        transcript_path=str(transcript),
+        cost_usd=run.cost_usd + (cost.usd or result.cost_usd),
+        transcript_findings=(*run.transcript_findings, *findings),
+    )
+
+
+def _pr_summary(run: ShipRun, story) -> str:
+    """The PR body's summary section — plan facts, run facts, no transcript."""
+    lines = [
+        "## Summary",
+        "",
+        f"Implements story `{run.story_id}` from the yeaboi sprint plan:",
+        "",
+        f"> {story.text}",
+        "",
+        "## Run record",
+        "",
+        f"- Diff: {run.diff_stat.splitlines()[-1] if run.diff_stat else 'see files changed'}",
+    ]
+    if run.validation.configured:
+        state = "passed" if run.validation.passed else f"FAILED (exit {run.validation.exit_code})"
+        lines.append(f"- Validation `{run.validation.command}`: {state}")
+    else:
+        lines.append("- Validation: none configured")
+    if run.cost_usd:
+        lines.append(f"- Agent cost: ${run.cost_usd:.2f}")
+    if run.rejection_count:
+        lines.append(f"- Gate rejections before approval: {run.rejection_count}")
+    return "\n".join(lines)

--- a/src/yeaboi/ship/engine.py
+++ b/src/yeaboi/ship/engine.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 MAX_REJECTION_ATTEMPTS = 3  # after this many gate rejections the run is terminal
 _GATE_POLL_S = 1.0
+_HEARTBEAT_S = 300.0  # budget-permit refresh cadence; well under budget.ACTIVE_STALE_S
 
 
 class _RunAbortError(Exception):
@@ -191,8 +192,21 @@ def run_ship(
     if not decision.allowed:
         return _failed(run, f"launch budget denied: {decision.reason}")
     permit = decision.permit_id
-    store = ShipStore(db_path)
+    # A whole run (agent + validation + an unbounded gate wait) can outlive
+    # the budget's stale-permit cutoff; the heartbeat keeps the concurrency
+    # slot honest for as long as this run actually lives.
+    stop_heartbeat = threading.Event()
+
+    def _keep_permit_alive() -> None:
+        while not stop_heartbeat.wait(_HEARTBEAT_S):
+            budget.heartbeat(permit)
+
+    threading.Thread(target=_keep_permit_alive, name="ship-budget-heartbeat", daemon=True).start()
+    store: ShipStore | None = None
     try:
+        # Inside the try: a locked/corrupt sessions.db must fail the run, not
+        # raise past the contract — and must not leak the permit for 30 min.
+        store = ShipStore(db_path)
         return _run_phases(
             store,
             run,
@@ -209,14 +223,17 @@ def run_ship(
     except Exception as exc:  # noqa: BLE001 — the engine contract: never raise
         logger.exception("Ship run %s crashed", run_id)
         failed = _failed(run, f"unexpected failure: {exc}")
-        try:
-            store.save_run(failed)
-        except Exception:
-            pass
+        if store is not None:
+            try:
+                store.save_run(failed)
+            except Exception:
+                pass
         return failed
     finally:
+        stop_heartbeat.set()
         budget.release(permit)
-        store.close()
+        if store is not None:
+            store.close()
 
 
 def _run_phases(
@@ -337,6 +354,12 @@ def _run_phases(
     _phase_done("finalize", outcome.detail, started)
     run = replace(run, status="approved", pr_url=outcome.pr_url, updated_at=_now_iso())
     run = _save(store, run, expect_status="awaiting_approval")
+    # The work is on origin now; the checkout has served its purpose. The
+    # branch is kept (delete_branch defaults False) — it IS the record. On
+    # every non-approved terminal path the checkout is kept too, for
+    # inspection of what the agent actually did.
+    if not worktree.remove(run.run_id):
+        logger.warning("Could not clean up worktree for %s; remove it by hand", run.run_id)
     _report(on_progress, "ship-finalize", "Pushing branch and opening PR", "completed", detail=outcome.pr_url)
     logger.info("Ship run %s finished: %s", run.run_id, outcome.detail)
     return run

--- a/src/yeaboi/ship/pipeline.py
+++ b/src/yeaboi/ship/pipeline.py
@@ -13,7 +13,9 @@ engine sequences these pieces and owns status transitions.
 from __future__ import annotations
 
 import logging
+import os
 import re
+import signal
 import subprocess
 import urllib.parse
 from dataclasses import dataclass
@@ -80,7 +82,9 @@ def build_prompt(story: UserStory, tasks: list[Task]) -> str:
         "Run contract:",
         "- Work only inside this repository checkout.",
         "- Follow the repository's existing conventions and test layout.",
-        "- Commit your work with clear messages. Do NOT push, do NOT open PRs.",
+        "- You have file-edit permissions and no shell: edit files only. The",
+        "  pipeline runs validation, commits your work, and pushes only after",
+        "  a human approves the diff — do not attempt git or gh commands.",
         "- If you cannot complete the story, say why plainly and change nothing.",
     ]
     return "\n".join(lines)
@@ -137,24 +141,33 @@ def run_validation(record: WorktreeRecord, command: str) -> ShipValidation:
     if not command.strip():
         return ShipValidation(configured=False)
     try:
-        proc = subprocess.run(  # noqa: S602 — the user's own check command (e.g. `make test`), by design
+        # Popen + its own process group, not subprocess.run: on timeout run()
+        # kills only the shell, and then blocks in communicate() on the pipes
+        # the orphaned grandchildren (pytest under make) still hold open —
+        # the "timed out" path would hang the worker forever.
+        proc = subprocess.Popen(  # noqa: S602 — the user's own check command (e.g. `make test`), by design
             command,
             shell=True,
             cwd=record.path,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
-            timeout=VALIDATION_TIMEOUT_S,
             env=git_subprocess_env(),
+            start_new_session=True,
         )
-        tail = ((proc.stdout or "") + (proc.stderr or ""))[-_TAIL_CHARS:]
-        return ShipValidation(
-            configured=True,
-            command=command,
-            passed=proc.returncode == 0,
-            exit_code=proc.returncode,
-            output_tail=tail,
-        )
+    except OSError as exc:
+        return ShipValidation(configured=True, command=command, passed=False, exit_code=-1, output_tail=str(exc))
+    try:
+        out, _ = proc.communicate(timeout=VALIDATION_TIMEOUT_S)
     except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            proc.kill()
+        try:
+            proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            logger.error("Validation command would not die: %s", command)
         return ShipValidation(
             configured=True,
             command=command,
@@ -162,8 +175,13 @@ def run_validation(record: WorktreeRecord, command: str) -> ShipValidation:
             exit_code=-1,
             output_tail=f"validation timed out after {VALIDATION_TIMEOUT_S}s",
         )
-    except OSError as exc:
-        return ShipValidation(configured=True, command=command, passed=False, exit_code=-1, output_tail=str(exc))
+    return ShipValidation(
+        configured=True,
+        command=command,
+        passed=proc.returncode == 0,
+        exit_code=proc.returncode,
+        output_tail=(out or "")[-_TAIL_CHARS:],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -196,8 +214,9 @@ def rework_prompt(comment: str, validation: ShipValidation) -> str:
         lines.append(f"Its output ended with:\n{validation.output_tail[-1500:]}")
     lines += [
         "",
-        "Address the feedback with further commits on this branch.",
-        "Commit your work. Do NOT push, do NOT open PRs.",
+        "Address the feedback by editing the files on this branch. You have",
+        "file-edit permissions and no shell; the pipeline re-validates and",
+        "commits your work — do not attempt git or gh commands.",
     ]
     return "\n".join(lines)
 

--- a/src/yeaboi/ship/pipeline.py
+++ b/src/yeaboi/ship/pipeline.py
@@ -1,0 +1,259 @@
+"""The deterministic halves of a ship run: prompt, bridges, validation, PR.
+
+The pipeline's honesty pattern is archon's precondition bridge: **an agent
+that declines a task still exits 0**, so after the implement phase a cheap
+deterministic check — is there actually a diff on disk? — is what decides
+whether the run proceeds. Exit codes from a model are not evidence of work; a
+commit is.
+
+Everything here is subprocess/git/HTTP plumbing with no LLM anywhere; the
+engine sequences these pieces and owns status transitions.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import urllib.parse
+from dataclasses import dataclass
+
+from yeaboi.agent.state import ShipValidation, Task, UserStory
+from yeaboi.ship.worktree import WorktreeError, WorktreeRecord, _git
+from yeaboi.tools.local_git import git_subprocess_env
+
+logger = logging.getLogger(__name__)
+
+VALIDATION_TIMEOUT_S = 15 * 60
+_TAIL_CHARS = 4000
+
+_GITHUB_REMOTE_RE = re.compile(r"github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?/?$")
+
+
+# ---------------------------------------------------------------------------
+# Story → prompt
+# ---------------------------------------------------------------------------
+
+
+def find_story(state: dict, story_id: str) -> tuple[UserStory, list[Task]]:
+    """The story and its tasks from a loaded planning state.
+
+    Raises ValueError with the available ids when the story is not there —
+    the caller turns that into a failed artifact, never a traceback.
+    """
+    stories = [s for s in state.get("stories") or [] if getattr(s, "id", "") == story_id]
+    if not stories:
+        available = ", ".join(getattr(s, "id", "?") for s in state.get("stories") or []) or "none"
+        raise ValueError(f"story {story_id!r} not found in this plan (available: {available})")
+    tasks = [t for t in state.get("tasks") or [] if getattr(t, "story_id", "") == story_id]
+    return stories[0], tasks
+
+
+def build_prompt(story: UserStory, tasks: list[Task]) -> str:
+    """The coding agent's instruction, assembled from the plan's own artifacts.
+
+    ``Task.ai_prompt`` is already an ARC-structured instruction written for AI
+    coding assistants (see the task decomposer); this frames the story around
+    them and adds the run contract: work in place, commit, never push — the
+    pipeline owns everything after the diff exists.
+    """
+    lines: list[str] = [
+        f"Implement the following user story in this repository: {story.title or story.id}",
+        "",
+        story.text,
+        "",
+        "Acceptance criteria:",
+    ]
+    for index, criterion in enumerate(story.acceptance_criteria, start=1):
+        lines.append(f"{index}. Given {criterion.given}, when {criterion.when}, then {criterion.then}.")
+    if tasks:
+        lines.append("")
+        lines.append("Tasks (in order):")
+        for task in tasks:
+            lines.append("")
+            lines.append(f"### {task.title}")
+            lines.append(task.ai_prompt or task.description)
+            if task.test_plan:
+                lines.append(f"Test plan: {task.test_plan}")
+    lines += [
+        "",
+        "Run contract:",
+        "- Work only inside this repository checkout.",
+        "- Follow the repository's existing conventions and test layout.",
+        "- Commit your work with clear messages. Do NOT push, do NOT open PRs.",
+        "- If you cannot complete the story, say why plainly and change nothing.",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Bridges — deterministic evidence checks between phases
+# ---------------------------------------------------------------------------
+
+
+def ensure_committed(record: WorktreeRecord) -> None:
+    """Commit anything the agent left uncommitted, so the branch is the work.
+
+    A no-op on a clean tree. The commit identity falls back to a run-local
+    one when the repo has none configured, because failing the whole run on
+    a missing user.email would punish the wrong party.
+    """
+    if not _git(record.path, "status", "--porcelain"):
+        return
+    _git(record.path, "add", "-A")
+    try:
+        _git(record.path, "commit", "-m", f"ship: agent output for {record.run_id}")
+    except WorktreeError:
+        _git(
+            record.path,
+            "-c",
+            "user.email=ship@yeaboi.local",
+            "-c",
+            "user.name=yeaboi ship",
+            "commit",
+            "-m",
+            f"ship: agent output for {record.run_id}",
+        )
+
+
+def diff_bridge(record: WorktreeRecord) -> tuple[bool, str]:
+    """(the agent produced work, `git diff --stat` vs the base).
+
+    This is the precondition bridge: it runs after implement and before
+    anything expensive, and an empty diff fails the run — whatever the agent's
+    exit code said.
+    """
+    ensure_committed(record)
+    stat = _git(record.path, "diff", "--stat", f"{record.base_sha}..HEAD")
+    return bool(stat.strip()), stat.strip()
+
+
+def run_validation(record: WorktreeRecord, command: str) -> ShipValidation:
+    """Run the configured validation command in the worktree. Deterministic.
+
+    No command is a *visible* state (``configured=False``), never a silent
+    pass — the approval screen shows exactly what was and wasn't proven.
+    """
+    if not command.strip():
+        return ShipValidation(configured=False)
+    try:
+        proc = subprocess.run(  # noqa: S602 — the user's own check command (e.g. `make test`), by design
+            command,
+            shell=True,
+            cwd=record.path,
+            capture_output=True,
+            text=True,
+            timeout=VALIDATION_TIMEOUT_S,
+            env=git_subprocess_env(),
+        )
+        tail = ((proc.stdout or "") + (proc.stderr or ""))[-_TAIL_CHARS:]
+        return ShipValidation(
+            configured=True,
+            command=command,
+            passed=proc.returncode == 0,
+            exit_code=proc.returncode,
+            output_tail=tail,
+        )
+    except subprocess.TimeoutExpired:
+        return ShipValidation(
+            configured=True,
+            command=command,
+            passed=False,
+            exit_code=-1,
+            output_tail=f"validation timed out after {VALIDATION_TIMEOUT_S}s",
+        )
+    except OSError as exc:
+        return ShipValidation(configured=True, command=command, passed=False, exit_code=-1, output_tail=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Finalize — push + PR
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FinalizeResult:
+    pushed: bool = False
+    pr_url: str = ""
+    detail: str = ""
+
+
+def _github_slug(remote_url: str) -> tuple[str, str] | None:
+    match = _GITHUB_REMOTE_RE.search(remote_url or "")
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def rework_prompt(comment: str, validation: ShipValidation) -> str:
+    """The follow-up instruction after a gate rejection, comment included."""
+    lines = [
+        "A human reviewed your changes on this branch and rejected them.",
+        f"Reviewer's feedback: {comment or '(no comment was given)'}",
+    ]
+    if validation.configured and not validation.passed:
+        lines.append(f"The validation command also failed: `{validation.command}` (exit {validation.exit_code}).")
+        lines.append(f"Its output ended with:\n{validation.output_tail[-1500:]}")
+    lines += [
+        "",
+        "Address the feedback with further commits on this branch.",
+        "Commit your work. Do NOT push, do NOT open PRs.",
+    ]
+    return "\n".join(lines)
+
+
+def build_pr_body(run_summary: str, gate_comment: str) -> str:
+    """The PR body, scrubbed the way every published text is."""
+    from yeaboi.standup.gap_issues import leak_check, scrub
+
+    parts = [run_summary]
+    if gate_comment:
+        parts += ["", f"Approved with: {gate_comment}"]
+    parts += ["", "---", "🦆 Shipped by yeaboi's supervised agent pipeline; a human approved this diff."]
+    body = scrub("\n".join(parts), {})
+    leak = leak_check(body)
+    if leak:
+        # Publishing is the one irreversible step; a suspicious body loses
+        # its prose rather than the run losing its PR.
+        logger.warning("PR body looked like it contained %s; sending the minimal body", leak)
+        return "Shipped by yeaboi's supervised agent pipeline; a human approved this diff."
+    return body
+
+
+def push_and_open_pr(record: WorktreeRecord, *, title: str, body: str) -> FinalizeResult:
+    """Push the branch and open a PR (API when a token exists, else a URL).
+
+    Never raises. On a non-GitHub remote the push still happens and the
+    detail says what to do next — the branch is the deliverable, the PR is
+    the convenience.
+    """
+    try:
+        _git(record.path, "push", "-u", "origin", record.branch)
+    except WorktreeError as exc:
+        return FinalizeResult(detail=f"push failed: {exc}")
+    try:
+        remote = _git(record.repo, "remote", "get-url", "origin")
+    except WorktreeError:
+        remote = ""
+    slug = _github_slug(remote)
+    if slug is None:
+        return FinalizeResult(pushed=True, detail="branch pushed; origin is not GitHub, open the PR by hand")
+    owner, name = slug
+    from yeaboi.config import get_github_token
+
+    if get_github_token():
+        try:
+            from yeaboi.tools.github import _get_github_client
+
+            gh_repo = _get_github_client().get_repo(f"{owner}/{name}")
+            pr = gh_repo.create_pull(title=title, body=body, head=record.branch, base=gh_repo.default_branch)
+            logger.info("Opened PR %s", pr.html_url)
+            return FinalizeResult(pushed=True, pr_url=pr.html_url, detail=f"opened PR #{pr.number}")
+        except Exception as exc:
+            logger.warning("PR creation failed: %s", exc)
+            # Fall through to the compare URL — the push already succeeded.
+    compare = (
+        f"https://github.com/{owner}/{name}/compare/{urllib.parse.quote(record.branch, safe='')}"
+        f"?expand=1&title={urllib.parse.quote(title)}"
+    )
+    return FinalizeResult(pushed=True, pr_url=compare, detail="branch pushed; open the PR from this URL")

--- a/src/yeaboi/ship/render.py
+++ b/src/yeaboi/ship/render.py
@@ -1,0 +1,88 @@
+"""Rich text rendering for ship runs — the CLI's text format.
+
+Same convention as ``provenance/render.py``: pure formatting over the frozen
+artifacts, shared by whichever surface wants a terminal rendering. No colour
+is load-bearing; the JSON format carries the same facts.
+"""
+
+from __future__ import annotations
+
+from rich.console import Group
+from rich.text import Text
+
+from yeaboi.agent.state import ShipRun
+from yeaboi.ship.budget import BudgetStatus
+
+_STATUS_STYLE = {
+    "approved": "bold green",
+    "rejected": "bold red",
+    "failed": "bold red",
+    "cancelled": "yellow",
+    "awaiting_approval": "bold yellow",
+    "running": "cyan",
+    "planned": "dim",
+}
+
+
+def format_run_rich(run: ShipRun) -> Group:
+    """One run, in full — the gate summary and the terminal report."""
+    lines: list[Text] = []
+    header = Text()
+    header.append(f"{run.story_id or '(no story)'} ", style="bold")
+    header.append(f"[{run.status}]", style=_STATUS_STYLE.get(run.status, ""))
+    if run.run_id:
+        header.append(f"  {run.run_id}", style="dim")
+    lines.append(header)
+    if run.branch:
+        lines.append(Text(f"  branch    {run.branch}"))
+    if run.diff_stat:
+        stat_tail = run.diff_stat.splitlines()[-1].strip()
+        lines.append(Text(f"  diff      {stat_tail}"))
+    if run.validation.configured:
+        verdict = "passed" if run.validation.passed else f"FAILED (exit {run.validation.exit_code})"
+        style = "green" if run.validation.passed else "red"
+        lines.append(Text(f"  checks    {run.validation.command} — {verdict}", style=style))
+    else:
+        lines.append(Text("  checks    none configured — nothing was proven", style="yellow"))
+    if run.cost_usd:
+        lines.append(Text(f"  cost      ${run.cost_usd:.2f}"))
+    for kind, severity, label in run.transcript_findings:
+        lines.append(Text(f"  finding   {severity}: {label} ({kind})", style="yellow"))
+    if run.pr_url:
+        lines.append(Text(f"  pr        {run.pr_url}", style="bold cyan"))
+    for warning in run.warnings:
+        lines.append(Text(f"  ⚠ {warning}", style="yellow"))
+    return Group(*lines)
+
+
+def format_history_rich(runs: list[ShipRun]) -> Group:
+    """Recent runs, one line each, newest first."""
+    if not runs:
+        return Group(Text("No ship runs yet — `yeaboi ship run <STORY>` starts one.", style="dim"))
+    lines: list[Text] = []
+    for run in runs:
+        line = Text()
+        line.append(f"{run.created_at[:16]:16}  ", style="dim")
+        line.append(f"{run.story_id:12}  ", style="bold")
+        line.append(f"{run.status:18}", style=_STATUS_STYLE.get(run.status, ""))
+        if run.cost_usd:
+            line.append(f"  ${run.cost_usd:.2f}", style="dim")
+        if run.pr_url:
+            line.append(f"  {run.pr_url}", style="cyan")
+        lines.append(line)
+    return Group(*lines)
+
+
+def format_budget_rich(status: BudgetStatus) -> Group:
+    """The launch budget's current posture."""
+    lines = [
+        Text("Launch budget", style="bold"),
+        Text(
+            f"  active {status.active}/{status.max_concurrent}"
+            f" · last hour {status.launched_last_hour}/{status.max_per_hour}"
+            f" · last 24h {status.launched_last_day}/{status.max_per_day}"
+        ),
+    ]
+    if status.paused_until:
+        lines.append(Text(f"  circuit OPEN: {status.paused_reason}", style="bold red"))
+    return Group(*lines)

--- a/src/yeaboi/ship/store.py
+++ b/src/yeaboi/ship/store.py
@@ -1,0 +1,265 @@
+"""Persistence for ship runs, including the approval-gate state machine.
+
+Shares ``sessions.db`` the way the roadmap/agentwatch stores do: an additive
+``CREATE TABLE IF NOT EXISTS`` schema executed on open (self-healing, no
+``CURRENT_SCHEMA_VERSION`` bump — which also leaves the Go sidecar's schema
+ceiling untouched).
+
+The gate protocol is archon's, and its core is that **resolution and resume
+are two independent compare-and-swap transitions**:
+
+- ``resolve_gate`` answers an *open* gate (``status='awaiting_approval' AND
+  gate_resolution=''``) exactly once; a losing concurrent approver writes
+  nothing and is told so. The audit event is inserted in the same transaction,
+  so a resolved gate can never exist without its trail.
+- ``save_run(..., expect_status=…)`` is the engine's guarded write for every
+  other transition; a mismatch means someone else moved the run first, and the
+  caller re-reads instead of clobbering.
+
+``status`` and ``gate_resolution`` are real columns (the CAS predicates), and
+the full artifact rides beside them as JSON; the columns are rewritten from
+the artifact on every write so they cannot drift.
+
+One store instance owns one SQLite connection and is **not** shared across
+threads — the TUI thread and the engine worker each open their own (the CAS
+is in the database, not in Python).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import asdict, replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+from yeaboi.agent.state import SHIP_STATUSES, ShipPhase, ShipRun, ShipValidation
+from yeaboi.paths import get_db_path
+
+logger = logging.getLogger(__name__)
+
+_SHIP_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ship_runs (
+    run_id TEXT PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'planned',
+    gate_resolution TEXT NOT NULL DEFAULT '',
+    run_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS ship_gate_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    event TEXT NOT NULL,
+    detail TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT ''
+);
+"""
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _run_to_json(run: ShipRun) -> str:
+    return json.dumps(asdict(run), ensure_ascii=False)
+
+
+def _dict_to_run(data: dict) -> ShipRun:
+    """Rebuild the frozen artifact from JSON; tolerant of missing keys."""
+    validation = data.get("validation") or {}
+    return ShipRun(
+        run_id=str(data.get("run_id", "")),
+        story_id=str(data.get("story_id", "")),
+        session_id=str(data.get("session_id", "")),
+        agent_session_id=str(data.get("agent_session_id", "")),
+        repo=str(data.get("repo", "")),
+        branch=str(data.get("branch", "")),
+        worktree=str(data.get("worktree", "")),
+        base_sha=str(data.get("base_sha", "")),
+        status=str(data.get("status", "planned")),
+        phases=tuple(
+            ShipPhase(
+                name=str(p.get("name", "")),
+                status=str(p.get("status", "")),
+                detail=str(p.get("detail", "")),
+                duration_s=float(p.get("duration_s", 0.0)),
+            )
+            for p in data.get("phases") or ()
+            if isinstance(p, dict)
+        ),
+        validation=ShipValidation(
+            configured=bool(validation.get("configured", False)),
+            command=str(validation.get("command", "")),
+            passed=bool(validation.get("passed", False)),
+            exit_code=int(validation.get("exit_code", -1)),
+            output_tail=str(validation.get("output_tail", "")),
+        ),
+        diff_stat=str(data.get("diff_stat", "")),
+        cost_usd=float(data.get("cost_usd", 0.0)),
+        transcript_findings=tuple(
+            (str(f[0]), str(f[1]), str(f[2])) for f in data.get("transcript_findings") or () if len(f) >= 3
+        ),
+        transcript_path=str(data.get("transcript_path", "")),
+        pr_url=str(data.get("pr_url", "")),
+        gate_resolution=str(data.get("gate_resolution", "")),
+        gate_comment=str(data.get("gate_comment", "")),
+        rejection_count=int(data.get("rejection_count", 0)),
+        created_at=str(data.get("created_at", "")),
+        updated_at=str(data.get("updated_at", "")),
+        warnings=tuple(str(w) for w in data.get("warnings") or ()),
+    )
+
+
+class ShipStore:
+    """Run history + gate state in the shared sessions database."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._path = db_path or get_db_path()
+        self._conn = sqlite3.connect(str(self._path))
+        self._conn.isolation_level = None  # explicit BEGIN IMMEDIATE below
+        self._conn.executescript(_SHIP_SCHEMA)
+
+    def __enter__(self) -> ShipStore:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        if getattr(self, "_conn", None) is not None:
+            self._conn.close()
+            self._conn = None  # type: ignore[assignment]
+
+    # -- writes ------------------------------------------------------------
+
+    def record_run(self, run: ShipRun) -> ShipRun:
+        """Insert a new run; stamps created_at/updated_at."""
+        # `replace`, never ShipRun(**asdict(...)): asdict recurses into the
+        # nested frozen dataclasses and would rebuild them as plain dicts.
+        stamped = replace(run, created_at=run.created_at or _now(), updated_at=_now())
+        self._conn.execute(
+            "INSERT INTO ship_runs (run_id, status, gate_resolution, run_json, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                stamped.run_id,
+                stamped.status,
+                stamped.gate_resolution,
+                _run_to_json(stamped),
+                stamped.created_at,
+                stamped.updated_at,
+            ),
+        )
+        logger.info("Recorded ship run %s (%s)", stamped.run_id, stamped.status)
+        return stamped
+
+    def save_run(self, run: ShipRun, *, expect_status: str | None = None) -> bool:
+        """Guarded full-artifact write. False when the CAS lost — re-read then.
+
+        With ``expect_status`` the write lands only if the stored status still
+        matches; without it the write is unconditional (first persist of a
+        terminal failure, where there is nothing to race).
+        """
+        if run.status not in SHIP_STATUSES:
+            raise ValueError(f"unknown ship status: {run.status!r}")
+        stamped = replace(run, updated_at=_now())
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            if expect_status is not None:
+                row = self._conn.execute("SELECT status FROM ship_runs WHERE run_id = ?", (run.run_id,)).fetchone()
+                if row is None or row[0] != expect_status:
+                    self._conn.execute("ROLLBACK")
+                    return False
+            self._conn.execute(
+                "UPDATE ship_runs SET status = ?, gate_resolution = ?, run_json = ?, updated_at = ? WHERE run_id = ?",
+                (stamped.status, stamped.gate_resolution, _run_to_json(stamped), stamped.updated_at, stamped.run_id),
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+        return True
+
+    def resolve_gate(self, run_id: str, resolution: str, comment: str = "") -> bool:
+        """Answer an open gate exactly once. False when there was none to answer.
+
+        The predicate is ``status='awaiting_approval' AND gate_resolution=''``
+        — a second approver, or an approver racing a cancel, loses cleanly.
+        The audit event commits in the same transaction: a resolved gate
+        without its trail can never exist.
+        """
+        if resolution not in ("approved", "rejected"):
+            raise ValueError(f"gate resolution must be approved|rejected, got {resolution!r}")
+        now = _now()
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = self._conn.execute(
+                "SELECT run_json FROM ship_runs WHERE run_id = ? AND status = 'awaiting_approval' "
+                "AND gate_resolution = ''",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                self._conn.execute("ROLLBACK")
+                return False
+            data = json.loads(row[0])
+            data["gate_resolution"] = resolution
+            data["gate_comment"] = comment
+            if resolution == "rejected":
+                data["rejection_count"] = int(data.get("rejection_count", 0)) + 1
+            data["updated_at"] = now
+            self._conn.execute(
+                "UPDATE ship_runs SET gate_resolution = ?, run_json = ?, updated_at = ? "
+                "WHERE run_id = ? AND status = 'awaiting_approval' AND gate_resolution = ''",
+                (resolution, json.dumps(data, ensure_ascii=False), now, run_id),
+            )
+            self._conn.execute(
+                "INSERT INTO ship_gate_events (run_id, event, detail, created_at) VALUES (?, ?, ?, ?)",
+                (run_id, resolution, comment, now),
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+        logger.info("Gate for %s resolved: %s", run_id, resolution)
+        return True
+
+    # -- reads -------------------------------------------------------------
+
+    def get_run(self, run_id: str) -> ShipRun | None:
+        row = self._conn.execute("SELECT run_json FROM ship_runs WHERE run_id = ?", (run_id,)).fetchone()
+        if row is None:
+            return None
+        try:
+            return _dict_to_run(json.loads(row[0]))
+        except ValueError:
+            logger.warning("Corrupt run_json for %s", run_id)
+            return None
+
+    def list_runs(self, *, limit: int = 20) -> list[ShipRun]:
+        """Newest first."""
+        rows = self._conn.execute(
+            "SELECT run_json FROM ship_runs ORDER BY created_at DESC, run_id DESC LIMIT ?",
+            (max(1, int(limit)),),
+        ).fetchall()
+        out: list[ShipRun] = []
+        for (raw,) in rows:
+            try:
+                out.append(_dict_to_run(json.loads(raw)))
+            except ValueError:
+                continue
+        return out
+
+    def gate_events(self, run_id: str) -> list[tuple[str, str, str]]:
+        """(event, detail, created_at) oldest first — the gate's audit trail."""
+        rows = self._conn.execute(
+            "SELECT event, detail, created_at FROM ship_gate_events WHERE run_id = ? ORDER BY id",
+            (run_id,),
+        ).fetchall()
+        return [(str(e), str(d), str(c)) for e, d, c in rows]

--- a/src/yeaboi/ship/store.py
+++ b/src/yeaboi/ship/store.py
@@ -98,7 +98,9 @@ def _dict_to_run(data: dict) -> ShipRun:
         diff_stat=str(data.get("diff_stat", "")),
         cost_usd=float(data.get("cost_usd", 0.0)),
         transcript_findings=tuple(
-            (str(f[0]), str(f[1]), str(f[2])) for f in data.get("transcript_findings") or () if len(f) >= 3
+            (str(f[0]), str(f[1]), str(f[2]))
+            for f in data.get("transcript_findings") or ()
+            if isinstance(f, list | tuple) and len(f) >= 3
         ),
         transcript_path=str(data.get("transcript_path", "")),
         pr_url=str(data.get("pr_url", "")),
@@ -180,10 +182,27 @@ class ShipStore:
                 if row is None or row[0] != expect_status:
                     self._conn.execute("ROLLBACK")
                     return False
-            self._conn.execute(
+            cursor = self._conn.execute(
                 "UPDATE ship_runs SET status = ?, gate_resolution = ?, run_json = ?, updated_at = ? WHERE run_id = ?",
                 (stamped.status, stamped.gate_resolution, _run_to_json(stamped), stamped.updated_at, stamped.run_id),
             )
+            if cursor.rowcount == 0:
+                # A terminal state for a run that never reached record_run
+                # (setup failed before the row existed). An UPDATE matching
+                # zero rows "succeeding" is how failures vanish from history,
+                # so the unconditional path inserts instead.
+                self._conn.execute(
+                    "INSERT INTO ship_runs (run_id, status, gate_resolution, run_json, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        stamped.run_id,
+                        stamped.status,
+                        stamped.gate_resolution,
+                        _run_to_json(stamped),
+                        stamped.created_at or stamped.updated_at,
+                        stamped.updated_at,
+                    ),
+                )
             self._conn.execute("COMMIT")
         except Exception:
             self._conn.execute("ROLLBACK")

--- a/src/yeaboi/ship/store.py
+++ b/src/yeaboi/ship/store.py
@@ -35,7 +35,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from yeaboi.agent.state import SHIP_STATUSES, ShipPhase, ShipRun, ShipValidation
-from yeaboi.paths import get_db_path
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +115,10 @@ class ShipStore:
     """Run history + gate state in the shared sessions database."""
 
     def __init__(self, db_path: Path | None = None) -> None:
+        # Lazy import so tests that monkeypatch yeaboi.paths.get_db_path
+        # redirect this store too (the provenance/engine convention).
+        from yeaboi.paths import get_db_path
+
         self._path = db_path or get_db_path()
         self._conn = sqlite3.connect(str(self._path))
         self._conn.isolation_level = None  # explicit BEGIN IMMEDIATE below

--- a/src/yeaboi/ship/worktree.py
+++ b/src/yeaboi/ship/worktree.py
@@ -138,6 +138,14 @@ def _validate_owned(path_str: str) -> Path:
     return resolved
 
 
+def _branch_exists(repo: Path | str, branch: str) -> bool:
+    try:
+        _git(repo, "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}")
+    except WorktreeError:
+        return False
+    return True
+
+
 def is_dirty(repo: Path | str) -> bool:
     """Whether the target repo has uncommitted changes (untracked included)."""
     return bool(_git(repo, "status", "--porcelain"))
@@ -164,6 +172,15 @@ def prepare(run_id: str, repo: Path | str, *, base_ref: str = "HEAD") -> Worktre
         )
     base_sha = _git(repo_top, "rev-parse", base_ref)
     branch = f"ship/{run_id}"
+    # Refuse, don't reuse: a pre-existing branch with this name belongs to a
+    # previous run (a lost registry, a hand-pruned worktree) and may hold
+    # unpushed commits. Failing here also keeps the rollback below honest —
+    # it only ever deletes a branch this call created.
+    if _branch_exists(repo_top, branch):
+        raise WorktreeError(
+            f"branch {branch} already exists in {repo_top} — a previous run left it; "
+            "delete it (or push it) and retry, or use a different run id"
+        )
     checkout = _checkout_path(repo_top, run_id)
     checkout.parent.mkdir(parents=True, exist_ok=True)
     try:

--- a/src/yeaboi/ship/worktree.py
+++ b/src/yeaboi/ship/worktree.py
@@ -1,0 +1,227 @@
+"""Isolated git worktrees for supervised coding-agent runs.
+
+Behaviors ported from ruflo's worktree coordinator (MIT), re-implemented for
+yeaboi — each one was a production scar upstream:
+
+- **IDs are whitelisted, never escaped** (``^[a-z0-9][a-z0-9._-]{0,63}$``): a
+  run id reaches branch names, directory names and registry keys, and escaping
+  three grammars correctly is harder than refusing one.
+- **A dirty target repo is refused**: the agent's diff must be attributable to
+  the agent; pre-existing uncommitted work would be swept into its branch.
+- **Prepare is idempotent**: re-preparing an existing run id returns the
+  existing record rather than stacking a second worktree.
+- **Partial failure rolls back** (best-effort, each removal individually
+  swallowed so one stuck worktree doesn't strand the rest).
+- **The registry is re-validated before any delete**: a tampered registry must
+  not be able to point ``remove()`` at an arbitrary path.
+
+One deliberate divergence: the checkout lives under yeaboi's own data root
+(``paths.SHIP_WORKTREES_DIR``), not beside the target repo. The fs sandbox
+already allows that tree read-write, so yeaboi-side reads and writes of the
+agent's workspace need no extra consent — only the *target repo* does (its
+``.git`` gains a worktree entry), which keeps the consent prompt honest: one
+grant, for the one directory the user named.
+
+Every git subprocess passes ``env=git_subprocess_env()`` — see local_git.py:
+inherited ``GIT_*`` vars from an enclosing hook would silently retarget a
+mutating command at the wrong repository.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+
+from yeaboi.paths import SHIP_WORKTREE_REGISTRY, SHIP_WORKTREES_DIR, _safe_key, get_ship_dir
+from yeaboi.tools.local_git import git_subprocess_env
+
+logger = logging.getLogger(__name__)
+
+# Whitelist, not an escape: applied to run ids before they reach branch names,
+# directory names, or registry keys.
+SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+_GIT_TIMEOUT_S = 60
+
+
+class WorktreeError(RuntimeError):
+    """A worktree operation failed; the message is user-facing and names why."""
+
+
+@dataclass(frozen=True)
+class WorktreeRecord:
+    """One prepared worktree: where it is, whose repo it came from."""
+
+    run_id: str = ""
+    repo: str = ""  # resolved toplevel of the target repository
+    path: str = ""  # the agent's checkout
+    branch: str = ""  # ship/<run-id> in the target repo
+    base_sha: str = ""  # the commit the branch was cut from
+
+
+def assert_safe_id(run_id: str) -> str:
+    """Return *run_id* if it matches the whitelist, else raise WorktreeError."""
+    if not SAFE_ID_RE.match(run_id or ""):
+        raise WorktreeError(
+            f"unsafe run id {run_id!r}: must match {SAFE_ID_RE.pattern} (lowercase, digits, . _ -, max 64 chars)"
+        )
+    return run_id
+
+
+def _git(repo: Path | str, *args: str) -> str:
+    """Run one git command against *repo*; raise WorktreeError with the tail."""
+    argv = ["git", "-C", str(repo), *args]
+    try:
+        proc = subprocess.run(  # noqa: S603 — fixed binary, whitelisted-id args
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+            check=False,
+            env=git_subprocess_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise WorktreeError(f"git {' '.join(args[:2])} failed: {exc}") from exc
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+        tail = detail[-1] if detail else f"exit {proc.returncode}"
+        raise WorktreeError(f"git {' '.join(args[:2])} failed: {tail}")
+    return proc.stdout.strip()
+
+
+def resolve_repo(repo: Path | str) -> Path:
+    """Resolve *repo* to its toplevel; refuse anything that is not a work tree."""
+    top = _git(repo, "rev-parse", "--show-toplevel")
+    if not top:
+        raise WorktreeError(f"not a git work tree: {repo}")
+    return Path(top)
+
+
+def _read_registry() -> dict:
+    try:
+        data = json.loads(SHIP_WORKTREE_REGISTRY.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except ValueError:
+        logger.warning("Worktree registry is corrupt; treating as empty")
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_registry(data: dict) -> None:
+    get_ship_dir()
+    tmp = SHIP_WORKTREE_REGISTRY.with_name(f"{SHIP_WORKTREE_REGISTRY.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(data, indent=1), encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    tmp.replace(SHIP_WORKTREE_REGISTRY)
+
+
+def _checkout_path(repo_top: Path, run_id: str) -> Path:
+    return SHIP_WORKTREES_DIR / _safe_key(repo_top.name, "repo") / run_id
+
+
+def _validate_owned(path_str: str) -> Path:
+    """A registry path must live under our worktree root before we touch it.
+
+    Symlink-following containment, never string prefix — the same rule
+    fs_policy applies (``/root-evil`` must not pass for ``/root``).
+    """
+    resolved = Path(path_str).expanduser().resolve(strict=False)
+    root = SHIP_WORKTREES_DIR.expanduser().resolve(strict=False)
+    if not resolved.is_relative_to(root):
+        raise WorktreeError(f"registry path escapes the owned worktree root: {path_str}")
+    return resolved
+
+
+def is_dirty(repo: Path | str) -> bool:
+    """Whether the target repo has uncommitted changes (untracked included)."""
+    return bool(_git(repo, "status", "--porcelain"))
+
+
+def prepare(run_id: str, repo: Path | str, *, base_ref: str = "HEAD") -> WorktreeRecord:
+    """Create (or return the existing) worktree + branch for *run_id*.
+
+    Raises WorktreeError on an unsafe id, a non-repo, a dirty repo, or a git
+    failure — after rolling back anything half-created.
+    """
+    assert_safe_id(run_id)
+    repo_top = resolve_repo(repo)
+    registry = _read_registry()
+    existing = registry.get(run_id)
+    if isinstance(existing, dict) and existing.get("path"):
+        # Idempotent: a re-prepare returns the record instead of stacking.
+        logger.info("Worktree for %s already prepared at %s", run_id, existing.get("path"))
+        return WorktreeRecord(**{f.name: str(existing.get(f.name, "")) for f in fields(WorktreeRecord)})
+    if is_dirty(repo_top):
+        raise WorktreeError(
+            f"refusing to prepare a worktree from a dirty repository: {repo_top} "
+            "(commit or stash first — the agent's diff must be attributable to the agent)"
+        )
+    base_sha = _git(repo_top, "rev-parse", base_ref)
+    branch = f"ship/{run_id}"
+    checkout = _checkout_path(repo_top, run_id)
+    checkout.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        _git(repo_top, "worktree", "add", "-b", branch, str(checkout), base_sha)
+    except WorktreeError:
+        # Roll back whatever half-landed; keep the failure that mattered.
+        try:
+            _git(repo_top, "worktree", "remove", "--force", str(checkout))
+        except WorktreeError:
+            pass  # retain for manual recovery
+        try:
+            _git(repo_top, "branch", "-D", branch)
+        except WorktreeError:
+            pass
+        raise
+    record = WorktreeRecord(run_id=run_id, repo=str(repo_top), path=str(checkout), branch=branch, base_sha=base_sha)
+    registry[run_id] = asdict(record)
+    _write_registry(registry)
+    logger.info("Prepared worktree %s (branch %s, base %s)", checkout, branch, base_sha[:12])
+    return record
+
+
+def get_record(run_id: str) -> WorktreeRecord | None:
+    """The registry record for *run_id*, or None."""
+    entry = _read_registry().get(run_id)
+    if not isinstance(entry, dict):
+        return None
+    return WorktreeRecord(**{f.name: str(entry.get(f.name, "")) for f in fields(WorktreeRecord)})
+
+
+def remove(run_id: str, *, delete_branch: bool = False) -> bool:
+    """Remove *run_id*'s worktree (and optionally its branch). True on success.
+
+    The branch survives by default: after a PR is opened it is the record of
+    the run, and deleting it is a separate, explicit decision.
+    """
+    assert_safe_id(run_id)
+    registry = _read_registry()
+    entry = registry.get(run_id)
+    if not isinstance(entry, dict):
+        return False
+    ok = True
+    path = str(entry.get("path", ""))
+    repo = str(entry.get("repo", ""))
+    if path and repo:
+        try:
+            checkout = _validate_owned(path)
+            _git(repo, "worktree", "remove", "--force", str(checkout))
+            _git(repo, "worktree", "prune")
+        except WorktreeError as exc:
+            logger.warning("Could not remove worktree for %s: %s", run_id, exc)
+            ok = False
+    if ok and delete_branch and repo and entry.get("branch"):
+        try:
+            _git(repo, "branch", "-D", str(entry["branch"]))
+        except WorktreeError as exc:
+            logger.warning("Could not delete branch for %s: %s", run_id, exc)
+    if ok:
+        registry.pop(run_id, None)
+        _write_registry(registry)
+    return ok

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -13498,6 +13498,22 @@ def select_mode(
                 _skip_fade_in = True
                 continue
 
+            # ── Route: Ship mode → supervised story → PR pipeline ────────
+            if chosen["key"] == "ship":
+                logger.info("Ship mode selected")
+                with mode_log("ship"):
+                    # Beta gate first: the mode launches a coding agent against
+                    # the user's own repository, so the caveat comes before the
+                    # story picker. Shown once ever; a decline returns to the
+                    # menu unrecorded.
+                    if show_beta_notice(live, console, read_key, _FRAME_TIME, _supports_timeout, mode_key="ship"):
+                        from yeaboi.ui.mode_select._ship import run_ship_page
+
+                        run_ship_page(console, live, read_key, _FRAME_TIME, _supports_timeout)
+                _restart_mode_select = True
+                _skip_fade_in = True
+                continue
+
             # ── Route: Usage mode → single-page dashboard ────────────────
             if chosen["key"] == "usage":
                 logger.info("Usage mode selected")

--- a/src/yeaboi/ui/mode_select/_ship.py
+++ b/src/yeaboi/ui/mode_select/_ship.py
@@ -121,9 +121,9 @@ def run_ship_page(console: Console, live, read_key, frame_time: float, supports_
                 return
             continue
         if key == "up":
-            selected = (selected - 1) % min(len(stories), 8)
+            selected = (selected - 1) % len(stories)
         elif key == "down":
-            selected = (selected + 1) % min(len(stories), 8)
+            selected = (selected + 1) % len(stories)
         elif key == "r":
             edit_field, edit["buf"], edit["cur"] = "repo", repo, len(repo)
         elif key == "c":

--- a/src/yeaboi/ui/mode_select/_ship.py
+++ b/src/yeaboi/ui/mode_select/_ship.py
@@ -1,0 +1,351 @@
+"""The Ship mode page: pick a story, supervise the run, approve at the gate.
+
+One dispatch entry (:func:`run_ship_page`) rather than another branch spelled
+inline in ``select_mode``. The engine runs on a daemon thread (the
+``_run_report_generate`` worker-thread template); this loop renders the phase
+checklist from its progress events, watches the store for the gate opening,
+and resolves the gate through ``ShipStore.resolve_gate`` — the same single
+seam a CLI approver uses, so the database CAS arbitrates whoever answers
+first.
+
+Imports from :mod:`yeaboi.ui.mode_select` happen lazily inside function bodies —
+the package imports this module's caller, so a top-level import is a cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from pathlib import Path
+
+from rich.console import Console
+
+from yeaboi.analysis.progress import is_component_progress
+from yeaboi.ui.mode_select.screens._screens_ship import (
+    SHIP_GATE_ACTIONS,
+    SHIP_PICK_ACTIONS,
+    SHIP_RESULT_ACTIONS,
+    _build_ship_gate_screen,
+    _build_ship_pick_screen,
+    _build_ship_progress_screen,
+    _build_ship_result_screen,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _load_stories() -> tuple[list, str, str]:
+    """(stories, session_id, message) from the latest saved plan. Never raises."""
+    from yeaboi.paths import get_db_path
+    from yeaboi.sessions import SessionStore
+
+    try:
+        with SessionStore(get_db_path()) as store:
+            session_id = store.get_latest_session_id()
+            if not session_id:
+                return [], "", ""
+            state = store.load_state(session_id) or {}
+    except Exception as exc:  # noqa: BLE001 — an unreadable DB must not crash the menu
+        logger.warning("Ship page: could not load sessions: %s", exc)
+        return [], "", "Could not read saved plans — see logs."
+    return list(state.get("stories") or []), session_id, ""
+
+
+def _repo_problem(repo: str) -> str:
+    """A user-facing reason this repo cannot take a run, or ""."""
+    from yeaboi.ship import worktree
+
+    try:
+        top = worktree.resolve_repo(Path(repo).expanduser())
+    except worktree.WorktreeError as exc:
+        return str(exc)
+    try:
+        if worktree.is_dirty(top):
+            return f"{top} has uncommitted changes — commit or stash first"
+    except worktree.WorktreeError as exc:
+        return str(exc)
+    return ""
+
+
+def run_ship_page(console: Console, live, read_key, frame_time: float, supports_timeout: bool) -> None:
+    """Enter Ship from the menu; returns when the user backs out."""
+    stories, session_id, message = _load_stories()
+    logger.info("Ship page opened: %d stories from session %s", len(stories), session_id or "(none)")
+    selected = 0
+    action_sel = 0
+    repo = str(Path.cwd())
+    check_command = ""
+    edit_field = ""
+    edit = {"buf": "", "cur": 0}
+    start = time.monotonic()
+
+    while True:
+        w, h = console.size
+        live.update(
+            _build_ship_pick_screen(
+                stories,
+                selected,
+                repo=repo,
+                check_command=check_command,
+                width=w,
+                height=h,
+                shimmer_tick=time.monotonic() - start,
+                action_sel=action_sel,
+                message=message,
+                edit_field=edit_field,
+                edit_buf=edit["buf"],
+            )
+        )
+        key = read_key(timeout=frame_time) if supports_timeout else read_key()
+        if edit_field:
+            if key == "enter":
+                if edit_field == "repo":
+                    repo = edit["buf"].strip() or repo
+                else:
+                    check_command = edit["buf"].strip()
+                edit_field = ""
+            elif key == "esc":
+                edit_field = ""
+            elif isinstance(key, str) and key:
+                from yeaboi.ui.mode_select import _settings_edit_keypress
+
+                _settings_edit_keypress(key, edit)
+            continue
+        if key in ("esc", "q"):
+            logger.info("Ship page closed from the picker")
+            return
+        if not stories:
+            if key == "enter":
+                return
+            continue
+        if key == "up":
+            selected = (selected - 1) % min(len(stories), 8)
+        elif key == "down":
+            selected = (selected + 1) % min(len(stories), 8)
+        elif key == "r":
+            edit_field, edit["buf"], edit["cur"] = "repo", repo, len(repo)
+        elif key == "c":
+            edit_field, edit["buf"], edit["cur"] = "check", check_command, len(check_command)
+        elif key == "left":
+            action_sel = (action_sel - 1) % len(SHIP_PICK_ACTIONS)
+        elif key == "right":
+            action_sel = (action_sel + 1) % len(SHIP_PICK_ACTIONS)
+        elif key == "enter":
+            if SHIP_PICK_ACTIONS[action_sel] == "Back":
+                return
+            message = _launch(
+                console,
+                live,
+                read_key,
+                frame_time,
+                supports_timeout,
+                story=stories[selected],
+                session_id=session_id,
+                repo=repo,
+                check_command=check_command,
+            )
+            # Returning here means the run finished (or never started) —
+            # message carries anything the picker should show.
+
+
+def _launch(
+    console,
+    live,
+    read_key,
+    frame_time,
+    supports_timeout,
+    *,
+    story,
+    session_id: str,
+    repo: str,
+    check_command: str,
+) -> str:
+    """Consent + worker thread + progress/gate/result loops. Returns a picker message."""
+    from yeaboi.ui.shared._consent import _preflight_path_consent
+
+    problem = _repo_problem(repo)
+    if problem:
+        return problem
+    if not _preflight_path_consent(
+        console,
+        live,
+        read_key,
+        frame_time,
+        supports_timeout,
+        repo,
+        mode="write",
+        context="Ship runs a coding agent against this repository",
+    ):
+        logger.info("Ship: consent denied for %s", repo)
+        return "Launch cancelled — the repository was not granted."
+
+    from yeaboi.ship import engine
+    from yeaboi.ship.store import ShipStore
+    from yeaboi.ui.shared._music_bar import duck_working_thread
+
+    logger.info("Ship: launching %s against %s", story.id, repo)
+    progress_q: queue.Queue = queue.Queue()
+    result_box: list = [None, None]
+    cancel = threading.Event()
+
+    def _work() -> None:
+        try:
+            result_box[0] = engine.run_ship(
+                story.id,
+                repo,
+                session_id=session_id,
+                check_command=check_command,
+                on_progress=progress_q.put,
+                cancel_event=cancel,
+            )
+        except BaseException as exc:  # noqa: BLE001 — belt and braces; the engine shouldn't raise
+            result_box[1] = exc
+
+    with ShipStore() as watch:
+        known = {r.run_id for r in watch.list_runs(limit=50)}
+        thread = duck_working_thread(_work, name="ship-run")
+        thread.start()
+        events_by_id: dict[str, dict] = {}
+        run_id = ""
+        start = time.monotonic()
+        last_poll = 0.0
+
+        while thread.is_alive():
+            while True:
+                try:
+                    item = progress_q.get_nowait()
+                except queue.Empty:
+                    break
+                if is_component_progress(item):
+                    events_by_id[item["component_id"]] = item
+            gated = None
+            if time.monotonic() - last_poll > 0.5:
+                last_poll = time.monotonic()
+                for row in watch.list_runs(limit=5):
+                    if row.run_id not in known:
+                        run_id = row.run_id
+                    if row.run_id == run_id and row.status == "awaiting_approval" and not row.gate_resolution:
+                        gated = row
+            if gated is not None:
+                outcome = _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, gated, cancel)
+                if outcome == "cancelled":
+                    pass  # the engine notices the event and winds down
+                continue
+            w, h = console.size
+            live.update(
+                _build_ship_progress_screen(
+                    list(events_by_id.values()),
+                    tick=time.monotonic() - start,
+                    width=w,
+                    height=h,
+                )
+            )
+            key = read_key(timeout=frame_time) if supports_timeout else read_key()
+            if key in ("esc", "q") and not cancel.is_set():
+                logger.info("Ship: cancel requested from the progress screen")
+                cancel.set()
+        thread.join()
+
+    run = result_box[0]
+    if run is None:
+        logger.error("Ship run crashed: %s", result_box[1])
+        return f"Run crashed: {result_box[1]} — see logs."
+    return _result_loop(console, live, read_key, frame_time, supports_timeout, run)
+
+
+def _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, run, cancel) -> str:
+    """The approval screen; returns "resolved" | "cancelled". Blocks until one."""
+    from yeaboi.ui.mode_select import _settings_edit_keypress
+
+    logger.info("Ship gate open for %s", run.run_id)
+    action_sel = 0
+    comment: str | None = None
+    edit = {"buf": "", "cur": 0}
+    message = ""
+    while True:
+        w, h = console.size
+        live.update(
+            _build_ship_gate_screen(
+                run,
+                action_sel=action_sel,
+                width=w,
+                height=h,
+                comment_edit=edit["buf"] if comment is not None else None,
+                message=message,
+            )
+        )
+        key = read_key(timeout=frame_time) if supports_timeout else read_key()
+        if comment is not None:
+            if key == "enter":
+                if watch.resolve_gate(run.run_id, "rejected", edit["buf"].strip()):
+                    logger.info("Ship gate: rejected with comment (%d chars)", len(edit["buf"].strip()))
+                    return "resolved"
+                message = "The gate was already answered."
+                comment = None
+            elif key == "esc":
+                comment = None
+            elif isinstance(key, str) and key:
+                _settings_edit_keypress(key, edit)
+            continue
+        if key in ("left",):
+            action_sel = (action_sel - 1) % len(SHIP_GATE_ACTIONS)
+        elif key in ("right", "tab"):
+            action_sel = (action_sel + 1) % len(SHIP_GATE_ACTIONS)
+        elif key == "enter":
+            action = SHIP_GATE_ACTIONS[action_sel]
+            if action == "Approve":
+                if watch.resolve_gate(run.run_id, "approved"):
+                    logger.info("Ship gate: approved")
+                    return "resolved"
+                message = "The gate was already answered."
+            elif action == "Reject":
+                comment = ""
+                edit["buf"], edit["cur"] = "", 0
+            elif action == "Cancel Run":
+                logger.info("Ship gate: run cancelled by the approver")
+                cancel.set()
+                return "cancelled"
+        elif key in ("esc", "q"):
+            # Esc at the gate means "not now", not "reject": keep the run
+            # waiting and fall back to the progress screen. The gate reopens
+            # on the next poll tick.
+            return "resolved"
+
+
+def _result_loop(console, live, read_key, frame_time, supports_timeout, run) -> str:
+    """The terminal screen; returns the message for the picker ("" usually)."""
+    logger.info("Ship run finished: %s (%s)", run.run_id or "(unstarted)", run.status)
+    action_sel = 0
+    notice = ""
+    start = time.monotonic()
+    while True:
+        w, h = console.size
+        live.update(
+            _build_ship_result_screen(
+                run,
+                action_sel=action_sel,
+                width=w,
+                height=h,
+                shimmer_tick=time.monotonic() - start,
+                notice=notice,
+            )
+        )
+        key = read_key(timeout=frame_time) if supports_timeout else read_key()
+        if key in ("esc", "q"):
+            return ""
+        if key == "left":
+            action_sel = (action_sel - 1) % len(SHIP_RESULT_ACTIONS)
+        elif key == "right":
+            action_sel = (action_sel + 1) % len(SHIP_RESULT_ACTIONS)
+        elif key == "enter":
+            action = SHIP_RESULT_ACTIONS[action_sel]
+            if action == "Back":
+                return ""
+            if action == "Copy":
+                from yeaboi.clipboard import copy_text
+
+                payload = run.pr_url or f"{run.story_id}: {run.status} on {run.branch}"
+                notice = "Copied." if copy_text(payload) else "Couldn't reach the clipboard."
+                logger.info("Ship result: copy %s", "ok" if notice == "Copied." else "failed")

--- a/src/yeaboi/ui/mode_select/screens/_screens.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens.py
@@ -90,6 +90,18 @@ _MODE_CARDS: list[dict[str, Any]] = [
         "color": "rgb(140,120,230)",
     },
     {
+        "key": "ship",
+        "title": "Ship",
+        "description": "Hand a plan story to a supervised coding agent: isolated branch, your approval, then a PR.",
+        # Beta like Performance: the mode runs end to end, but it drives a
+        # coding agent against the user's own repository — "available" stays
+        # True (it gates Enter, click, and the tip jump), the badge carries
+        # the caveat.
+        "available": True,
+        "badge": BETA_LABEL,
+        "color": "rgb(235,140,60)",
+    },
+    {
         "key": "usage",
         "title": "Usage",
         "description": "View API token usage, session history, and cost estimates.",

--- a/src/yeaboi/ui/mode_select/screens/_screens_ship.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_ship.py
@@ -93,8 +93,15 @@ def _build_ship_pick_screen(
             Text("Generate a plan in Planning first — Ship implements its stories.", style="dim", justify="center")
         )
     else:
-        shown = stories[:_MAX_STORY_ROWS]
-        for index, story in enumerate(shown):
+        # A window that follows the selection, not a hard cap: a sprint plan
+        # routinely has more than eight stories and every one must be
+        # launchable from here.
+        start = max(0, min(selected - _MAX_STORY_ROWS // 2, len(stories) - _MAX_STORY_ROWS))
+        shown = stories[start : start + _MAX_STORY_ROWS]
+        if start:
+            parts.append(Text(f"{PAD}… {start} earlier", style="dim"))
+        for offset, story in enumerate(shown):
+            index = start + offset
             row = Text()
             row.append(PAD)
             marker = "▸ " if index == selected else "  "
@@ -108,8 +115,9 @@ def _build_ship_pick_screen(
             if points is not None:
                 row.append(f"  · {int(points)} pts", style=theme.muted)
             parts.append(row)
-        if len(stories) > _MAX_STORY_ROWS:
-            parts.append(Text(f"{PAD}… and {len(stories) - _MAX_STORY_ROWS} more", style="dim"))
+        remaining = len(stories) - (start + len(shown))
+        if remaining > 0:
+            parts.append(Text(f"{PAD}… and {remaining} more", style="dim"))
         parts.append(Text(""))
         parts.append(
             _field_row("Repo", edit_buf if edit_field == "repo" else repo, editing=edit_field == "repo", theme=theme)

--- a/src/yeaboi/ui/mode_select/screens/_screens_ship.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_ship.py
@@ -1,0 +1,270 @@
+"""Screen builders for the Ship mode page (story → coding agent → PR).
+
+Same shared-component structure as every other mode page (tui-standards):
+pinned wordmark title + subtitle + content, wrapped in ``build_page_panel``
+with the ship theme. Lists are CAPPED, not scrolled — the gate screen shows
+the top rows of the diff and validation tail and says how many more exist,
+so the page renders correctly at the minimum terminal size.
+
+Builders are pure (no clocks, no logging — they run every frame); the page
+loop in ``_ship.py`` owns time, keys, and state.
+"""
+
+from __future__ import annotations
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.text import Text
+
+from yeaboi.agent.state import ShipRun
+from yeaboi.ui.mode_select.screens._screens_agents import _build_agent_progress_body, _fmt_elapsed
+from yeaboi.ui.shared._components import (
+    PAD,
+    SHIP_THEME,
+    build_action_buttons,
+    build_page_panel,
+    build_reveal_subtitle,
+    ship_title,
+)
+
+SHIP_PICK_ACTIONS = ["Launch", "Back"]
+SHIP_GATE_ACTIONS = ["Approve", "Reject", "Cancel Run"]
+SHIP_RESULT_ACTIONS = ["Copy", "Back"]
+
+_MAX_STORY_ROWS = 8
+_MAX_DIFF_ROWS = 8
+_MAX_TAIL_ROWS = 6
+_MAX_FINDING_ROWS = 4
+
+# The engine's component ids (ship/engine.py emits these); the screen owns
+# what "pending" looks like.
+SHIP_PHASES: tuple[tuple[str, str], ...] = (
+    ("ship-setup", "Prepare isolated worktree"),
+    ("ship-implement", "Run the coding agent"),
+    ("ship-validate", "Validate the diff"),
+    ("ship-gate", "Await your approval"),
+    ("ship-finalize", "Push branch, open PR"),
+)
+
+
+def _field_row(label: str, value: str, *, editing: bool, theme) -> Text:
+    """One settings-style field line: label, value, and an edit cursor."""
+    row = Text()
+    row.append(PAD)
+    row.append(f"{label}: ", style=theme.muted)
+    if editing:
+        row.append(value, style="bold white")
+        row.append("▏", style=theme.accent_bright)
+    else:
+        row.append(value or "(none)", style="rgb(200,200,210)" if value else "rgb(110,110,125)")
+    return row
+
+
+def _build_ship_pick_screen(
+    stories: list,
+    selected: int,
+    *,
+    repo: str,
+    check_command: str,
+    width: int = 80,
+    height: int = 24,
+    shimmer_tick: float | None = None,
+    action_sel: int = 0,
+    message: str = "",
+    edit_field: str = "",
+    edit_buf: str = "",
+) -> Panel:
+    """The launch screen: pick a story, confirm repo + check command.
+
+    ``stories`` is a list of ``UserStory``; ``edit_field`` is ``""`` (not
+    editing), ``"repo"`` or ``"check"``, with ``edit_buf`` as the live buffer.
+    """
+    theme = SHIP_THEME
+    parts: list = [
+        Text(""),
+        ship_title(shimmer_tick, width=width),
+        build_reveal_subtitle("A story from your plan, implemented behind your approval", None, justify="center"),
+        Text(""),
+    ]
+    if not stories:
+        parts.append(Text(""))
+        parts.append(Text("No stories found in your latest plan.", style="rgb(200,200,210)", justify="center"))
+        parts.append(
+            Text("Generate a plan in Planning first — Ship implements its stories.", style="dim", justify="center")
+        )
+    else:
+        shown = stories[:_MAX_STORY_ROWS]
+        for index, story in enumerate(shown):
+            row = Text()
+            row.append(PAD)
+            marker = "▸ " if index == selected else "  "
+            row.append(marker, style=theme.accent_bright if index == selected else "dim")
+            row.append(f"{story.id}", style=theme.id if index == selected else "rgb(120,140,160)")
+            title = getattr(story, "title", "") or getattr(story, "goal", "")
+            row.append(
+                f"  {title[: max(10, width - 30)]}", style="bold white" if index == selected else "rgb(160,160,175)"
+            )
+            points = getattr(story, "story_points", None)
+            if points is not None:
+                row.append(f"  · {int(points)} pts", style=theme.muted)
+            parts.append(row)
+        if len(stories) > _MAX_STORY_ROWS:
+            parts.append(Text(f"{PAD}… and {len(stories) - _MAX_STORY_ROWS} more", style="dim"))
+        parts.append(Text(""))
+        parts.append(
+            _field_row("Repo", edit_buf if edit_field == "repo" else repo, editing=edit_field == "repo", theme=theme)
+        )
+        parts.append(
+            _field_row(
+                "Check",
+                edit_buf if edit_field == "check" else check_command,
+                editing=edit_field == "check",
+                theme=theme,
+            )
+        )
+        parts.append(Text(f"{PAD}↑/↓ story · r edit repo · c edit check command", style="dim"))
+    parts.append(Text(""))
+    parts.append(Text(message, style=theme.warn if message else "", justify="center"))
+    parts.append(Text(""))
+    parts.extend(build_action_buttons(SHIP_PICK_ACTIONS, action_sel))
+    return build_page_panel(Group(*parts), theme=theme, height=height)
+
+
+def _build_ship_progress_screen(
+    progress: list,
+    *,
+    tick: float,
+    width: int = 80,
+    height: int = 24,
+    status: str = "",
+) -> Panel:
+    """The in-flight page: the phase checklist fed by the engine's events."""
+    theme = SHIP_THEME
+    parts: list = [
+        Text(""),
+        ship_title(None, width=width),
+        build_reveal_subtitle("Supervising the coding agent", None, justify="center"),
+    ]
+    parts.extend(_build_agent_progress_body(SHIP_PHASES, progress, tick=tick, theme=theme, status=status))
+    parts.append(Text(""))
+    parts.append(
+        Text("esc cancels the run — the agent is stopped and nothing is pushed", style="dim", justify="center")
+    )
+    return build_page_panel(Group(*parts), theme=theme, height=height)
+
+
+def _gate_line(label: str, value: str, *, style: str = "rgb(200,200,210)") -> Text:
+    row = Text()
+    row.append(PAD)
+    row.append(f"{label}  ", style="rgb(110,110,125)")
+    row.append(value, style=style)
+    return row
+
+
+def _build_ship_gate_screen(
+    run: ShipRun,
+    *,
+    action_sel: int = 0,
+    width: int = 80,
+    height: int = 24,
+    comment_edit: str | None = None,
+    message: str = "",
+) -> Panel:
+    """The approval gate: what the agent did, what was proven, your call.
+
+    ``comment_edit`` non-None means the rejection comment is being typed; it
+    renders an input line and the buttons step back.
+    """
+    theme = SHIP_THEME
+    parts: list = [
+        Text(""),
+        ship_title(None, width=width),
+        build_reveal_subtitle("Review the diff like a stranger wrote it — one did", None, justify="center"),
+        Text(""),
+        _gate_line("Story ", run.story_id),
+        _gate_line("Branch", run.branch, style=theme.id),
+    ]
+    diff_lines = run.diff_stat.splitlines()
+    for line in diff_lines[:_MAX_DIFF_ROWS]:
+        parts.append(Text(f"{PAD}  {line[: max(20, width - 10)]}", style="rgb(160,160,175)"))
+    if len(diff_lines) > _MAX_DIFF_ROWS:
+        parts.append(Text(f"{PAD}  … and {len(diff_lines) - _MAX_DIFF_ROWS} more lines", style="dim"))
+    parts.append(Text(""))
+    if run.validation.configured:
+        state = "✓ passed" if run.validation.passed else f"✗ FAILED (exit {run.validation.exit_code})"
+        style = theme.good if run.validation.passed else theme.bad
+        parts.append(_gate_line("Checks", f"{run.validation.command} — {state}", style=style))
+        if not run.validation.passed:
+            for line in run.validation.output_tail.splitlines()[-_MAX_TAIL_ROWS:]:
+                parts.append(Text(f"{PAD}  {line[: max(20, width - 10)]}", style="rgb(140,120,120)"))
+    else:
+        parts.append(_gate_line("Checks", "none configured — nothing was proven", style=theme.warn))
+    if run.cost_usd:
+        parts.append(_gate_line("Cost  ", f"${run.cost_usd:.2f}"))
+    if run.transcript_findings:
+        parts.append(_gate_line("Safety", f"{len(run.transcript_findings)} transcript finding(s):", style=theme.warn))
+        for kind, severity, label in run.transcript_findings[:_MAX_FINDING_ROWS]:
+            parts.append(Text(f"{PAD}  {severity}: {label} ({kind})", style=theme.warn))
+    if run.rejection_count:
+        parts.append(_gate_line("Rework", f"attempt {run.rejection_count + 1} after your feedback"))
+    parts.append(Text(""))
+    if comment_edit is not None:
+        prompt = Text()
+        prompt.append(PAD)
+        prompt.append("Why reject? ", style=theme.muted)
+        prompt.append(comment_edit, style="bold white")
+        prompt.append("▏", style=theme.accent_bright)
+        parts.append(prompt)
+        parts.append(Text(f"{PAD}enter sends the feedback to the agent · esc keeps reviewing", style="dim"))
+    parts.append(Text(message, style=theme.warn if message else "", justify="center"))
+    parts.append(Text(""))
+    parts.extend(build_action_buttons(SHIP_GATE_ACTIONS, action_sel))
+    return build_page_panel(Group(*parts), theme=theme, height=height)
+
+
+def _build_ship_result_screen(
+    run: ShipRun,
+    *,
+    action_sel: int = 0,
+    width: int = 80,
+    height: int = 24,
+    shimmer_tick: float | None = None,
+    notice: str = "",
+) -> Panel:
+    """The terminal page: what happened, where the PR is, what it cost."""
+    theme = SHIP_THEME
+    headline = {
+        "approved": ("✓ Shipped", theme.good),
+        "rejected": ("✗ Rejected at the gate", theme.bad),
+        "failed": ("✗ Run failed", theme.bad),
+        "cancelled": ("Run cancelled", theme.warn),
+    }.get(run.status, (run.status, theme.muted))
+    parts: list = [
+        Text(""),
+        ship_title(shimmer_tick, width=width),
+        build_reveal_subtitle("Run finished", None, justify="center"),
+        Text(""),
+        Text(f"{PAD}{headline[0]}", style=f"bold {headline[1]}" if not headline[1].startswith("bold") else headline[1]),
+        Text(""),
+    ]
+    if run.story_id:
+        parts.append(_gate_line("Story ", run.story_id))
+    if run.branch:
+        parts.append(_gate_line("Branch", run.branch, style=theme.id))
+    if run.pr_url:
+        parts.append(_gate_line("PR    ", run.pr_url, style=theme.accent_bright))
+    if run.cost_usd:
+        parts.append(_gate_line("Cost  ", f"${run.cost_usd:.2f}"))
+    for phase in run.phases:
+        mark = {"completed": "✓", "failed": "✗", "skipped": "○"}.get(phase.status, "○")
+        style = {"✓": theme.good, "✗": theme.bad}.get(mark, "dim")
+        detail = f" · {phase.detail}" if phase.detail else ""
+        stamp = f" ({_fmt_elapsed(phase.duration_s)})" if phase.duration_s >= 1 else ""
+        parts.append(Text(f"{PAD}{mark} {phase.name}{detail}{stamp}"[: max(30, width - 6)], style=style))
+    for warning in run.warnings[:3]:
+        parts.append(Text(f"{PAD}⚠ {warning[: max(30, width - 8)]}", style=theme.warn))
+    parts.append(Text(""))
+    parts.append(Text(notice, style=theme.accent if notice else "", justify="center"))
+    parts.append(Text(""))
+    parts.extend(build_action_buttons(SHIP_RESULT_ACTIONS, action_sel))
+    return build_page_panel(Group(*parts), theme=theme, height=height)

--- a/src/yeaboi/ui/shared/_animations.py
+++ b/src/yeaboi/ui/shared/_animations.py
@@ -40,6 +40,7 @@ COLOR_RGB: dict[str, tuple[int, int, int]] = {
     "rgb(120,210,170)": (120, 210, 170),  # Agent Standup accent (mint)
     "rgb(230,90,120)": (230, 90, 120),  # Agent Security accent (alert rose)
     "rgb(240,180,70)": (240, 180, 70),  # Agent Advisor accent (amber)
+    "rgb(235,140,60)": (235, 140, 60),  # Ship accent (cargo orange)
 }
 
 # Grey levels for fade-out (bright → invisible) and fade-in (invisible → bright).

--- a/src/yeaboi/ui/shared/_beta_notice.py
+++ b/src/yeaboi/ui/shared/_beta_notice.py
@@ -35,6 +35,7 @@ from yeaboi.ui.shared._components import (
     AGENT_USAGE_THEME,
     PAD,
     PERFORMANCE_THEME,
+    SHIP_THEME,
     Theme,
     agent_advisor_title,
     agent_security_title,
@@ -45,6 +46,7 @@ from yeaboi.ui.shared._components import (
     build_page_panel,
     build_reveal_subtitle,
     performance_title,
+    ship_title,
 )
 
 logger = logging.getLogger(__name__)
@@ -81,6 +83,22 @@ _BETA_MODES: dict[str, _BetaMode] = {
             "",
             "Nothing is sent to anyone automatically. Exports stay on this machine",
             "under ~/.yeaboi/exports/performance.",
+        ),
+    ),
+    "ship": _BetaMode(
+        title_fn=ship_title,
+        theme=SHIP_THEME,
+        subtitle="Beta — worth thirty seconds",
+        headline="Ship is in beta.",
+        body=(
+            "Ship launches a real coding agent (Claude Code) against a repository you",
+            "name, on an isolated branch cut from a clean tree. It spends real API",
+            "quota — a launch budget caps runs at 2 per hour, 12 per day.",
+            "",
+            "Nothing merges by itself: the branch is pushed and the pull request is",
+            "opened only after you approve the diff at the gate.",
+            "",
+            "Review the diff like a stranger wrote it, because one did.",
         ),
     ),
     "agent-usage": _BetaMode(

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -97,6 +97,7 @@ AGENT_USAGE_THEME = Theme(accent="rgb(70,190,230)", accent_bright="rgb(110,225,2
 AGENT_STANDUP_THEME = Theme(accent="rgb(120,210,170)", accent_bright="rgb(160,245,205)")
 AGENT_SECURITY_THEME = Theme(accent="rgb(230,90,120)", accent_bright="rgb(255,130,160)")
 AGENT_ADVISOR_THEME = Theme(accent="rgb(240,180,70)", accent_bright="rgb(255,210,110)")
+SHIP_THEME = Theme(accent="rgb(235,140,60)", accent_bright="rgb(255,175,95)")
 
 # Button color scheme: (accent_border, accent_label, grey_border, grey_label)
 _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
@@ -171,6 +172,13 @@ _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
     "Back": ("rgb(100,100,120)", "rgb(140,140,160)", "rgb(40,40,50)", "rgb(50,50,60)"),
     # Advisory action on the analysis review when a Small project looks bigger.
     "Switch to Large": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
+    # Ship mode (cargo-orange accent). Approve is the "go" green like Accept;
+    # Reject is amber, not red — it stages a rework, it does not end the run;
+    # Cancel Run is the destructive-ish amber family; Launch carries the mode accent.
+    "Launch": ("rgb(200,115,45)", "rgb(240,155,80)", "rgb(52,44,38)", "rgb(62,54,48)"),
+    "Approve": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),
+    "Reject": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
+    "Cancel Run": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
     # Feedback form (silver chrome; Submit green like Accept, Open Browser blue like Export).
     "Submit": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),
     "AI Polish": ("rgb(160,160,180)", "rgb(200,200,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
@@ -397,6 +405,11 @@ def agent_security_title(shimmer_tick: float | None = None, *, width: int | None
 def agent_advisor_title(shimmer_tick: float | None = None, *, width: int | None = None) -> Text:
     """Return the Agent Advisor ASCII title (amber accent). Optionally shimmering."""
     return build_ascii_title("Advisor", "rgb(240,180,70)", shimmer_tick=shimmer_tick, width=width)
+
+
+def ship_title(shimmer_tick: float | None = None, *, width: int | None = None) -> Text:
+    """Return the Ship ASCII title (cargo-orange accent). Optionally shimmering."""
+    return build_ascii_title("Ship", "rgb(235,140,60)", shimmer_tick=shimmer_tick, width=width)
 
 
 def tips_title(shimmer_tick: float | None = None, *, width: int | None = None) -> Text:

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -192,6 +192,12 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
         "\U0001f512 Tip: `yeaboi provenance audit` verifies the tamper-evident log behind every signal",
         is_new=True,
     ),
+    FeatureTip(
+        "ship",
+        "\U0001f6a2 Tip: Ship hands a story from your plan to a coding agent — your approval gates the PR",
+        mode_key="ship",
+        is_beta=True,
+    ),
 )
 
 # Ambient tips — not tied to a capability, so exempt from parity. The generic

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -1293,3 +1293,68 @@ class TestProvenanceCommand:
         assert _run_subcommand(args) == 1
         payload = json.loads(capsys.readouterr().out)
         assert payload["found"] is False
+
+
+class TestShipCommand:
+    def test_run_parses_with_defaults(self):
+        args = build_parser().parse_args(["ship", "run", "US-001"])
+        assert args.command == "ship"
+        assert args.ship_command == "run"
+        assert args.story_id == "US-001"
+        assert args.repo == "."
+        assert args.check == ""
+        assert args.timeout_minutes == 30
+        assert args.dry_run is False
+        assert args.strict is False
+
+    def test_status_and_history_parse(self):
+        status = build_parser().parse_args(["ship", "status", "--format", "json"])
+        assert status.ship_command == "status"
+        history = build_parser().parse_args(["ship", "history", "--limit", "3"])
+        assert history.ship_command == "history"
+        assert history.limit == 3
+
+    def test_history_json_on_an_empty_store(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        args = build_parser().parse_args(["ship", "history", "--format", "json"])
+        assert _run_subcommand(args) == 0
+        assert json.loads(capsys.readouterr().out) == []
+
+    def test_status_json_reports_budget_posture(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        args = build_parser().parse_args(["ship", "status", "--format", "json"])
+        assert _run_subcommand(args) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["latest"] is None
+        assert payload["budget"]["max_per_hour"] >= 1
+
+    def test_dry_run_is_canned_and_touches_nothing(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        args = build_parser().parse_args(["ship", "run", "US-001", "--dry-run", "--format", "json"])
+        assert _run_subcommand(args) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "approved"
+        assert any("dry run" in w for w in payload["warnings"])
+
+    def test_run_refuses_without_a_terminal(self, monkeypatch, capsys, tmp_path):
+        # stdin in tests is not a tty, and the repo path is sandbox-allowed
+        # (pytest tmp dirs are whitelisted) — so this exercises the tty guard.
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(tmp_path)])
+        assert _run_subcommand(args) == 2
+        assert "interactive terminal" in capsys.readouterr().err
+
+    def test_run_strict_exits_3_when_not_approved(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        monkeypatch.setattr("sys.stdin", __import__("io").StringIO(""))
+
+        from yeaboi.agent.state import ShipRun
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+        monkeypatch.setattr(
+            "yeaboi.ship.engine.run_ship",
+            lambda *a, **k: ShipRun(run_id="r", story_id="US-001", status="failed", warnings=("boom",)),
+        )
+        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(tmp_path), "--strict"])
+        assert _run_subcommand(args) == 3
+        assert "⚠ boom" in capsys.readouterr().err

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -73,6 +73,8 @@ EXPECTED_TOOLS = {
     "agents_security_history",
     "provenance_audit",
     "provenance_trace",
+    "ship_history",
+    "ship_status",
 }
 
 
@@ -1279,3 +1281,32 @@ class TestProvenanceTools:
         out = call_tool("provenance_trace", {"entity_id": "  "})
         assert out["ok"] is False
         assert "entity_id" in out["error"]["message"]
+
+
+class TestShipTools:
+    def test_history_is_empty_before_the_first_run(self, tmp_db):
+        out = call_tool("ship_history")
+        assert out["ok"] is True
+        assert out["data"]["runs"] == []
+
+    def test_history_rejects_a_bad_limit(self, tmp_db):
+        out = call_tool("ship_history", {"limit": 0})
+        assert out["ok"] is False
+        assert "limit" in out["error"]["message"]
+
+    def test_history_round_trips_a_recorded_run(self, tmp_db):
+        from yeaboi.agent.state import ShipRun
+        from yeaboi.ship.store import ShipStore
+
+        with ShipStore(tmp_db) as store:
+            store.record_run(ShipRun(run_id="run-1", story_id="US-001", status="approved", pr_url="https://x/pr/1"))
+        out = call_tool("ship_history")
+        assert out["ok"] is True
+        assert out["data"]["runs"][0]["story_id"] == "US-001"
+        assert out["data"]["runs"][0]["pr_url"] == "https://x/pr/1"
+
+    def test_status_reports_latest_run_and_budget(self, tmp_db):
+        out = call_tool("ship_status")
+        assert out["ok"] is True
+        assert out["data"]["latest"] is None
+        assert "max_per_hour" in out["data"]["budget"]

--- a/tests/unit/test_mode_cards.py
+++ b/tests/unit/test_mode_cards.py
@@ -66,10 +66,13 @@ class TestPerformanceCardRegistration:
         assert _performance_card()["available"] is True
 
     def test_no_other_card_carries_a_badge(self):
+        # Performance and Ship are the two beta modes on the Humans menu;
+        # test_beta_surfaces.py keeps their three markers (badge, notice, tip)
+        # in agreement.
         badged = [
             card["key"]
             for card in (*_MODE_CARDS, *_INTAKE_CARDS, *_OFFLINE_CARDS)
-            if card.get("badge") and card.get("key") != "performance"
+            if card.get("badge") and card.get("key") not in ("performance", "ship")
         ]
         assert badged == []
 

--- a/tests/unit/test_ship_budget.py
+++ b/tests/unit/test_ship_budget.py
@@ -100,10 +100,19 @@ class TestCircuitBreaker:
     def test_quota_pattern_matches_real_quota_errors_only(self):
         assert budget.looks_like_quota_error("Error: HTTP 429")
         assert budget.looks_like_quota_error("rate_limit_error from API")
+        assert budget.looks_like_quota_error("You have been rate limited")
+        assert budget.looks_like_quota_error("rate limit exceeded")
         assert budget.looks_like_quota_error("overloaded_error")
         assert budget.looks_like_quota_error("usage limit reached")
+        assert budget.looks_like_quota_error("quota exhausted")
         assert not budget.looks_like_quota_error("all tests passed")
         assert not budget.looks_like_quota_error("")
+
+    def test_agent_prose_about_rate_limiting_does_not_trip_the_breaker(self):
+        # The error text is the agent's stdout tail, which can echo the user's
+        # own code — a topic word alone must never open a user-global pause.
+        assert not budget.looks_like_quota_error("I refactored the rate limiter in quota.py")
+        assert not budget.looks_like_quota_error("added a per-user quota field to the model")
 
 
 class TestFailClosed:
@@ -205,7 +214,33 @@ class TestLimitsEnv:
         monkeypatch.setenv("YEABOI_AI_MAX_PER_HOUR", "7")
         assert budget.limits()[:2] == (3, 7)
 
-    def test_garbage_and_nonpositive_env_falls_back_to_defaults(self, monkeypatch):
+    def test_garbage_and_negative_env_falls_back_to_defaults(self, monkeypatch):
         monkeypatch.setenv("YEABOI_AI_MAX_CONCURRENT", "banana")
-        monkeypatch.setenv("YEABOI_AI_MAX_PER_HOUR", "0")
+        monkeypatch.setenv("YEABOI_AI_MAX_PER_HOUR", "-1")
         assert budget.limits()[:2] == (budget.DEFAULT_MAX_CONCURRENT, budget.DEFAULT_MAX_PER_HOUR)
+
+    def test_zero_is_honoured_as_deny_everything(self, budget_dir, clock, monkeypatch):
+        # Fail-closed: 0 is the user saying "no launches", never "use the default".
+        monkeypatch.setenv("YEABOI_AI_MAX_CONCURRENT", "0")
+        denied = budget.reserve()
+        assert not denied.allowed
+        assert "global-concurrency" in denied.reason
+
+
+class TestHeartbeat:
+    def test_heartbeat_keeps_a_long_run_alive(self, budget_dir, clock):
+        first = budget.reserve()
+        assert first.allowed
+        clock[0] += budget.ACTIVE_STALE_S - 60
+        budget.heartbeat(first.permit_id)
+        clock[0] += budget.ACTIVE_STALE_S - 60
+        # Without the heartbeat the permit would have been reaped by now and
+        # this second reserve would (wrongly) be allowed.
+        second = budget.reserve()
+        assert not second.allowed
+        assert "global-concurrency" in second.reason
+
+    def test_heartbeat_on_unknown_or_bypass_permit_is_harmless(self, budget_dir, clock):
+        budget.heartbeat("permit_nonexistent")
+        budget.heartbeat("bypass_123")
+        assert not budget.SHIP_BUDGET_FILE.exists() or budget.reserve().allowed

--- a/tests/unit/test_ship_budget.py
+++ b/tests/unit/test_ship_budget.py
@@ -1,0 +1,211 @@
+"""Tests for the user-global launch budget (ship/budget.py).
+
+The fuse's contract is deny-by-default under doubt: every limit denies with a
+named reason, an unreadable ledger denies, and only the explicit env escape
+hatch bypasses. The clock is injected via ``_now`` so window arithmetic is
+tested deterministically.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from yeaboi.ship import budget
+
+
+@pytest.fixture()
+def budget_dir(tmp_path, monkeypatch):
+    """Redirect every budget file into an isolated temp dir."""
+    d = tmp_path / "ship"
+    d.mkdir()
+    monkeypatch.setattr(budget, "SHIP_BUDGET_FILE", d / "ai-budget.json")
+    monkeypatch.setattr(budget, "SHIP_BUDGET_LOCK", d / "ai-budget.lock")
+    monkeypatch.setattr(budget, "SHIP_BUDGET_RECEIPTS", d / "ai-budget-receipts.jsonl")
+    monkeypatch.setattr(budget, "get_ship_dir", lambda: d)
+    return d
+
+
+@pytest.fixture()
+def clock(monkeypatch):
+    """A settable wall clock for the ledger's window arithmetic."""
+    state = [1_700_000_000.0]
+    monkeypatch.setattr(budget, "_now", lambda: state[0])
+    return state
+
+
+class TestReserveRelease:
+    def test_first_reserve_is_allowed_with_a_permit(self, budget_dir, clock):
+        decision = budget.reserve()
+        assert decision.allowed
+        assert decision.permit_id.startswith("permit_")
+
+    def test_concurrency_denies_while_a_permit_is_active(self, budget_dir, clock):
+        first = budget.reserve()
+        assert first.allowed
+        second = budget.reserve()
+        assert not second.allowed
+        assert "global-concurrency" in second.reason
+
+    def test_release_frees_the_slot_but_the_launch_stays_counted(self, budget_dir, clock):
+        first = budget.reserve()
+        budget.release(first.permit_id)
+        second = budget.reserve()
+        assert second.allowed
+        # Two launches within the hour — the default hourly limit is spent.
+        budget.release(second.permit_id)
+        third = budget.reserve()
+        assert not third.allowed
+        assert "hourly-budget" in third.reason
+
+    def test_hourly_window_slides(self, budget_dir, clock):
+        for _ in range(2):
+            budget.release(budget.reserve().permit_id)
+        assert not budget.reserve().allowed
+        clock[0] += budget.HOUR_S + 1
+        assert budget.reserve().allowed
+
+    def test_daily_limit_counts_all_launches_in_24h(self, budget_dir, clock, monkeypatch):
+        monkeypatch.setenv("YEABOI_AI_MAX_PER_HOUR", "100")
+        for _ in range(12):
+            decision = budget.reserve()
+            assert decision.allowed
+            budget.release(decision.permit_id)
+            clock[0] += 60
+        denied = budget.reserve()
+        assert not denied.allowed
+        assert "daily-budget" in denied.reason
+        clock[0] += budget.DAY_S
+        assert budget.reserve().allowed
+
+    def test_release_of_unknown_permit_is_harmless(self, budget_dir, clock):
+        budget.release("permit_nonexistent")
+        assert budget.reserve().allowed
+
+
+class TestCircuitBreaker:
+    def test_quota_error_opens_the_circuit(self, budget_dir, clock):
+        budget.record_quota_error("HTTP 429 too many requests")
+        denied = budget.reserve()
+        assert not denied.allowed
+        assert "circuit-open" in denied.reason
+
+    def test_circuit_closes_after_the_pause_window(self, budget_dir, clock):
+        budget.record_quota_error("rate limit")
+        clock[0] += budget.DEFAULT_QUOTA_PAUSE_MINUTES * 60 + 1
+        assert budget.reserve().allowed
+
+    def test_quota_pattern_matches_real_quota_errors_only(self):
+        assert budget.looks_like_quota_error("Error: HTTP 429")
+        assert budget.looks_like_quota_error("rate_limit_error from API")
+        assert budget.looks_like_quota_error("overloaded_error")
+        assert budget.looks_like_quota_error("usage limit reached")
+        assert not budget.looks_like_quota_error("all tests passed")
+        assert not budget.looks_like_quota_error("")
+
+
+class TestFailClosed:
+    def test_unreadable_ledger_denies(self, budget_dir, clock, monkeypatch):
+        def _boom(path):
+            raise OSError("disk error")
+
+        monkeypatch.setattr(budget, "_read_ledger", _boom)
+        denied = budget.reserve()
+        assert not denied.allowed
+        assert "budget-unavailable" in denied.reason
+
+    def test_symlinked_ledger_denies(self, budget_dir, clock, tmp_path):
+        target = tmp_path / "elsewhere.json"
+        target.write_text("{}", encoding="utf-8")
+        budget.SHIP_BUDGET_FILE.symlink_to(target)
+        denied = budget.reserve()
+        assert not denied.allowed
+        assert "budget-unavailable" in denied.reason
+
+    def test_held_lock_denies_after_the_deadline(self, budget_dir, clock, monkeypatch):
+        monkeypatch.setattr(budget, "_LOCK_DEADLINE_S", 0.05)
+        budget.SHIP_BUDGET_LOCK.write_text(str(os.getpid()), encoding="utf-8")
+        denied = budget.reserve()
+        assert not denied.allowed
+        assert "budget-unavailable" in denied.reason
+
+    def test_stale_lock_is_taken_over(self, budget_dir, clock):
+        budget.SHIP_BUDGET_LOCK.write_text("99999", encoding="utf-8")
+        stale = budget.SHIP_BUDGET_LOCK.stat().st_mtime - budget.LOCK_STALE_S - 5
+        os.utime(budget.SHIP_BUDGET_LOCK, (stale, stale))
+        assert budget.reserve().allowed
+
+    def test_corrupt_ledger_starts_fresh_instead_of_blocking(self, budget_dir, clock):
+        budget.SHIP_BUDGET_FILE.write_text("{not json", encoding="utf-8")
+        assert budget.reserve().allowed
+
+
+class TestSelfHealing:
+    def test_dead_process_frees_its_reservation(self, budget_dir, clock, monkeypatch):
+        first = budget.reserve()
+        assert first.allowed
+        monkeypatch.setattr(budget, "_is_process_alive", lambda pid: False)
+        second = budget.reserve()
+        assert second.allowed, second.reason
+
+    def test_stale_reservation_expires_even_with_a_live_process(self, budget_dir, clock):
+        assert budget.reserve().allowed
+        clock[0] += budget.ACTIVE_STALE_S + 1
+        assert budget.reserve().allowed
+
+
+class TestEscapeHatch:
+    def test_disable_env_bypasses_every_limit(self, budget_dir, clock, monkeypatch):
+        monkeypatch.setenv("YEABOI_AI_BUDGET_DISABLE", "1")
+        budget.record_quota_error("429")
+        decision = budget.reserve()
+        assert decision.allowed
+        assert decision.permit_id.startswith("bypass_")
+
+    def test_bypass_permit_release_touches_nothing(self, budget_dir, clock):
+        budget.release("bypass_123")
+        assert not budget.SHIP_BUDGET_FILE.exists()
+
+
+class TestTelemetry:
+    def test_receipts_record_launches_and_denials(self, budget_dir, clock):
+        budget.reserve()
+        budget.reserve()  # denied: concurrency
+        lines = [json.loads(line) for line in budget.SHIP_BUDGET_RECEIPTS.read_text(encoding="utf-8").splitlines()]
+        events = [entry["event"] for entry in lines]
+        assert "launch" in events
+        assert "deny" in events
+
+    def test_receipt_failure_never_affects_enforcement(self, budget_dir, clock, monkeypatch):
+        def _boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        # The ledger itself uses Path methods; only the receipt append opens a
+        # file handle, so this breaks telemetry and nothing else.
+        monkeypatch.setattr(budget, "open", _boom, raising=False)
+        assert budget.reserve().allowed
+
+    def test_status_reports_counts_and_pause(self, budget_dir, clock):
+        budget.reserve()
+        snapshot = budget.status()
+        assert snapshot.active == 1
+        assert snapshot.launched_last_hour == 1
+        assert snapshot.paused_until == 0.0
+        budget.record_quota_error("quota")
+        paused = budget.status()
+        assert paused.paused_until > 0
+        assert paused.paused_reason == "quota"
+
+
+class TestLimitsEnv:
+    def test_env_overrides_are_read(self, monkeypatch):
+        monkeypatch.setenv("YEABOI_AI_MAX_CONCURRENT", "3")
+        monkeypatch.setenv("YEABOI_AI_MAX_PER_HOUR", "7")
+        assert budget.limits()[:2] == (3, 7)
+
+    def test_garbage_and_nonpositive_env_falls_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("YEABOI_AI_MAX_CONCURRENT", "banana")
+        monkeypatch.setenv("YEABOI_AI_MAX_PER_HOUR", "0")
+        assert budget.limits()[:2] == (budget.DEFAULT_MAX_CONCURRENT, budget.DEFAULT_MAX_PER_HOUR)

--- a/tests/unit/test_ship_costing.py
+++ b/tests/unit/test_ship_costing.py
@@ -1,0 +1,110 @@
+"""Tests for per-run transcript costing (ship/costing.py).
+
+The fixture mirrors the real Claude Code JSONL shape the agentwatch collector
+parses — including the requestId dedup trap and a planted fake secret that
+must surface as a finding (label + line only, never content).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from yeaboi.ship import costing
+
+PLANTED_SECRET = "sk-ant-PLANTED000FAKE111SECRET222"
+
+
+def _assistant(request_id, *, usage=None):
+    return {
+        "type": "assistant",
+        "requestId": request_id,
+        "timestamp": "2026-08-07T10:00:00.000Z",
+        "sessionId": "sess-run",
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-5",
+            "usage": usage
+            or {
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 0,
+                "cache_creation": {"ephemeral_1h_input_tokens": 0, "ephemeral_5m_input_tokens": 0},
+            },
+            "content": [{"type": "text", "text": "working"}],
+        },
+    }
+
+
+def _write_transcript(path, lines):
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+
+
+class TestCostTranscript:
+    def test_prices_deduped_usage(self, tmp_path):
+        transcript = tmp_path / "sess-run.jsonl"
+        # The same requestId twice — one API response split across lines must
+        # be priced once.
+        _write_transcript(transcript, [_assistant("req-1"), _assistant("req-1"), _assistant("req-2")])
+        cost = costing.cost_transcript(transcript)
+        assert cost is not None
+        assert cost.session_id == "sess-run"
+        assert cost.known_models
+        # Opus 5: (1000/1e6)*5 + (500/1e6)*25 per unique request = 0.0175 × 2.
+        assert cost.usd == pytest.approx(0.035)
+
+    def test_unknown_model_is_reported_not_hidden(self, tmp_path):
+        transcript = tmp_path / "sess-run.jsonl"
+        record = _assistant("req-1")
+        record["message"]["model"] = "future-model-x"
+        _write_transcript(transcript, [record])
+        cost = costing.cost_transcript(transcript)
+        assert cost is not None
+        assert not cost.known_models
+        assert cost.usd > 0  # priced at the fallback tier, not zero
+
+    def test_planted_secret_becomes_a_finding_without_content(self, tmp_path):
+        transcript = tmp_path / "sess-run.jsonl"
+        _write_transcript(
+            transcript,
+            [
+                {
+                    "type": "user",
+                    "sessionId": "sess-run",
+                    "message": {"role": "user", "content": f"my key is {PLANTED_SECRET}"},
+                },
+                _assistant("req-1"),
+            ],
+        )
+        cost = costing.cost_transcript(transcript)
+        assert cost is not None
+        assert any(f.kind == "secret" for f in cost.findings)
+        for finding in cost.findings:
+            assert PLANTED_SECRET not in finding.label
+
+    def test_unreadable_file_returns_none(self, tmp_path):
+        assert costing.cost_transcript(tmp_path / "missing.jsonl") is None
+
+    def test_malformed_lines_do_not_break_pricing(self, tmp_path):
+        transcript = tmp_path / "sess-run.jsonl"
+        transcript.write_text("{broken\n" + json.dumps(_assistant("req-1")) + "\n", encoding="utf-8")
+        cost = costing.cost_transcript(transcript)
+        assert cost is not None
+        assert cost.usd > 0
+
+
+class TestLocateTranscript:
+    def test_finds_the_file_named_after_the_session(self, tmp_path, monkeypatch):
+        root = tmp_path / "projects"
+        (root / "some-proj").mkdir(parents=True)
+        target = root / "some-proj" / "sess-42.jsonl"
+        target.write_text("", encoding="utf-8")
+        monkeypatch.setattr(costing, "_source_roots", lambda: (("claude_code", root),))
+        assert costing.locate_transcript("sess-42") == target
+        assert costing.locate_transcript("sess-404") is None
+
+    def test_rejects_path_shaped_session_ids(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(costing, "_source_roots", lambda: (("claude_code", tmp_path),))
+        assert costing.locate_transcript("../../etc/passwd") is None
+        assert costing.locate_transcript("") is None

--- a/tests/unit/test_ship_driver.py
+++ b/tests/unit/test_ship_driver.py
@@ -1,0 +1,143 @@
+"""Tests for the headless coding-agent driver (ship/driver.py).
+
+The driver is exercised against a real subprocess — a Python shim standing in
+for the ``claude`` binary — because the things it guards (prompt over stdin,
+process-group kill, env stripping, lenient envelope parsing) are exactly the
+things a mock would fake away.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import threading
+import time
+
+import pytest
+
+from yeaboi.ship import driver
+
+
+def _make_shim(tmp_path, body: str) -> str:
+    """Write an executable Python shim that plays the claude binary."""
+    shim = tmp_path / "claude-shim"
+    shim.write_text("#!/usr/bin/env python3\n" + body, encoding="utf-8")
+    shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+    return str(shim)
+
+
+ECHO_ENVELOPE = """
+import json, sys
+prompt = sys.stdin.read()
+print(json.dumps({
+    "type": "result",
+    "result": f"got {len(prompt)} chars",
+    "session_id": "sess-shim",
+    "total_cost_usd": 0.12,
+    "num_turns": 3,
+    "is_error": False,
+}))
+"""
+
+
+class TestRun:
+    def test_success_parses_the_envelope(self, tmp_path):
+        d = driver.ClaudeCodeDriver(binary=_make_shim(tmp_path, ECHO_ENVELOPE))
+        result = d.run("x" * 500, tmp_path)
+        assert result.ok
+        assert result.output == "got 500 chars"  # the prompt travelled over stdin
+        assert result.session_id == "sess-shim"
+        assert result.cost_usd == pytest.approx(0.12)
+        assert result.num_turns == 3
+        assert result.warnings == ()
+
+    def test_non_envelope_output_degrades_to_raw_text(self, tmp_path):
+        shim = _make_shim(tmp_path, "import sys; sys.stdin.read(); print('plain text, no json')")
+        result = driver.ClaudeCodeDriver(binary=shim).run("go", tmp_path)
+        assert result.ok
+        assert "plain text" in result.output
+        assert any("JSON envelope" in w for w in result.warnings)
+
+    def test_nonzero_exit_fails_with_the_tail(self, tmp_path):
+        shim = _make_shim(tmp_path, "import sys; sys.stdin.read(); print('boom: quota'); sys.exit(2)")
+        result = driver.ClaudeCodeDriver(binary=shim).run("go", tmp_path)
+        assert not result.ok
+        assert result.returncode == 2
+        assert "boom: quota" in result.error
+
+    def test_is_error_envelope_fails_even_on_exit_zero(self, tmp_path):
+        body = "import sys, json; sys.stdin.read(); print(json.dumps({'result': 'declined', 'is_error': True}))"
+        result = driver.ClaudeCodeDriver(binary=_make_shim(tmp_path, body)).run("go", tmp_path)
+        assert not result.ok
+
+    def test_timeout_kills_the_process(self, tmp_path):
+        shim = _make_shim(tmp_path, "import sys, time; sys.stdin.read(); time.sleep(60)")
+        started = time.monotonic()
+        result = driver.ClaudeCodeDriver(binary=shim).run("go", tmp_path, timeout_s=0.5)
+        assert result.timed_out
+        assert not result.ok
+        assert time.monotonic() - started < 15
+
+    def test_cancel_event_stops_the_run(self, tmp_path):
+        shim = _make_shim(tmp_path, "import sys, time; sys.stdin.read(); time.sleep(60)")
+        cancel = threading.Event()
+        threading.Timer(0.4, cancel.set).start()
+        result = driver.ClaudeCodeDriver(binary=shim).run("go", tmp_path, timeout_s=60, cancel_event=cancel)
+        assert result.cancelled
+        assert not result.ok
+
+    def test_session_env_vars_are_stripped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "outer-session")
+        monkeypatch.setenv("CLAUDECODE", "1")
+        body = (
+            "import sys, os, json; sys.stdin.read(); "
+            "print(json.dumps({'result': repr(sorted(k for k in os.environ if k.startswith('CLAUDE')))}))"
+        )
+        result = driver.ClaudeCodeDriver(binary=_make_shim(tmp_path, body)).run("go", tmp_path)
+        assert "CLAUDE_SESSION_ID" not in result.output
+        assert "CLAUDECODE" not in result.output
+
+    def test_on_line_sees_output_and_may_raise(self, tmp_path):
+        shim = _make_shim(tmp_path, "import sys; sys.stdin.read(); print('line one'); print('line two')")
+        seen: list[str] = []
+
+        def _cb(line: str) -> None:
+            seen.append(line)
+            raise RuntimeError("UI hiccup")  # must never kill the pump
+
+        result = driver.ClaudeCodeDriver(binary=shim).run("go", tmp_path, on_line=_cb)
+        assert result.ok
+        assert "line one" in seen
+
+    def test_missing_binary_reports_instead_of_raising(self, tmp_path):
+        result = driver.ClaudeCodeDriver(binary=str(tmp_path / "nope")).run("go", tmp_path)
+        assert not result.ok
+        assert "could not launch" in result.error
+
+
+class TestAvailability:
+    def test_missing_binary(self):
+        ok, detail = driver.ClaudeCodeDriver(binary="definitely-not-a-real-binary").available()
+        assert not ok
+        assert "not found" in detail
+
+    def test_probe_reads_the_version(self, tmp_path, monkeypatch):
+        shim = _make_shim(tmp_path, "print('9.9.9 (shim)')")
+        monkeypatch.setenv("PATH", str(tmp_path), prepend=":")
+        ok, detail = driver.ClaudeCodeDriver(binary=shim).available()
+        assert ok
+        assert "9.9.9" in detail
+
+
+class TestEnvelopeParsing:
+    def test_whole_output_json(self):
+        assert driver._parse_envelope('{"result": "hi"}') == {"result": "hi"}
+
+    def test_json_after_progress_noise(self):
+        raw = "warming up...\nstill going\n" + json.dumps({"result": "done"})
+        assert driver._parse_envelope(raw) == {"result": "done"}
+
+    def test_garbage_is_empty_not_an_error(self):
+        assert driver._parse_envelope("complete nonsense {broken") == {}
+        assert driver._parse_envelope("") == {}
+        assert driver._parse_envelope("[1, 2]") == {}

--- a/tests/unit/test_ship_driver.py
+++ b/tests/unit/test_ship_driver.py
@@ -114,6 +114,16 @@ class TestRun:
         assert not result.ok
         assert "could not launch" in result.error
 
+    def test_the_permission_envelope_is_mechanical_not_prose(self, tmp_path):
+        # The "nothing pushes without approval" guarantee rests on these argv
+        # flags: acceptEdits (files editable headlessly, Bash denied) plus an
+        # explicit git-push/gh deny list. Losing them would leave only a
+        # sentence in the prompt between the agent and `git push`.
+        body = "import sys, json; sys.stdin.read(); print(json.dumps({'result': ' '.join(sys.argv[1:])}))"
+        result = driver.ClaudeCodeDriver(binary=_make_shim(tmp_path, body)).run("go", tmp_path)
+        assert "--permission-mode acceptEdits" in result.output
+        assert "--disallowedTools Bash(git push:*) Bash(gh:*)" in result.output
+
 
 class TestAvailability:
     def test_missing_binary(self):

--- a/tests/unit/test_ship_engine.py
+++ b/tests/unit/test_ship_engine.py
@@ -1,0 +1,277 @@
+"""Tests for the ship engine (ship/engine.py) — the full run, end to end.
+
+A FakeDriver stands in for Claude Code (writing files into the real worktree
+the engine prepared), the budget is stubbed per test, and gate resolutions
+arrive from a second thread through a second store connection — the same path
+a real approving surface takes. The engine's contract under test: it never
+raises, every failure is a status with a reason, and the diff on disk — not
+the driver's word — decides whether a run proceeds.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from yeaboi.agent.state import AcceptanceCriterion, Priority, StoryPointValue, Task, UserStory
+from yeaboi.ship import budget, engine, worktree
+from yeaboi.ship.driver import DriverResult
+from yeaboi.ship.store import ShipStore
+from yeaboi.tools.local_git import git_subprocess_env
+
+
+def _run_git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, env=git_subprocess_env())
+
+
+def _story():
+    return UserStory(
+        id="US-001",
+        feature_id="F-001",
+        persona="developer",
+        goal="ship faster",
+        benefit="less toil",
+        acceptance_criteria=(AcceptanceCriterion(given="a plan", when="ship runs", then="a PR opens"),),
+        story_points=StoryPointValue.THREE,
+        priority=Priority.HIGH,
+        title="Ship pipeline",
+    )
+
+
+def _task():
+    return Task(id="T-1", story_id="US-001", title="wire", description="wire it", ai_prompt="Add x to y.")
+
+
+class FakeDriver:
+    """A scripted agent: each call runs the next behavior in the list.
+
+    Behaviors: "work" writes a new file into the cwd, "nothing" does nothing,
+    "fail_quota" fails with a quota-shaped error, "cancelled" reports a
+    cancelled run.
+    """
+
+    def __init__(self, behaviors=("work",)):
+        self.behaviors = list(behaviors)
+        self.calls: list[str] = []  # the prompts, for assertions
+
+    def available(self):
+        return True, "fake 1.0"
+
+    def get_type(self):
+        return "fake"
+
+    def get_capabilities(self):
+        return {}
+
+    def run(self, prompt, cwd, *, timeout_s=0, cancel_event=None, on_line=None):
+        self.calls.append(prompt)
+        behavior = self.behaviors.pop(0) if self.behaviors else "nothing"
+        if behavior == "work":
+            (Path(cwd) / f"agent_{len(self.calls)}.py").write_text("x = 1\n", encoding="utf-8")
+            return DriverResult(ok=True, output="implemented", session_id="", returncode=0)
+        if behavior == "fail_quota":
+            return DriverResult(ok=False, error="HTTP 429 rate limit", returncode=1)
+        if behavior == "cancelled":
+            return DriverResult(ok=False, cancelled=True, returncode=-1)
+        return DriverResult(ok=True, output="I could not find anything to change.", returncode=0)
+
+
+@pytest.fixture()
+def ship_env(tmp_path, monkeypatch):
+    """Everything a run touches, isolated: worktree root, budget, db, repo."""
+    home = tmp_path / "ship-home"
+    home.mkdir()
+    monkeypatch.setattr(worktree, "SHIP_WORKTREES_DIR", home / "worktrees")
+    monkeypatch.setattr(worktree, "SHIP_WORKTREE_REGISTRY", home / "worktrees.json")
+    monkeypatch.setattr(worktree, "get_ship_dir", lambda: home)
+    released: list[str] = []
+    monkeypatch.setattr(budget, "reserve", lambda **kw: budget.BudgetDecision(allowed=True, permit_id="permit_test"))
+    monkeypatch.setattr(budget, "release", released.append)
+    monkeypatch.setattr(engine, "_GATE_POLL_S", 0.02)
+
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _run_git(repo, "init", "-q", "-b", "main")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run_git(repo, "add", "README.md")
+    _run_git(repo, "commit", "-q", "-m", "init")
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True, env=git_subprocess_env())
+    _run_git(repo, "remote", "add", "origin", str(bare))
+
+    monkeypatch.setattr(engine, "_load_story", lambda sid, story_id, db: (_story(), [_task()], "sess-1"))
+
+    class Env:
+        pass
+
+    env = Env()
+    env.repo = repo
+    env.db = tmp_path / "sessions.db"
+    env.released = released
+    return env
+
+
+def _resolver(db_path, resolutions, comments=()):
+    """A thread that answers the gate each time it opens, like a real surface."""
+    comments = list(comments) + [""] * len(resolutions)
+
+    def _work():
+        with ShipStore(db_path) as store:
+            for index, resolution in enumerate(resolutions):
+                deadline = time.monotonic() + 30
+                while time.monotonic() < deadline:
+                    runs = store.list_runs(limit=1)
+                    if runs and runs[0].status == "awaiting_approval" and not runs[0].gate_resolution:
+                        store.resolve_gate(runs[0].run_id, resolution, comments[index])
+                        break
+                    time.sleep(0.02)
+
+    thread = threading.Thread(target=_work, daemon=True)
+    thread.start()
+    return thread
+
+
+class TestDryRun:
+    def test_dry_run_is_canned_and_touches_nothing(self, tmp_path):
+        run = engine.run_ship("US-001", str(tmp_path), dry_run=True)
+        assert run.status == "approved"
+        assert any("dry run" in w for w in run.warnings)
+        assert not (tmp_path / ".git").exists()
+
+
+class TestFailurePaths:
+    def test_unloadable_story_is_a_failed_run(self, ship_env, monkeypatch):
+        def _boom(sid, story_id, db):
+            raise ValueError("story US-404 not found in this plan")
+
+        monkeypatch.setattr(engine, "_load_story", _boom)
+        run = engine.run_ship("US-404", str(ship_env.repo), db_path=ship_env.db, driver=FakeDriver())
+        assert run.status == "failed"
+        assert any("US-404" in w for w in run.warnings)
+
+    def test_budget_denial_is_a_failed_run_before_any_git(self, ship_env, monkeypatch):
+        monkeypatch.setattr(budget, "reserve", lambda **kw: budget.BudgetDecision(reason="hourly-budget (2/2)"))
+        run = engine.run_ship("US-001", str(ship_env.repo), db_path=ship_env.db, driver=FakeDriver())
+        assert run.status == "failed"
+        assert any("hourly-budget" in w for w in run.warnings)
+        assert not (worktree.SHIP_WORKTREES_DIR / "proj").exists()
+
+    def test_unavailable_agent_fails_before_the_budget(self, ship_env):
+        driver = FakeDriver()
+        driver.available = lambda: (False, "claude not found on PATH")
+        run = engine.run_ship("US-001", str(ship_env.repo), db_path=ship_env.db, driver=driver)
+        assert run.status == "failed"
+        assert any("not found on PATH" in w for w in run.warnings)
+
+    def test_no_diff_fails_whatever_the_agent_said(self, ship_env):
+        driver = FakeDriver(behaviors=("nothing",))
+        resolver = _resolver(ship_env.db, [])  # gate never opens
+        run = engine.run_ship("US-001", str(ship_env.repo), db_path=ship_env.db, driver=driver)
+        resolver.join(timeout=1)
+        assert run.status == "failed"
+        assert any("produced no changes" in w for w in run.warnings)
+        assert any("could not find anything" in w for w in run.warnings)  # the agent's own words surface
+
+    def test_quota_failure_trips_the_circuit_breaker(self, ship_env, monkeypatch):
+        tripped: list[str] = []
+        monkeypatch.setattr(budget, "record_quota_error", tripped.append)
+        run = engine.run_ship(
+            "US-001", str(ship_env.repo), db_path=ship_env.db, driver=FakeDriver(behaviors=("fail_quota",))
+        )
+        assert run.status == "failed"
+        assert tripped and "429" in tripped[0]
+
+    def test_budget_is_released_even_when_the_run_fails(self, ship_env):
+        engine.run_ship("US-001", str(ship_env.repo), db_path=ship_env.db, driver=FakeDriver(behaviors=("nothing",)))
+        assert ship_env.released == ["permit_test"]
+
+
+class TestHappyPath:
+    def test_approved_run_pushes_and_persists(self, ship_env):
+        driver = FakeDriver(behaviors=("work",))
+        resolver = _resolver(ship_env.db, ["approved"], ["looks right"])
+        run = engine.run_ship("US-001", str(ship_env.repo), db_path=ship_env.db, check_command="echo ok", driver=driver)
+        resolver.join(timeout=5)
+        assert run.status == "approved", run.warnings
+        assert run.gate_comment == "looks right"
+        assert run.validation.passed
+        assert "agent_1.py" in run.diff_stat
+        assert run.pr_url == ""  # local origin — branch pushed, no GitHub
+        with ShipStore(ship_env.db) as store:
+            stored = store.get_run(run.run_id)
+        assert stored.status == "approved"
+        # The branch reached origin.
+        heads = subprocess.run(
+            ["git", "-C", str(ship_env.repo), "ls-remote", "--heads", "origin"],
+            capture_output=True,
+            text=True,
+            env=git_subprocess_env(),
+        ).stdout
+        assert run.branch in heads
+
+    def test_progress_events_cover_every_phase(self, ship_env):
+        events: list[dict] = []
+        resolver = _resolver(ship_env.db, ["approved"])
+        engine.run_ship(
+            "US-001",
+            str(ship_env.repo),
+            db_path=ship_env.db,
+            driver=FakeDriver(behaviors=("work",)),
+            on_progress=events.append,
+        )
+        resolver.join(timeout=5)
+        seen = {e.get("component_id") for e in events if isinstance(e, dict)}
+        assert {"ship-setup", "ship-implement", "ship-validate", "ship-gate", "ship-finalize"} <= seen
+
+
+class TestGateLoop:
+    def test_rejection_reworks_with_the_reviewers_words(self, ship_env):
+        driver = FakeDriver(behaviors=("work", "work"))
+        resolver = _resolver(ship_env.db, ["rejected", "approved"], ["use tabs not spaces", "better"])
+        run = engine.run_ship("US-001", str(ship_env.repo), db_path=ship_env.db, driver=driver)
+        resolver.join(timeout=10)
+        assert run.status == "approved", run.warnings
+        assert run.rejection_count == 1
+        assert len(driver.calls) == 2
+        assert "use tabs not spaces" in driver.calls[1]  # the rework prompt carries the comment
+
+    def test_rejections_at_the_cap_are_terminal(self, ship_env, monkeypatch):
+        monkeypatch.setattr(engine, "MAX_REJECTION_ATTEMPTS", 2)
+        driver = FakeDriver(behaviors=("work", "work", "work"))
+        resolver = _resolver(ship_env.db, ["rejected", "rejected"], ["no", "still no"])
+        run = engine.run_ship("US-001", str(ship_env.repo), db_path=ship_env.db, driver=driver)
+        resolver.join(timeout=10)
+        assert run.status == "rejected"
+        assert run.rejection_count == 2
+        assert len(driver.calls) == 2  # rework ran once; the second rejection was terminal
+
+    def test_cancel_while_awaiting_approval(self, ship_env):
+        cancel = threading.Event()
+
+        def _cancel_when_gated():
+            with ShipStore(ship_env.db) as store:
+                deadline = time.monotonic() + 30
+                while time.monotonic() < deadline:
+                    runs = store.list_runs(limit=1)
+                    if runs and runs[0].status == "awaiting_approval":
+                        cancel.set()
+                        return
+                    time.sleep(0.02)
+
+        thread = threading.Thread(target=_cancel_when_gated, daemon=True)
+        thread.start()
+        run = engine.run_ship(
+            "US-001",
+            str(ship_env.repo),
+            db_path=ship_env.db,
+            driver=FakeDriver(behaviors=("work",)),
+            cancel_event=cancel,
+        )
+        thread.join(timeout=5)
+        assert run.status == "cancelled"

--- a/tests/unit/test_ship_pipeline.py
+++ b/tests/unit/test_ship_pipeline.py
@@ -60,7 +60,8 @@ class TestBuildPrompt:
         assert "Given a plan, when I run ship, then a PR opens." in prompt
         assert "You are implementing the wiring." in prompt
         assert "Test plan: run the tests" in prompt
-        assert "Do NOT push" in prompt
+        assert "do not attempt git or gh commands" in prompt
+        assert "no shell" in prompt
 
     def test_rework_prompt_carries_the_reviewers_words_and_the_failure(self):
         validation = ShipValidation(configured=True, command="make test", passed=False, exit_code=2, output_tail="boom")

--- a/tests/unit/test_ship_pipeline.py
+++ b/tests/unit/test_ship_pipeline.py
@@ -1,0 +1,193 @@
+"""Tests for the deterministic pipeline pieces (ship/pipeline.py).
+
+The bridge tests run against a real prepared worktree: the bridge's one job
+is telling "the agent said done" apart from "there is work on disk", and only
+a real git tree can prove that distinction.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from yeaboi.agent.state import AcceptanceCriterion, Priority, ShipValidation, StoryPointValue, Task, UserStory
+from yeaboi.ship import pipeline, worktree
+from yeaboi.tools.local_git import git_subprocess_env
+
+
+def _story(story_id="US-001"):
+    return UserStory(
+        id=story_id,
+        feature_id="F-001",
+        persona="developer",
+        goal="ship faster",
+        benefit="less toil",
+        acceptance_criteria=(AcceptanceCriterion(given="a plan", when="I run ship", then="a PR opens"),),
+        story_points=StoryPointValue.THREE,
+        priority=Priority.HIGH,
+        title="Ship pipeline",
+    )
+
+
+def _task(task_id="T-001", story_id="US-001"):
+    return Task(
+        id=task_id,
+        story_id=story_id,
+        title="Wire the thing",
+        description="Wire it up",
+        test_plan="run the tests",
+        ai_prompt="You are implementing the wiring. Add X to Y.",
+    )
+
+
+class TestFindStory:
+    def test_finds_story_and_its_tasks(self):
+        state = {"stories": [_story()], "tasks": [_task(), _task("T-9", story_id="US-999")]}
+        story, tasks = pipeline.find_story(state, "US-001")
+        assert story.id == "US-001"
+        assert [t.id for t in tasks] == ["T-001"]
+
+    def test_missing_story_names_the_available_ids(self):
+        with pytest.raises(ValueError, match="US-001"):
+            pipeline.find_story({"stories": [_story()], "tasks": []}, "US-404")
+
+
+class TestBuildPrompt:
+    def test_carries_story_criteria_tasks_and_the_run_contract(self):
+        prompt = pipeline.build_prompt(_story(), [_task()])
+        assert "As a developer" in prompt
+        assert "Given a plan, when I run ship, then a PR opens." in prompt
+        assert "You are implementing the wiring." in prompt
+        assert "Test plan: run the tests" in prompt
+        assert "Do NOT push" in prompt
+
+    def test_rework_prompt_carries_the_reviewers_words_and_the_failure(self):
+        validation = ShipValidation(configured=True, command="make test", passed=False, exit_code=2, output_tail="boom")
+        prompt = pipeline.rework_prompt("wrong file, fix models.py", validation)
+        assert "wrong file, fix models.py" in prompt
+        assert "make test" in prompt
+        assert "boom" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Bridges against a real worktree
+# ---------------------------------------------------------------------------
+
+
+def _run_git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, env=git_subprocess_env())
+
+
+@pytest.fixture()
+def prepared(tmp_path, monkeypatch):
+    """A real repo + prepared ship worktree, isolated under tmp."""
+    home = tmp_path / "ship-home"
+    home.mkdir()
+    monkeypatch.setattr(worktree, "SHIP_WORKTREES_DIR", home / "worktrees")
+    monkeypatch.setattr(worktree, "SHIP_WORKTREE_REGISTRY", home / "worktrees.json")
+    monkeypatch.setattr(worktree, "get_ship_dir", lambda: home)
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _run_git(repo, "init", "-q", "-b", "main")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run_git(repo, "add", "README.md")
+    _run_git(repo, "commit", "-q", "-m", "init")
+    return worktree.prepare("run-1", repo)
+
+
+class TestDiffBridge:
+    def test_no_work_is_no_work_whatever_the_agent_said(self, prepared):
+        has_work, stat = pipeline.diff_bridge(prepared)
+        assert not has_work
+        assert stat == ""
+
+    def test_uncommitted_agent_output_is_committed_and_counted(self, prepared):
+        (worktree._validate_owned(prepared.path) / "new.py").write_text("x = 1\n", encoding="utf-8")
+        has_work, stat = pipeline.diff_bridge(prepared)
+        assert has_work
+        assert "new.py" in stat
+        # And the tree is clean afterwards — the branch owns the work.
+        assert not worktree.is_dirty(prepared.path)
+
+    def test_committed_agent_work_counts_too(self, prepared):
+        path = worktree._validate_owned(prepared.path)
+        (path / "done.py").write_text("y = 2\n", encoding="utf-8")
+        _run_git(path, "add", "done.py")
+        _run_git(path, "commit", "-q", "-m", "agent work")
+        has_work, stat = pipeline.diff_bridge(prepared)
+        assert has_work
+        assert "done.py" in stat
+
+
+class TestRunValidation:
+    def test_no_command_is_visible_not_a_silent_pass(self, prepared):
+        validation = pipeline.run_validation(prepared, "")
+        assert not validation.configured
+        assert not validation.passed
+
+    def test_passing_command(self, prepared):
+        validation = pipeline.run_validation(prepared, "echo all good")
+        assert validation.configured
+        assert validation.passed
+        assert "all good" in validation.output_tail
+
+    def test_failing_command_carries_exit_and_tail(self, prepared):
+        validation = pipeline.run_validation(prepared, "echo broke; exit 3")
+        assert validation.configured
+        assert not validation.passed
+        assert validation.exit_code == 3
+        assert "broke" in validation.output_tail
+
+
+class TestGithubSlug:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "git@github.com:owner/proj.git",
+            "https://github.com/owner/proj.git",
+            "https://github.com/owner/proj",
+            "ssh://git@github.com/owner/proj.git",
+        ],
+    )
+    def test_github_shapes(self, url):
+        assert pipeline._github_slug(url) == ("owner", "proj")
+
+    def test_non_github_is_none(self):
+        assert pipeline._github_slug("https://gitlab.com/owner/proj.git") is None
+        assert pipeline._github_slug("/some/local/path") is None
+        assert pipeline._github_slug("") is None
+
+
+class TestPrBody:
+    def test_normal_body_carries_summary_and_approval(self):
+        body = pipeline.build_pr_body("## Summary\nimplements US-001", "looks right")
+        assert "implements US-001" in body
+        assert "looks right" in body
+        assert "a human approved this diff" in body
+
+    def test_leaky_body_is_replaced_not_published(self):
+        secret = "sk-ant-PLANTED000FAKE111SECRET222"
+        body = pipeline.build_pr_body(f"## Summary\ntoken {secret}", "")
+        assert secret not in body
+
+
+class TestPushAndOpenPr:
+    def test_push_to_a_local_origin_without_github(self, prepared, tmp_path):
+        bare = tmp_path / "origin.git"
+        subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True, env=git_subprocess_env())
+        _run_git(prepared.repo, "remote", "add", "origin", str(bare))
+        path = worktree._validate_owned(prepared.path)
+        (path / "new.py").write_text("x = 1\n", encoding="utf-8")
+        pipeline.diff_bridge(prepared)  # commit the work
+        outcome = pipeline.push_and_open_pr(prepared, title="t", body="b")
+        assert outcome.pushed
+        assert outcome.pr_url == ""
+        assert "not GitHub" in outcome.detail
+
+    def test_failed_push_reports_instead_of_raising(self, prepared):
+        outcome = pipeline.push_and_open_pr(prepared, title="t", body="b")  # no origin at all
+        assert not outcome.pushed
+        assert "push failed" in outcome.detail

--- a/tests/unit/test_ship_render.py
+++ b/tests/unit/test_ship_render.py
@@ -1,0 +1,90 @@
+"""Tests for the ship CLI text renderers (ship/render.py).
+
+Rendered through a real Console; the assertions are that the load-bearing
+facts appear and that legitimately-empty store values (a blank created_at, a
+run with nothing but a status) render instead of crashing.
+"""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from yeaboi.agent.state import ShipRun, ShipValidation
+from yeaboi.ship.budget import BudgetStatus
+from yeaboi.ship.render import format_budget_rich, format_history_rich, format_run_rich
+
+
+def _render(renderable, width: int = 120) -> str:
+    console = Console(file=io.StringIO(), width=width)
+    console.print(renderable)
+    return console.file.getvalue()
+
+
+class TestFormatRun:
+    def test_full_run_shows_the_gate_facts(self):
+        run = ShipRun(
+            run_id="run-1",
+            story_id="US-001",
+            branch="ship/run-1",
+            status="awaiting_approval",
+            diff_stat="src/app.py | 10 ++\n2 files changed",
+            validation=ShipValidation(configured=True, command="make test", passed=True, exit_code=0),
+            cost_usd=0.42,
+            transcript_findings=(("secret", "critical", "api key"),),
+            pr_url="",
+            warnings=("one warning",),
+        )
+        out = _render(format_run_rich(run))
+        assert "US-001" in out
+        assert "ship/run-1" in out
+        assert "2 files changed" in out
+        assert "make test — passed" in out
+        assert "$0.42" in out
+        assert "critical: api key" in out
+        assert "⚠ one warning" in out
+
+    def test_no_validation_is_a_visible_warning(self):
+        out = _render(format_run_rich(ShipRun(run_id="r", story_id="US-1", status="failed")))
+        assert "nothing was proven" in out
+
+    def test_empty_run_renders_without_crashing(self):
+        out = _render(format_run_rich(ShipRun()))
+        assert "(no story)" in out
+
+
+class TestFormatHistory:
+    def test_empty_history_names_the_next_step(self):
+        out = _render(format_history_rich([]))
+        assert "yeaboi ship run" in out
+
+    def test_rows_carry_story_status_and_pr(self):
+        runs = [
+            ShipRun(run_id="r2", story_id="US-002", status="approved", created_at="2026-08-17T10:00:00", pr_url="u"),
+            ShipRun(run_id="r1", story_id="US-001", status="failed"),  # created_at legitimately empty
+        ]
+        out = _render(format_history_rich(runs))
+        assert "US-002" in out
+        assert "approved" in out
+        assert "US-001" in out
+        assert "failed" in out
+
+
+class TestFormatBudget:
+    def test_counts_and_open_circuit(self):
+        status = BudgetStatus(
+            active=1,
+            launched_last_hour=2,
+            launched_last_day=5,
+            paused_until=999.0,
+            paused_reason="HTTP 429",
+        )
+        out = _render(format_budget_rich(status))
+        assert "active 1/1" in out
+        assert "last hour 2/2" in out
+        assert "circuit OPEN: HTTP 429" in out
+
+    def test_quiet_budget_has_no_circuit_line(self):
+        out = _render(format_budget_rich(BudgetStatus()))
+        assert "circuit" not in out

--- a/tests/unit/test_ship_screens.py
+++ b/tests/unit/test_ship_screens.py
@@ -77,6 +77,14 @@ class TestPickScreen:
         assert "US-011" not in out
         assert "and 4 more" in out
 
+    def test_the_window_follows_a_late_selection(self):
+        # Story 9+ must be reachable, not just counted — the window slides.
+        stories = [_story(f"US-{n:03d}") for n in range(12)]
+        out = _render(_build_ship_pick_screen(stories, 11, repo="/p", check_command=""))
+        assert "US-011" in out
+        assert "▸ US-011" in out
+        assert "earlier" in out
+
     def test_edit_mode_shows_the_live_buffer(self):
         out = _render(
             _build_ship_pick_screen(

--- a/tests/unit/test_ship_screens.py
+++ b/tests/unit/test_ship_screens.py
@@ -1,0 +1,187 @@
+"""Render tests for the Ship mode screens (_screens_ship.py).
+
+Every ``_build_*_screen`` renders through a real Console — the assertion is
+that the load-bearing facts (story ids, validation verdicts, findings, the
+gate's warning states) are actually visible, and that masking rules hold
+(the diff stat and validation tail are capped, never dumped whole).
+"""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from yeaboi.agent.state import (
+    AcceptanceCriterion,
+    Priority,
+    ShipPhase,
+    ShipRun,
+    ShipValidation,
+    StoryPointValue,
+    UserStory,
+)
+from yeaboi.ui.mode_select.screens._screens_ship import (
+    _build_ship_gate_screen,
+    _build_ship_pick_screen,
+    _build_ship_progress_screen,
+    _build_ship_result_screen,
+)
+
+
+def _render(panel, width: int = 100) -> str:
+    console = Console(file=io.StringIO(), width=width, height=40)
+    console.print(panel)
+    return console.file.getvalue()
+
+
+def _story(story_id="US-001", title="Ship pipeline"):
+    return UserStory(
+        id=story_id,
+        feature_id="F-1",
+        persona="dev",
+        goal="ship",
+        benefit="speed",
+        acceptance_criteria=(AcceptanceCriterion(given="g", when="w", then="t"),),
+        story_points=StoryPointValue.THREE,
+        priority=Priority.HIGH,
+        title=title,
+    )
+
+
+class TestPickScreen:
+    def test_lists_stories_with_points_and_fields(self):
+        out = _render(
+            _build_ship_pick_screen(
+                [_story(), _story("US-002", "Second story")],
+                0,
+                repo="/home/dev/proj",
+                check_command="make test",
+            )
+        )
+        assert "US-001" in out
+        assert "Ship pipeline" in out
+        assert "3 pts" in out
+        assert "/home/dev/proj" in out
+        assert "make test" in out
+
+    def test_empty_plan_names_the_next_step(self):
+        out = _render(_build_ship_pick_screen([], 0, repo="/p", check_command=""))
+        assert "No stories found" in out
+        assert "Planning" in out
+
+    def test_story_overflow_is_counted_not_dumped(self):
+        stories = [_story(f"US-{n:03d}") for n in range(12)]
+        out = _render(_build_ship_pick_screen(stories, 0, repo="/p", check_command=""))
+        assert "US-007" in out
+        assert "US-011" not in out
+        assert "and 4 more" in out
+
+    def test_edit_mode_shows_the_live_buffer(self):
+        out = _render(
+            _build_ship_pick_screen(
+                [_story()], 0, repo="/old", check_command="", edit_field="repo", edit_buf="/typed/so/far"
+            )
+        )
+        assert "/typed/so/far" in out
+
+
+class TestProgressScreen:
+    def test_checklist_shows_pending_and_running_phases(self):
+        events = [
+            {
+                "kind": "analysis_component",
+                "component_id": "ship-setup",
+                "label": "Preparing isolated worktree",
+                "status": "completed",
+                "detail": "",
+            },
+            {
+                "kind": "analysis_component",
+                "component_id": "ship-implement",
+                "label": "Implementing",
+                "status": "running",
+                "detail": "",
+            },
+        ]
+        out = _render(_build_ship_progress_screen(events, tick=3.0))
+        assert "Prepare isolated worktree" in out
+        assert "Run the coding agent" in out
+        assert "Await your approval" in out  # pending rows render too
+        assert "esc cancels the run" in out
+
+
+class TestGateScreen:
+    def _run(self, **overrides):
+        base = ShipRun(
+            run_id="run-1",
+            story_id="US-001",
+            branch="ship/run-1",
+            status="awaiting_approval",
+            diff_stat="src/app.py | 10 ++++\n2 files changed, 12 insertions(+)",
+            validation=ShipValidation(configured=True, command="make test", passed=True, exit_code=0),
+            cost_usd=0.42,
+        )
+        return ShipRun(**{**base.__dict__, **overrides})
+
+    def test_shows_diff_validation_and_cost(self):
+        out = _render(_build_ship_gate_screen(self._run()))
+        assert "US-001" in out
+        assert "ship/run-1" in out
+        assert "2 files changed" in out
+        assert "make test" in out
+        assert "passed" in out
+        assert "$0.42" in out
+
+    def test_failed_validation_is_loud_with_its_tail(self):
+        run = self._run(
+            validation=ShipValidation(
+                configured=True, command="make test", passed=False, exit_code=2, output_tail="FAILED test_x"
+            )
+        )
+        out = _render(_build_ship_gate_screen(run))
+        assert "FAILED" in out
+        assert "FAILED test_x" in out
+
+    def test_no_validation_is_a_visible_warning_not_silence(self):
+        run = self._run(validation=ShipValidation())
+        out = _render(_build_ship_gate_screen(run))
+        assert "nothing was proven" in out
+
+    def test_transcript_findings_surface_as_labels_only(self):
+        run = self._run(transcript_findings=(("secret", "critical", "anthropic api key"),))
+        out = _render(_build_ship_gate_screen(run))
+        assert "anthropic api key" in out
+        assert "1 transcript finding" in out
+
+    def test_rejection_comment_editor_renders(self):
+        out = _render(_build_ship_gate_screen(self._run(), comment_edit="wrong file"))
+        assert "Why reject?" in out
+        assert "wrong file" in out
+
+
+class TestResultScreen:
+    def test_approved_run_shows_pr_and_phases(self):
+        run = ShipRun(
+            run_id="run-1",
+            story_id="US-001",
+            branch="ship/run-1",
+            status="approved",
+            pr_url="https://github.com/o/r/pull/7",
+            cost_usd=1.2,
+            phases=(
+                ShipPhase(name="setup", status="completed", duration_s=2.0),
+                ShipPhase(name="implement", status="completed", duration_s=120.0),
+            ),
+        )
+        out = _render(_build_ship_result_screen(run))
+        assert "Shipped" in out
+        assert "github.com/o/r/pull/7" in out
+        assert "implement" in out
+        assert "$1.20" in out
+
+    def test_failed_run_carries_its_warnings(self):
+        run = ShipRun(run_id="run-1", status="failed", warnings=("the agent produced no changes",))
+        out = _render(_build_ship_result_screen(run))
+        assert "Run failed" in out
+        assert "produced no changes" in out

--- a/tests/unit/test_ship_store.py
+++ b/tests/unit/test_ship_store.py
@@ -75,6 +75,17 @@ class TestSaveRun:
             assert not store.save_run(ShipRun(run_id="run-1", status="failed"), expect_status="running")
             assert store.get_run("run-1").status == "awaiting_approval"
 
+    def test_unconditional_save_of_an_unrecorded_run_inserts_it(self, db_path):
+        # A setup failure aborts before record_run; its terminal artifact must
+        # still reach history — an UPDATE matching zero rows must not count
+        # as "persisted".
+        with ShipStore(db_path) as store:
+            assert store.save_run(ShipRun(run_id="run-x", status="failed", warnings=("dirty repo",)))
+            stored = store.get_run("run-x")
+        assert stored is not None
+        assert stored.status == "failed"
+        assert stored.warnings == ("dirty repo",)
+
     def test_unknown_status_is_rejected_loudly(self, db_path):
         with ShipStore(db_path) as store:
             with pytest.raises(ValueError, match="unknown ship status"):

--- a/tests/unit/test_ship_store.py
+++ b/tests/unit/test_ship_store.py
@@ -1,0 +1,144 @@
+"""Tests for ship run persistence and the gate CAS (ship/store.py).
+
+The gate protocol's whole value is that resolution happens exactly once, in
+the database, whoever asks — so the race test uses two independent store
+connections the way two real surfaces would.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from yeaboi.agent.state import ShipPhase, ShipRun, ShipValidation
+from yeaboi.ship.store import ShipStore, _dict_to_run
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    return tmp_path / "sessions.db"
+
+
+def _full_run(run_id="run-1", status="running"):
+    return ShipRun(
+        run_id=run_id,
+        story_id="US-001",
+        session_id="sess-1",
+        agent_session_id="agent-sess",
+        repo="/tmp/proj",
+        branch=f"ship/{run_id}",
+        worktree="/tmp/wt",
+        base_sha="a" * 40,
+        status=status,
+        phases=(ShipPhase(name="setup", status="completed", detail="ok", duration_s=1.5),),
+        validation=ShipValidation(configured=True, command="make test", passed=True, exit_code=0, output_tail="ok"),
+        diff_stat="2 files changed",
+        cost_usd=0.42,
+        transcript_findings=(("secret", "critical", "api key"),),
+        transcript_path="/tmp/t.jsonl",
+        warnings=("one warning",),
+    )
+
+
+class TestRoundTrip:
+    def test_record_and_get_preserve_the_whole_artifact(self, db_path):
+        with ShipStore(db_path) as store:
+            recorded = store.record_run(_full_run())
+            loaded = store.get_run("run-1")
+        assert loaded == recorded
+        assert loaded.phases[0].duration_s == 1.5
+        assert loaded.validation.command == "make test"
+        assert loaded.transcript_findings == (("secret", "critical", "api key"),)
+
+    def test_list_runs_newest_first_with_limit(self, db_path):
+        with ShipStore(db_path) as store:
+            for n in range(5):
+                store.record_run(ShipRun(run_id=f"run-{n}", status="failed", created_at=f"2026-08-1{n}T00:00:00"))
+            runs = store.list_runs(limit=3)
+        assert [r.run_id for r in runs] == ["run-4", "run-3", "run-2"]
+
+    def test_dict_to_run_tolerates_missing_keys(self):
+        run = _dict_to_run({"run_id": "x"})
+        assert run.run_id == "x"
+        assert run.status == "planned"
+        assert run.validation == ShipValidation()
+
+
+class TestSaveRun:
+    def test_cas_write_lands_only_on_the_expected_status(self, db_path):
+        with ShipStore(db_path) as store:
+            store.record_run(_full_run(status="running"))
+            moved = ShipRun(run_id="run-1", status="awaiting_approval")
+            assert store.save_run(moved, expect_status="running")
+            # A stale writer expecting the old status loses.
+            assert not store.save_run(ShipRun(run_id="run-1", status="failed"), expect_status="running")
+            assert store.get_run("run-1").status == "awaiting_approval"
+
+    def test_unknown_status_is_rejected_loudly(self, db_path):
+        with ShipStore(db_path) as store:
+            with pytest.raises(ValueError, match="unknown ship status"):
+                store.save_run(ShipRun(run_id="run-1", status="banana"))
+
+
+class TestGate:
+    def _awaiting(self, store):
+        store.record_run(_full_run(status="awaiting_approval"))
+
+    def test_resolve_approves_once_and_writes_the_audit_event(self, db_path):
+        with ShipStore(db_path) as store:
+            self._awaiting(store)
+            assert store.resolve_gate("run-1", "approved", "ship it")
+            run = store.get_run("run-1")
+            assert run.gate_resolution == "approved"
+            assert run.gate_comment == "ship it"
+            assert run.status == "awaiting_approval"  # resolve ≠ resume
+            assert store.gate_events("run-1") == [("approved", "ship it", run.updated_at)]
+
+    def test_second_resolution_loses_cleanly(self, db_path):
+        with ShipStore(db_path) as store:
+            self._awaiting(store)
+            assert store.resolve_gate("run-1", "approved")
+            assert not store.resolve_gate("run-1", "rejected", "too late")
+            assert store.get_run("run-1").gate_resolution == "approved"
+
+    def test_rejection_counts_attempts(self, db_path):
+        with ShipStore(db_path) as store:
+            self._awaiting(store)
+            assert store.resolve_gate("run-1", "rejected", "wrong file")
+            run = store.get_run("run-1")
+            assert run.gate_resolution == "rejected"
+            assert run.rejection_count == 1
+
+    def test_gate_on_a_non_awaiting_run_refuses(self, db_path):
+        with ShipStore(db_path) as store:
+            store.record_run(_full_run(status="running"))
+            assert not store.resolve_gate("run-1", "approved")
+            assert not store.resolve_gate("run-404", "approved")
+
+    def test_invalid_resolution_raises(self, db_path):
+        with ShipStore(db_path) as store:
+            self._awaiting(store)
+            with pytest.raises(ValueError):
+                store.resolve_gate("run-1", "maybe")
+
+    def test_two_surfaces_racing_resolve_exactly_once(self, db_path):
+        with ShipStore(db_path) as store:
+            self._awaiting(store)
+        results: list[bool] = []
+        barrier = threading.Barrier(2)
+
+        def _approver(resolution):
+            with ShipStore(db_path) as surface:
+                barrier.wait()
+                results.append(surface.resolve_gate("run-1", resolution, f"from {resolution}"))
+
+        threads = [threading.Thread(target=_approver, args=(r,)) for r in ("approved", "rejected")]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert sorted(results) == [False, True]
+        with ShipStore(db_path) as store:
+            events = store.gate_events("run-1")
+        assert len(events) == 1  # the loser wrote no audit row either

--- a/tests/unit/test_ship_worktree.py
+++ b/tests/unit/test_ship_worktree.py
@@ -1,0 +1,164 @@
+"""Tests for the ship worktree coordinator (ship/worktree.py).
+
+Real git repos in tmp dirs — the coordinator's whole job is the boundary
+between our registry and git's on-disk state, so faking git would test the
+mock. Every subprocess in these tests passes ``git_subprocess_env()`` for the
+same reason production does: under the pre-commit hook, inherited ``GIT_*``
+would silently retarget commands at the outer repository.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from yeaboi.ship import worktree
+from yeaboi.tools.local_git import git_subprocess_env
+
+
+def _run_git(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        env=git_subprocess_env(),
+    )
+
+
+@pytest.fixture()
+def ship_home(tmp_path, monkeypatch):
+    """Redirect the registry and worktree root into an isolated temp dir."""
+    home = tmp_path / "ship-home"
+    home.mkdir()
+    monkeypatch.setattr(worktree, "SHIP_WORKTREES_DIR", home / "worktrees")
+    monkeypatch.setattr(worktree, "SHIP_WORKTREE_REGISTRY", home / "worktrees.json")
+    monkeypatch.setattr(worktree, "get_ship_dir", lambda: home)
+    return home
+
+
+@pytest.fixture()
+def target_repo(tmp_path):
+    """A real git repo with one commit."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _run_git(repo, "init", "-q", "-b", "main")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run_git(repo, "add", "README.md")
+    _run_git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+class TestSafeId:
+    def test_accepts_the_shapes_runs_use(self):
+        for good in ("run-1", "story-yea-42.a", "a", "x" * 64):
+            assert worktree.assert_safe_id(good) == good
+
+    def test_rejects_everything_else(self):
+        for bad in ("", "Run-1", "a/b", "-lead", ".lead", "x" * 65, "a b", "a;rm"):
+            with pytest.raises(worktree.WorktreeError):
+                worktree.assert_safe_id(bad)
+
+
+class TestPrepare:
+    def test_creates_worktree_branch_and_record(self, ship_home, target_repo):
+        record = worktree.prepare("run-1", target_repo)
+        assert record.branch == "ship/run-1"
+        assert (worktree.SHIP_WORKTREES_DIR / "proj" / "run-1" / "README.md").exists()
+        branches = subprocess.run(
+            ["git", "-C", str(target_repo), "branch", "--list", "ship/run-1"],
+            capture_output=True,
+            text=True,
+            env=git_subprocess_env(),
+        ).stdout
+        assert "ship/run-1" in branches
+        assert len(record.base_sha) == 40
+
+    def test_prepare_is_idempotent(self, ship_home, target_repo):
+        first = worktree.prepare("run-1", target_repo)
+        second = worktree.prepare("run-1", target_repo)
+        assert second == first
+
+    def test_refuses_a_dirty_repository(self, ship_home, target_repo):
+        (target_repo / "wip.txt").write_text("uncommitted", encoding="utf-8")
+        with pytest.raises(worktree.WorktreeError, match="dirty repository"):
+            worktree.prepare("run-1", target_repo)
+
+    def test_refuses_a_non_repo(self, ship_home, tmp_path):
+        plain = tmp_path / "not-a-repo"
+        plain.mkdir()
+        with pytest.raises(worktree.WorktreeError):
+            worktree.prepare("run-1", plain)
+
+    def test_failed_add_rolls_the_branch_back(self, ship_home, target_repo):
+        # Pre-fill the checkout target so `git worktree add` fails after the
+        # branch bookkeeping began.
+        blocked = worktree.SHIP_WORKTREES_DIR / "proj" / "run-1"
+        blocked.mkdir(parents=True)
+        (blocked / "junk").write_text("x", encoding="utf-8")
+        with pytest.raises(worktree.WorktreeError):
+            worktree.prepare("run-1", target_repo)
+        branches = subprocess.run(
+            ["git", "-C", str(target_repo), "branch", "--list", "ship/run-1"],
+            capture_output=True,
+            text=True,
+            env=git_subprocess_env(),
+        ).stdout
+        assert "ship/run-1" not in branches
+        assert worktree.get_record("run-1") is None
+
+
+class TestRemove:
+    def test_removes_checkout_and_keeps_the_branch_by_default(self, ship_home, target_repo):
+        record = worktree.prepare("run-1", target_repo)
+        assert worktree.remove("run-1")
+        assert not (worktree.SHIP_WORKTREES_DIR / "proj" / "run-1").exists()
+        branches = subprocess.run(
+            ["git", "-C", str(target_repo), "branch", "--list", record.branch],
+            capture_output=True,
+            text=True,
+            env=git_subprocess_env(),
+        ).stdout
+        assert record.branch in branches
+        assert worktree.get_record("run-1") is None
+
+    def test_delete_branch_is_explicit(self, ship_home, target_repo):
+        record = worktree.prepare("run-1", target_repo)
+        assert worktree.remove("run-1", delete_branch=True)
+        branches = subprocess.run(
+            ["git", "-C", str(target_repo), "branch", "--list", record.branch],
+            capture_output=True,
+            text=True,
+            env=git_subprocess_env(),
+        ).stdout
+        assert record.branch not in branches
+
+    def test_unknown_run_returns_false(self, ship_home):
+        assert not worktree.remove("run-404")
+
+    def test_tampered_registry_path_is_refused(self, ship_home, target_repo, tmp_path):
+        worktree.prepare("run-1", target_repo)
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        registry = json.loads(worktree.SHIP_WORKTREE_REGISTRY.read_text(encoding="utf-8"))
+        registry["run-1"]["path"] = str(victim)
+        worktree.SHIP_WORKTREE_REGISTRY.write_text(json.dumps(registry), encoding="utf-8")
+        assert not worktree.remove("run-1")
+        assert victim.exists()
+        # The record stays for a human to look at — a refused delete must not
+        # silently drop the evidence.
+        assert worktree.get_record("run-1") is not None
+
+
+class TestRegistry:
+    def test_get_record_roundtrip(self, ship_home, target_repo):
+        prepared = worktree.prepare("run-1", target_repo)
+        assert worktree.get_record("run-1") == prepared
+        assert worktree.get_record("run-2") is None
+
+    def test_corrupt_registry_reads_as_empty(self, ship_home):
+        worktree.SHIP_WORKTREE_REGISTRY.write_text("{broken", encoding="utf-8")
+        assert worktree.get_record("run-1") is None

--- a/tests/unit/test_ship_worktree.py
+++ b/tests/unit/test_ship_worktree.py
@@ -93,6 +93,21 @@ class TestPrepare:
         with pytest.raises(worktree.WorktreeError):
             worktree.prepare("run-1", plain)
 
+    def test_refuses_a_preexisting_branch_instead_of_reusing_it(self, ship_home, target_repo):
+        # A leftover ship/<id> branch may hold a previous run's unpushed
+        # commits; prepare must refuse — and the refusal is also what keeps
+        # the rollback honest (it only deletes branches this call created).
+        _run_git(target_repo, "branch", "ship/run-1")
+        with pytest.raises(worktree.WorktreeError, match="already exists"):
+            worktree.prepare("run-1", target_repo)
+        branches = subprocess.run(
+            ["git", "-C", str(target_repo), "branch", "--list", "ship/run-1"],
+            capture_output=True,
+            text=True,
+            env=git_subprocess_env(),
+        ).stdout
+        assert "ship/run-1" in branches  # untouched
+
     def test_failed_add_rolls_the_branch_back(self, ship_home, target_repo):
         # Pre-fill the checkout target so `git worktree add` fails after the
         # branch bookkeeping began.

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -313,6 +313,18 @@ CAPABILITIES: dict[str, dict] = {
         "cli": {"provenance"},
         "skill": "provenance",
     },
+    "ship": {
+        # The supervised story → PR pipeline. run_ship is the one entry point;
+        # the MCP surface is read-only by design — launching holds a live
+        # subprocess for many minutes behind the server's engine lock, and the
+        # approval gate is a human decision made at a terminal (the
+        # output-sharing precedent).
+        "engines": {("yeaboi.ship.engine", "run_ship")},
+        "mcp_tools": {"ship_history", "ship_status"},
+        "tui_mode": "ship",
+        "cli": {"ship"},
+        "skill": "ship",
+    },
 }
 
 # Engine modules discovered by convention: every src/yeaboi/*/engine.py, plus
@@ -400,6 +412,7 @@ CLI_PARAM_PAIRS: dict[str, tuple[str, str]] = {
     "agents cost": ("yeaboi.agentwatch.engine", "run_agent_usage"),
     "agents standup": ("yeaboi.agentwatch.engine", "run_agent_standup"),
     "agents security": ("yeaboi.agentwatch.engine", "run_agent_security"),
+    "ship run": ("yeaboi.ship.engine", "run_ship"),
 }
 
 # CLI dest → engine param renames (the CLI keeps short ergonomic flag names).
@@ -412,6 +425,7 @@ CLI_RENAMES: dict[str, dict[str, str]] = {
     "perf prep": {"session": "session_id"},
     "perf complete": {"session": "session_id"},
     "perf review": {"session": "session_id", "months": "period_months"},
+    "ship run": {"session": "session_id", "check": "check_command"},
     "analyze": {
         "project": "project_key",
         "sprints": "sprint_count",
@@ -446,6 +460,7 @@ CLI_ONLY_DESTS: dict[str, set[str]] = {
     "agents cost": {"format", "strict"},
     "agents standup": {"format", "strict"},
     "agents security": {"format", "strict"},
+    "ship run": {"format", "strict"},
     # delivery/code/docs are assembled into the engine's `components` dict (component
     # → sub-source map); each flag names a component's sub-sources, not an engine param.
     "analyze": {
@@ -473,6 +488,10 @@ CLI_HIDDEN: dict[str, dict[str, str]] = {
         "components": "assembled from per-component --delivery/--code/--docs sub-source flags",
         "analysis_scope": "assembled from the four provider-specific scope flags",
         "cancel_event": "in-process threading.Event cancel seam for the TUI worker; the CLI cancels via Ctrl-C",
+    },
+    "ship run": {
+        "cancel_event": "in-process threading.Event cancel seam for the TUI worker; the CLI cancels via Ctrl-C",
+        "driver": "AgentDriver injection seam for tests; every wire surface runs the real Claude Code driver",
     },
 }
 


### PR DESCRIPTION
## Summary

Track C of the repo-scan roadmap: yeaboi closes the loop from its own sprint plan. A user story from a saved plan is handed to a supervised coding agent (Claude Code headless) in an isolated git worktree, its diff is validated deterministically, a human approves it at a gate, and only then is the branch pushed and a PR opened. Native Python — archon's pipeline shape and gate protocol plus ruflo's ops rails, re-implemented with our tests; no new runtime dependencies.

- **Budget fuse** (`ship/budget.py`): user-global ledger, fail-closed, 1 concurrent / 2 per hour / 12 per day, 60-min circuit breaker on quota-shaped errors only, permit heartbeat for the run's real lifetime.
- **Worktree coordinator** (`ship/worktree.py`): whitelisted run ids, dirty-repo and pre-existing-branch refusal, idempotent prepare with rollback, registry re-validated before any delete; checkouts live under `~/.yeaboi/ship/worktrees` so only the target repo needs a consent grant.
- **Driver** (`ship/driver.py`): `claude --print --output-format json` with the prompt over stdin, stripped session env vars, its own process group + kill ladder, lenient envelope parsing — and a **mechanical capability envelope**: `--permission-mode acceptEdits` + `--disallowedTools "Bash(git push:*)" "Bash(gh:*)"`, so the agent can edit files and cannot run git at all; the pipeline commits and pushes.
- **Pipeline + gate** (`ship/pipeline.py`, `ship/store.py`, `ship/engine.py`): archon's precondition bridge (an empty diff fails the run whatever the agent said), validation in its own process group, resolve ≠ resume gate CAS in SQLite with the audit event in the same transaction, reject → rework carrying the reviewer's words (3-attempt cap). Additive tables only — no `CURRENT_SCHEMA_VERSION` bump, Go schema ceiling untouched.
- **Costing** (`ship/costing.py`): per-run cost + transcript security findings via a thin adapter over agentwatch internals, so the Go-parity-mirrored files are untouched.
- **Surfaces**: TUI card (beta, with notice) + picker/progress/gate/result screens; `yeaboi ship run|status|history` (the gate prompts at the terminal, and only for runs this invocation started); read-only `ship_history`/`ship_status` MCP tools; plugin skill; full parity/tip/beta registrations.

Deliberate absences, noted for follow-up: remote web approval gate (sharing/), stream-json live transcript view, a `ship clean` bulk-cleanup verb (approved runs clean their checkout; failed runs keep theirs for inspection), `ship/export.py`.

## Test plan

- 180+ new unit tests across budget (clock-injected windows, fail-closed, stale-lock takeover, heartbeat), worktree (real git repos: dirty/pre-existing-branch refusal, rollback, tampered registry), driver (a real subprocess shim: stdin prompt, env stripping, timeout/cancel kill, permission argv), pipeline (bridge against real worktrees, validation process group, PR-body scrubbing), store (gate CAS race between two connections), engine (full runs end to end with a scripted driver and gate resolutions arriving from a second thread), screens, render, CLI, MCP.
- `make ship-gate` green: lint, format-check, full suite (13.9k tests), security, and all six preflight jobs the diff needed (golden evaluators included).
- Independent fresh-context review completed pre-PR; its blocker (no mechanical push restraint on the spawned agent) and ten should-fixes are all addressed in the final commit.

Go sidecar: `ship/` is on no mirrored surface — no Go twin needed; the mirrored agentwatch files are untouched by design.

Closes YEA-107

🤖 Generated with [Claude Code](https://claude.com/claude-code)