### PR TITLE
harden the ship gate: deny bash, consent on the toplevel, show the patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.18.0"
+version = "3.18.1"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/yeaboi/agent/state.py
+++ b/src/yeaboi/agent/state.py
@@ -1694,6 +1694,7 @@ class ShipRun:
     phases: tuple[ShipPhase, ...] = ()
     validation: ShipValidation = ShipValidation()
     diff_stat: str = ""  # `git diff --stat` summary shown at the gate
+    diff_text: str = ""  # the capped patch itself — the gate approves a diff, not a file count
     cost_usd: float = 0.0
     transcript_findings: tuple[tuple[str, str, str], ...] = ()  # (kind, severity, label)
     transcript_path: str = ""

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -4,7 +4,7 @@
     {
       "version": "3.18.1",
       "date": "2026-08-17",
-      "summary": "Ship mode hardening and safety improvements prevent agent capability creep, tighten consent checks, and show you the exact changes before approval. The agent's Bash tool is now completely denied (not just git/gh commands), closing permission-bypass risks from other shell features. Consent is checked against the git toplevel where worktree setup actually lands, so approval names the directory that is actually touched. The approval gate now renders a scrollable patch pane showing your complete diff alongside validation results, with measured button positioning that never leaves buttons off-screen on minimum terminals. Gates answer only their own run by capturing the run id immediately, preventing concurrent runs from presenting stale diffs to the wrong user. Session IDs now carry a random suffix preventing same-second collisions, and removal operations report correctly whether they found an entry.",
+      "summary": "Ship mode hardening and safety improvements prevent agent capability creep, tighten consent checks, and show you the exact changes before approval. The agent's Bash tool is now completely denied (not just git/gh commands), closing permission-bypass risks from other shell features. Consent is checked against the git toplevel where worktree setup actually lands, so approval names the directory that is actually touched. The approval gate now renders a scrollable patch pane showing your complete diff alongside validation results, with measured button positioning that never leaves buttons off-screen on minimum terminals. Gates answer only their own run by capturing the run id immediately, preventing concurrent runs from presenting stale diffs to the wrong user. Run IDs now carry a random suffix preventing same-second collisions, and removal operations report correctly whether they found an entry.",
       "highlights": [
         {
           "text": "Agent permissions hardened: Bash tool is completely denied, not just git/gh commands, closing permission bypasses",
@@ -27,7 +27,7 @@
           ]
         },
         {
-          "text": "Gate buttons stay on screen at minimum terminal size (84x40); elastic sections (findings, stats) yield space gracefully",
+          "text": "The approval buttons always stay on screen, however long the diff or failure log; supporting detail yields space first",
           "areas": [
             "planning"
           ]

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,46 @@
   "schema_version": 1,
   "entries": [
     {
+      "version": "3.18.1",
+      "date": "2026-08-17",
+      "summary": "Ship mode hardening and safety improvements prevent agent capability creep, tighten consent checks, and show you the exact changes before approval. The agent's Bash tool is now completely denied (not just git/gh commands), closing permission-bypass risks from other shell features. Consent is checked against the git toplevel where worktree setup actually lands, so approval names the directory that is actually touched. The approval gate now renders a scrollable patch pane showing your complete diff alongside validation results, with measured button positioning that never leaves buttons off-screen on minimum terminals. Gates answer only their own run by capturing the run id immediately, preventing concurrent runs from presenting stale diffs to the wrong user. Session IDs now carry a random suffix preventing same-second collisions, and removal operations report correctly whether they found an entry.",
+      "highlights": [
+        {
+          "text": "Agent permissions hardened: Bash tool is completely denied, not just git/gh commands, closing permission bypasses",
+          "areas": [
+            "planning",
+            "general"
+          ]
+        },
+        {
+          "text": "Consent checks the git toplevel, so approval dialog names the exact directory that is touched",
+          "areas": [
+            "planning",
+            "general"
+          ]
+        },
+        {
+          "text": "Approval gate shows the full diff in a scrollable patch pane with validation results and the worktree path",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Gate buttons stay on screen at minimum terminal size (84x40); elastic sections (findings, stats) yield space gracefully",
+          "areas": [
+            "planning"
+          ]
+        },
+        {
+          "text": "Gates answer only their own run via immediate run-id callback; concurrent runs no longer see stale diffs",
+          "areas": [
+            "planning",
+            "general"
+          ]
+        }
+      ]
+    },
+    {
       "version": "3.18.0",
       "date": "2026-08-17",
       "summary": "Wave 6 of the Go migration brings the documentation quality scoring engine behind the yeaboi-core sidecar. The analysis module now scores documentation clarity, AI usage patterns, and content quality in the background Go service with Python fallback, running ~100x faster than the Python implementation. Two new deterministic RPC methods enable the analysis pipeline to classify content markers and score documentation across your team's work without blocking the standup or analysis runs. Parity tests enforce byte-level equivalence across Python and Go implementations, and contract definitions lock the RPC interface across versions. This completes the deterministic scoring seam that began with Wave 5 (code health and practices).",
@@ -81,7 +121,7 @@
     {
       "version": "3.16.0",
       "date": "2026-08-16",
-      "summary": "Planning mode's prior-art intake flow now batches all candidate repos into a single multi-select carousel instead of asking about each one individually. Select multiple repos at once with Space, navigate with arrow keys, and use X to permanently dismiss a candidate. Rejections no longer blacklist repos globally — unchecking just skips them for this project, while X explicitly bans them forever. The new batch grammar works everywhere: TUI carousel, CLI flags, headless APIs, and REPL forms all use the same syntax (numbers, ranges, all, none, or !N bans). Resume now correctly replays the batch prompt instead of stale hints.",
+      "summary": "Planning mode's prior-art intake flow now batches all candidate repos into a single multi-select carousel instead of asking about each one individually. Select multiple repos at once with Space, navigate with arrow keys, and use X to permanently dismiss a candidate. Rejections no longer blacklist repos globally \u2014 unchecking just skips them for this project, while X explicitly bans them forever. The new batch grammar works everywhere: TUI carousel, CLI flags, headless APIs, and REPL forms all use the same syntax (numbers, ranges, all, none, or !N bans). Resume now correctly replays the batch prompt instead of stale hints.",
       "highlights": [
         {
           "text": "Batch multi-select carousel for prior-art intake: select all relevant repos at once instead of one-by-one confirmation",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -1888,12 +1888,15 @@ def _cmd_ship(args: argparse.Namespace, console: Console) -> int:
 
     if args.ship_command == "history":
         from yeaboi.ship.render import format_history_rich
-        from yeaboi.ship.store import ShipStore
+        from yeaboi.ship.store import ShipStore, listing_dict
 
         with ShipStore() as store:
             runs = store.list_runs(limit=args.limit)
         if args.format == "json":
-            print(json.dumps([asdict(r) for r in runs], indent=2))
+            # `listing_dict` drops the stored patch: capped per run is not
+            # capped per response, and a listing is polled in a loop. The
+            # single run `ship run --format json` prints keeps it.
+            print(json.dumps([listing_dict(r) for r in runs], indent=2))
         else:
             console.print(format_history_rich(runs))
         return 0
@@ -1901,13 +1904,13 @@ def _cmd_ship(args: argparse.Namespace, console: Console) -> int:
     if args.ship_command == "status":
         from yeaboi.ship import budget
         from yeaboi.ship.render import format_budget_rich, format_run_rich
-        from yeaboi.ship.store import ShipStore
+        from yeaboi.ship.store import ShipStore, listing_dict
 
         with ShipStore() as store:
             runs = store.list_runs(limit=1)
         posture = budget.status()
         if args.format == "json":
-            print(json.dumps({"latest": asdict(runs[0]) if runs else None, "budget": asdict(posture)}, indent=2))
+            print(json.dumps({"latest": listing_dict(runs[0]) if runs else None, "budget": asdict(posture)}, indent=2))
         else:
             if runs:
                 console.print(format_run_rich(runs[0]))
@@ -1984,12 +1987,14 @@ def _ship_run(args: argparse.Namespace, console: Console) -> int:
                     continue  # a cancelled run winds down on its own; stop prompting
                 if not mine[0]:
                     continue  # the id has not been minted yet; nothing can be ours
-                # An open gate is one this loop has not answered yet: resolving
-                # stamps gate_resolution, and a rework clears it again — so the
-                # reopened gate prompts again by construction.
-                for run in store.list_runs(limit=3):
-                    if run.run_id != mine[0] or run.status != "awaiting_approval" or run.gate_resolution:
-                        continue
+                # Fetched by id, never scanned out of a newest-first page: with
+                # concurrency raised, runs started after ours would push it off
+                # the end and its gate would never render here. An open gate is
+                # one this loop has not answered yet — resolving stamps
+                # gate_resolution and a rework clears it, so a reopened gate
+                # prompts again by construction.
+                run = store.get_run(mine[0])
+                if run is not None and run.status == "awaiting_approval" and not run.gate_resolution:
                     # The gate is the only control before a push; it shows the
                     # patch, not a file count.
                     console.print(format_run_rich(run, show_diff=True))

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -1928,12 +1928,21 @@ def _ship_run(args: argparse.Namespace, console: Console) -> int:
     from dataclasses import asdict
 
     from yeaboi import fs_policy
-    from yeaboi.ship import engine
+    from yeaboi.ship import engine, worktree
     from yeaboi.ship.render import format_run_rich
     from yeaboi.ship.store import ShipStore
 
     repo = str(Path(args.repo).expanduser().resolve())
     if not args.dry_run:
+        try:
+            # Resolve the toplevel BEFORE the consent check: every write lands
+            # there (`git worktree add` into <toplevel>/.git, the later push),
+            # and fs_policy containment is `is_relative_to` — so granting a
+            # subdirectory would let yeaboi write outside the approved root.
+            repo = str(worktree.resolve_repo(repo))
+        except worktree.WorktreeError as exc:
+            print(f"✗ {exc}", file=sys.stderr)
+            return 2
         try:
             fs_policy.resolve_and_check(repo, mode="write", context="ship: run a coding agent against this repository")
         except PermissionError as exc:

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -1987,7 +1987,9 @@ def _ship_run(args: argparse.Namespace, console: Console) -> int:
                 for run in store.list_runs(limit=3):
                     if run.run_id in known or run.status != "awaiting_approval" or run.gate_resolution:
                         continue
-                    console.print(format_run_rich(run))
+                    # The gate is the only control before a push; it shows the
+                    # patch, not a file count.
+                    console.print(format_run_rich(run, show_diff=True))
                     try:
                         answer = input("Approve and open a PR? [y]es / [n]o with feedback / [c]ancel run: ")
                     except EOFError:

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -1956,6 +1956,11 @@ def _ship_run(args: argparse.Namespace, console: Console) -> int:
 
     result_box: list = [None]
     cancel = threading.Event()
+    # The engine hands its run id back the moment it exists. Anything else in
+    # the store belongs to ANOTHER session (a TUI in another terminal, a stale
+    # process) — prompting for one of those would let this user approve, and
+    # push, a diff they are not looking at.
+    mine: list[str] = [""]
 
     def _work() -> None:
         result_box[0] = engine.run_ship(
@@ -1965,14 +1970,10 @@ def _ship_run(args: argparse.Namespace, console: Console) -> int:
             check_command=args.check,
             timeout_minutes=args.timeout_minutes,
             dry_run=args.dry_run,
+            on_run_id=lambda run_id: mine.__setitem__(0, run_id),
             cancel_event=cancel,
         )
 
-    with ShipStore() as preexisting:
-        # Runs that already exist belong to OTHER sessions (a TUI in another
-        # terminal, a stale process). Prompting for those would let this user
-        # approve a diff they are not looking at — and push it.
-        known = {r.run_id for r in preexisting.list_runs(limit=100)}
     worker = threading.Thread(target=_work, daemon=True)
     worker.start()
     try:
@@ -1981,11 +1982,13 @@ def _ship_run(args: argparse.Namespace, console: Console) -> int:
                 worker.join(timeout=0.5)
                 if not worker.is_alive() or cancel.is_set():
                     continue  # a cancelled run winds down on its own; stop prompting
+                if not mine[0]:
+                    continue  # the id has not been minted yet; nothing can be ours
                 # An open gate is one this loop has not answered yet: resolving
                 # stamps gate_resolution, and a rework clears it again — so the
                 # reopened gate prompts again by construction.
                 for run in store.list_runs(limit=3):
-                    if run.run_id in known or run.status != "awaiting_approval" or run.gate_resolution:
+                    if run.run_id != mine[0] or run.status != "awaiting_approval" or run.gate_resolution:
                         continue
                     # The gate is the only control before a push; it shows the
                     # patch, not a file count.

--- a/src/yeaboi/mcp/tools_ship.py
+++ b/src/yeaboi/mcp/tools_ship.py
@@ -16,41 +16,24 @@ from yeaboi.mcp.runtime import run_readonly
 logger = logging.getLogger(__name__)
 
 
-def _listing(run) -> dict:
-    """One run as JSON, without the stored patch.
-
-    ``diff_text`` is capped at 20k characters *per run*; a hundred of them in
-    one listing is megabytes of patch nobody asked for. The stat, the branch
-    and the worktree are here — reading the change itself is a git command
-    away, and the gate that needs it is not this surface.
-    """
-    from dataclasses import asdict
-
-    # asdict per run: to_jsonable only unpacks a TOP-LEVEL dataclass, and a
-    # nested one would degrade to its repr via json's default=str.
-    payload = asdict(run)
-    payload.pop("diff_text", None)
-    return payload
-
-
 def _history(limit: int):
     if limit < 1 or limit > 100:
         raise ValueError("limit must be between 1 and 100.")
-    from yeaboi.ship.store import ShipStore
+    from yeaboi.ship.store import ShipStore, listing_dict
 
     with ShipStore() as store:
-        return {"runs": [_listing(run) for run in store.list_runs(limit=limit)]}
+        return {"runs": [listing_dict(run) for run in store.list_runs(limit=limit)]}
 
 
 def _status():
     from dataclasses import asdict
 
     from yeaboi.ship import budget
-    from yeaboi.ship.store import ShipStore
+    from yeaboi.ship.store import ShipStore, listing_dict
 
     with ShipStore() as store:
         runs = store.list_runs(limit=1)
-    return {"latest": _listing(runs[0]) if runs else None, "budget": asdict(budget.status())}
+    return {"latest": listing_dict(runs[0]) if runs else None, "budget": asdict(budget.status())}
 
 
 def register(app) -> None:

--- a/src/yeaboi/mcp/tools_ship.py
+++ b/src/yeaboi/mcp/tools_ship.py
@@ -16,17 +16,30 @@ from yeaboi.mcp.runtime import run_readonly
 logger = logging.getLogger(__name__)
 
 
-def _history(limit: int):
-    if limit < 1 or limit > 100:
-        raise ValueError("limit must be between 1 and 100.")
-    from dataclasses import asdict
+def _listing(run) -> dict:
+    """One run as JSON, without the stored patch.
 
-    from yeaboi.ship.store import ShipStore
+    ``diff_text`` is capped at 20k characters *per run*; a hundred of them in
+    one listing is megabytes of patch nobody asked for. The stat, the branch
+    and the worktree are here — reading the change itself is a git command
+    away, and the gate that needs it is not this surface.
+    """
+    from dataclasses import asdict
 
     # asdict per run: to_jsonable only unpacks a TOP-LEVEL dataclass, and a
     # nested one would degrade to its repr via json's default=str.
+    payload = asdict(run)
+    payload.pop("diff_text", None)
+    return payload
+
+
+def _history(limit: int):
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100.")
+    from yeaboi.ship.store import ShipStore
+
     with ShipStore() as store:
-        return {"runs": [asdict(run) for run in store.list_runs(limit=limit)]}
+        return {"runs": [_listing(run) for run in store.list_runs(limit=limit)]}
 
 
 def _status():
@@ -37,7 +50,7 @@ def _status():
 
     with ShipStore() as store:
         runs = store.list_runs(limit=1)
-    return {"latest": asdict(runs[0]) if runs else None, "budget": asdict(budget.status())}
+    return {"latest": _listing(runs[0]) if runs else None, "budget": asdict(budget.status())}
 
 
 def register(app) -> None:

--- a/src/yeaboi/ship/costing.py
+++ b/src/yeaboi/ship/costing.py
@@ -20,6 +20,7 @@ Reading ``~/.claude/projects`` is already permitted (and read-only) under
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,6 +28,8 @@ from yeaboi.agentwatch.collector import IngestStats, _parse_file, _source_roots
 from yeaboi.agentwatch.engine import _session_cost
 
 logger = logging.getLogger(__name__)
+
+_SESSION_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,128}")
 
 
 @dataclass(frozen=True)
@@ -56,7 +59,11 @@ def locate_transcript(session_id: str) -> Path | None:
     The filename is the session id — Claude Code writes one
     ``<session-id>.jsonl`` per session under ``~/.claude/projects/<project>/``.
     """
-    if not session_id or "/" in session_id or "\\" in session_id:
+    # The id comes out of the agent's own JSON envelope and goes straight into
+    # an rglob pattern, so a glob metacharacter (``*``, ``?``, ``[``) would
+    # match some other run's transcript and price the wrong one. Whitelist the
+    # shape rather than escaping it — session ids are uuid-shaped.
+    if not _SESSION_ID_RE.fullmatch(session_id or ""):
         return None
     for _source, root in _source_roots():
         if not root.is_dir():

--- a/src/yeaboi/ship/driver.py
+++ b/src/yeaboi/ship/driver.py
@@ -20,8 +20,12 @@ production failure upstream:
   downstream, the deterministic bridge judges the run by the diff on disk,
   not by what the agent said.
 - **The capability envelope is argv, not prose** (``_PERMISSION_ARGS``): the
-  agent edits files and has no shell, so nothing it does can reach ``origin``
-  ahead of the human gate.
+  agent edits files, has no shell, and loads no MCP servers, so it cannot
+  itself run git. That is a bound on the *agent*, not a proof about the run:
+  the pipeline afterwards executes the user's validation command with a shell
+  in this same worktree, so code the agent wrote into a ``Makefile`` or a test
+  still runs before the gate. What the gate guarantees is that nothing reaches
+  ``origin`` until a human has approved the diff.
 
 Supervision follows ``voice_install._run_installer``: a daemon pump thread
 reads stdout for the process's whole life (so the pipe can never fill and
@@ -73,11 +77,17 @@ _SESSION_ENV_VARS = ("CLAUDE_SESSION_ID", "CLAUDE_PARENT_SESSION_ID", "CLAUDECOD
 # `git remote set-url`, or an edit to `.git/config` all sit outside it. A deny
 # rule outranks every allow rule from every source, which is what makes this
 # boundary hold regardless of what the target repo ships.
+#
+# `--strict-mcp-config` with no `--mcp-config` beside it is the same argument
+# one layer out: MCP servers are resolved from the user's `~/.claude.json`,
+# and a git or GitHub server there is a push path that no tool deny mentions.
+# The run needs none of them, so it loads none.
 _PERMISSION_ARGS = (
     "--permission-mode",
     "acceptEdits",
     "--disallowedTools",
     "Bash",
+    "--strict-mcp-config",
 )
 
 

--- a/src/yeaboi/ship/driver.py
+++ b/src/yeaboi/ship/driver.py
@@ -19,6 +19,9 @@ production failure upstream:
   or newer CLI degrades to raw text with a warning, never an exception —
   downstream, the deterministic bridge judges the run by the diff on disk,
   not by what the agent said.
+- **The capability envelope is argv, not prose** (``_PERMISSION_ARGS``): the
+  agent edits files and has no shell, so nothing it does can reach ``origin``
+  ahead of the human gate.
 
 Supervision follows ``voice_install._run_installer``: a daemon pump thread
 reads stdout for the process's whole life (so the pipe can never fill and
@@ -57,17 +60,24 @@ _SESSION_ENV_VARS = ("CLAUDE_SESSION_ID", "CLAUDE_PARENT_SESSION_ID", "CLAUDECOD
 # The agent's capability envelope, and it is MECHANICAL, not prose:
 # `acceptEdits` lets file edits land without a prompt (a headless --print run
 # cannot answer one, so the default mode would leave the agent unable to edit
-# at all), while Bash and every other gated tool stay denied — the agent
-# cannot run git, so it physically cannot push, commit, or open a PR; the
-# pipeline commits its work and pushes only after the human gate. The
-# disallow list is belt and braces on top: an explicit deny outranks every
-# permission mode if one is ever passed.
+# at all), and `--disallowedTools Bash` denies the shell outright — so the
+# agent physically cannot push, commit, or open a PR; the pipeline commits its
+# work and pushes only after the human gate.
+#
+# The deny must be the whole *tool*, not a pattern over commands, because the
+# child resolves settings we do not control: the user's own
+# `~/.claude/settings.json`, and — since `cwd` is a checkout of the target
+# repo — that repo's `.claude/settings.json` too. A run against a repo whose
+# committed allow list starts `Bash(make test)` would hand the agent a shell,
+# and a narrow deny list (`Bash(git push:*)`) is porous anyway: `git -c … push`,
+# `git remote set-url`, or an edit to `.git/config` all sit outside it. A deny
+# rule outranks every allow rule from every source, which is what makes this
+# boundary hold regardless of what the target repo ships.
 _PERMISSION_ARGS = (
     "--permission-mode",
     "acceptEdits",
     "--disallowedTools",
-    "Bash(git push:*)",
-    "Bash(gh:*)",
+    "Bash",
 )
 
 

--- a/src/yeaboi/ship/engine.py
+++ b/src/yeaboi/ship/engine.py
@@ -298,7 +298,15 @@ def _run_phases(
             _report(on_progress, "ship-validate", "Validating the diff", "failed", detail="no changes")
             _abort(_failed(run, detail, phase="implement"))
         validation = pipeline.run_validation(record, check_command)
-        run = replace(run, diff_stat=diff_stat, validation=validation, updated_at=_now_iso())
+        # The patch travels with the artifact, so every gate surface shows the
+        # change itself rather than a file count.
+        run = replace(
+            run,
+            diff_stat=diff_stat,
+            diff_text=pipeline.diff_text(record),
+            validation=validation,
+            updated_at=_now_iso(),
+        )
         _phase_done("validate", "passed" if validation.passed else "see gate screen", started)
         _report(
             on_progress,

--- a/src/yeaboi/ship/engine.py
+++ b/src/yeaboi/ship/engine.py
@@ -22,6 +22,7 @@ the database CAS is the arbiter, so two surfaces racing resolve exactly once.
 from __future__ import annotations
 
 import logging
+import secrets
 import threading
 import time
 from collections.abc import Callable
@@ -62,9 +63,17 @@ def _report(on_progress, component_id: str, label: str, status: str, **kwargs) -
 
 
 def _new_run_id(story_id: str) -> str:
+    """A run id: story, second-resolution stamp, and a random suffix.
+
+    The suffix is what makes the id an identity rather than a description.
+    Two runs of the same story started in the same second would otherwise
+    collide — and since both surfaces now find *their* run by this id, and
+    ``worktree.prepare`` is idempotent per id, a collision would hand the
+    second run the first one's checkout and let one gate answer for both.
+    """
     stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     safe = "".join(c if c.isalnum() or c in "._-" else "-" for c in story_id.lower()).strip("-.")[:40]
-    return f"{safe or 'story'}-{stamp}"
+    return f"{safe or 'story'}-{stamp}-{secrets.token_hex(3)}"
 
 
 def _failed(run: ShipRun, reason: str, *, phase: str = "") -> ShipRun:

--- a/src/yeaboi/ship/engine.py
+++ b/src/yeaboi/ship/engine.py
@@ -148,6 +148,7 @@ def run_ship(
     db_path: Path | None = None,
     dry_run: bool = False,
     on_progress: Callable | None = None,
+    on_run_id: Callable[[str], None] | None = None,
     cancel_event: threading.Event | None = None,
     driver: object | None = None,
 ) -> ShipRun:
@@ -156,6 +157,12 @@ def run_ship(
     ``driver`` is an injection seam (an ``AgentDriver``); the default is
     Claude Code headless. The human gate always resolves through
     ``ShipStore.resolve_gate`` — this function only waits for it.
+
+    ``on_run_id`` fires once, as soon as the id exists, because the surfaces
+    poll a shared store for the gate: without it they can only identify "my
+    run" as "one that was not there when I started", which stops being true
+    the moment two runs are allowed at once — and then a user is asked to
+    approve, and push, a diff they have never seen.
     """
     if dry_run:
         return _dry_run_artifact(story_id, repo)
@@ -178,6 +185,11 @@ def run_ship(
         )
 
     run_id = _new_run_id(story_id)
+    if on_run_id is not None:
+        try:
+            on_run_id(run_id)
+        except Exception:  # a surface's bookkeeping must never kill the run
+            logger.debug("on_run_id callback failed", exc_info=True)
     run = ShipRun(
         run_id=run_id,
         story_id=story_id,

--- a/src/yeaboi/ship/pipeline.py
+++ b/src/yeaboi/ship/pipeline.py
@@ -169,12 +169,18 @@ def diff_text(record: WorktreeRecord, *, max_chars: int = DIFF_TEXT_CAP) -> str:
         logger.warning("Could not read the diff for %s: %s", record.run_id, exc)
         patch = ""
     finally:
-        # Stop git writing the rest into a pipe nobody drains, then reap it.
-        proc.stdout.close() if proc.stdout else None
+        # Stop git writing the rest into a pipe nobody drains, then reap it —
+        # including after the kill, or the dead child lingers as a zombie.
+        if proc.stdout is not None:
+            proc.stdout.close()
         try:
             proc.wait(timeout=_DIFF_REAP_S)
         except subprocess.TimeoutExpired:
             proc.kill()
+            try:
+                proc.wait(timeout=_DIFF_REAP_S)
+            except subprocess.TimeoutExpired:
+                logger.error("git diff for %s would not die", record.run_id)
     if proc.returncode not in (0, None) and not patch:
         logger.warning("git diff for %s exited %s", record.run_id, proc.returncode)
         return ""

--- a/src/yeaboi/ship/pipeline.py
+++ b/src/yeaboi/ship/pipeline.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 VALIDATION_TIMEOUT_S = 15 * 60
 DIFF_TEXT_CAP = 20_000  # the gate shows the patch; a runaway diff is capped, never dropped
+_DIFF_REAP_S = 10.0
 _TAIL_CHARS = 4000
 
 _GITHUB_REMOTE_RE = re.compile(r"github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?/?$")
@@ -141,11 +142,41 @@ def diff_text(record: WorktreeRecord, *, max_chars: int = DIFF_TEXT_CAP) -> str:
     this a pure function of the artifact; the trailer names the exact command
     for reading the rest out of band. Never raises — a diff we cannot read is
     an empty string, and the gate says so rather than the run dying.
+
+    The read is bounded, not sliced after the fact: an agent that commits a
+    generated lockfile produces a patch of megabytes, and this runs on the
+    TUI's worker thread. Only ``max_chars`` are ever pulled off the pipe.
     """
+    argv = ["git", "-C", str(record.path), "diff", f"{record.base_sha}..HEAD"]
     try:
-        patch = _git(record.path, "diff", f"{record.base_sha}..HEAD")
-    except WorktreeError as exc:
+        proc = subprocess.Popen(  # noqa: S603 — fixed binary, whitelisted-id args
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=git_subprocess_env(),
+            cwd=str(record.path),
+        )
+    except OSError as exc:
         logger.warning("Could not read the diff for %s: %s", record.run_id, exc)
+        return ""
+    try:
+        assert proc.stdout is not None
+        patch = proc.stdout.read(max_chars + 1)
+    except OSError as exc:
+        logger.warning("Could not read the diff for %s: %s", record.run_id, exc)
+        patch = ""
+    finally:
+        # Stop git writing the rest into a pipe nobody drains, then reap it.
+        proc.stdout.close() if proc.stdout else None
+        try:
+            proc.wait(timeout=_DIFF_REAP_S)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    if proc.returncode not in (0, None) and not patch:
+        logger.warning("git diff for %s exited %s", record.run_id, proc.returncode)
         return ""
     if len(patch) <= max_chars:
         return patch

--- a/src/yeaboi/ship/pipeline.py
+++ b/src/yeaboi/ship/pipeline.py
@@ -27,6 +27,7 @@ from yeaboi.tools.local_git import git_subprocess_env
 logger = logging.getLogger(__name__)
 
 VALIDATION_TIMEOUT_S = 15 * 60
+DIFF_TEXT_CAP = 20_000  # the gate shows the patch; a runaway diff is capped, never dropped
 _TAIL_CHARS = 4000
 
 _GITHUB_REMOTE_RE = re.compile(r"github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?/?$")
@@ -130,6 +131,29 @@ def diff_bridge(record: WorktreeRecord) -> tuple[bool, str]:
     ensure_committed(record)
     stat = _git(record.path, "diff", "--stat", f"{record.base_sha}..HEAD")
     return bool(stat.strip()), stat.strip()
+
+
+def diff_text(record: WorktreeRecord, *, max_chars: int = DIFF_TEXT_CAP) -> str:
+    """The patch itself, capped — what the approver is actually asked to approve.
+
+    A ``--stat`` is a file count, and the gate is the only control between
+    agent-authored code and a pushed branch. Capping rather than paging keeps
+    this a pure function of the artifact; the trailer names the exact command
+    for reading the rest out of band. Never raises — a diff we cannot read is
+    an empty string, and the gate says so rather than the run dying.
+    """
+    try:
+        patch = _git(record.path, "diff", f"{record.base_sha}..HEAD")
+    except WorktreeError as exc:
+        logger.warning("Could not read the diff for %s: %s", record.run_id, exc)
+        return ""
+    if len(patch) <= max_chars:
+        return patch
+    return (
+        patch[:max_chars].rstrip()
+        + f"\n\n… truncated at {max_chars} characters — read the rest with:\n"
+        + f"  git -C {record.path} diff {record.base_sha}..HEAD"
+    )
 
 
 def run_validation(record: WorktreeRecord, command: str) -> ShipValidation:

--- a/src/yeaboi/ship/render.py
+++ b/src/yeaboi/ship/render.py
@@ -62,7 +62,10 @@ def format_run_rich(run: ShipRun, *, show_diff: bool = False) -> Group:
     if run.worktree:
         lines.append(Text(f"  worktree  {run.worktree}", style="dim"))
     if run.diff_stat:
-        for index, stat_line in enumerate(run.diff_stat.splitlines()):
+        # The gate wants every file; a status line wants the totals. A 60-file
+        # run should not print 60 rows every time someone asks what happened.
+        stat_lines = run.diff_stat.splitlines() if show_diff else run.diff_stat.splitlines()[-1:]
+        for index, stat_line in enumerate(stat_lines):
             label = "diff     " if index == 0 else "         "
             lines.append(Text(f"  {label} {stat_line.strip()}"))
     if run.validation.configured:

--- a/src/yeaboi/ship/render.py
+++ b/src/yeaboi/ship/render.py
@@ -24,8 +24,32 @@ _STATUS_STYLE = {
 }
 
 
-def format_run_rich(run: ShipRun) -> Group:
-    """One run, in full — the gate summary and the terminal report."""
+def format_diff_rich(diff: str) -> Group:
+    """The patch, tinted. Additions green, removals red, hunk headers cyan."""
+    lines: list[Text] = []
+    for raw in diff.splitlines():
+        if raw.startswith("+++") or raw.startswith("---"):
+            style = "bold"
+        elif raw.startswith("+"):
+            style = "green"
+        elif raw.startswith("-"):
+            style = "red"
+        elif raw.startswith("@@"):
+            style = "cyan"
+        elif raw.startswith("diff --git"):
+            style = "bold"
+        else:
+            style = ""
+        lines.append(Text(raw, style=style))
+    return Group(*lines)
+
+
+def format_run_rich(run: ShipRun, *, show_diff: bool = False) -> Group:
+    """One run, in full — the gate summary and the terminal report.
+
+    ``show_diff`` is what the *gate* passes: approving a push on a file count
+    is not review, so the prompt renders the patch and the worktree path.
+    """
     lines: list[Text] = []
     header = Text()
     header.append(f"{run.story_id or '(no story)'} ", style="bold")
@@ -35,9 +59,12 @@ def format_run_rich(run: ShipRun) -> Group:
     lines.append(header)
     if run.branch:
         lines.append(Text(f"  branch    {run.branch}"))
+    if run.worktree:
+        lines.append(Text(f"  worktree  {run.worktree}", style="dim"))
     if run.diff_stat:
-        stat_tail = run.diff_stat.splitlines()[-1].strip()
-        lines.append(Text(f"  diff      {stat_tail}"))
+        for index, stat_line in enumerate(run.diff_stat.splitlines()):
+            label = "diff     " if index == 0 else "         "
+            lines.append(Text(f"  {label} {stat_line.strip()}"))
     if run.validation.configured:
         verdict = "passed" if run.validation.passed else f"FAILED (exit {run.validation.exit_code})"
         style = "green" if run.validation.passed else "red"
@@ -52,7 +79,20 @@ def format_run_rich(run: ShipRun) -> Group:
         lines.append(Text(f"  pr        {run.pr_url}", style="bold cyan"))
     for warning in run.warnings:
         lines.append(Text(f"  ⚠ {warning}", style="yellow"))
-    return Group(*lines)
+    parts: list = [Group(*lines)]
+    if show_diff:
+        parts.append(Text(""))
+        if run.diff_text:
+            parts.append(Text("  the change itself:", style="bold"))
+            parts.append(format_diff_rich(run.diff_text))
+        else:
+            parts.append(
+                Text(
+                    "  the diff could not be read — inspect the worktree before approving",
+                    style="yellow",
+                )
+            )
+    return Group(*parts)
 
 
 def format_history_rich(runs: list[ShipRun]) -> Group:

--- a/src/yeaboi/ship/render.py
+++ b/src/yeaboi/ship/render.py
@@ -7,11 +7,31 @@ is load-bearing; the JSON format carries the same facts.
 
 from __future__ import annotations
 
+import re
+
 from rich.console import Group
 from rich.text import Text
 
 from yeaboi.agent.state import ShipRun
 from yeaboi.ship.budget import BudgetStatus
+
+# Every C0 control and DEL except tab and newline — notably ESC (0x1b), which
+# rich does NOT strip (``STRIP_CONTROL_CODES`` is only BEL/BS/VT/FF/CR) and
+# which reaches the terminal verbatim inside a Text segment.
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
+
+def safe_console_text(text: str) -> str:
+    """Strip control characters from agent-authored text before it is drawn.
+
+    The patch and the validation tail are written by the coding agent, and the
+    gate is the only control before a push — so a file containing escape
+    sequences could move the cursor and repaint over what the reviewer is
+    reading, and they would approve what they saw rather than what is on disk.
+    Newlines survive: callers split on them to build rows.
+    """
+    return _CONTROL_RE.sub("", text)
+
 
 _STATUS_STYLE = {
     "approved": "bold green",
@@ -27,7 +47,7 @@ _STATUS_STYLE = {
 def format_diff_rich(diff: str) -> Group:
     """The patch, tinted. Additions green, removals red, hunk headers cyan."""
     lines: list[Text] = []
-    for raw in diff.splitlines():
+    for raw in safe_console_text(diff).splitlines():
         if raw.startswith("+++") or raw.startswith("---"):
             style = "bold"
         elif raw.startswith("+"):
@@ -64,14 +84,15 @@ def format_run_rich(run: ShipRun, *, show_diff: bool = False) -> Group:
     if run.diff_stat:
         # The gate wants every file; a status line wants the totals. A 60-file
         # run should not print 60 rows every time someone asks what happened.
-        stat_lines = run.diff_stat.splitlines() if show_diff else run.diff_stat.splitlines()[-1:]
+        stat_all = safe_console_text(run.diff_stat).splitlines()
+        stat_lines = stat_all if show_diff else stat_all[-1:]
         for index, stat_line in enumerate(stat_lines):
             label = "diff     " if index == 0 else "         "
             lines.append(Text(f"  {label} {stat_line.strip()}"))
     if run.validation.configured:
         verdict = "passed" if run.validation.passed else f"FAILED (exit {run.validation.exit_code})"
         style = "green" if run.validation.passed else "red"
-        lines.append(Text(f"  checks    {run.validation.command} — {verdict}", style=style))
+        lines.append(Text(f"  checks    {safe_console_text(run.validation.command)} — {verdict}", style=style))
     else:
         lines.append(Text("  checks    none configured — nothing was proven", style="yellow"))
     if run.cost_usd:

--- a/src/yeaboi/ship/store.py
+++ b/src/yeaboi/ship/store.py
@@ -65,6 +65,23 @@ def _run_to_json(run: ShipRun) -> str:
     return json.dumps(asdict(run), ensure_ascii=False)
 
 
+def listing_dict(run: ShipRun) -> dict:
+    """One run as JSON for a *listing* surface — without the stored patch.
+
+    ``diff_text`` is capped per run, not per response, so a hundred rows of it
+    is megabytes of patch nobody asked for; a listing is also the thing people
+    poll in a loop. The stat, the branch and the worktree stay, and reading the
+    change itself is a git command away — the gate that needs it renders from
+    the artifact, not from this.
+
+    ``asdict`` per run rather than on the list: the MCP layer's ``to_jsonable``
+    only unpacks a top-level dataclass, so a nested one would arrive as a repr.
+    """
+    payload = asdict(run)
+    payload.pop("diff_text", None)
+    return payload
+
+
 def _dict_to_run(data: dict) -> ShipRun:
     """Rebuild the frozen artifact from JSON; tolerant of missing keys."""
     validation = data.get("validation") or {}

--- a/src/yeaboi/ship/store.py
+++ b/src/yeaboi/ship/store.py
@@ -96,6 +96,7 @@ def _dict_to_run(data: dict) -> ShipRun:
             output_tail=str(validation.get("output_tail", "")),
         ),
         diff_stat=str(data.get("diff_stat", "")),
+        diff_text=str(data.get("diff_text", "")),
         cost_usd=float(data.get("cost_usd", 0.0)),
         transcript_findings=tuple(
             (str(f[0]), str(f[1]), str(f[2]))

--- a/src/yeaboi/ship/worktree.py
+++ b/src/yeaboi/ship/worktree.py
@@ -222,17 +222,22 @@ def remove(run_id: str, *, delete_branch: bool = False) -> bool:
     entry = registry.get(run_id)
     if not isinstance(entry, dict):
         return False
-    ok = True
     path = str(entry.get("path", ""))
     repo = str(entry.get("repo", ""))
-    if path and repo:
-        try:
-            checkout = _validate_owned(path)
-            _git(repo, "worktree", "remove", "--force", str(checkout))
-            _git(repo, "worktree", "prune")
-        except WorktreeError as exc:
-            logger.warning("Could not remove worktree for %s: %s", run_id, exc)
-            ok = False
+    if not (path and repo):
+        # A hand-edited registry can name a run with no checkout behind it.
+        # Popping the row and reporting success would claim a removal that
+        # never happened, so say what is true: nothing was removed.
+        logger.warning("Registry entry for %s names no worktree; nothing removed", run_id)
+        return False
+    ok = True
+    try:
+        checkout = _validate_owned(path)
+        _git(repo, "worktree", "remove", "--force", str(checkout))
+        _git(repo, "worktree", "prune")
+    except WorktreeError as exc:
+        logger.warning("Could not remove worktree for %s: %s", run_id, exc)
+        ok = False
     if ok and delete_branch and repo and entry.get("branch"):
         try:
             _git(repo, "branch", "-D", str(entry["branch"]))

--- a/src/yeaboi/ui/mode_select/_ship.py
+++ b/src/yeaboi/ui/mode_select/_ship.py
@@ -53,20 +53,27 @@ def _load_stories() -> tuple[list, str, str]:
     return list(state.get("stories") or []), session_id, ""
 
 
-def _repo_problem(repo: str) -> str:
-    """A user-facing reason this repo cannot take a run, or ""."""
+def _resolve_target(repo: str) -> tuple[str, str]:
+    """(the git toplevel this run will touch, a user-facing problem or "").
+
+    The toplevel, not the typed path, is what every later write targets —
+    ``git worktree add`` writes into ``<toplevel>/.git`` and the push runs from
+    there. Consent is checked with ``is_relative_to`` containment, so granting a
+    *subdirectory* would not grant the toplevel: resolving first is what keeps
+    the consent prompt honest about what is about to be touched.
+    """
     from yeaboi.ship import worktree
 
     try:
         top = worktree.resolve_repo(Path(repo).expanduser())
     except worktree.WorktreeError as exc:
-        return str(exc)
+        return "", str(exc)
     try:
         if worktree.is_dirty(top):
-            return f"{top} has uncommitted changes — commit or stash first"
+            return str(top), f"{top} has uncommitted changes — commit or stash first"
     except worktree.WorktreeError as exc:
-        return str(exc)
-    return ""
+        return str(top), str(exc)
+    return str(top), ""
 
 
 def run_ship_page(console: Console, live, read_key, frame_time: float, supports_timeout: bool) -> None:
@@ -165,7 +172,7 @@ def _launch(
     """Consent + worker thread + progress/gate/result loops. Returns a picker message."""
     from yeaboi.ui.shared._consent import _preflight_path_consent
 
-    problem = _repo_problem(repo)
+    repo, problem = _resolve_target(repo)
     if problem:
         return problem
     if not _preflight_path_consent(

--- a/src/yeaboi/ui/mode_select/_ship.py
+++ b/src/yeaboi/ui/mode_select/_ship.py
@@ -35,6 +35,8 @@ from yeaboi.ui.mode_select.screens._screens_ship import (
 
 logger = logging.getLogger(__name__)
 
+_DIFF_PAGE_ROWS = 10  # pgup/pgdn stride through the gate's patch pane
+
 
 def _load_stories() -> tuple[list, str, str]:
     """(stories, session_id, message) from the latest saved plan. Never raises."""
@@ -271,6 +273,7 @@ def _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, run
     comment: str | None = None
     edit = {"buf": "", "cur": 0}
     message = ""
+    diff_offset = 0
     while True:
         w, h = console.size
         live.update(
@@ -281,6 +284,7 @@ def _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, run
                 height=h,
                 comment_edit=edit["buf"] if comment is not None else None,
                 message=message,
+                diff_offset=diff_offset,
             )
         )
         key = read_key(timeout=frame_time) if supports_timeout else read_key()
@@ -300,6 +304,15 @@ def _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, run
             action_sel = (action_sel - 1) % len(SHIP_GATE_ACTIONS)
         elif key in ("right", "tab"):
             action_sel = (action_sel + 1) % len(SHIP_GATE_ACTIONS)
+        elif key == "up":
+            # The builder clamps; a large offset just parks at the last page.
+            diff_offset = max(0, diff_offset - 1)
+        elif key == "down":
+            diff_offset += 1
+        elif key == "pgup":
+            diff_offset = max(0, diff_offset - _DIFF_PAGE_ROWS)
+        elif key == "pgdn":
+            diff_offset += _DIFF_PAGE_ROWS
         elif key == "enter":
             action = SHIP_GATE_ACTIONS[action_sel]
             if action == "Approve":

--- a/src/yeaboi/ui/mode_select/_ship.py
+++ b/src/yeaboi/ui/mode_select/_ship.py
@@ -199,6 +199,11 @@ def _launch(
     result_box: list = [None, None]
     cancel = threading.Event()
 
+    # The engine hands its run id back as soon as it exists; everything else
+    # in the shared store belongs to another session, and this loop must never
+    # open a gate over a diff this user did not launch.
+    mine: list[str] = [""]
+
     def _work() -> None:
         try:
             result_box[0] = engine.run_ship(
@@ -207,17 +212,16 @@ def _launch(
                 session_id=session_id,
                 check_command=check_command,
                 on_progress=progress_q.put,
+                on_run_id=lambda run_id: mine.__setitem__(0, run_id),
                 cancel_event=cancel,
             )
         except BaseException as exc:  # noqa: BLE001 — belt and braces; the engine shouldn't raise
             result_box[1] = exc
 
     with ShipStore() as watch:
-        known = {r.run_id for r in watch.list_runs(limit=50)}
         thread = duck_working_thread(_work, name="ship-run")
         thread.start()
         events_by_id: dict[str, dict] = {}
-        run_id = ""
         start = time.monotonic()
         last_poll = 0.0
 
@@ -230,12 +234,10 @@ def _launch(
                 if is_component_progress(item):
                     events_by_id[item["component_id"]] = item
             gated = None
-            if time.monotonic() - last_poll > 0.5:
+            if mine[0] and time.monotonic() - last_poll > 0.5:
                 last_poll = time.monotonic()
                 for row in watch.list_runs(limit=5):
-                    if row.run_id not in known:
-                        run_id = row.run_id
-                    if row.run_id == run_id and row.status == "awaiting_approval" and not row.gate_resolution:
+                    if row.run_id == mine[0] and row.status == "awaiting_approval" and not row.gate_resolution:
                         gated = row
             if gated is not None:
                 outcome = _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, gated, cancel)

--- a/src/yeaboi/ui/mode_select/_ship.py
+++ b/src/yeaboi/ui/mode_select/_ship.py
@@ -32,10 +32,9 @@ from yeaboi.ui.mode_select.screens._screens_ship import (
     _build_ship_progress_screen,
     _build_ship_result_screen,
 )
+from yeaboi.ui.shared._scroll import SCROLL_KEYS, coalesce_scroll
 
 logger = logging.getLogger(__name__)
-
-_DIFF_PAGE_ROWS = 10  # pgup/pgdn stride through the gate's patch pane
 
 
 def _load_stories() -> tuple[list, str, str]:
@@ -236,9 +235,12 @@ def _launch(
             gated = None
             if mine[0] and time.monotonic() - last_poll > 0.5:
                 last_poll = time.monotonic()
-                for row in watch.list_runs(limit=5):
-                    if row.run_id == mine[0] and row.status == "awaiting_approval" and not row.gate_resolution:
-                        gated = row
+                # By id, not by scanning a newest-first page: with concurrency
+                # raised, later runs would push ours off the end and its gate
+                # would never open on the surface that launched it.
+                row = watch.get_run(mine[0])
+                if row is not None and row.status == "awaiting_approval" and not row.gate_resolution:
+                    gated = row
             if gated is not None:
                 outcome = _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, gated, cancel)
                 if outcome == "cancelled":
@@ -276,6 +278,10 @@ def _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, run
     edit = {"buf": "", "cur": 0}
     message = ""
     diff_offset = 0
+    # The builder publishes the pane's true geometry here; apply_scroll clamps
+    # to exactly what is on screen, so the loop counter and the visible
+    # position can never diverge (see ui/shared/_scroll.py).
+    scroll_meta: dict = {}
     while True:
         w, h = console.size
         live.update(
@@ -287,6 +293,7 @@ def _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, run
                 comment_edit=edit["buf"] if comment is not None else None,
                 message=message,
                 diff_offset=diff_offset,
+                scroll_meta=scroll_meta,
             )
         )
         key = read_key(timeout=frame_time) if supports_timeout else read_key()
@@ -302,19 +309,14 @@ def _gate_loop(console, live, read_key, frame_time, supports_timeout, watch, run
             elif isinstance(key, str) and key:
                 _settings_edit_keypress(key, edit)
             continue
-        if key in ("left",):
+        if key in SCROLL_KEYS:
+            # One membership test routes arrows, wheel, page and home/end; the
+            # burst is drained in one shot so a fast wheel flick repaints once.
+            diff_offset = coalesce_scroll(diff_offset, key, scroll_meta, read_key)
+        elif key in ("left",):
             action_sel = (action_sel - 1) % len(SHIP_GATE_ACTIONS)
         elif key in ("right", "tab"):
             action_sel = (action_sel + 1) % len(SHIP_GATE_ACTIONS)
-        elif key == "up":
-            # The builder clamps; a large offset just parks at the last page.
-            diff_offset = max(0, diff_offset - 1)
-        elif key == "down":
-            diff_offset += 1
-        elif key == "pgup":
-            diff_offset = max(0, diff_offset - _DIFF_PAGE_ROWS)
-        elif key == "pgdn":
-            diff_offset += _DIFF_PAGE_ROWS
         elif key == "enter":
             action = SHIP_GATE_ACTIONS[action_sel]
             if action == "Approve":

--- a/src/yeaboi/ui/mode_select/screens/_screens_ship.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_ship.py
@@ -23,10 +23,12 @@ from rich.table import Table
 from rich.text import Text
 
 from yeaboi.agent.state import ShipRun
+from yeaboi.ship.render import safe_console_text
 from yeaboi.ui.mode_select.screens._screens_agents import _build_agent_progress_body, _fmt_elapsed
 from yeaboi.ui.shared._components import (
     PAD,
     SHIP_THEME,
+    TITLE_ROWS,
     build_action_buttons,
     build_page_panel,
     build_reveal_subtitle,
@@ -44,8 +46,12 @@ _MAX_DIFF_ROWS = 8
 _MAX_TAIL_ROWS = 6
 _MAX_FINDING_ROWS = 4
 _MIN_DIFF_PANE_ROWS = 3  # below this the pane is dropped, never overlapped onto the buttons
-_TITLE_ROWS = 6  # the ASCII wordmark's own height
 PANEL_CHROME_ROWS = 4  # build_page_panel's border (2) + padding (2), same as calc_viewport's
+# Inner content width: the border (2) plus build_page_panel's padding=(1, 2) (4).
+# Every row the gate draws is clipped to this and marked no_wrap, because a row
+# that wraps is a row the layout did not count — and uncounted rows are what
+# push the buttons off a fixed-height Panel.
+_PANEL_SIDE_COLS = 6
 
 # The engine's component ids (ship/engine.py emits these); the screen owns
 # what "pending" looks like.
@@ -172,11 +178,24 @@ def _build_ship_progress_screen(
     return build_page_panel(Group(*parts), theme=theme, height=height)
 
 
-def _gate_line(label: str, value: str, *, style: str = "rgb(200,200,210)") -> Text:
-    row = Text()
-    row.append(PAD)
-    row.append(f"{label}  ", style="rgb(110,110,125)")
-    row.append(value, style=style)
+def _one_row(text: str, *, width: int, style: str = "") -> Text:
+    """One row that is guaranteed to stay one row.
+
+    ``no_wrap`` + ``crop`` rather than arithmetic alone: a wrapped row is a row
+    the layout did not count, and uncounted rows crop the buttons off the
+    bottom of a fixed-height Panel. (``no_wrap`` only takes effect when the
+    Text is rendered inside a Panel/Group, which is how every gate row is
+    drawn — a bare ``console.print`` of the same Text would ignore it.)
+    """
+    return Text(
+        safe_console_text(text)[: max(20, width - _PANEL_SIDE_COLS)], style=style, no_wrap=True, overflow="crop"
+    )
+
+
+def _gate_line(label: str, value: str, *, style: str = "rgb(200,200,210)", width: int = 80) -> Text:
+    row = _one_row(f"{PAD}{label}  ", width=width, style="rgb(110,110,125)")
+    row.append(safe_console_text(value), style=style)
+    row.truncate(max(20, width - _PANEL_SIDE_COLS), overflow="ellipsis")
     return row
 
 
@@ -189,18 +208,19 @@ def _diff_row(line: str, *, width: int, theme) -> Text:
     }.get(line[:1], "rgb(160,160,175)")
     if line.startswith(("+++", "---", "diff --git")):
         style = "bold rgb(200,200,210)"
-    return Text(f"{PAD}  {line[: max(20, width - 10)]}", style=style)
+    return _one_row(f"{PAD}  {line}", width=width, style=style)
 
 
 def _rows_of(parts: list) -> int:
     """How many terminal rows ``parts`` occupies.
 
-    Every entry is a single ``Text`` row except the ASCII wordmark. The gate
-    needs an exact count, not an estimate: a row too many crops the button
-    block off the bottom of a fixed-height Panel, and a gate whose buttons are
-    off screen still answers Enter with "Approve" — which is a push.
+    Every entry is a single ``Text`` row except the ASCII wordmark, which is
+    ``TITLE_ROWS`` tall — the shared constant, never a second copy of the
+    number. The gate needs an exact count, not an estimate: a row too many
+    crops the button block off the bottom of a fixed-height Panel, and a gate
+    whose buttons are off screen still answers Enter with "Approve".
     """
-    return sum(_TITLE_ROWS if isinstance(part, Text) and "█" in part.plain else 1 for part in parts)
+    return sum(TITLE_ROWS if isinstance(part, Text) and "█" in part.plain else 1 for part in parts)
 
 
 def _diff_viewport(run: ShipRun, *, width: int, rows: int, offset: int, theme) -> tuple[object, int, int]:
@@ -250,34 +270,35 @@ def _build_ship_gate_screen(
     loop's offset can never run past what is on screen.
     """
     theme = SHIP_THEME
-    clip = max(20, width - 10)
     head: list = [
         Text(""),
         ship_title(None, width=width),
         build_reveal_subtitle("Review the diff like a stranger wrote it — one did", None, justify="center"),
         Text(""),
-        _gate_line("Story ", run.story_id),
-        _gate_line("Branch", run.branch, style=theme.id),
+        _gate_line("Story ", run.story_id, width=width),
+        _gate_line("Branch", run.branch, style=theme.id, width=width),
     ]
     if run.worktree:
         # Where to look when the pane is not enough — the patch is capped, the
         # checkout is not.
-        head.append(_gate_line("Tree  ", run.worktree, style="rgb(140,140,155)"))
+        head.append(_gate_line("Tree  ", run.worktree, style="rgb(140,140,155)", width=width))
 
     # The elastic sections, each with a floor it may not drop below. When the
     # window cannot hold everything these give way, in this order, so the
     # fixed rows and the buttons always survive: losing the tail of a failure
     # log is a far cheaper loss than losing the controls.
-    stat_rows = [Text(f"{PAD}  {line[:clip]}", style="rgb(160,160,175)") for line in run.diff_stat.splitlines()]
+    stat_rows = [
+        _one_row(f"{PAD}  {line}", width=width, style="rgb(160,160,175)") for line in run.diff_stat.splitlines()
+    ]
     tail_rows: list = []
     check_rows: list = []
     if run.validation.configured:
         state = "✓ passed" if run.validation.passed else f"✗ FAILED (exit {run.validation.exit_code})"
         style = theme.good if run.validation.passed else theme.bad
-        check_rows.append(_gate_line("Checks", f"{run.validation.command} — {state}", style=style))
+        check_rows.append(_gate_line("Checks", f"{run.validation.command} — {state}", style=style, width=width))
         if not run.validation.passed:
             tail_rows = [
-                Text(f"{PAD}  {line[:clip]}", style="rgb(140,120,120)")
+                _one_row(f"{PAD}  {line}", width=width, style="rgb(140,120,120)")
                 for line in run.validation.output_tail.splitlines()[-_MAX_TAIL_ROWS:]
             ]
     else:
@@ -285,17 +306,19 @@ def _build_ship_gate_screen(
     finding_rows: list = []
     if run.transcript_findings:
         finding_rows.append(
-            _gate_line("Safety", f"{len(run.transcript_findings)} transcript finding(s):", style=theme.warn)
+            _gate_line(
+                "Safety", f"{len(run.transcript_findings)} transcript finding(s):", style=theme.warn, width=width
+            )
         )
         finding_rows += [
-            Text(f"{PAD}  {severity}: {label} ({kind})", style=theme.warn)
+            _one_row(f"{PAD}  {severity}: {label} ({kind})", width=width, style=theme.warn)
             for kind, severity, label in run.transcript_findings[:_MAX_FINDING_ROWS]
         ]
     extra_rows: list = []
     if run.cost_usd:
-        extra_rows.append(_gate_line("Cost  ", f"${run.cost_usd:.2f}"))
+        extra_rows.append(_gate_line("Cost  ", f"${run.cost_usd:.2f}", width=width))
     if run.rejection_count:
-        extra_rows.append(_gate_line("Rework", f"attempt {run.rejection_count + 1} after your feedback"))
+        extra_rows.append(_gate_line("Rework", f"attempt {run.rejection_count + 1} after your feedback", width=width))
 
     # Everything below the pane is fixed, so build it first: what is left over
     # decides how much elastic content — and then how much patch — fits.
@@ -307,7 +330,9 @@ def _build_ship_gate_screen(
         prompt.append(comment_edit, style="bold white")
         prompt.append("▏", style=theme.accent_bright)
         foot.append(prompt)
-        foot.append(Text(f"{PAD}enter sends the feedback to the agent · esc keeps reviewing", style="dim"))
+        foot.append(
+            _one_row(f"{PAD}enter sends the feedback to the agent · esc keeps reviewing", width=width, style="dim")
+        )
     foot.append(Text(message, style=theme.warn if message else "", justify="center"))
     foot.append(Text(""))
     foot.extend(build_action_buttons(SHIP_GATE_ACTIONS, action_sel))
@@ -323,19 +348,29 @@ def _build_ship_gate_screen(
         - _rows_of(foot)
         - 2  # the spacer below the stat and the one above the buttons
     )
-    label = Text(f"{PAD}the change itself  ↑↓ pgup/pgdn home/end scroll", style="rgb(110,110,125)")
+    label = _one_row(f"{PAD}the change itself  ↑↓ pgup/pgdn home/end scroll", width=width, style="rgb(110,110,125)")
+
+    # Which END a section sheds from is not arbitrary: a failure tail's LAST
+    # lines are the actual error, and the stat's last line is the "N files
+    # changed" total. Both shed from the front so the row that carries the
+    # meaning is the one that survives.
+    def _shed(rows: list, floor: int, wanted: int) -> int:
+        while wanted > 0 and len(rows) > floor:
+            rows.pop(0)
+            wanted -= 1
+        return wanted
+
+    elastic = ((tail_rows, 0), (finding_rows, 1), (stat_rows, 1))
     pane_rows = 0
     if comment_edit is None:
         pane_rows = budget - len(stat_rows) - len(tail_rows) - len(finding_rows) - 1  # 1 for the label row
-        for rows, floor in ((tail_rows, 0), (finding_rows, 1), (stat_rows, 1)):
+        for rows, floor in elastic:
             while len(rows) > floor and pane_rows < _MIN_DIFF_PANE_ROWS:
-                rows.pop()
+                rows.pop(0)
                 pane_rows += 1
     over = len(stat_rows) + len(tail_rows) + len(finding_rows) + max(0, pane_rows) - budget
-    for rows, floor in ((tail_rows, 0), (finding_rows, 1), (stat_rows, 1)):
-        while over > 0 and len(rows) > floor:
-            rows.pop()
-            over -= 1
+    for rows, floor in elastic:
+        over = _shed(rows, floor, over)
 
     parts: list = [*head, *stat_rows, Text(""), *check_rows, *tail_rows, *extra_rows, *finding_rows, Text("")]
     if comment_edit is None and pane_rows >= _MIN_DIFF_PANE_ROWS:

--- a/src/yeaboi/ui/mode_select/screens/_screens_ship.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_ship.py
@@ -2,9 +2,14 @@
 
 Same shared-component structure as every other mode page (tui-standards):
 pinned wordmark title + subtitle + content, wrapped in ``build_page_panel``
-with the ship theme. Lists are CAPPED, not scrolled — the gate screen shows
-the top rows of the diff and validation tail and says how many more exist,
-so the page renders correctly at the minimum terminal size.
+with the ship theme.
+
+The gate screen is the exception to "lists are capped, not scrolled", because
+it is the only control between agent-authored code and a pushed branch: the
+patch gets a real scrolling viewport, and everything else on the screen is
+elastic around it. The layout's one invariant is that the **buttons always
+render** — a Panel of fixed height crops from the bottom, and a gate whose
+button row is off screen still answers Enter with "Approve".
 
 Builders are pure (no clocks, no logging — they run every frame); the page
 loop in ``_ship.py`` owns time, keys, and state.
@@ -28,6 +33,7 @@ from yeaboi.ui.shared._components import (
     build_scrollbar,
     ship_title,
 )
+from yeaboi.ui.shared._scroll import clamp_scroll, max_scroll, publish_geometry
 
 SHIP_PICK_ACTIONS = ["Launch", "Back"]
 SHIP_GATE_ACTIONS = ["Approve", "Reject", "Cancel Run"]
@@ -37,9 +43,9 @@ _MAX_STORY_ROWS = 8
 _MAX_DIFF_ROWS = 8
 _MAX_TAIL_ROWS = 6
 _MAX_FINDING_ROWS = 4
-_MIN_DIFF_PANE_ROWS = 3  # the pane is never zero rows; a short terminal scrolls harder
+_MIN_DIFF_PANE_ROWS = 3  # below this the pane is dropped, never overlapped onto the buttons
 _TITLE_ROWS = 6  # the ASCII wordmark's own height
-_GATE_FOOTER_ROWS = 5  # message row + spacer + the three button rows
+PANEL_CHROME_ROWS = 4  # build_page_panel's border (2) + padding (2), same as calc_viewport's
 
 # The engine's component ids (ship/engine.py emits these); the screen owns
 # what "pending" looks like.
@@ -186,26 +192,41 @@ def _diff_row(line: str, *, width: int, theme) -> Text:
     return Text(f"{PAD}  {line[: max(20, width - 10)]}", style=style)
 
 
-def _diff_viewport(run: ShipRun, *, width: int, rows: int, offset: int, theme) -> tuple[object, int]:
-    """(the renderable, the clamped offset) for the scrollable patch pane."""
+def _rows_of(parts: list) -> int:
+    """How many terminal rows ``parts`` occupies.
+
+    Every entry is a single ``Text`` row except the ASCII wordmark. The gate
+    needs an exact count, not an estimate: a row too many crops the button
+    block off the bottom of a fixed-height Panel, and a gate whose buttons are
+    off screen still answers Enter with "Approve" — which is a push.
+    """
+    return sum(_TITLE_ROWS if isinstance(part, Text) and "█" in part.plain else 1 for part in parts)
+
+
+def _diff_viewport(run: ShipRun, *, width: int, rows: int, offset: int, theme) -> tuple[object, int, int]:
+    """(renderable, clamped offset, max offset) for the scrollable patch pane."""
     lines = run.diff_text.splitlines()
     if not lines:
-        return Text(
-            f"{PAD}  the diff could not be read — inspect the worktree before approving",
-            style=theme.warn,
-        ), 0
-    max_start = max(0, len(lines) - rows)
-    start = max(0, min(offset, max_start))
+        return (
+            Text(
+                f"{PAD}  the diff could not be read — inspect the worktree before approving",
+                style=theme.warn,
+            ),
+            0,
+            0,
+        )
+    max_start = max_scroll(len(lines), rows)
+    start = clamp_scroll(offset, len(lines), rows)
     visible = [_diff_row(line, width=width, theme=theme) for line in lines[start : start + rows]]
     visible.extend(Text("") for _ in range(max(0, rows - len(visible))))
     scrollbar = build_scrollbar(rows, len(lines), start, max_start)
     if scrollbar is None:
-        return Group(*visible), start
+        return Group(*visible), start, max_start
     shell = Table.grid(expand=True, padding=0)
     shell.add_column(ratio=1)
     shell.add_column(width=1)
     shell.add_row(Group(*visible), scrollbar)
-    return shell, start
+    return shell, start, max_start
 
 
 def _build_ship_gate_screen(
@@ -217,16 +238,20 @@ def _build_ship_gate_screen(
     comment_edit: str | None = None,
     message: str = "",
     diff_offset: int = 0,
+    scroll_meta: dict | None = None,
 ) -> Panel:
     """The approval gate: what the agent did, what was proven, your call.
 
     ``comment_edit`` non-None means the rejection comment is being typed; it
     renders an input line and the buttons step back. ``diff_offset`` scrolls
     the patch pane — the gate is the only control before a push, so it shows
-    the change itself and the worktree path, never just a file count.
+    the change itself and the worktree path, never just a file count — and the
+    builder publishes the pane's real geometry into ``scroll_meta`` so the
+    loop's offset can never run past what is on screen.
     """
     theme = SHIP_THEME
-    parts: list = [
+    clip = max(20, width - 10)
+    head: list = [
         Text(""),
         ship_title(None, width=width),
         build_reveal_subtitle("Review the diff like a stranger wrote it — one did", None, justify="center"),
@@ -237,51 +262,102 @@ def _build_ship_gate_screen(
     if run.worktree:
         # Where to look when the pane is not enough — the patch is capped, the
         # checkout is not.
-        parts.append(_gate_line("Tree  ", run.worktree, style="rgb(140,140,155)"))
-    diff_lines = run.diff_stat.splitlines()
-    for line in diff_lines[:_MAX_DIFF_ROWS]:
-        parts.append(Text(f"{PAD}  {line[: max(20, width - 10)]}", style="rgb(160,160,175)"))
-    if len(diff_lines) > _MAX_DIFF_ROWS:
-        parts.append(Text(f"{PAD}  … and {len(diff_lines) - _MAX_DIFF_ROWS} more lines", style="dim"))
-    parts.append(Text(""))
+        head.append(_gate_line("Tree  ", run.worktree, style="rgb(140,140,155)"))
+
+    # The elastic sections, each with a floor it may not drop below. When the
+    # window cannot hold everything these give way, in this order, so the
+    # fixed rows and the buttons always survive: losing the tail of a failure
+    # log is a far cheaper loss than losing the controls.
+    stat_rows = [Text(f"{PAD}  {line[:clip]}", style="rgb(160,160,175)") for line in run.diff_stat.splitlines()]
+    tail_rows: list = []
+    check_rows: list = []
     if run.validation.configured:
         state = "✓ passed" if run.validation.passed else f"✗ FAILED (exit {run.validation.exit_code})"
         style = theme.good if run.validation.passed else theme.bad
-        parts.append(_gate_line("Checks", f"{run.validation.command} — {state}", style=style))
+        check_rows.append(_gate_line("Checks", f"{run.validation.command} — {state}", style=style))
         if not run.validation.passed:
-            for line in run.validation.output_tail.splitlines()[-_MAX_TAIL_ROWS:]:
-                parts.append(Text(f"{PAD}  {line[: max(20, width - 10)]}", style="rgb(140,120,120)"))
+            tail_rows = [
+                Text(f"{PAD}  {line[:clip]}", style="rgb(140,120,120)")
+                for line in run.validation.output_tail.splitlines()[-_MAX_TAIL_ROWS:]
+            ]
     else:
-        parts.append(_gate_line("Checks", "none configured — nothing was proven", style=theme.warn))
-    if run.cost_usd:
-        parts.append(_gate_line("Cost  ", f"${run.cost_usd:.2f}"))
+        check_rows.append(_gate_line("Checks", "none configured — nothing was proven", style=theme.warn))
+    finding_rows: list = []
     if run.transcript_findings:
-        parts.append(_gate_line("Safety", f"{len(run.transcript_findings)} transcript finding(s):", style=theme.warn))
-        for kind, severity, label in run.transcript_findings[:_MAX_FINDING_ROWS]:
-            parts.append(Text(f"{PAD}  {severity}: {label} ({kind})", style=theme.warn))
+        finding_rows.append(
+            _gate_line("Safety", f"{len(run.transcript_findings)} transcript finding(s):", style=theme.warn)
+        )
+        finding_rows += [
+            Text(f"{PAD}  {severity}: {label} ({kind})", style=theme.warn)
+            for kind, severity, label in run.transcript_findings[:_MAX_FINDING_ROWS]
+        ]
+    extra_rows: list = []
+    if run.cost_usd:
+        extra_rows.append(_gate_line("Cost  ", f"${run.cost_usd:.2f}"))
     if run.rejection_count:
-        parts.append(_gate_line("Rework", f"attempt {run.rejection_count + 1} after your feedback"))
-    parts.append(Text(""))
-    # The patch pane takes whatever the fixed chrome leaves. The ASCII title is
-    # _TITLE_ROWS tall and the button block three; the rest of ``parts`` is one
-    # row each, so the remainder is what the viewport may use.
-    if comment_edit is None:
-        pane_rows = max(_MIN_DIFF_PANE_ROWS, height - len(parts) - _TITLE_ROWS - _GATE_FOOTER_ROWS)
-        viewport, diff_offset = _diff_viewport(run, width=width, rows=pane_rows, offset=diff_offset, theme=theme)
-        parts.append(Text(f"{PAD}the change itself  ↑↓ scrolls", style="rgb(110,110,125)"))
-        parts.append(viewport)
-        parts.append(Text(""))
+        extra_rows.append(_gate_line("Rework", f"attempt {run.rejection_count + 1} after your feedback"))
+
+    # Everything below the pane is fixed, so build it first: what is left over
+    # decides how much elastic content — and then how much patch — fits.
+    foot: list = []
     if comment_edit is not None:
         prompt = Text()
         prompt.append(PAD)
         prompt.append("Why reject? ", style=theme.muted)
         prompt.append(comment_edit, style="bold white")
         prompt.append("▏", style=theme.accent_bright)
-        parts.append(prompt)
-        parts.append(Text(f"{PAD}enter sends the feedback to the agent · esc keeps reviewing", style="dim"))
-    parts.append(Text(message, style=theme.warn if message else "", justify="center"))
-    parts.append(Text(""))
-    parts.extend(build_action_buttons(SHIP_GATE_ACTIONS, action_sel))
+        foot.append(prompt)
+        foot.append(Text(f"{PAD}enter sends the feedback to the agent · esc keeps reviewing", style="dim"))
+    foot.append(Text(message, style=theme.warn if message else "", justify="center"))
+    foot.append(Text(""))
+    foot.extend(build_action_buttons(SHIP_GATE_ACTIONS, action_sel))
+
+    # PANEL_CHROME_ROWS is what build_page_panel's border and padding cost;
+    # calc_viewport documents the same 4 for the screens that can use it.
+    budget = (
+        height
+        - PANEL_CHROME_ROWS
+        - _rows_of(head)
+        - len(check_rows)
+        - len(extra_rows)
+        - _rows_of(foot)
+        - 2  # the spacer below the stat and the one above the buttons
+    )
+    label = Text(f"{PAD}the change itself  ↑↓ pgup/pgdn home/end scroll", style="rgb(110,110,125)")
+    pane_rows = 0
+    if comment_edit is None:
+        pane_rows = budget - len(stat_rows) - len(tail_rows) - len(finding_rows) - 1  # 1 for the label row
+        for rows, floor in ((tail_rows, 0), (finding_rows, 1), (stat_rows, 1)):
+            while len(rows) > floor and pane_rows < _MIN_DIFF_PANE_ROWS:
+                rows.pop()
+                pane_rows += 1
+    over = len(stat_rows) + len(tail_rows) + len(finding_rows) + max(0, pane_rows) - budget
+    for rows, floor in ((tail_rows, 0), (finding_rows, 1), (stat_rows, 1)):
+        while over > 0 and len(rows) > floor:
+            rows.pop()
+            over -= 1
+
+    parts: list = [*head, *stat_rows, Text(""), *check_rows, *tail_rows, *extra_rows, *finding_rows, Text("")]
+    if comment_edit is None and pane_rows >= _MIN_DIFF_PANE_ROWS:
+        viewport, diff_offset, max_offset = _diff_viewport(
+            run, width=width, rows=pane_rows, offset=diff_offset, theme=theme
+        )
+        publish_geometry(scroll_meta, max_offset, pane_rows)
+        parts.append(label)
+        parts.append(viewport)
+    elif comment_edit is None:
+        # Too short to show a patch AND the buttons. Say where the patch is
+        # rather than rendering a gate that looks reviewed when it was not.
+        publish_geometry(scroll_meta, 0, 1)
+        parts.append(
+            Text(
+                f"{PAD}patch hidden — window too short; read it in {run.worktree or 'the worktree'}",
+                style=theme.warn,
+            )
+        )
+    else:
+        publish_geometry(scroll_meta, 0, 1)
+    parts.extend(foot)
     return build_page_panel(Group(*parts), theme=theme, height=height)
 
 

--- a/src/yeaboi/ui/mode_select/screens/_screens_ship.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_ship.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from rich.console import Group
 from rich.panel import Panel
+from rich.table import Table
 from rich.text import Text
 
 from yeaboi.agent.state import ShipRun
@@ -24,6 +25,7 @@ from yeaboi.ui.shared._components import (
     build_action_buttons,
     build_page_panel,
     build_reveal_subtitle,
+    build_scrollbar,
     ship_title,
 )
 
@@ -35,6 +37,9 @@ _MAX_STORY_ROWS = 8
 _MAX_DIFF_ROWS = 8
 _MAX_TAIL_ROWS = 6
 _MAX_FINDING_ROWS = 4
+_MIN_DIFF_PANE_ROWS = 3  # the pane is never zero rows; a short terminal scrolls harder
+_TITLE_ROWS = 6  # the ASCII wordmark's own height
+_GATE_FOOTER_ROWS = 5  # message row + spacer + the three button rows
 
 # The engine's component ids (ship/engine.py emits these); the screen owns
 # what "pending" looks like.
@@ -169,6 +174,40 @@ def _gate_line(label: str, value: str, *, style: str = "rgb(200,200,210)") -> Te
     return row
 
 
+def _diff_row(line: str, *, width: int, theme) -> Text:
+    """One patch line, tinted by what it does to the file."""
+    style = {
+        "+": theme.good,
+        "-": theme.bad,
+        "@": "rgb(120,170,200)",
+    }.get(line[:1], "rgb(160,160,175)")
+    if line.startswith(("+++", "---", "diff --git")):
+        style = "bold rgb(200,200,210)"
+    return Text(f"{PAD}  {line[: max(20, width - 10)]}", style=style)
+
+
+def _diff_viewport(run: ShipRun, *, width: int, rows: int, offset: int, theme) -> tuple[object, int]:
+    """(the renderable, the clamped offset) for the scrollable patch pane."""
+    lines = run.diff_text.splitlines()
+    if not lines:
+        return Text(
+            f"{PAD}  the diff could not be read — inspect the worktree before approving",
+            style=theme.warn,
+        ), 0
+    max_start = max(0, len(lines) - rows)
+    start = max(0, min(offset, max_start))
+    visible = [_diff_row(line, width=width, theme=theme) for line in lines[start : start + rows]]
+    visible.extend(Text("") for _ in range(max(0, rows - len(visible))))
+    scrollbar = build_scrollbar(rows, len(lines), start, max_start)
+    if scrollbar is None:
+        return Group(*visible), start
+    shell = Table.grid(expand=True, padding=0)
+    shell.add_column(ratio=1)
+    shell.add_column(width=1)
+    shell.add_row(Group(*visible), scrollbar)
+    return shell, start
+
+
 def _build_ship_gate_screen(
     run: ShipRun,
     *,
@@ -177,11 +216,14 @@ def _build_ship_gate_screen(
     height: int = 24,
     comment_edit: str | None = None,
     message: str = "",
+    diff_offset: int = 0,
 ) -> Panel:
     """The approval gate: what the agent did, what was proven, your call.
 
     ``comment_edit`` non-None means the rejection comment is being typed; it
-    renders an input line and the buttons step back.
+    renders an input line and the buttons step back. ``diff_offset`` scrolls
+    the patch pane — the gate is the only control before a push, so it shows
+    the change itself and the worktree path, never just a file count.
     """
     theme = SHIP_THEME
     parts: list = [
@@ -192,6 +234,10 @@ def _build_ship_gate_screen(
         _gate_line("Story ", run.story_id),
         _gate_line("Branch", run.branch, style=theme.id),
     ]
+    if run.worktree:
+        # Where to look when the pane is not enough — the patch is capped, the
+        # checkout is not.
+        parts.append(_gate_line("Tree  ", run.worktree, style="rgb(140,140,155)"))
     diff_lines = run.diff_stat.splitlines()
     for line in diff_lines[:_MAX_DIFF_ROWS]:
         parts.append(Text(f"{PAD}  {line[: max(20, width - 10)]}", style="rgb(160,160,175)"))
@@ -216,6 +262,15 @@ def _build_ship_gate_screen(
     if run.rejection_count:
         parts.append(_gate_line("Rework", f"attempt {run.rejection_count + 1} after your feedback"))
     parts.append(Text(""))
+    # The patch pane takes whatever the fixed chrome leaves. The ASCII title is
+    # _TITLE_ROWS tall and the button block three; the rest of ``parts`` is one
+    # row each, so the remainder is what the viewport may use.
+    if comment_edit is None:
+        pane_rows = max(_MIN_DIFF_PANE_ROWS, height - len(parts) - _TITLE_ROWS - _GATE_FOOTER_ROWS)
+        viewport, diff_offset = _diff_viewport(run, width=width, rows=pane_rows, offset=diff_offset, theme=theme)
+        parts.append(Text(f"{PAD}the change itself  ↑↓ scrolls", style="rgb(110,110,125)"))
+        parts.append(viewport)
+        parts.append(Text(""))
     if comment_edit is not None:
         prompt = Text()
         prompt.append(PAD)

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -1401,6 +1401,37 @@ class TestShipCommand:
         assert checked == [str(repo.resolve())]
         assert launched == [str(repo.resolve())]
 
+    def test_the_gate_prompt_ignores_a_run_this_invocation_did_not_start(self, monkeypatch, capsys, tmp_path):
+        # Concurrency is user-settable (YEABOI_AI_MAX_CONCURRENT), so a second
+        # terminal's run can open its gate mid-loop. Prompting for it would
+        # ask this user to approve — and push — a diff they never saw.
+        import time
+
+        from yeaboi.agent.state import ShipRun
+        from yeaboi.ship.store import ShipStore
+
+        db = tmp_path / "sessions.db"
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
+        repo, _ = self._git_repo(tmp_path / "proj")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+        def _refuse_to_prompt(*_a, **_kw):
+            raise AssertionError("the gate prompted for a foreign run")
+
+        monkeypatch.setattr("builtins.input", _refuse_to_prompt)
+
+        def _fake_run_ship(story_id, target, **kw):
+            # Another session's run opens its gate while ours is working.
+            with ShipStore(db) as store:
+                store.record_run(ShipRun(run_id="someone-else", story_id="US-999", status="awaiting_approval"))
+            kw["on_run_id"]("ours")
+            time.sleep(1.2)  # long enough for the loop to poll the store
+            return ShipRun(run_id="ours", story_id=story_id, status="failed")
+
+        monkeypatch.setattr("yeaboi.ship.engine.run_ship", _fake_run_ship)
+        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(repo)])
+        assert _run_subcommand(args) == 0
+
     def test_run_strict_exits_3_when_not_approved(self, monkeypatch, capsys, tmp_path):
         monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
         monkeypatch.setattr("sys.stdin", __import__("io").StringIO(""))

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -1336,13 +1336,70 @@ class TestShipCommand:
         assert payload["status"] == "approved"
         assert any("dry run" in w for w in payload["warnings"])
 
+    @staticmethod
+    def _git_repo(root):
+        """A real repo with a subdirectory — the toplevel is what gets touched."""
+        import subprocess
+
+        from yeaboi.tools.local_git import git_subprocess_env
+
+        def _git(*a):
+            subprocess.run(["git", "-C", str(root), *a], check=True, capture_output=True, env=git_subprocess_env())
+
+        root.mkdir(exist_ok=True)
+        _git("init", "-q", "-b", "main")
+        _git("config", "user.email", "t@example.com")
+        _git("config", "user.name", "T")
+        (root / "README.md").write_text("hi\n", encoding="utf-8")
+        _git("add", "README.md")
+        _git("commit", "-q", "-m", "init")
+        sub = root / "src"
+        sub.mkdir()
+        return root, sub
+
     def test_run_refuses_without_a_terminal(self, monkeypatch, capsys, tmp_path):
         # stdin in tests is not a tty, and the repo path is sandbox-allowed
         # (pytest tmp dirs are whitelisted) — so this exercises the tty guard.
         monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
-        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(tmp_path)])
+        repo, _ = self._git_repo(tmp_path / "proj")
+        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(repo)])
         assert _run_subcommand(args) == 2
         assert "interactive terminal" in capsys.readouterr().err
+
+    def test_run_refuses_a_path_that_is_not_a_git_work_tree(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(tmp_path)])
+        assert _run_subcommand(args) == 2
+        # git's own words when the rev-parse fails, ours when it returns empty.
+        assert "not a git" in capsys.readouterr().err
+
+    def test_consent_is_checked_against_the_toplevel_not_the_typed_path(self, monkeypatch, tmp_path):
+        # fs_policy containment is `is_relative_to`, and every write lands on
+        # the toplevel — so pointing --repo at a subdirectory must still ask
+        # about (and run against) the repository root.
+        from pathlib import Path
+
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        repo, sub = self._git_repo(tmp_path / "proj")
+        checked: list[str] = []
+        monkeypatch.setattr(
+            "yeaboi.fs_policy.resolve_and_check",
+            lambda path, **kw: checked.append(str(path)) or Path(path),
+        )
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+        launched: list[str] = []
+
+        from yeaboi.agent.state import ShipRun
+
+        def _fake_run_ship(story_id, target, **kw):
+            launched.append(target)
+            return ShipRun(run_id="r", story_id=story_id, status="failed")
+
+        monkeypatch.setattr("yeaboi.ship.engine.run_ship", _fake_run_ship)
+        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(sub)])
+        assert _run_subcommand(args) == 0
+        assert checked == [str(repo.resolve())]
+        assert launched == [str(repo.resolve())]
 
     def test_run_strict_exits_3_when_not_approved(self, monkeypatch, capsys, tmp_path):
         monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
@@ -1350,11 +1407,12 @@ class TestShipCommand:
 
         from yeaboi.agent.state import ShipRun
 
+        repo, _ = self._git_repo(tmp_path / "proj")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
         monkeypatch.setattr(
             "yeaboi.ship.engine.run_ship",
             lambda *a, **k: ShipRun(run_id="r", story_id="US-001", status="failed", warnings=("boom",)),
         )
-        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(tmp_path), "--strict"])
+        args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(repo), "--strict"])
         assert _run_subcommand(args) == 3
         assert "⚠ boom" in capsys.readouterr().err

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1310,3 +1310,24 @@ class TestShipTools:
         assert out["ok"] is True
         assert out["data"]["latest"] is None
         assert "max_per_hour" in out["data"]["budget"]
+
+    def test_the_stored_patch_stays_out_of_the_listing(self, tmp_db):
+        # diff_text is capped per run, not per response; a hundred runs of it
+        # is megabytes of patch nobody asked for. The stat and worktree stay.
+        from yeaboi.agent.state import ShipRun
+        from yeaboi.ship.store import ShipStore
+
+        with ShipStore(tmp_db) as store:
+            store.record_run(
+                ShipRun(
+                    run_id="run-1",
+                    story_id="US-001",
+                    status="approved",
+                    diff_stat="1 file changed",
+                    diff_text="@@ -1 +1 @@\n+enormous\n",
+                )
+            )
+        row = call_tool("ship_history")["data"]["runs"][0]
+        assert "diff_text" not in row
+        assert row["diff_stat"] == "1 file changed"
+        assert "diff_text" not in call_tool("ship_status")["data"]["latest"]

--- a/tests/unit/test_ship_costing.py
+++ b/tests/unit/test_ship_costing.py
@@ -108,3 +108,14 @@ class TestLocateTranscript:
         monkeypatch.setattr(costing, "_source_roots", lambda: (("claude_code", tmp_path),))
         assert costing.locate_transcript("../../etc/passwd") is None
         assert costing.locate_transcript("") is None
+
+    def test_rejects_glob_shaped_session_ids(self, tmp_path, monkeypatch):
+        # The id comes from the agent's own envelope and lands in an rglob
+        # pattern — a wildcard would match, and price, an unrelated run.
+        root = tmp_path / "projects"
+        (root / "some-proj").mkdir(parents=True)
+        (root / "some-proj" / "sess-42.jsonl").write_text("", encoding="utf-8")
+        monkeypatch.setattr(costing, "_source_roots", lambda: (("claude_code", root),))
+        assert costing.locate_transcript("*") is None
+        assert costing.locate_transcript("sess-4?") is None
+        assert costing.locate_transcript("sess-[0-9]*") is None

--- a/tests/unit/test_ship_driver.py
+++ b/tests/unit/test_ship_driver.py
@@ -116,13 +116,21 @@ class TestRun:
 
     def test_the_permission_envelope_is_mechanical_not_prose(self, tmp_path):
         # The "nothing pushes without approval" guarantee rests on these argv
-        # flags: acceptEdits (files editable headlessly, Bash denied) plus an
-        # explicit git-push/gh deny list. Losing them would leave only a
-        # sentence in the prompt between the agent and `git push`.
+        # flags: acceptEdits (files editable headlessly) plus a deny of the
+        # whole Bash tool. Losing them would leave only a sentence in the
+        # prompt between the agent and `git push`.
         body = "import sys, json; sys.stdin.read(); print(json.dumps({'result': ' '.join(sys.argv[1:])}))"
         result = driver.ClaudeCodeDriver(binary=_make_shim(tmp_path, body)).run("go", tmp_path)
         assert "--permission-mode acceptEdits" in result.output
-        assert "--disallowedTools Bash(git push:*) Bash(gh:*)" in result.output
+        assert "--disallowedTools Bash" in result.output
+
+    def test_the_deny_is_the_whole_tool_not_a_command_pattern(self):
+        # A pattern deny (`Bash(git push:*)`) is porous — `git -c … push` and
+        # an edit to `.git/config` sit outside it — and the child still reads
+        # the *target repo's* .claude/settings.json allow list, which for this
+        # very repo starts `Bash(make test)`. Only a whole-tool deny holds.
+        assert "Bash" in driver._PERMISSION_ARGS
+        assert not any(arg.startswith("Bash(") for arg in driver._PERMISSION_ARGS)
 
 
 class TestAvailability:

--- a/tests/unit/test_ship_engine.py
+++ b/tests/unit/test_ship_engine.py
@@ -215,6 +215,56 @@ class TestHappyPath:
         ).stdout
         assert run.branch in heads
 
+    def test_the_run_id_reaches_the_caller_before_the_gate_opens(self, ship_env):
+        # Surfaces poll a shared store for the gate; identifying "my run" by
+        # elimination stops being true the moment two runs are allowed at
+        # once, and then someone approves a diff they never saw.
+        seen: list[str] = []
+        resolver = _resolver(ship_env.db, ["approved"])
+        run = engine.run_ship(
+            "US-001",
+            str(ship_env.repo),
+            db_path=ship_env.db,
+            driver=FakeDriver(behaviors=("work",)),
+            on_run_id=seen.append,
+        )
+        resolver.join(timeout=5)
+        assert seen == [run.run_id]
+
+    def test_the_run_id_is_handed_over_even_when_the_run_fails(self, ship_env):
+        seen: list[str] = []
+        run = engine.run_ship(
+            "US-001",
+            str(ship_env.repo),
+            db_path=ship_env.db,
+            driver=FakeDriver(behaviors=("nothing",)),
+            on_run_id=seen.append,
+        )
+        assert run.status == "failed"
+        assert seen == [run.run_id]
+
+    def test_a_raising_run_id_callback_does_not_kill_the_run(self, ship_env):
+        def _boom(_run_id):
+            raise RuntimeError("a surface hiccup")
+
+        resolver = _resolver(ship_env.db, ["approved"])
+        run = engine.run_ship(
+            "US-001",
+            str(ship_env.repo),
+            db_path=ship_env.db,
+            driver=FakeDriver(behaviors=("work",)),
+            on_run_id=_boom,
+        )
+        resolver.join(timeout=5)
+        assert run.status == "approved", run.warnings
+
+    def test_the_patch_travels_with_the_artifact(self, ship_env):
+        resolver = _resolver(ship_env.db, ["approved"])
+        run = engine.run_ship("US-001", str(ship_env.repo), db_path=ship_env.db, driver=FakeDriver(("work",)))
+        resolver.join(timeout=5)
+        assert "agent_1.py" in run.diff_text
+        assert run.diff_text.startswith("diff --git")
+
     def test_progress_events_cover_every_phase(self, ship_env):
         events: list[dict] = []
         resolver = _resolver(ship_env.db, ["approved"])

--- a/tests/unit/test_ship_page.py
+++ b/tests/unit/test_ship_page.py
@@ -1,0 +1,183 @@
+"""Tests for the Ship TUI page loop (ui/mode_select/_ship.py).
+
+The page loop is where two of the gate's guarantees actually live: the repo a
+run is launched against is the *git toplevel* (so the consent prompt names what
+will be written), and the patch pane scrolls through the shared ``_scroll``
+helpers rather than a hand-rolled offset that can drift past the last line.
+
+The loop itself is driven with a scripted ``read_key`` and a fake Live, the
+same shape the other page-loop tests use — no terminal, no threads.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from yeaboi.agent.state import ShipRun, ShipValidation
+from yeaboi.tools.local_git import git_subprocess_env
+from yeaboi.ui.mode_select import _ship
+
+
+def _git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, env=git_subprocess_env())
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A real repo with a subdirectory and one commit."""
+    root = tmp_path / "proj"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "README.md").write_text("hi\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-q", "-m", "init")
+    (root / "src").mkdir()
+    return root
+
+
+class TestResolveTarget:
+    def test_a_subdirectory_resolves_to_the_toplevel(self, repo):
+        # Consent is checked against what comes back, and every write lands on
+        # the toplevel — so a subdirectory must not be what gets granted.
+        target, problem = _ship._resolve_target(str(repo / "src"))
+        assert problem == ""
+        assert target == str(repo)
+
+    def test_a_dirty_repo_is_refused_by_name(self, repo):
+        (repo / "README.md").write_text("changed\n", encoding="utf-8")
+        target, problem = _ship._resolve_target(str(repo))
+        assert target == str(repo)
+        assert "uncommitted changes" in problem
+
+    def test_a_path_outside_any_repo_has_no_target(self, tmp_path):
+        target, problem = _ship._resolve_target(str(tmp_path))
+        assert target == ""
+        assert problem  # git's own words; the caller shows them and stops
+
+
+class _Live:
+    """Captures whatever the loop renders; the last frame is the assertion."""
+
+    def __init__(self):
+        self.frames: list = []
+
+    def update(self, renderable):
+        self.frames.append(renderable)
+
+
+class _Console:
+    size = (84, 40)
+
+
+class _Store:
+    """A stand-in ShipStore that records how the gate was resolved."""
+
+    def __init__(self):
+        self.resolved: list[tuple[str, str, str]] = []
+
+    def resolve_gate(self, run_id, resolution, comment=""):
+        self.resolved.append((run_id, resolution, comment))
+        return True
+
+
+def _keys(*sequence):
+    """A read_key that plays a script; timeout=0.0 polls drain as empty."""
+    remaining = list(sequence)
+
+    def _read(timeout=None):
+        if timeout == 0.0:
+            return ""  # nothing buffered — ends a coalesced scroll burst
+        return remaining.pop(0) if remaining else "esc"
+
+    return _read
+
+
+def _gated_run(**overrides):
+    base = {
+        "run_id": "run-1",
+        "story_id": "US-001",
+        "branch": "ship/run-1",
+        "worktree": "/tmp/wt/run-1",
+        "status": "awaiting_approval",
+        "diff_stat": "src/app.py | 2 +-\n1 file changed",
+        "diff_text": "\n".join(f"+line {n:03d}" for n in range(200)),
+        "validation": ShipValidation(configured=True, command="make test", passed=True, exit_code=0),
+    }
+    return ShipRun(**{**base, **overrides})
+
+
+class TestGateLoop:
+    def _run_loop(self, keys, store=None, run=None):
+        live, cancel = _Live(), __import__("threading").Event()
+        outcome = _ship._gate_loop(
+            _Console(),
+            live,
+            keys,
+            0.05,
+            True,
+            store or _Store(),
+            run or _gated_run(),
+            cancel,
+        )
+        return outcome, live, cancel
+
+    def test_enter_on_approve_resolves_the_gate(self):
+        store = _Store()
+        outcome, _live, _cancel = self._run_loop(_keys("enter"), store=store)
+        assert outcome == "resolved"
+        assert store.resolved == [("run-1", "approved", "")]
+
+    def test_esc_keeps_the_run_waiting_without_answering(self):
+        store = _Store()
+        outcome, _live, _cancel = self._run_loop(_keys("esc"), store=store)
+        assert outcome == "resolved"  # back to the progress screen
+        assert store.resolved == []  # …but nothing was approved or rejected
+
+    def test_cancel_run_sets_the_event(self):
+        outcome, _live, cancel = self._run_loop(_keys("right", "right", "enter"))
+        assert outcome == "cancelled"
+        assert cancel.is_set()
+
+    @pytest.mark.parametrize("key", ["down", "pagedown", "end", "scroll_down"])
+    def test_every_scroll_key_moves_the_patch(self, key):
+        # pgup/pgdn used to be spelled "pgup"/"pgdn" here and simply never
+        # fired — read_key emits "pageup"/"pagedown". Routing through
+        # SCROLL_KEYS is what makes the whole family work at once.
+        _outcome, live, _cancel = self._run_loop(_keys(key, "esc"))
+        first, second = _render(live.frames[0]), _render(live.frames[1])
+        assert "+line 000" in first
+        assert first != second
+
+    def test_scrolling_past_the_end_does_not_strand_the_offset(self):
+        # The builder publishes the true maximum, so five "end"s land on the
+        # same offset as one and a single "up" moves visibly. A loop keeping
+        # its own counter would need four dead keypresses to come back.
+        _outcome, live, _cancel = self._run_loop(_keys(*(["end"] * 5), "up", "esc"))
+        # One frame is painted before each key is read, so the last two are
+        # "parked at the bottom" and "one line back up".
+        at_bottom = _render(live.frames[-2])
+        after_one_up = _render(live.frames[-1])
+        assert "+line 199" in at_bottom
+        assert "+line 199" not in after_one_up
+        assert "+line 198" in after_one_up
+
+    def test_rejection_sends_the_typed_comment(self):
+        store = _Store()
+        keys = _keys("right", "enter", "n", "o", "enter")
+        outcome, _live, _cancel = self._run_loop(keys, store=store)
+        assert outcome == "resolved"
+        assert store.resolved == [("run-1", "rejected", "no")]
+
+
+def _render(panel, width: int = 84, height: int = 40) -> str:
+    import io
+
+    from rich.console import Console
+
+    console = Console(file=io.StringIO(), width=width, height=height)
+    console.print(panel)
+    return console.file.getvalue()

--- a/tests/unit/test_ship_pipeline.py
+++ b/tests/unit/test_ship_pipeline.py
@@ -7,6 +7,7 @@ a real git tree can prove that distinction.
 
 from __future__ import annotations
 
+import dataclasses
 import subprocess
 
 import pytest
@@ -121,6 +122,29 @@ class TestDiffBridge:
         has_work, stat = pipeline.diff_bridge(prepared)
         assert has_work
         assert "done.py" in stat
+
+
+class TestDiffText:
+    def test_the_patch_itself_reaches_the_gate(self, prepared):
+        path = worktree._validate_owned(prepared.path)
+        (path / "new.py").write_text("x = 1\n", encoding="utf-8")
+        pipeline.diff_bridge(prepared)  # commit the work
+        patch = pipeline.diff_text(prepared)
+        assert "+x = 1" in patch
+        assert "new.py" in patch
+
+    def test_a_runaway_diff_is_capped_with_the_command_to_read_the_rest(self, prepared):
+        path = worktree._validate_owned(prepared.path)
+        (path / "big.py").write_text("y = 2\n" * 5000, encoding="utf-8")
+        pipeline.diff_bridge(prepared)
+        patch = pipeline.diff_text(prepared, max_chars=500)
+        assert len(patch) < 900  # the cap plus the trailer, not the whole file
+        assert "truncated at 500 characters" in patch
+        assert f"git -C {prepared.path} diff" in patch
+
+    def test_an_unreadable_diff_is_empty_not_an_exception(self, prepared):
+        broken = dataclasses.replace(prepared, base_sha="not-a-real-sha")
+        assert pipeline.diff_text(broken) == ""
 
 
 class TestRunValidation:

--- a/tests/unit/test_ship_render.py
+++ b/tests/unit/test_ship_render.py
@@ -53,6 +53,31 @@ class TestFormatRun:
         out = _render(format_run_rich(ShipRun()))
         assert "(no story)" in out
 
+    def test_the_gate_rendering_carries_the_patch_and_the_worktree(self):
+        # show_diff is what the CLI gate passes: approving a push on a file
+        # count is not review.
+        run = ShipRun(
+            run_id="run-1",
+            story_id="US-001",
+            worktree="/tmp/wt/run-1",
+            diff_stat="src/app.py | 2 +-\n1 file changed",
+            diff_text="@@ -1 +1 @@\n-old = 1\n+new = 2\n",
+        )
+        out = _render(format_run_rich(run, show_diff=True))
+        assert "+new = 2" in out
+        assert "-old = 1" in out
+        assert "/tmp/wt/run-1" in out
+        assert "src/app.py" in out  # the whole stat, not only its last line
+
+    def test_the_summary_rendering_stays_a_summary(self):
+        run = ShipRun(run_id="r", story_id="US-1", diff_text="@@ -1 +1 @@\n+leaked into the summary\n")
+        assert "leaked into the summary" not in _render(format_run_rich(run))
+
+    def test_an_unreadable_patch_is_a_warning_at_the_gate(self):
+        run = ShipRun(run_id="r", story_id="US-1", diff_stat="1 file changed", diff_text="")
+        out = _render(format_run_rich(run, show_diff=True))
+        assert "could not be read" in out
+
 
 class TestFormatHistory:
     def test_empty_history_names_the_next_step(self):

--- a/tests/unit/test_ship_render.py
+++ b/tests/unit/test_ship_render.py
@@ -73,6 +73,20 @@ class TestFormatRun:
         run = ShipRun(run_id="r", story_id="US-1", diff_text="@@ -1 +1 @@\n+leaked into the summary\n")
         assert "leaked into the summary" not in _render(format_run_rich(run))
 
+    def test_control_characters_in_the_patch_never_reach_the_terminal(self):
+        # rich's Text strips BEL/BS/VT/FF/CR but not ESC, and the patch is
+        # agent-authored: an escape sequence at the CLI gate could repaint over
+        # what the approver is reading before they answer the prompt.
+        run = ShipRun(
+            run_id="r",
+            story_id="US-1",
+            diff_stat="1 file changed",
+            diff_text="+innocent\n+\x1b[2J\x1b[Hwiped\n",
+        )
+        out = _render(format_run_rich(run, show_diff=True))
+        assert "\x1b[2J" not in out
+        assert "wiped" in out
+
     def test_an_unreadable_patch_is_a_warning_at_the_gate(self):
         run = ShipRun(run_id="r", story_id="US-1", diff_stat="1 file changed", diff_text="")
         out = _render(format_run_rich(run, show_diff=True))

--- a/tests/unit/test_ship_screens.py
+++ b/tests/unit/test_ship_screens.py
@@ -29,8 +29,8 @@ from yeaboi.ui.mode_select.screens._screens_ship import (
 )
 
 
-def _render(panel, width: int = 100) -> str:
-    console = Console(file=io.StringIO(), width=width, height=40)
+def _render(panel, width: int = 100, height: int = 40) -> str:
+    console = Console(file=io.StringIO(), width=width, height=height)
     console.print(panel)
     return console.file.getvalue()
 
@@ -120,6 +120,12 @@ class TestProgressScreen:
 
 
 class TestGateScreen:
+    # The TUI refuses to run below 84x40 (`_screens.py` _MIN_WIDTH/_MIN_HEIGHT),
+    # so the gate is asserted at the smallest window a user can actually be in
+    # — the builder's own 24-row default is a size the app never renders.
+    def _gate(self, run, *, width: int = 84, height: int = 40, **kwargs) -> str:
+        return _render(_build_ship_gate_screen(run, width=width, height=height, **kwargs), width=width, height=height)
+
     def _run(self, **overrides):
         base = ShipRun(
             run_id="run-1",
@@ -133,7 +139,7 @@ class TestGateScreen:
         return ShipRun(**{**base.__dict__, **overrides})
 
     def test_shows_diff_validation_and_cost(self):
-        out = _render(_build_ship_gate_screen(self._run()))
+        out = self._gate(self._run())
         assert "US-001" in out
         assert "ship/run-1" in out
         assert "2 files changed" in out
@@ -147,23 +153,23 @@ class TestGateScreen:
                 configured=True, command="make test", passed=False, exit_code=2, output_tail="FAILED test_x"
             )
         )
-        out = _render(_build_ship_gate_screen(run))
+        out = self._gate(run)
         assert "FAILED" in out
         assert "FAILED test_x" in out
 
     def test_no_validation_is_a_visible_warning_not_silence(self):
         run = self._run(validation=ShipValidation())
-        out = _render(_build_ship_gate_screen(run))
+        out = self._gate(run)
         assert "nothing was proven" in out
 
     def test_transcript_findings_surface_as_labels_only(self):
         run = self._run(transcript_findings=(("secret", "critical", "anthropic api key"),))
-        out = _render(_build_ship_gate_screen(run))
+        out = self._gate(run)
         assert "anthropic api key" in out
         assert "1 transcript finding" in out
 
     def test_rejection_comment_editor_renders(self):
-        out = _render(_build_ship_gate_screen(self._run(), comment_edit="wrong file"))
+        out = self._gate(self._run(), comment_edit="wrong file")
         assert "Why reject?" in out
         assert "wrong file" in out
 
@@ -171,22 +177,65 @@ class TestGateScreen:
         # The gate is the only control before a push; approving on a --stat
         # summary is not review.
         patch = "diff --git a/app.py b/app.py\n@@ -1,2 +1,2 @@\n-old = 1\n+new = 2\n"
-        out = _render(_build_ship_gate_screen(self._run(diff_text=patch, worktree="/tmp/wt/run-1"), height=40))
+        out = self._gate(self._run(diff_text=patch, worktree="/tmp/wt/run-1"))
         assert "+new = 2" in out
         assert "-old = 1" in out
         assert "/tmp/wt/run-1" in out  # where to read the rest out of band
 
     def test_a_long_patch_scrolls_rather_than_truncating_silently(self):
         patch = "\n".join(f"+line {n:03d}" for n in range(200))
-        top = _render(_build_ship_gate_screen(self._run(diff_text=patch), diff_offset=0))
-        scrolled = _render(_build_ship_gate_screen(self._run(diff_text=patch), diff_offset=100))
+        top = self._gate(self._run(diff_text=patch), diff_offset=0)
+        scrolled = self._gate(self._run(diff_text=patch), diff_offset=100)
         assert "+line 000" in top
         assert "+line 000" not in scrolled
         assert "+line 100" in scrolled
 
     def test_an_unreadable_patch_says_so_instead_of_looking_clean(self):
-        out = _render(_build_ship_gate_screen(self._run(diff_text="")))
+        out = self._gate(self._run(diff_text=""))
         assert "could not be read" in out
+
+    def test_the_buttons_survive_a_crowded_gate_at_the_minimum_terminal_size(self):
+        # The pane takes what is left and no more. A Panel of fixed height
+        # crops from the bottom, and a cropped button row still answers Enter
+        # with "Approve" — which is a push nobody could see the buttons for.
+        run = self._run(
+            diff_stat="\n".join(f"src/f{n}.py | 4 ++--" for n in range(8)) + "\n8 files changed",
+            diff_text="\n".join(f"+line {n:03d}" for n in range(500)),
+            validation=ShipValidation(
+                configured=True,
+                command="make test",
+                passed=False,
+                exit_code=1,
+                output_tail="\n".join(f"FAILED test_{n}" for n in range(8)),
+            ),
+            transcript_findings=(
+                ("secret", "critical", "api key"),
+                ("risky_tool", "high", "curl | sh"),
+                ("secret", "high", "token"),
+                ("risky_tool", "medium", "rm -rf"),
+            ),
+            rejection_count=1,
+        )
+        for width, height in ((84, 40), (100, 40), (120, 24)):
+            out = self._gate(run, width=width, height=height)
+            assert "Approve" in out, f"buttons cropped at {width}x{height}"
+            assert "Reject" in out, f"buttons cropped at {width}x{height}"
+
+    def test_a_window_too_short_for_both_drops_the_pane_and_says_where_to_look(self):
+        run = self._run(diff_text="\n".join(f"+line {n}" for n in range(200)), worktree="/tmp/wt/run-1")
+        out = self._gate(run, height=22)
+        assert "Approve" in out
+        assert "patch hidden" in out
+        assert "/tmp/wt/run-1" in out
+
+    def test_the_builder_publishes_the_panes_geometry_to_the_loop(self):
+        # The loop clamps with these numbers; a builder that clamps privately
+        # is the "scrolling sometimes does nothing" bug _scroll.py exists for.
+        meta: dict = {}
+        run = self._run(diff_text="\n".join(f"+line {n}" for n in range(200)))
+        self._gate(run, scroll_meta=meta)
+        assert meta["max_offset"] == 200 - meta["viewport_h"]
+        assert meta["viewport_h"] >= 3
 
 
 class TestResultScreen:

--- a/tests/unit/test_ship_screens.py
+++ b/tests/unit/test_ship_screens.py
@@ -167,6 +167,27 @@ class TestGateScreen:
         assert "Why reject?" in out
         assert "wrong file" in out
 
+    def test_the_patch_itself_is_on_the_screen_not_just_a_file_count(self):
+        # The gate is the only control before a push; approving on a --stat
+        # summary is not review.
+        patch = "diff --git a/app.py b/app.py\n@@ -1,2 +1,2 @@\n-old = 1\n+new = 2\n"
+        out = _render(_build_ship_gate_screen(self._run(diff_text=patch, worktree="/tmp/wt/run-1"), height=40))
+        assert "+new = 2" in out
+        assert "-old = 1" in out
+        assert "/tmp/wt/run-1" in out  # where to read the rest out of band
+
+    def test_a_long_patch_scrolls_rather_than_truncating_silently(self):
+        patch = "\n".join(f"+line {n:03d}" for n in range(200))
+        top = _render(_build_ship_gate_screen(self._run(diff_text=patch), diff_offset=0))
+        scrolled = _render(_build_ship_gate_screen(self._run(diff_text=patch), diff_offset=100))
+        assert "+line 000" in top
+        assert "+line 000" not in scrolled
+        assert "+line 100" in scrolled
+
+    def test_an_unreadable_patch_says_so_instead_of_looking_clean(self):
+        out = _render(_build_ship_gate_screen(self._run(diff_text="")))
+        assert "could not be read" in out
+
 
 class TestResultScreen:
     def test_approved_run_shows_pr_and_phases(self):

--- a/tests/unit/test_ship_screens.py
+++ b/tests/unit/test_ship_screens.py
@@ -221,6 +221,45 @@ class TestGateScreen:
             assert "Approve" in out, f"buttons cropped at {width}x{height}"
             assert "Reject" in out, f"buttons cropped at {width}x{height}"
 
+    def test_full_width_patch_lines_and_a_real_worktree_path_do_not_crop_the_buttons(self):
+        # A wrapped row is a row the layout did not count. Patch lines at this
+        # repo's own 120-column limit and a real ~/.yeaboi worktree path are
+        # the normal case, not the edge one.
+        run = self._run(
+            worktree="/Users/somebody/.yeaboi/ship/worktrees/yeaboi-ai/us-001-20260817083000-a1b2c3",
+            branch="ship/us-001-20260817083000-a1b2c3",
+            diff_stat="src/some/deeply/nested/module_with_a_very_long_name.py | 40 +++++++++-----\n1 file changed",
+            diff_text="\n".join("+" + "x" * 118 for _ in range(200)),
+            validation=ShipValidation(
+                configured=True,
+                command="make test && make lint && make parity",
+                passed=False,
+                exit_code=1,
+                output_tail="\n".join("E   " + "y" * 116 for _ in range(6)),
+            ),
+        )
+        for width in (84, 100, 120):
+            out = self._gate(run, width=width)
+            assert "Approve" in out, f"buttons cropped at {width} columns"
+            body_rows = [line for line in out.splitlines() if line.startswith("│")]
+            assert len(body_rows) <= 40, f"panel overflowed its height at {width} columns"
+
+    def test_control_characters_in_agent_text_never_reach_the_terminal(self):
+        # The patch is written by the agent and this gate is the only control
+        # before a push: an escape sequence could repaint over what the
+        # reviewer is reading, so they approve what they saw and not what is
+        # on disk. Rich strips BEL/BS/VT/FF/CR but NOT ESC.
+        run = self._run(
+            diff_text="+innocent\n+\x1b[2J\x1b[Hwiped the screen\n",
+            validation=ShipValidation(
+                configured=True, command="make test", passed=False, exit_code=1, output_tail="\x1b[31mFAILED\x07"
+            ),
+        )
+        out = self._gate(run)
+        assert "\x1b[2J" not in out
+        assert "\x1b[31m" not in out
+        assert "wiped the screen" in out  # the text survives; only the controls go
+
     def test_a_window_too_short_for_both_drops_the_pane_and_says_where_to_look(self):
         run = self._run(diff_text="\n".join(f"+line {n}" for n in range(200)), worktree="/tmp/wt/run-1")
         out = self._gate(run, height=22)

--- a/tests/unit/test_ship_store.py
+++ b/tests/unit/test_ship_store.py
@@ -34,6 +34,7 @@ def _full_run(run_id="run-1", status="running"):
         phases=(ShipPhase(name="setup", status="completed", detail="ok", duration_s=1.5),),
         validation=ShipValidation(configured=True, command="make test", passed=True, exit_code=0, output_tail="ok"),
         diff_stat="2 files changed",
+        diff_text="@@ -1 +1 @@\n-old\n+new\n",
         cost_usd=0.42,
         transcript_findings=(("secret", "critical", "api key"),),
         transcript_path="/tmp/t.jsonl",
@@ -50,6 +51,7 @@ class TestRoundTrip:
         assert loaded.phases[0].duration_s == 1.5
         assert loaded.validation.command == "make test"
         assert loaded.transcript_findings == (("secret", "critical", "api key"),)
+        assert loaded.diff_text == "@@ -1 +1 @@\n-old\n+new\n"  # the patch survives history
 
     def test_list_runs_newest_first_with_limit(self, db_path):
         with ShipStore(db_path) as store:

--- a/tests/unit/test_ship_worktree.py
+++ b/tests/unit/test_ship_worktree.py
@@ -154,6 +154,16 @@ class TestRemove:
     def test_unknown_run_returns_false(self, ship_home):
         assert not worktree.remove("run-404")
 
+    def test_an_entry_naming_no_checkout_reports_failure_not_success(self, ship_home, target_repo):
+        # Nothing was deleted, so nothing may claim it was — and the row stays
+        # for a human to look at rather than being popped on the way out.
+        worktree.prepare("run-1", target_repo)
+        registry = json.loads(worktree.SHIP_WORKTREE_REGISTRY.read_text(encoding="utf-8"))
+        registry["run-1"]["path"] = ""
+        worktree.SHIP_WORKTREE_REGISTRY.write_text(json.dumps(registry), encoding="utf-8")
+        assert not worktree.remove("run-1")
+        assert worktree.get_record("run-1") is not None
+
     def test_tampered_registry_path_is_refused(self, ship_home, target_repo, tmp_path):
         worktree.prepare("run-1", target_repo)
         victim = tmp_path / "victim"

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -361,7 +361,10 @@ PARAM_PAIRS: dict[str, tuple[str, str]] = {
 }
 
 # Injection/test seams that are never exposed on any wire surface.
-HIDDEN_ALWAYS = {"db_path", "today", "on_progress", "dry_run"}
+# ``on_run_id`` joins them for the same reason as ``on_progress``: it hands a
+# caller-side callback the id of the run being started, which only a surface
+# that owns the process can use.
+HIDDEN_ALWAYS = {"db_path", "today", "on_progress", "on_run_id", "dry_run"}
 
 # Per-tool engine params deliberately not exposed on the MCP tool. Every entry
 # needs a reason; a stale entry (param gone from the engine) fails the tests.

--- a/uv.lock
+++ b/uv.lock
@@ -3370,7 +3370,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "3.18.0"
+version = "3.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Summary

Follow-up to #284, addressing all four should-fix findings from that PR's post-CI review (advisory on a hand-shipped branch, so it never held the merge — the findings were real all the same). Two of them were safety claims the code did not actually make good on.

**The agent's capability envelope is now mechanical.** The headless `claude` child was launched with `--disallowedTools "Bash(git push:*)" "Bash(gh:*)"` while the docstring, the run prompt and the changelog all said "no shell". It resolves settings we do not control — the user's `~/.claude/settings.json`, and (its cwd is a checkout of the target repo) that repo's `.claude/settings.json` too. A run against *this* repo would have handed the agent `Bash(make test)`, and a command-pattern deny is porous anyway: `git -c … push`, `git remote set-url` and an edit to `.git/config` all sit outside it. The deny is now the whole `Bash` tool, which outranks every allow rule from every source.

**Consent is checked against the git toplevel.** `fs_policy` containment is `is_relative_to`, so granting `~/code/repo/src` never granted `~/code/repo` — but `worktree.prepare` resolves to the toplevel and every write lands there (`git worktree add` into `<toplevel>/.git`, the later push). Both surfaces now resolve the toplevel *before* the consent prompt and run against it, so the prompt names the directory that is actually touched.

**The gate shows the change.** It rendered `git diff --stat` — eight stat lines in the TUI, the last line only in the CLI — and neither surface showed the worktree path, so the only control before a push was answered on a file count. `ShipRun` now carries `diff_text` (captured by `pipeline.diff_text()`, capped with a trailer naming the git command for the rest); the TUI gate has a scrollable tinted patch pane and the CLI prints the patch inline, both with the worktree path. The stored patch is stripped from the MCP listings — capped per run is not capped per response.

**A gate answers only its own run.** Both loops identified "my run" as "one that was not in the store snapshot I took before launching", which stops being true the moment `YEABOI_AI_MAX_CONCURRENT` > 1 or `YEABOI_AI_BUDGET_DISABLE=1`: another terminal's run opening its gate after the snapshot would be offered to this user to approve and push. `run_ship(..., on_run_id=…)` hands the id back as soon as it is minted, and the heuristic is gone.

An independent pre-PR review then found that the new patch pane could crop the gate's own button row at the enforced minimum terminal size (84x40) — and a gate whose buttons are off screen still answers Enter with "Approve". The gate now measures its rows exactly, gives the elastic sections (validation tail, findings, stat) back in priority order to make room, and drops the pane with a pointer to the worktree rather than ever pushing the buttons off. Its scrolling moved onto the shared `ui/shared/_scroll.py` helpers, which also fixed dead Page Up/Down keys (`read_key` emits `pageup`/`pagedown`, not `pgup`/`pgdn`) and an offset that could run past the last line. The same review's remaining points are in here too: the "nothing reaches origin" claim is now scoped to what argv actually delivers (the validation command still runs a shell in the worktree before the gate, and `--strict-mcp-config` closes the MCP push path), both loops fetch their run by id instead of scanning a bounded newest-first page that concurrency could push it off, run ids carry a random suffix so two same-second runs of one story cannot collide, and the full `--stat` is now the gate's alone rather than every status line's.

Two nits from the same review: `costing.locate_transcript` whitelists the session-id shape (it came from the agent's own JSON envelope and went straight into an `rglob` pattern, where a `*` would have matched and priced an unrelated run), and `worktree.remove()` reports `False` rather than `True` when the registry entry names no checkout. The third nit — `get_ship_log_dir()` having no caller — is deliberate: `paths.py`'s `get_*_log_dir` exports are the API the Observability rule requires, and the hygiene-lens policy already records that shape as unadopted rather than dead.

No schema change (`diff_text` rides the existing run JSON), no new capability, and `ship/` remains off every Go-mirrored surface.

## Test plan

- `make ship-gate` green: lint, format-check, the full suite, security scan, and the preflight jobs this diff needs.
- New tests, each verified to fail without its fix: the whole-tool deny (`test_ship_driver.py`), consent landing on the toplevel and a foreign run never being prompted (`test_cli_subcommands.py`), the patch reaching and scrolling in both gates (`test_ship_screens.py`, `test_ship_render.py`), `diff_text` capping with its trailer and surviving the store round-trip (`test_ship_pipeline.py`, `test_ship_store.py`), `on_run_id` firing exactly once on success and on failure and surviving a raising callback (`test_ship_engine.py`), the glob-shaped session id (`test_ship_costing.py`), and the empty-entry removal (`test_ship_worktree.py`).
- Manual: `yeaboi ship run US-001 --dry-run` renders the canned artifact unchanged.

Closes YEA-111
