### PR TITLE
run the migration campaign hourly, and stop two sessions sharing a wave

### DIFF
--- a/cowork/README.md
+++ b/cowork/README.md
@@ -330,7 +330,7 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 | `cron/release-promote-ask.md` | `0 9 * * 1` Mon | — | `fast` | https://claude.ai/code/routines/trig_01G4TuU1wYY7GXJ1cEXZUNSu |
 | `cron/cd-deploy.md` | `0 4 * * *` daily + push (any branch) | — | `standard` | https://claude.ai/code/routines/trig_01AkW6ojpjKcra8H64R3Astr |
 | `cron/retune.md` | `0 8 * * 0` Sun | fleet | `standard` | https://claude.ai/code/routines/trig_01KYYfRyy1kKCYXq8EFn6ac6 |
-| `cron/go-migration-campaign.md` | `40 7 * * 1-5` weekdays | go-migration | `heavy` | https://claude.ai/code/routines/trig_01M9VRz8rvNTusXLuxBwzwSB |
+| `cron/go-migration-campaign.md` | `0 * * * *` hourly | go-migration | `heavy` | https://claude.ai/code/routines/trig_01M9VRz8rvNTusXLuxBwzwSB |
 | `cron/go-migration-daily.md` | `0 17 * * *` daily | go-migration | `fast` | https://claude.ai/code/routines/trig_01A9NbWuCDoS137MH3u3scsn |
 | `events/pr-opened-dod-audit.md` | PR opened / synchronized | — | `standard` | https://claude.ai/code/routines/trig_01Egz2NXy4GwzJzRRC7Z4Zm3 |
 | `events/pr-merged-close-loop.md` | PR closed (merged) | — | `fast` | https://claude.ai/code/routines/trig_019gLyX5qWx7g5rXZkUKaDAo |

--- a/cowork/routines/cron/go-migration-campaign.md
+++ b/cowork/routines/cron/go-migration-campaign.md
@@ -1,6 +1,6 @@
 # go migration campaign
 
-**Trigger** — cron `40 7 * * 1-5` (weekdays 07:40 UTC)
+**Trigger** — cron `0 * * * *` (hourly)
 **Summary** — advances the current Go-migration wave by one phase, or opens the next wave
 **Workstream** — [`workstreams/go-migration.md`](../../workstreams/go-migration.md)
 **Model** — `heavy` ([models.md](../../models.md))
@@ -8,10 +8,27 @@
 The fleet's second building lane. The program of record is
 [`cowork/migration/program.md`](../../migration/program.md); the lane and its approval story
 are [`house-rules.md`](../../house-rules.md), **The migration lane** — read both, the charter,
-and the program doc's §5 conventions before anything else. `40 7` on purpose: `0 7` carries
-sweeps, `20 7` the integrations campaign, `30 7` the fortnightlies.
+and the program doc's §5 conventions before anything else.
+
+**Hourly, because the program is a fixed amount of work and the cron was the only thing making
+it slow.** Thirteen waves is roughly a hundred phase-runs; at five runs a week that is five
+months, and at one an hour it is about four days. One run still advances exactly one phase —
+nothing about the unit of work changed, only how often the unit is attempted. `0 * * * *` is the
+floor the routines API allows; a shorter interval is rejected, not merely discouraged.
+
+**Two sessions must never work one wave branch.** An hourly cron will fire again while a long
+phase is still running, and the second session would read the same spec, implement the same
+phase, and race the first to push. Step 0 is what stops that, and it is not optional.
 
 ## Run
+
+0. **Take the lane, or leave.** `git fetch origin` and look at the wave branch this run would
+   touch (`cowork/migration-w<N>`, or the branch of the open wave PR from step 1).
+   **If its newest commit is under 90 minutes old, exit immediately and say so in the run log** —
+   another session is mid-phase, and a phase is allowed to take longer than an hour. Do the same
+   if `git push` is rejected as non-fast-forward at any later point: that is the same collision
+   seen from the other end, and the answer is always to exit rather than to force or to merge.
+   A skipped hour costs one hour; two sessions writing one phase costs the wave.
 
 1. **Work in flight.** `gh pr list --label "workstream:go-migration" --state open`. If one is
    open, drive it to green on both halves — CI via `gh pr checks` (the `Go core` and


### PR DESCRIPTION
Thirteen waves is roughly **a hundred phase-runs**. At `40 7 * * 1-5` that is about five months. At one an hour it is about four days, plus the ~13 merge gates — so the cron was the entire schedule, not the work.

The unit of work is unchanged: one run still advances exactly one phase. Nothing about scope, gating or review moves. `0 * * * *` is the routines API's floor — a shorter interval is rejected outright.

## The one thing hourly firing breaks

A phase can take longer than an hour. The next fire would then read the same spec, implement the same phase, and race the first session to push the same branch — a failure the old five-a-week cadence could not produce.

**Step 0 takes the lane or leaves it.** If the wave branch has a commit under 90 minutes old, another session is mid-phase and this run exits. A `git push` rejected as non-fast-forward is the same collision seen from the other end, and the answer is the same — exit, never force and never merge. A skipped hour costs an hour; two sessions writing one phase costs the wave.

## Why not parallel lanes

The program sanctions four parallel worktrees after W8, and I costed it. It is not needed: serial-hourly already lands inside the target, and parallel lanes would require relaxing **one open PR per workstream** — the guardrail that makes a many-session wave serial in the first place. Lanes stay available if the real throughput lags the estimate, which the daily post will show within two days.

## Verification

`make cowork-check` clean; `make lint` clean; `tests/unit/test_cowork_setup.py` 876 passed. The cron in the routine file and the README table agree, which is what `cowork-check` enforces.

Generated with [Claude Code](https://claude.com/claude-code)
