### PR TITLE
carry main forward on the wave branch, not by pushing at the integration branch

### DIFF
--- a/cowork/routines/cron/go-migration-campaign.md
+++ b/cowork/routines/cron/go-migration-campaign.md
@@ -33,34 +33,39 @@ phase, and race the first to push. Step 0 is what stops that, and it is not opti
 1. **Work in flight.** `gh pr list --label "workstream:go-migration" --state open`. If one is
    open, drive it to green on both halves — CI via `gh pr checks` (the `Go core` and
    `Python ↔ Go parity` checks must be present and green, not skipped), review via the
-   `pr-feedback` status — merge it per step 6 the moment both are green, and **stop**. That is
+   `pr-feedback` status — merge it per step 5 the moment both are green, and **stop**. That is
    the whole run and the normal weekday.
 
-2. **Carry `main` forward.** With nothing in flight, merge `origin/main` into
-   `chore/go-migration` and push. The integration branch is long-lived — thirteen waves live on
-   it before any of it reaches `main` — so `main` keeps moving underneath it (Dependabot, a
-   human's own work). Merging forward once per wave keeps each conflict small and local to the
-   wave that caused it; skipping it saves nothing and hands the final PR every conflict at once.
-   If the merge conflicts, resolve it, run `make test-scoped`, and treat that as the whole run.
-
-3. **Which wave?** Read the program doc's §3 table. The next wave is the first unchecked row
+2. **Which wave?** Read the program doc's §3 table. The next wave is the first unchecked row
    whose ordering dependencies (§3, **Ordering**) are all checked. Never infer progress from
    memory or from Slack — the table and
    `gh pr list --label "workstream:go-migration" --state merged` are the state.
 
-4. **Spec first.** If the wave has no `## PR N — Wave X` section in the program doc yet, this
+3. **Spec first.** If the wave has no `## PR N — Wave X` section in the program doc yet, this
    run writes one — following the §6/§7 template: verified ground truth, scope in/out, the
    gate, phase commits, lockstep bumps, risks — commits it on the wave branch as phase 0, and
    stops. Code starts next run, against a spec that exists.
 
-5. **Advance one phase.** On branch `cowork/migration-w<N>`, **cut from and based on
+4. **Advance one phase.** On branch `cowork/migration-w<N>`, **cut from and based on
    `chore/go-migration`** (one branch per wave, kept for the wave's whole life — **the prefix is
    load-bearing**: `scripts/pr_feedback.py`'s parity hold keys on `cowork/migration-w` plus the
    workstream label, so a wave built on any other branch name merges without its gate
    enforced; the *base* is what keeps the wave off `main`, the *prefix* is what keeps its gate
    armed, and they are independent): implement the next phase commit from the wave's
-   spec section. Every
-   phase ends green on the verification the spec names (`make go-test && make go-lint &&
+   spec section.
+
+   **On the run that creates the branch, merge `origin/main` into it first**, as its own commit
+   before any porting. The integration branch is long-lived — thirteen waves live on it before
+   any of it reaches `main` — so `main` keeps moving underneath it (Dependabot, a human's own
+   work), and carrying it forward once per wave keeps each conflict small and local to the wave
+   that caused it. It rides *this* branch rather than being pushed straight at
+   `chore/go-migration` because the integration branch's ruleset requires the six contexts on
+   anything that lands, so a direct push — even a fast-forward of commits `main` already
+   tested — is refused. Riding the wave PR costs no extra CI run, because the wave PR was going
+   to run one anyway. If the merge conflicts, resolve it, run `make test-scoped`, and treat that
+   as the whole run.
+
+   Every phase ends green on the verification the spec names (`make go-test && make go-lint &&
    make parity && make test && make lint`, as applicable). When the last phase is done: flip
    the wave's checkbox — `☐` becomes `✔`, exactly that glyph, per the program doc's own edit
    note — and add the previous wave's freeze-table entry on the same branch,
@@ -73,7 +78,7 @@ phase, and race the first to push. Step 0 is what stops that, and it is not opti
    (`gh pr create --base chore/go-migration`); a wave PR opened against `main` is wrong and
    must be re-based rather than merged.
 
-6. **Merge the wave into `chore/go-migration` once both halves are green.** CI via
+5. **Merge the wave into `chore/go-migration` once both halves are green.** CI via
    `gh pr checks` — the `Go core` and `Python ↔ Go parity` checks **present and passing, never
    skipped** — and review via the `pr-feedback` status. Then `gh pr merge <n> --merge`. This is
    the one place the fleet merges its own work, and it is bounded: the integration branch is
@@ -85,10 +90,10 @@ phase, and race the first to push. Step 0 is what stops that, and it is not opti
    already carries wave N. Keep `semver:none` on every wave — the version bump and the
    `yeaboi-core` wheel ride the final merge to `main`, once, not thirteen times.
 
-7. **Post nothing to the channel.** [`cron/go-migration-daily.md`](go-migration-daily.md) carries
+6. **Post nothing to the channel.** [`cron/go-migration-daily.md`](go-migration-daily.md) carries
    this lane's story; a building routine that also narrates is two voices for one fact.
 
-8. **Check in.** Whatever happened above — including nothing — close the run by following
+7. **Check in.** Whatever happened above — including nothing — close the run by following
    [check-in.md](../../check-in.md). It is the last thing you do.
 
 ## Stop conditions


### PR DESCRIPTION
A design bug in #293, found by testing the ruleset rather than reasoning about it.

The campaign's step 2 was *"merge `origin/main` into `chore/go-migration` and push"*. The integration branch's ruleset requires its six contexts on anything that lands, and that applies to a plain `git push` as much as to a PR merge. The actual rejection:

```
remote: - 4 of 6 required status checks have not succeeded: 1 expected.
 ! [remote rejected]   origin/main -> chore/go-migration (push declined due to repository rule violations)
```

That is a fast-forward of commits `main` had already tested, and it was still refused — correctly. So step 2 would have failed on every single run.

## The fix

Merge `main` into the **wave branch** instead, as its own commit on the run that creates the branch. Same end state — the integration branch gains `main`'s commits when the wave merges — and **no extra CI run**, because the wave PR was always going to have one. A conflict now surfaces inside the wave that has to resolve it anyway, rather than against a branch nobody is watching.

Steps renumbered: old step 2 is gone, and the merge-forward opens step 4.

## Verification

`make cowork-check` clean. The rejection above is the evidence for the change; the ruleset is unmodified and still refuses direct pushes, which is what we want it doing.

Generated with [Claude Code](https://claude.com/claude-code)
