### PR TITLE
claim the migration lane with a ref, and record the cron the account keeps

### DIFF
--- a/cowork/README.md
+++ b/cowork/README.md
@@ -330,7 +330,7 @@ Cadence is tiered to surface size — a 1.2k-LOC mode asked for findings weekly 
 | `cron/release-promote-ask.md` | `0 9 * * 1` Mon | — | `fast` | https://claude.ai/code/routines/trig_01G4TuU1wYY7GXJ1cEXZUNSu |
 | `cron/cd-deploy.md` | `0 4 * * *` daily + push (any branch) | — | `standard` | https://claude.ai/code/routines/trig_01AkW6ojpjKcra8H64R3Astr |
 | `cron/retune.md` | `0 8 * * 0` Sun | fleet | `standard` | https://claude.ai/code/routines/trig_01KYYfRyy1kKCYXq8EFn6ac6 |
-| `cron/go-migration-campaign.md` | `0 * * * *` hourly | go-migration | `heavy` | https://claude.ai/code/routines/trig_01M9VRz8rvNTusXLuxBwzwSB |
+| `cron/go-migration-campaign.md` | `54 * * * *` hourly | go-migration | `heavy` | https://claude.ai/code/routines/trig_01M9VRz8rvNTusXLuxBwzwSB |
 | `cron/go-migration-daily.md` | `0 17 * * *` daily | go-migration | `fast` | https://claude.ai/code/routines/trig_01A9NbWuCDoS137MH3u3scsn |
 | `events/pr-opened-dod-audit.md` | PR opened / synchronized | — | `standard` | https://claude.ai/code/routines/trig_01Egz2NXy4GwzJzRRC7Z4Zm3 |
 | `events/pr-merged-close-loop.md` | PR closed (merged) | — | `fast` | https://claude.ai/code/routines/trig_019gLyX5qWx7g5rXZkUKaDAo |

--- a/cowork/routines/cron/go-migration-campaign.md
+++ b/cowork/routines/cron/go-migration-campaign.md
@@ -27,15 +27,42 @@ cron, read it back, and write the stored value here.
 phase is still running, and the second session would read the same spec, implement the same
 phase, and race the first to push. Step 0 is what stops that, and it is not optional.
 
+It stops it with a **claim ref**, not with the age of the last commit, and the difference is the
+whole schedule. A commit's age cannot tell "the previous run finished twenty minutes ago" — where
+this run should start immediately — from "the previous run is still working and has not committed
+yet" — where it must not. Treating both as busy costs an hour every hour: at one phase per two
+hours the program takes eight days rather than four, which is the entire benefit of the hourly
+cron given back. A ref that a run creates when it starts and deletes when it stops says exactly
+which of the two is true.
+
 ## Run
 
-0. **Take the lane, or leave.** `git fetch origin` and look at the wave branch this run would
-   touch (`cowork/migration-w<N>`, or the branch of the open wave PR from step 1).
-   **If its newest commit is under 90 minutes old, exit immediately and say so in the run log** —
-   another session is mid-phase, and a phase is allowed to take longer than an hour. Do the same
-   if `git push` is rejected as non-fast-forward at any later point: that is the same collision
-   seen from the other end, and the answer is always to exit rather than to force or to merge.
-   A skipped hour costs one hour; two sessions writing one phase costs the wave.
+0. **Take the lane, or leave.** The lane is claimed by one ref, `refs/heads/lane/go-migration`,
+   and this step is the only thing that reads or writes it.
+
+   ```bash
+   git fetch origin '+refs/heads/lane/*:refs/remotes/origin/lane/*' --prune
+   git log -1 --format=%cI origin/lane/go-migration 2>/dev/null   # empty ⇒ unclaimed
+   ```
+
+   - **No such ref** — the lane is free. Take it: commit an empty claim
+     (`git commit --allow-empty -m "claim: <run url>"` on a branch cut from `origin/main`) and
+     `git push origin HEAD:refs/heads/lane/go-migration`. **If that push is rejected, another
+     session claimed it in the same minute — exit.** The push is the lock, and losing the race
+     is a normal outcome, not an error.
+   - **Claimed, under 90 minutes old** — a session is mid-phase. Exit immediately and say so in
+     the run log. A phase is allowed to take longer than an hour.
+   - **Claimed, over 90 minutes old** — the run that claimed it died without releasing. Say so
+     in the run log, force-delete the ref, and claim it yourself. Nothing else clears a stale
+     claim, so skipping this stalls the lane permanently.
+
+   **Release it in step 7, whatever happened** — including on an early exit from any later step,
+   and including when the run did nothing: `git push origin --delete lane/go-migration`. A run
+   that exits holding the claim costs the next 90 minutes.
+
+   The same rule from the other end: if `git push` is rejected as non-fast-forward at any later
+   point, exit rather than force or merge. A skipped hour costs one hour; two sessions writing
+   one phase costs the wave.
 
 1. **Work in flight.** `gh pr list --label "workstream:go-migration" --state open`. If one is
    open, drive it to green on both halves — CI via `gh pr checks` (the `Go core` and
@@ -100,13 +127,18 @@ phase, and race the first to push. Step 0 is what stops that, and it is not opti
 6. **Post nothing to the channel.** [`cron/go-migration-daily.md`](go-migration-daily.md) carries
    this lane's story; a building routine that also narrates is two voices for one fact.
 
-7. **Check in.** Whatever happened above — including nothing — close the run by following
-   [check-in.md](../../check-in.md). It is the last thing you do.
+7. **Release the lane, then check in.** `git push origin --delete lane/go-migration` — before
+   the check-in, so a failure in the check-in cannot leave the lane held. Then close the run by
+   following [check-in.md](../../check-in.md). Releasing is unconditional: a run that exited at
+   step 1 with nothing to do still held the claim, and still hands it back.
 
 ## Stop conditions
 
 - **An open PR on `workstream:go-migration`** → drive it, stop. One open PR per workstream is
   what makes a many-session wave serial.
+- **The lane claim is held and fresh** → exit before doing anything else, and do **not** release
+  it: it is not yours. Releasing another session's claim is the one way this design fails
+  silently, because the next fire then starts a second writer on the same branch.
 - **The next wave's ordering dependencies are unmerged** → exit quietly; the program's
   ordering is not yours to reorder.
 - **A gate that will not go green after two runs of honest effort** → comment the blocker on

--- a/cowork/routines/cron/go-migration-campaign.md
+++ b/cowork/routines/cron/go-migration-campaign.md
@@ -1,6 +1,6 @@
 # go migration campaign
 
-**Trigger** — cron `0 * * * *` (hourly)
+**Trigger** — cron `54 * * * *` (hourly, at :54)
 **Summary** — advances the current Go-migration wave by one phase, or opens the next wave
 **Workstream** — [`workstreams/go-migration.md`](../../workstreams/go-migration.md)
 **Model** — `heavy` ([models.md](../../models.md))
@@ -13,8 +13,15 @@ and the program doc's §5 conventions before anything else.
 **Hourly, because the program is a fixed amount of work and the cron was the only thing making
 it slow.** Thirteen waves is roughly a hundred phase-runs; at five runs a week that is five
 months, and at one an hour it is about four days. One run still advances exactly one phase —
-nothing about the unit of work changed, only how often the unit is attempted. `0 * * * *` is the
+nothing about the unit of work changed, only how often the unit is attempted. One hour is the
 floor the routines API allows; a shorter interval is rejected, not merely discouraged.
+
+**`54`, not `0`, and the minute is not cosmetic.** Registering `0 * * * *` does not store
+`0 * * * *`: the API moves a routine off the contended top-of-hour and stores what it chose —
+here `54`. The repo would then hold a cron the account does not, `--check` would report drift
+every run, and a `deploy` "fixing" it would post `0` and be moved again, forever. So the file
+records the minute the account actually keeps. Anything re-timing this routine should set the
+cron, read it back, and write the stored value here.
 
 **Two sessions must never work one wave branch.** An hourly cron will fire again while a long
 phase is still running, and the second session would read the same spec, implement the same


### PR DESCRIPTION
Two corrections to the hourly campaign, both found by running it rather than reading it. The second is the one that matters.

## 1. The lane claim — this is the schedule

#294 guarded against two sessions sharing a wave branch by exiting if the branch's newest commit was under 90 minutes old. That guard gives back the entire benefit of the hourly cron.

A commit's age cannot distinguish:

- *"the previous run finished twenty minutes ago"* — this run should start **now**; from
- *"the previous run is still working and has not committed yet"* — this run **must not** start.

Treating both as busy means one phase every **two** hours, not one:

```
phase takes 25m -> at the next fire the commit is 35m old -> guard says EXIT
phase takes 40m -> at the next fire the commit is 20m old -> guard says EXIT
phase takes 55m -> at the next fire the commit is  5m old -> guard says EXIT

99 phases x 2h = 198 hours = 8.2 days
```

8.2 days instead of 4.1 — the difference between inside the target and outside it.

**`refs/heads/lane/go-migration` says which of the two is true**, because a run creates it on start and deletes it on stop. The push that creates it *is* the lock: losing that race is a normal exit, not an error. A claim older than 90 minutes is a run that died, which the next run reports and clears — nothing else clears one, so skipping that would stall the lane permanently. Step 7 releases unconditionally and *before* the check-in, so a failing check-in cannot strand the lane.

Neither ruleset covers `refs/heads/lane/*`, so the create and the delete are both allowed — checked against the live rulesets, not assumed.

## 2. The cron minute

Registering `0 * * * *` does not store `0 * * * *`. The API moves a schedule off the contended top-of-hour and stores what it picked — here **`54`**. Verified by setting and reading back twice: `0` came back as `54`, `54` came back as `54`.

`compared_fields` diffs cron as an exact string, so left alone `/cowork status` would report drift on the campaign every run, and a `deploy` "fixing" it would post `0` and be moved again. Drift that repairs itself into existence. The file and the README now record what the account keeps, with the procedure for re-timing it: set, read back, write down.

## Verification

`make cowork-check` clean, `tests/unit/test_cowork_setup.py` 876 passed. The first campaign run is live as this is written — it cut `cowork/migration-w7` off the integration branch and merged `main` forward as its own commit, confirming #296.

Generated with [Claude Code](https://claude.com/claude-code)
