### PR TITLE
add contracts/site.json — the package facts the website vendors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ UV := $(or $(shell command -v uv 2>/dev/null),$(HOME)/.local/bin/uv)
 # two pytest processes in one worktree invent failures.
 .NOTPARALLEL:
 
-.PHONY: install dev test test-fast test-compat test-slow test-scoped test-v test-all lint format format-check security package-check preflight ship-gate run run-dry clean env pre-commit graph demo demo-render eval contract record smoke-test snapshot-update budget-report bump-patch bump-minor bump-major build publish help web web-dev web-check web-test web-install dev-board dev-poker dev-deck dev-editable site-seo site-check site-og site-serve pr-feedback
+.PHONY: install dev test test-fast test-compat test-slow test-scoped test-v test-all lint format format-check security package-check preflight ship-gate run run-dry clean env pre-commit graph demo demo-render eval contract record smoke-test snapshot-update budget-report bump-patch bump-minor bump-major build publish help web web-dev web-check web-test web-install dev-board dev-poker dev-deck dev-editable site-contract site-seo site-check site-og site-serve pr-feedback
 
 help: ## Show this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -312,6 +312,12 @@ desktop-dist: ## Signed installers into desktop/dist — needs the signing env v
 # dozen meta tags is exactly what rots by hand. The staleness check lives in
 # tests/unit/test_site_seo.py (so it runs in make test-fast and every CI lane);
 # site-check is the same assertion for humans.
+
+# contracts/site.json is what the website repo vendors instead of reading this
+# repo's pyproject.toml: the Python floor, the repo URL, the install target.
+# tests/unit/test_site_contract.py asserts it is fresh on every lane.
+site-contract: ## Regenerate contracts/site.json from pyproject (the facts the website vendors)
+	$(UV) run python scripts/gen_site_contract.py
 
 site-seo: ## Regenerate the SEO block, crawlable footer, ?v=, sitemap.xml and robots.txt in docs/
 	$(UV) run python scripts/gen_site_seo.py

--- a/contracts/site.json
+++ b/contracts/site.json
@@ -1,0 +1,8 @@
+{
+  "package": "yeaboi",
+  "requires_python": ">=3.10",
+  "description": "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents.",
+  "homepage": "https://yeaboi.ai",
+  "repository": "https://github.com/dinho149/yeaboi.ai",
+  "pypi": "https://pypi.org/project/yeaboi/"
+}

--- a/scripts/gen_site_contract.py
+++ b/scripts/gen_site_contract.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate ``contracts/site.json`` — the package facts the website advertises.
+
+The website lives in its own repo (``yeaboi-site``) and states things about this
+package: the Python floor in its structured data, the repo URL in its JSON-LD
+``codeRepository``, the ``pip install`` target. Those are facts about *this*
+repo, and before the split the site's generator simply read ``pyproject.toml``
+next to it.
+
+Across repos it vendors this file instead, pinned by sha (``make
+contracts-sync``). So the rule is the same one that held before: the site never
+restates a fact it can derive.
+
+``version`` is deliberately absent. ``auto-version.yml`` bumps it on every merged
+PR, and a contract that changes every release is one the site is permanently
+behind on for no benefit — the site advertises no version anywhere, by design.
+
+Usage::
+
+    uv run python scripts/gen_site_contract.py           # write
+    uv run python scripts/gen_site_contract.py --check   # assert, never write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+CONTRACT = ROOT / "contracts" / "site.json"
+
+
+def build() -> dict[str, str]:
+    """Derive the contract from pyproject's [project] table."""
+    meta = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["project"]
+    name = meta["name"]
+    return {
+        "package": name,
+        "requires_python": meta["requires-python"],
+        "description": meta["description"],
+        "homepage": meta["urls"]["Homepage"],
+        "repository": meta["urls"]["Repository"],
+        "pypi": f"https://pypi.org/project/{name}/",
+    }
+
+
+def render(contract: dict[str, str]) -> str:
+    return json.dumps(contract, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if the committed file is stale")
+    args = parser.parse_args(argv)
+
+    want = render(build())
+
+    if args.check:
+        have = CONTRACT.read_text(encoding="utf-8") if CONTRACT.exists() else ""
+        if have != want:
+            print(
+                f"{CONTRACT.relative_to(ROOT)} is stale — run `make site-contract` and commit the result",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{CONTRACT.relative_to(ROOT)} is up to date")
+        return 0
+
+    CONTRACT.parent.mkdir(parents=True, exist_ok=True)
+    CONTRACT.write_text(want, encoding="utf-8")
+    print(f"wrote {CONTRACT.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_site_contract.py
+++ b/scripts/gen_site_contract.py
@@ -26,8 +26,12 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import tomllib
 from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # 3.10 — tomllib landed in 3.11; the `dev` extra supplies the backport.
+    import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = ROOT / "pyproject.toml"

--- a/scripts/test_scope.py
+++ b/scripts/test_scope.py
@@ -79,6 +79,15 @@ AREAS: tuple[Area, ...] = (
         src=(".tooling-rev", "scripts/tooling-sync.sh", "scripts/provision.sh"),
     ),
     Area(
+        # The seam to yeaboi-site: the facts the website advertises about this
+        # package, derived from pyproject and vendored over there by sha. No
+        # `tests` — tests/unit/test_site_contract.py is in ALWAYS, because the
+        # fact that goes stale most easily (`requires-python`) lives in
+        # pyproject.toml, which no site path implies.
+        "site-contract",
+        src=("contracts/site.json", "scripts/gen_site_contract.py"),
+    ),
+    Area(
         "standup",
         src=("src/yeaboi/standup/", "src/yeaboi/mcp/tools_standup.py"),
         tests=("tests/unit/test_mcp_server.py", "tests/unit/test_standup_*.py", "tests/unit/prompts/test_standup_*.py"),
@@ -465,6 +474,11 @@ ALWAYS: tuple[str, ...] = (
     "tests/unit/test_web_assets.py",
     "tests/unit/test_web_frontend_guards.py",
     "tests/unit/test_site_seo.py",
+    # contracts/site.json is derived from pyproject.toml and consumed by another
+    # repo. The path that invalidates it — pyproject.toml — is GLOBAL, but a
+    # hand-edit of the JSON itself is claimed by one small area, so the freshness
+    # assertion belongs here rather than behind either trigger.
+    "tests/unit/test_site_contract.py",
     # repo + CI metadata
     "tests/unit/test_workflow_schema.py",
     "tests/unit/test_workflow_concurrency.py",

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -147,6 +147,29 @@ class TestFloorGuard:
             f"enum.{name} behaves differently below 3.11. Import it from `yeaboi._compat`:\n  " + "\n  ".join(offenders)
         )
 
+    def test_no_module_imports_tomllib_unguarded(self):
+        """`import tomllib` at module scope is an ImportError on 3.10.
+
+        Not in `yeaboi._compat` because the shim is an import, not a class: the
+        convention here is the two-line `sys.version_info` fork with `tomli` as
+        the fallback, which the `dev` extra supplies. This guard exists because
+        the unit lane runs on the floor only in CI, so a bare import passes
+        every local run and fails after the push.
+        """
+        offenders = []
+        for path in _python_files():
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                # Guarded imports live inside an `if`; only module-scope ones bite.
+                if not isinstance(node, ast.Module):
+                    continue
+                for stmt in node.body:
+                    if isinstance(stmt, ast.Import) and any(a.name == "tomllib" for a in stmt.names):
+                        offenders.append(f"{path.relative_to(ROOT)}:{stmt.lineno}")
+        assert not offenders, (
+            "tomllib is 3.11+. Fork on sys.version_info and fall back to `tomli as tomllib`:\n  "
+            + "\n  ".join(offenders)
+        )
+
     def test_the_shim_module_exports_exactly_what_the_guard_bans(self):
         """A construct added to __all__ without a guard arm is a silent hole; a
         guard arm for a name the shim does not export is a dead assertion."""

--- a/tests/unit/test_site_contract.py
+++ b/tests/unit/test_site_contract.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
-import tomllib
 from pathlib import Path
 
 import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # 3.10 — tomllib landed in 3.11; the `dev` extra supplies the backport.
+    import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parents[2]
 CONTRACT = ROOT / "contracts" / "site.json"

--- a/tests/unit/test_site_contract.py
+++ b/tests/unit/test_site_contract.py
@@ -1,0 +1,79 @@
+"""Guards for ``contracts/site.json`` — the package facts the website vendors.
+
+The website is its own repo now. It states this package's Python floor, repo URL
+and install target, and it takes them from a pinned copy of this file rather
+than restating them. That makes staleness here invisible from over there, so
+the freshness assertion has to live on this side.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts" / "site.json"
+_MODULE_PATH = ROOT / "scripts" / "gen_site_contract.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("gen_site_contract", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["gen_site_contract"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_generator()
+
+
+@pytest.fixture(scope="module")
+def contract() -> dict[str, str]:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+class TestFreshness:
+    def test_the_committed_contract_matches_pyproject(self) -> None:
+        """The whole point: the site cannot advertise a floor this repo has moved off."""
+        assert CONTRACT.read_text(encoding="utf-8") == gen.render(gen.build()), (
+            "contracts/site.json is stale — run `make site-contract` and commit the result"
+        )
+
+    def test_every_field_is_derived_from_pyproject(self, contract: dict[str, str]) -> None:
+        meta = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+        assert contract["package"] == meta["name"]
+        assert contract["requires_python"] == meta["requires-python"]
+        assert contract["description"] == meta["description"]
+        assert contract["homepage"] == meta["urls"]["Homepage"]
+        assert contract["repository"] == meta["urls"]["Repository"]
+
+
+class TestShape:
+    def test_it_carries_no_version(self, contract: dict[str, str]) -> None:
+        """A version here would churn the contract on every merged PR.
+
+        ``auto-version.yml`` bumps ``pyproject.toml`` on every PR branch, so a
+        version field would make the site's pin stale once per release while the
+        site displays no version anywhere. The same reasoning keeps
+        ``softwareVersion`` out of the site's structured data.
+        """
+        assert "version" not in contract
+
+    def test_the_floor_is_a_usable_specifier(self, contract: dict[str, str]) -> None:
+        """The site parses this to render "Python X.Y+" — it must stay parseable."""
+        floor = contract["requires_python"]
+        assert floor.startswith(">="), f"the site's floor parser expects a >= specifier, got {floor!r}"
+        major, _, minor = floor.lstrip(">=").split(",")[0].strip().partition(".")
+        assert major.isdigit() and minor.isdigit(), f"cannot read a X.Y floor out of {floor!r}"
+
+    def test_the_pypi_url_matches_the_package_name(self, contract: dict[str, str]) -> None:
+        assert contract["pypi"].rstrip("/").rsplit("/", 1)[-1] == contract["package"]
+
+    def test_urls_are_absolute_https(self, contract: dict[str, str]) -> None:
+        for key in ("homepage", "repository", "pypi"):
+            assert contract[key].startswith("https://"), f"{key} is not an absolute https URL"


### PR DESCRIPTION
## Summary

First of two PRs that split the marketing/docs website out into `yeaboi-site` (Phase 2 of the 5-repo refactor).

The site's generator (`scripts/gen_site_seo.py`) and both of its test files read this repo's `pyproject.toml` today — for the Python floor it advertises in structured data, the repo URL in its JSON-LD `codeRepository`, and the PyPI install target. Once the site is its own repo it can't do that, so those facts become a vendored contract: the site pins a sha and takes a copy (`make contracts-sync`, the machinery already in `yeaboi-tooling`).

This PR only *adds* the contract. Nothing is deleted here — `docs/` moves in the follow-up, after the site repo is live and Pages has been cut over, so yeaboi.ai is never down.

**No `version` field, deliberately.** `auto-version.yml` bumps `pyproject.toml` on every merged PR, so a version here would leave the site's pin stale once per release for a fact it displays nowhere — the same reasoning that already keeps `softwareVersion` out of the site's JSON-LD.

### Files

- `scripts/gen_site_contract.py` — derives the contract from `[project]`; `--check` asserts.
- `contracts/site.json` — the generated, committed artefact.
- `tests/unit/test_site_contract.py` — freshness (every field re-derived from pyproject) plus the shape guards the consumer depends on: no version, a parseable `>=X.Y` floor, PyPI URL matching the package name.
- `make site-contract`.
- `scripts/test_scope.py` — a `site-contract` area for the two source paths, and the guard in `ALWAYS`. It has to be `ALWAYS`: the path that actually invalidates the contract is `pyproject.toml`, which no site path implies.

## Test plan

- `make lint` — clean.
- `make format-check` — clean.
- `make test-scoped` — 15036 passed, 50 skipped.
- `uv run python scripts/gen_site_contract.py --check` — up to date.

## Note for the reviewer

`contracts/site.json` records `repository = https://github.com/dinho149/yeaboi.ai`, taken verbatim from `pyproject.toml`. The repo actually lives at `yeaboi-ai/yeaboi.ai` now and the old path 301s. That predates this PR and I've left it alone rather than change what the site advertises as a side effect — but pyproject's own comment argues a redirect splits link equity, so it's probably worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)