### PR TITLE
point every published URL at the org

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Powered by Claude](https://img.shields.io/badge/Powered%20by-Claude-ff6600?style=for-the-badge&logo=anthropic&logoColor=white)](https://anthropic.com)
 [![Built with LangGraph](https://img.shields.io/badge/Built%20with-LangGraph-00CED1?style=for-the-badge)](https://langchain-ai.github.io/langgraph/)
 
-[![Tests](https://img.shields.io/github/actions/workflow/status/dinho149/yeaboi.ai/ci.yml?style=for-the-badge&label=Tests&logo=github)](https://github.com/dinho149/yeaboi.ai/actions)
+[![Tests](https://img.shields.io/github/actions/workflow/status/yeaboi-ai/yeaboi.ai/ci.yml?style=for-the-badge&label=Tests&logo=github)](https://github.com/yeaboi-ai/yeaboi.ai/actions)
 [![PyPI](https://img.shields.io/pypi/v/yeaboi?style=for-the-badge&logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/yeaboi/)
 
 </div>
@@ -102,7 +102,7 @@ pipx install --python 3.12 --fetch-missing-python "yeaboi[voice]"   # equivalent
 ### From source
 
 ```bash
-git clone https://github.com/dinho149/yeaboi.ai.git
+git clone https://github.com/yeaboi-ai/yeaboi.ai.git
 cd yeaboi.ai
 make install        # installs uv, creates venv, installs dependencies
 make env            # creates .env from .env.example — add your API key

--- a/contracts/site.json
+++ b/contracts/site.json
@@ -3,7 +3,7 @@
   "requires_python": ">=3.10",
   "description": "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents.",
   "homepage": "https://yeaboi.ai",
-  "repository": "https://github.com/dinho149/yeaboi.ai",
+  "repository": "https://github.com/yeaboi-ai/yeaboi.ai",
   "pypi": "https://pypi.org/project/yeaboi/",
   "beta": {
     "label": "BETA",

--- a/packaging/scrum-agent-shim/README.md
+++ b/packaging/scrum-agent-shim/README.md
@@ -19,4 +19,4 @@ yeaboi
 ```
 
 - Homepage: https://yeaboi.ai
-- Source: https://github.com/dinho149/yeaboi.ai
+- Source: https://github.com/yeaboi-ai/yeaboi.ai

--- a/packaging/scrum-agent-shim/pyproject.toml
+++ b/packaging/scrum-agent-shim/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = ["yeaboi>=2.8.0"]
 
 [project.urls]
 Homepage = "https://yeaboi.ai"
-Repository = "https://github.com/dinho149/yeaboi.ai"
+Repository = "https://github.com/yeaboi-ai/yeaboi.ai"
 
 # Metadata-only wheel: there is no code to ship, only the dependency on `yeaboi`.
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,15 +129,15 @@ dev = [
 ]
 
 [project.urls]
-# Canonical owner, not the old omardin14 path — that still works via GitHub's
-# 301, but a redirect splits link equity and PyPI's sidebar links are real
-# backlinks from a high-authority domain. tests/unit/test_site_seo.py asserts
-# Repository here matches the codeRepository in the site's JSON-LD.
+# The org, not a personal path — the old ones still work via GitHub's 301, but a
+# redirect splits link equity and PyPI's sidebar links are real backlinks from a
+# high-authority domain. Repository travels to the site in contracts/site.json,
+# where it becomes the JSON-LD codeRepository.
 Homepage = "https://yeaboi.ai"
 Documentation = "https://yeaboi.ai/docs/index.html"
-Repository = "https://github.com/dinho149/yeaboi.ai"
-Issues = "https://github.com/dinho149/yeaboi.ai/issues"
-Changelog = "https://github.com/dinho149/yeaboi.ai/blob/main/CHANGELOG.md"
+Repository = "https://github.com/yeaboi-ai/yeaboi.ai"
+Issues = "https://github.com/yeaboi-ai/yeaboi.ai/issues"
+Changelog = "https://github.com/yeaboi-ai/yeaboi.ai/blob/main/CHANGELOG.md"
 
 [project.scripts]
 yeaboi = "yeaboi.cli:main"


### PR DESCRIPTION
The repo lives at `yeaboi-ai/yeaboi.ai`, but `pyproject.toml`, the README and the legacy `scrum-agent` shim still named `dinho149/yeaboi.ai`. GitHub 301s it, so nothing 404s — but three published surfaces state a URL that is not the repo:

- **PyPI's sidebar** — `Repository` / `Issues` / `Changelog` in `[project.urls]`.
- **The PyPI project page body** — `readme = "README.md"`, so the CI badge and the `git clone` line are rendered there too.
- **yeaboi.ai's JSON-LD `codeRepository`** — via `contracts/site.json`, regenerated here by `make site-contract`.

A redirect also splits link equity, which is the reason the comment above `[project.urls]` gives for caring — that comment was itself stale: it called the personal path canonical and cited `tests/unit/test_site_seo.py`, which moved to yeaboi-site in Phase 2. Rewritten to point at the contract instead.

**Left alone deliberately:** the old path still appears in `tests/fixtures/*.json` (Slack threads, cowork trigger and GitHub-access recordings read by `scripts/pr_feedback.py`). Those are snapshots of what the APIs actually returned; rewriting them would falsify a recording.

**Follow-up:** yeaboi-site vendors `contracts/site.json` by sha, so it is one `make contracts-sync` behind until somebody bumps its `.contracts-rev` after this merges.

`make ship-gate` green: 14447 passed / 55 skipped across 3.11–3.14, lint, format-check, security, preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)