### PR TITLE
point the last personal paths at the org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ budget-report: ## Show live prompt token counts for trend monitoring (runs token
 
 # graph, demo and demo-render read this repo and write into a yeaboi-site
 # checkout, which is where the website serves them from. Set YEABOI_SITE or keep
-# the two repos side by side; scripts/_site_repo.py explains the resolution.
+# the two repos side by side; scripts/_sibling_repos.py explains the resolution.
 graph: ## Generate the agent graph PNG into the yeaboi-site checkout
 	$(UV) run python scripts/generate_graph_png.py
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 [![Built with LangGraph](https://img.shields.io/badge/Built%20with-LangGraph-00CED1?style=for-the-badge)](https://langchain-ai.github.io/langgraph/)
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/yeaboi-ai/yeaboi.ai/ci.yml?style=for-the-badge&label=Tests&logo=github)](https://github.com/yeaboi-ai/yeaboi.ai/actions)
-[![PyPI](https://img.shields.io/pypi/v/yeaboi?style=for-the-badge&logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/yeaboi/)
 
 </div>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in yeaboi, please report it privately so
 it can be fixed before public disclosure.
 
-- **Preferred:** open a [GitHub private security advisory](https://github.com/omardin14/yeaboi.ai/security/advisories/new)
+- **Preferred:** open a [GitHub private security advisory](https://github.com/yeaboi-ai/yeaboi.ai/security/advisories/new)
   (Security → Advisories → *Report a vulnerability*).
 - **Alternatively:** email **onoureldin@gmail.com** with the details.
 

--- a/claude-plugin/yeaboi/.claude-plugin/plugin.json
+++ b/claude-plugin/yeaboi/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Omar Din"
   },
   "homepage": "https://yeaboi.ai",
-  "repository": "https://github.com/omardin14/yeaboi.ai",
+  "repository": "https://github.com/yeaboi-ai/yeaboi.ai",
   "license": "MIT",
   "keywords": ["scrum", "agile", "sprint-planning", "standup", "project-management"]
 }

--- a/claude-plugin/yeaboi/README.md
+++ b/claude-plugin/yeaboi/README.md
@@ -35,7 +35,7 @@ coding agents working alongside it. Without leaving your coding agent.
 ## Install
 
 ```bash
-claude plugin marketplace add omardin14/yeaboi.ai
+claude plugin marketplace add yeaboi-ai/yeaboi.ai
 /plugin install yeaboi@yeaboi
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,6 @@ Homepage = "https://yeaboi.ai"
 Documentation = "https://yeaboi.ai/docs/index.html"
 Repository = "https://github.com/yeaboi-ai/yeaboi.ai"
 Issues = "https://github.com/yeaboi-ai/yeaboi.ai/issues"
-Changelog = "https://github.com/yeaboi-ai/yeaboi.ai/blob/main/CHANGELOG.md"
 
 [project.scripts]
 yeaboi = "yeaboi.cli:main"

--- a/src/yeaboi/feedback.py
+++ b/src/yeaboi/feedback.py
@@ -42,7 +42,7 @@ from yeaboi.ui.shared._attachments import CHIP_RE
 logger = logging.getLogger(__name__)
 
 # The public repo feedback issues are filed against.
-FEEDBACK_REPO = "omardin14/yeaboi.ai"
+FEEDBACK_REPO = "yeaboi-ai/yeaboi.ai"
 
 FEEDBACK_TYPES: tuple[str, ...] = ("Bug", "Feature", "Improvement", "Other")
 

--- a/tests/unit/test_feedback_screen.py
+++ b/tests/unit/test_feedback_screen.py
@@ -146,7 +146,7 @@ class TestResultView:
             _build_feedback_screen(
                 "result",
                 status="Issue #42 created!",
-                result_url="https://github.com/omardin14/yeaboi.ai/issues/42",
+                result_url="https://github.com/yeaboi-ai/yeaboi.ai/issues/42",
                 width=100,
                 height=40,
             )

--- a/tests/unit/test_standup_gap_issues.py
+++ b/tests/unit/test_standup_gap_issues.py
@@ -41,7 +41,7 @@ class FakeIssue:
         self.state = state
         self.body = body
         self.title = title
-        self.html_url = f"https://github.com/omardin14/yeaboi.ai/issues/{number}"
+        self.html_url = f"https://github.com/yeaboi-ai/yeaboi.ai/issues/{number}"
         self.comments: list[str] = []
 
     def create_comment(self, body):


### PR DESCRIPTION
PR #328 moved the published URLs to the `yeaboi-ai` org but missed five that were not in the sweep.

**One is a live code path.** `src/yeaboi/feedback.py:45` set `FEEDBACK_REPO = "omardin14/yeaboi.ai"`, so in-app feedback and standup gap-issues were filing against the personal path. The others:

| file | what |
|---|---|
| `claude-plugin/yeaboi/.claude-plugin/plugin.json:9` | `repository` |
| `claude-plugin/yeaboi/README.md:38` | `claude plugin marketplace add …` — a command users copy |
| `SECURITY.md:8` | the private security advisory link |

The remaining `omardin14` hits are left alone deliberately: the `tests/unit/test_standup_*.py` ones use it as a *username* in alias fixtures, and `omardin14/homebrew-tap` is a genuinely separate, deliberately disabled repo.

## Also

- **`Changelog` URL dropped from `[project.urls]`** — there is no `CHANGELOG.md`, so PyPI's sidebar link 404s. Generating one from `src/yeaboi/changelog_data.json` is its own task.
- **The PyPI badge appeared twice** in the README (lines 10 and 17).
- **A `Makefile` comment** named `scripts/_site_repo.py`, renamed to `_sibling_repos.py`.

`make ship-gate` green: 14,447 passed on 3.11–3.14.

## Not in this PR

`packaging/yeaboi-core/pyproject.toml:30` has `Source = "https://github.com/yeaboi-ai/yeaboi"`, which **404s today** — the repo is `yeaboi.ai`. That line exists only on `chore/go-migration`, so it needs a one-line PR against that branch. The published `yeaboi-core` 0.4.0 keeps the dead link until its next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)