### PR TITLE
Desktop manifest: planning-platform routes join the surface (all chrome)

### DIFF
--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -220,6 +220,81 @@
       "path": "action:edit-artifact",
       "capability": "artifact-editing",
       "title": "Correct a shared artifact"
+    },
+    {
+      "path": "/projects",
+      "capability": null,
+      "title": "Projects"
+    },
+    {
+      "path": "/projects/:id",
+      "capability": null,
+      "title": "Project"
+    },
+    {
+      "path": "/projects/:id/board-settings",
+      "capability": null,
+      "title": "Board settings"
+    },
+    {
+      "path": "/projects/:id/blueprint",
+      "capability": null,
+      "title": "Blueprint"
+    },
+    {
+      "path": "/projects/:id/sessions/new",
+      "capability": null,
+      "title": "New session"
+    },
+    {
+      "path": "/projects/:id/sessions/:sessionId",
+      "capability": null,
+      "title": "Session"
+    },
+    {
+      "path": "/projects/:id/sessions/:sessionId/completed",
+      "capability": null,
+      "title": "Session recap"
+    },
+    {
+      "path": "/board",
+      "capability": null,
+      "title": "Board"
+    },
+    {
+      "path": "/tickets/:id",
+      "capability": null,
+      "title": "Ticket"
+    },
+    {
+      "path": "/settings",
+      "capability": null,
+      "title": "Settings"
+    },
+    {
+      "path": "/settings/themes",
+      "capability": null,
+      "title": "Themes"
+    },
+    {
+      "path": "/settings/themes/edit",
+      "capability": null,
+      "title": "Theme editor"
+    },
+    {
+      "path": "/recordings/:id",
+      "capability": null,
+      "title": "Recording"
+    },
+    {
+      "path": "/recording/:token",
+      "capability": null,
+      "title": "Shared recording"
+    },
+    {
+      "path": "/clip/:token",
+      "capability": null,
+      "title": "Shared clip"
     }
   ],
   "settings_tabs": [


### PR DESCRIPTION
## Summary

The unified desktop (yeaboi-desktop `feature/unified-local`) serves the planning-platform workspace beside the TUI-parity surface. Its regenerated `routes_manifest.json` adds those routes — projects/board/tickets/session pages plus the recordings/clip share pages — with `capability: null`: pure chrome to the CAPABILITIES registry, which the two-way comparison skips by design. The 39 TUI-parity paths are byte-identical to before.

## Test plan

`tests/unit/test_surface_parity.py` — all 29 pass unchanged, including `TestDesktop` against the superset manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kx9dPYqXVBUKfe1shYyGrq