### PR TITLE
add a screensaver style preference, shared with the desktop

### DIFF
--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -495,7 +495,7 @@ other tool-served capability.
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/ambience` | duck, music, saver and pet preferences, plus the station catalogue |
+| GET | `/api/ambience` | duck, music, saver and pet preferences, plus the station and screensaver catalogues |
 | POST | `/api/ambience` | persist any subset of them |
 | GET | `/api/beta` | the one-time entry gates and which have been acknowledged |
 | POST | `/api/beta/{mode_key}/ack` | record that a gate was accepted |
@@ -517,6 +517,15 @@ terminal hands a station URL to `ffplay`; the desktop hands the same URL to an
 and never round-trips. A bad channel index is refused rather than clamped, and
 `true` is not accepted as an index — `bool` is an `int` in Python, and silently
 selecting station 1 is worse than a 400.
+
+`saver` is the same shape for the same reason: `idle_seconds`, the `styles`
+catalogue (key → display name) and the chosen `style`, set with `saver_style`.
+Only the surface drawing the screensaver knows how — the desktop renders every
+style on a canvas from its own theme tokens, and the terminal understands just
+`off`, drawing its ducks for anything else. So a style the reader cannot render
+is not an error: `off` is the one value both surfaces must honour. `style` is
+clamped to the default on the way out and refused on the way in, matching the
+channel index.
 
 `polish` never submits and never fails: `polished` is null when no LLM is
 configured or the call failed, `status` says why, and the draft the person wrote

--- a/src/yeaboi/ambience.py
+++ b/src/yeaboi/ambience.py
@@ -42,6 +42,22 @@ DUCK_QUIPS: dict[str, str] = {
 #: How long a surface waits on a person before the screensaver takes over.
 IDLE_SECONDS = 5 * 60
 
+# The screensaver catalogue: key → the name a picker shows. Like the music
+# stations, this is served as a catalogue *and* a preference, because only the
+# surface drawing it knows how — the desktop renders all of these on a canvas,
+# the terminal draws its ducks for any of them and honours "off".
+SAVER_STYLES: dict[str, str] = {
+    "duck-yard": "Duck Yard",
+    "constellation": "Constellation",
+    "ricochet": "Ricochet",
+    "aurora": "Aurora",
+    "shuffle": "Shuffle",
+    "off": "Off",
+}
+
+#: What an unset or unrecognised SAVER_STYLE behaves as.
+DEFAULT_SAVER_STYLE = "duck-yard"
+
 
 def music_channels() -> list[dict[str, str]]:
     """The station list, as data.
@@ -60,6 +76,7 @@ def state() -> dict:
 
     channels = music_channels()
     channel = config.get_music_channel()
+    style = config.get_saver_style()
     return {
         "duck": {"enabled": config.is_duck_enabled(), "quips": dict(DUCK_QUIPS)},
         "music": {
@@ -67,7 +84,11 @@ def state() -> dict:
             "channel": channel if 0 <= channel < len(channels) else 0,
             "enabled": config.is_music_enabled(),
         },
-        "saver": {"idle_seconds": IDLE_SECONDS},
+        "saver": {
+            "idle_seconds": IDLE_SECONDS,
+            "style": style if style in SAVER_STYLES else DEFAULT_SAVER_STYLE,
+            "styles": dict(SAVER_STYLES),
+        },
         "pet": {"enabled": config.is_pet_enabled()},
     }
 
@@ -80,7 +101,7 @@ def apply(changes: dict) -> dict:
     """
     from yeaboi import config
 
-    known = {"duck_enabled", "music_enabled", "music_channel", "pet_enabled"}
+    known = {"duck_enabled", "music_enabled", "music_channel", "pet_enabled", "saver_style"}
     unknown = sorted(set(changes) - known)
     if unknown:
         raise ValueError(f"unknown ambience setting(s): {', '.join(unknown)} — one of {', '.join(sorted(known))}")
@@ -93,6 +114,8 @@ def apply(changes: dict) -> dict:
         config.set_music_channel(_channel(changes["music_channel"]))
     if "pet_enabled" in changes:
         config.set_pet_enabled(_flag(changes["pet_enabled"], "pet_enabled"))
+    if "saver_style" in changes:
+        config.set_saver_style(_saver_style(changes["saver_style"]))
     logger.info("ambience updated: %s", ", ".join(sorted(changes)))
     return state()
 
@@ -101,6 +124,15 @@ def _flag(value: object, field: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"{field} must be true or false, got {value!r}")
     return value
+
+
+def _saver_style(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"saver_style must be a string, got {value!r}")
+    style = value.strip().lower()
+    if style not in SAVER_STYLES:
+        raise ValueError(f"unknown saver_style {value!r} — one of {', '.join(sorted(SAVER_STYLES))}")
+    return style
 
 
 def _channel(value: object) -> int:

--- a/src/yeaboi/config.py
+++ b/src/yeaboi/config.py
@@ -243,6 +243,25 @@ def set_pet_enabled(enabled: bool) -> None:
     logger.info("Desktop pet %s (persisted to %s)", "enabled" if enabled else "disabled", config_file)
 
 
+def get_saver_style() -> str:
+    """Return the persisted idle-screensaver style key (defaults to "duck-yard").
+
+    Unvalidated on the way out, like :func:`get_music_channel`: the catalogue
+    lives in :mod:`yeaboi.ambience`, which clamps an unrecognised key to the
+    default. The one value every surface understands without the catalogue is
+    "off".
+    """
+    return os.getenv("SAVER_STYLE", "duck-yard").strip().lower() or "duck-yard"
+
+
+def set_saver_style(style: str) -> None:
+    """Persist the idle-screensaver style to ~/.scrum-agent/.env and apply it now."""
+    value = style.strip().lower()
+    config_file = set_config_value("SAVER_STYLE", value)
+    os.environ["SAVER_STYLE"] = value
+    logger.info("Screensaver style set to %s (persisted to %s)", value, config_file)
+
+
 def is_music_enabled() -> bool:
     """Return True if background music was left enabled (default off).
 

--- a/src/yeaboi/settings/engine.py
+++ b/src/yeaboi/settings/engine.py
@@ -73,6 +73,7 @@ def _provider_tables() -> tuple[tuple[str, ...], dict[str, str], dict[str, str]]
 
 def _build_fields() -> tuple[SettingField, ...]:
     providers, _envs, _names = _provider_tables()
+    from yeaboi.ambience import DEFAULT_SAVER_STYLE, SAVER_STYLES
     from yeaboi.config import VALID_LOG_LEVELS
 
     on_off = {"true": "on", "false": "off"}
@@ -155,6 +156,14 @@ def _build_fields() -> tuple[SettingField, ...]:
         ),
         SettingField(
             "DUCK_ENABLED", "Duck", "advanced", choices=("true", "false"), choice_labels=on_off, default="true"
+        ),
+        SettingField(
+            "SAVER_STYLE",
+            "Screensaver",
+            "advanced",
+            choices=tuple(SAVER_STYLES),
+            choice_labels=dict(SAVER_STYLES),
+            default=DEFAULT_SAVER_STYLE,
         ),
         SettingField(
             "LANGSMITH_TRACING",

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -1495,6 +1495,7 @@ def _collect_settings_data() -> dict:
         "LANGSMITH_TRACING",
         "TIPS_ENABLED",
         "DUCK_ENABLED",
+        "SAVER_STYLE",
         # Slack — a provider now rather than a delivery detail. The webhook
         # posts; the bot token is what lets a reaction or a reply be read back.
         "SLACK_WEBHOOK_URL",

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -18,6 +18,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from yeaboi.ambience import DEFAULT_SAVER_STYLE, SAVER_STYLES
 from yeaboi.beta import BETA_LABEL, BETA_RGB
 from yeaboi.config import VALID_LOG_LEVELS
 from yeaboi.timeparse import parse_datetime
@@ -6215,6 +6216,10 @@ SETTINGS_ACTION_ENVS: frozenset[str] = frozenset({ANTHROPIC_OAUTH_ENV})
 SETTINGS_CHOICES: dict[str, tuple[str, ...]] = {
     "TIPS_ENABLED": ("true", "false"),
     "DUCK_ENABLED": ("true", "false"),
+    # The whole catalogue, not just on/off: the value is shared with the desktop,
+    # so cycling this row must not flatten a style the app is drawing into a bare
+    # "on". The terminal renders its ducks for everything except "off".
+    "SAVER_STYLE": tuple(SAVER_STYLES),
     "LANGSMITH_TRACING": ("true", "false"),
     "LOG_LEVEL": VALID_LOG_LEVELS,
     "LLM_PROVIDER": LLM_PROVIDERS,
@@ -6226,6 +6231,7 @@ SETTINGS_CHOICES: dict[str, tuple[str, ...]] = {
 SETTINGS_CHOICE_LABELS: dict[str, dict[str, str]] = {
     "TIPS_ENABLED": {"true": "on", "false": "off"},
     "DUCK_ENABLED": {"true": "on", "false": "off"},
+    "SAVER_STYLE": dict(SAVER_STYLES),
     "LANGSMITH_TRACING": {"true": "enabled", "false": "disabled"},
     "ANTHROPIC_AUTH_MODE": {"api_key": "api key", "subscription": "subscription"},
 }
@@ -6236,6 +6242,7 @@ SETTINGS_CHOICE_LABELS: dict[str, dict[str, str]] = {
 SETTINGS_CHOICE_DEFAULTS: dict[str, str] = {
     "TIPS_ENABLED": "true",
     "DUCK_ENABLED": "true",
+    "SAVER_STYLE": DEFAULT_SAVER_STYLE,
     "LANGSMITH_TRACING": "false",
     "LOG_LEVEL": "WARNING",
     # Matches agent/llm.py's own default when LLM_PROVIDER is unset.
@@ -6917,6 +6924,7 @@ def _build_settings_screen(
         _row("Session Prune Days", config_data.get("SESSION_PRUNE_DAYS", "30"), env="SESSION_PRUNE_DAYS")
         _choice_row("Tips", "TIPS_ENABLED")
         _choice_row("Duck", "DUCK_ENABLED")
+        _choice_row("Screensaver", "SAVER_STYLE")
         _choice_row("LangSmith", "LANGSMITH_TRACING")
         _row("Config File", config_data.get("_config_path", ""))  # read-only path
 

--- a/src/yeaboi/ui/shared/_screensaver.py
+++ b/src/yeaboi/ui/shared/_screensaver.py
@@ -39,6 +39,22 @@ _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
 
+def _saver_off() -> bool:
+    """Whether the person has turned the screensaver off.
+
+    Read per call rather than cached, so toggling it in Settings takes effect
+    without a restart. Deliberately silent: this sits on the once-per-frame
+    render path, where logging is banned.
+
+    The terminal understands only "off" from the style catalogue — it draws its
+    ducks for every other value and leaves the rest to the surfaces that can
+    render them.
+    """
+    from yeaboi import config
+
+    return config.get_saver_style() == "off"
+
+
 class IdleController:
     """Thread-safe idle state shared by terminal input and Rich's refresh thread."""
 
@@ -86,7 +102,7 @@ class IdleController:
         """Return whether the saver should replace the current renderable."""
         now = self._clock()
         with self._lock:
-            if self._suppression_depth or not self._waiting_for_input:
+            if _saver_off() or self._suppression_depth or not self._waiting_for_input:
                 self._active = False
                 return False
             if not self._active and now - self._last_activity >= self.idle_seconds:
@@ -105,7 +121,7 @@ class IdleController:
         """
         now = self._clock()
         with self._lock:
-            if self._suppression_depth:
+            if _saver_off() or self._suppression_depth:
                 return False
             self._waiting_for_input = True
             self._active = True

--- a/tests/unit/test_ambience.py
+++ b/tests/unit/test_ambience.py
@@ -13,7 +13,7 @@ from yeaboi import ambience, config
 def env(monkeypatch):
     """Preferences that write to os.environ only — no ~/.env is touched."""
     monkeypatch.setattr(config, "set_config_value", lambda _k, _v: Path("/tmp/.env"))
-    for key in ("DUCK_ENABLED", "MUSIC_ENABLED", "MUSIC_CHANNEL", "PET_ENABLED"):
+    for key in ("DUCK_ENABLED", "MUSIC_ENABLED", "MUSIC_CHANNEL", "PET_ENABLED", "SAVER_STYLE"):
         monkeypatch.delenv(key, raising=False)
     return monkeypatch
 
@@ -41,6 +41,7 @@ class TestState:
         assert state["music"]["channel"] == 0
         assert state["pet"]["enabled"] is False
         assert state["saver"]["idle_seconds"] == ambience.IDLE_SECONDS
+        assert state["saver"]["style"] == ambience.DEFAULT_SAVER_STYLE
 
     def test_channels_carry_a_name_and_a_stream(self, env):
         channels = ambience.state()["music"]["channels"]
@@ -54,9 +55,19 @@ class TestState:
         env.setenv("MUSIC_CHANNEL", "99")
         assert ambience.state()["music"]["channel"] == 0
 
+    def test_an_unrecognised_persisted_style_reads_as_the_default(self, env):
+        # A style written by a newer desktop must not blank the terminal's saver.
+        env.setenv("SAVER_STYLE", "lava-lamp")
+        assert ambience.state()["saver"]["style"] == ambience.DEFAULT_SAVER_STYLE
+
+    def test_the_style_catalogue_travels_with_the_state(self, env):
+        assert ambience.state()["saver"]["styles"] == ambience.SAVER_STYLES
+
     def test_the_state_is_a_copy_a_caller_cannot_corrupt(self, env):
         ambience.state()["duck"]["quips"]["standup_done"] = "nope"
         assert ambience.DUCK_QUIPS["standup_done"] != "nope"
+        ambience.state()["saver"]["styles"]["off"] = "nope"
+        assert ambience.SAVER_STYLES["off"] != "nope"
 
 
 class TestApply:
@@ -85,3 +96,15 @@ class TestApply:
         # bool is an int in Python; True must not select station 1.
         with pytest.raises(ValueError, match="must be an integer"):
             ambience.apply({"music_channel": True})
+
+    def test_writes_the_saver_style(self, env):
+        assert ambience.apply({"saver_style": "aurora"})["saver"]["style"] == "aurora"
+
+    def test_an_unknown_style_is_refused_rather_than_defaulted(self, env):
+        # Silently storing "duck-yard" would tell the caller its pick had landed.
+        with pytest.raises(ValueError, match="unknown saver_style"):
+            ambience.apply({"saver_style": "lava-lamp"})
+
+    def test_a_style_must_be_a_string(self, env):
+        with pytest.raises(ValueError, match="must be a string"):
+            ambience.apply({"saver_style": 3})

--- a/tests/unit/test_app_wire.py
+++ b/tests/unit/test_app_wire.py
@@ -58,6 +58,27 @@ class TestSseWire:
         assert {"type", "seq", "ts", "op_id", "tool", "progress", "total", "message"} == set(payload)
 
 
+class TestAmbienceWire:
+    """The desktop hand-maintains a TypeScript mirror of this payload."""
+
+    def test_saver_keys_are_pinned(self, monkeypatch):
+        from pathlib import Path as _Path
+
+        from yeaboi import ambience, config
+
+        monkeypatch.setattr(config, "set_config_value", lambda _k, _v: _Path("/tmp/.env"))
+        monkeypatch.delenv("SAVER_STYLE", raising=False)
+        assert set(ambience.state()["saver"]) == {"idle_seconds", "style", "styles"}
+
+    def test_off_is_always_offerable(self):
+        # Both surfaces honour it; a catalogue without it takes away the only
+        # way to turn the screensaver off.
+        from yeaboi import ambience
+
+        assert "off" in ambience.SAVER_STYLES
+        assert ambience.DEFAULT_SAVER_STYLE in ambience.SAVER_STYLES
+
+
 class TestContractDoc:
     def test_every_route_is_documented(self):
         from yeaboi.app.registry import ROUTES

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -205,6 +205,43 @@ def test_set_duck_enabled_round_trips(monkeypatch, tmp_path):
     assert is_duck_enabled() is True
 
 
+def test_saver_style_defaults_to_the_duck_yard(monkeypatch):
+    from yeaboi.config import get_saver_style
+
+    monkeypatch.delenv("SAVER_STYLE", raising=False)
+    assert get_saver_style() == "duck-yard"
+
+
+def test_saver_style_is_normalised_but_not_validated(monkeypatch):
+    # The catalogue lives in ambience, which clamps; this only reads the value.
+    from yeaboi.config import get_saver_style
+
+    monkeypatch.setenv("SAVER_STYLE", "  Aurora  ")
+    assert get_saver_style() == "aurora"
+    monkeypatch.setenv("SAVER_STYLE", "lava-lamp")
+    assert get_saver_style() == "lava-lamp"
+
+
+def test_a_blank_saver_style_reads_as_the_default(monkeypatch):
+    from yeaboi.config import get_saver_style
+
+    monkeypatch.setenv("SAVER_STYLE", "   ")
+    assert get_saver_style() == "duck-yard"
+
+
+def test_set_saver_style_round_trips(monkeypatch, tmp_path):
+    from yeaboi.config import get_saver_style, set_saver_style
+
+    config_file = tmp_path / ".env"
+    monkeypatch.setattr("yeaboi.config.get_config_file", lambda: config_file)
+    monkeypatch.delenv("SAVER_STYLE", raising=False)
+
+    set_saver_style("Off")
+    assert os.environ["SAVER_STYLE"] == "off"
+    assert "SAVER_STYLE" in config_file.read_text()
+    assert get_saver_style() == "off"
+
+
 def test_set_tips_enabled_round_trips(monkeypatch, tmp_path):
     # Point config at a temp file so we don't touch the real ~/.yeaboi/.env.
     config_file = tmp_path / ".env"

--- a/tests/unit/test_screensaver.py
+++ b/tests/unit/test_screensaver.py
@@ -118,6 +118,40 @@ def test_ctrl_y_preview_is_ignored_during_processing(monkeypatch):
         assert controller.should_show() is False
 
 
+class TestSaverOff:
+    """The one style value the terminal understands from the shared catalogue."""
+
+    def test_idling_never_takes_the_screen_over(self, monkeypatch):
+        monkeypatch.setenv("SAVER_STYLE", "off")
+        controller, clock = _controller(seconds=5)
+        controller.begin_input_wait()
+        clock.advance(1000)
+        assert controller.should_show() is False
+
+    def test_ctrl_y_does_nothing(self, monkeypatch):
+        monkeypatch.setenv("SAVER_STYLE", "off")
+        controller, _clock = _controller()
+        assert controller.show_now() is False
+        assert controller.should_show() is False
+
+    def test_every_other_style_still_draws_the_ducks(self, monkeypatch):
+        # The terminal has no canvas; a desktop-only style is not a reason to
+        # leave a terminal user without the saver they already had.
+        monkeypatch.setenv("SAVER_STYLE", "aurora")
+        controller, _clock = _controller()
+        assert controller.show_now() is True
+        assert controller.should_show() is True
+
+    def test_turning_it_back_on_needs_no_restart(self, monkeypatch):
+        monkeypatch.setenv("SAVER_STYLE", "off")
+        controller, clock = _controller(seconds=5)
+        controller.begin_input_wait()
+        clock.advance(1000)
+        assert controller.should_show() is False
+        monkeypatch.setenv("SAVER_STYLE", "duck-yard")
+        assert controller.should_show() is True
+
+
 def test_live_swaps_saver_without_losing_underlying_renderable(monkeypatch):
     controller, clock = _controller(seconds=1)
     monkeypatch.setattr(_screensaver, "idle_controller", controller)


### PR DESCRIPTION
## Why

The terminal's idle screensaver has never been configurable — it fires after five minutes and draws its ducks, with no way to pick anything else or turn it off. The desktop app has no screensaver at all, though `src/renderer/lib/yeaboi/ambience.ts` already types `saver.idle_seconds` off `/api/ambience` and then drops it on the floor.

This is the **preference half**. The desktop half (four canvas screensavers) is a separate PR in `yeaboi-desktop`, and does not depend on this landing first: without it the app falls back to its own default.

## What

`saver` now serves a **catalogue and a pick**, the same shape `music` already uses — and for the same reason. Only the surface drawing a screensaver knows how to draw it: the desktop renders every style on a canvas from its own theme tokens, and the terminal understands just `off`, drawing its ducks for anything else. So a style a surface cannot render is not an error; `off` is the one value both must honour.

| | |
|---|---|
| `config.py` | `SAVER_STYLE`, read unvalidated and clamped by `ambience`, exactly as `get_music_channel` is. Unknown style refused on the way in, defaulted on the way out. |
| `ambience.py` | `SAVER_STYLES` catalogue, `saver.style` / `saver.styles` in `state()`, `saver_style` accepted by `apply()`. |
| `_screensaver.py` | `should_show()` / `show_now()` honour `off`. Read per call rather than cached, so Settings takes effect without a restart — and silently, because that path runs once a frame. |
| Settings → Advanced | A **Screensaver** row cycling the whole catalogue rather than a bare on/off: the value is shared with the desktop, and flattening a style it is drawing into "on" would lose the pick. |
| `contracts/v1/app_http.md` | The wire, pinned by `test_app_wire.py`. |

## Notes for review

- **No surface-parity work.** Ambience carries no `capability` row today — the contract already says why ("none of it is work anyone would ask an agent to do") — and this adds none.
- **The settings-engine field was not optional.** `test_settings_engine.py` holds the engine registry and the TUI's choice tables against each other both ways, so a TUI row without an engine field fails, and an engine field the TUI never collects fails too. Both edits are here; the suite caught it when only one was.
- The Screensaver row adds a *row* to an existing section, so `_SETTINGS_TAB_SECTIONS` is untouched and `test_tui_parity.py::TestSettingsSections` stays green with no manifest change.

## Verification

`make ship-gate` passes (14462 passed, 55 skipped; unit lane on 3.11–3.14; preflight 3 jobs).

Exercised by hand:

```
GET /api/ambience  -> saver: {idle_seconds: 300, style: "duck-yard", styles: {...}}
POST {"saver_style": "aurora"}   -> style: "aurora"
POST {"saver_style": "lava-lamp"} -> refused: unknown saver_style 'lava-lamp' — one of aurora, constellation, duck-yard, off, ricochet, shuffle
```

In the TUI: Settings → System → Advanced → Screensaver → `off`, then `Ctrl+Y` does nothing; back to `duck-yard` and the ducks return, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbKsnJvXgsLb6ZGgieCoJt