### PR TITLE
tag changelog highlights by surface and filter the TUI page to tui

### DIFF
--- a/.claude/skills/ci-and-release/SKILL.md
+++ b/.claude/skills/ci-and-release/SKILL.md
@@ -67,7 +67,7 @@ gh api repos/:owner/:repo/rulesets/<id> --jq '.rules[] | select(.type=="required
 
 `release.yml` in **yeaboi-desktop** builds, signs and notarizes the app, and it holds the eight signing secrets that used to live here — `CSC_LINK` + `CSC_KEY_PASSWORD`, `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` + `APPLE_TEAM_ID`, `AZURE_TENANT_ID` + `AZURE_CLIENT_ID` + `AZURE_CLIENT_SECRET`. Nothing here triggers it, and nothing here needs them.
 
-What still matters on this side is the ordering: **the desktop wraps a wheel that already exists.** Its workflow refuses a version that is not a final `X.Y.Z` on PyPI, so a desktop release always lags a Python one and is promoted by hand. The app's version *is* the version of the yeaboi it bundles; that repo has no version line of its own.
+What still matters on this side is the ordering: **the desktop wraps a wheel that already exists.** Its workflow refuses a wheel version that is not a final `X.Y.Z` on PyPI, so a desktop release always lags a Python one and is promoted by hand. The app carries **its own semver** (that repo's `package.json`, bumped by hand alongside its shell changelog); the bundled wheel version is a separate workflow input, visible at runtime via `/api/meta/version`. Changelog separation: highlights in `src/yeaboi/changelog_data.json` may carry a `surfaces` tag (`tui`/`desktop`/`web`, absent = all three); the TUI's `c` page filters to `tui`, the desktop's What's New filters to `desktop` and merges in its own shell ledger.
 
 ### When a Claude workflow fails
 

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -333,7 +333,8 @@ jobs:
                - "version": the new version (no leading "v")
                - "date": today's UTC date, YYYY-MM-DD
                - "summary": one user-friendly paragraph describing what this PR changes for a user of the app — plain English, no code or file names
-               - "highlights": 1-5 objects of {"text": "...", "areas": [...]} — each a short user-facing change, tagged ONLY with areas from this fixed vocabulary: analysis, planning, standup, retro, performance, reporting, usage, settings, general
+               - "highlights": 1-5 objects of {"text": "...", "areas": [...]} — each a short user-facing change, tagged ONLY with areas from this fixed vocabulary: analysis, planning, standup, retro, performance, reporting, usage, settings, agents, general
+               - Each highlight MAY also carry "surfaces": which of the product's surfaces the change applies to, from this fixed vocabulary: tui (terminal app + CLI), desktop (the desktop app), web (browser share/board pages). OMIT the key when the change applies everywhere — backend/engine work, the common case. Tag only surface-specific changes: a terminal screen layout change is ["tui"], a share-page change is ["web"], a desktop-only backend route is ["desktop"].
                If an entry for that version already exists, update it in place instead. Keep the JSON valid (validate by running: python -c "import json; json.load(open('src/yeaboi/changelog_data.json'))").
 
             5. Commit the pyproject.toml and changelog_data.json changes together (changelog-only mode: just changelog_data.json) to this PR branch and push. Use commit message:

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -35,7 +35,7 @@ The token never appears in URLs. Missing/wrong token → `401 {"error":"unauthor
 | GET | `/api/meta/version` | `{version, schema_version, python, platform}` |
 | GET | `/api/meta/capabilities` | the TUI card inventory verbatim: `{categories, modes, agents, intake}` |
 | GET | `/api/meta/tips` | `{tips: [{key, text, mode_key, is_new, is_beta}]}` |
-| GET | `/api/meta/changelog` | `{entries: [{version, date, summary, highlights[{text, areas}]}]}` |
+| GET | `/api/meta/changelog` | `{entries: [{version, date, summary, highlights[{text, areas, surfaces}]}]}` |
 | GET | `/api/tools` | `{available, tools: [name…]}` — the MCP inventory the dispatcher serves |
 | POST | `/api/tool/{name}` | body `{"arguments": {...}, "op_id"?: "..."}` → the MCP envelope verbatim: `{ok, llm_mode, warnings, data}` or `{ok:false, error:{type,message}, hint?}`. 404 unknown tool, 503 when the `mcp` extra is missing |
 | GET | `/api/events` | SSE; see below |
@@ -44,6 +44,11 @@ The token never appears in URLs. Missing/wrong token → `401 {"error":"unauthor
 
 Errors are always `{"error": "<message>"}` with 400 (bad input), 401, 404,
 405 (right path, wrong method), 503.
+
+A changelog highlight's `surfaces` names which product surfaces it applies to,
+from the fixed vocabulary `tui`, `desktop`, `web`. The key is always present on
+the wire — the loader coerces a missing or invalid tag in the bundled data to
+all three — and clients filter to their own surface.
 
 ## Settings routes (M4)
 

--- a/src/yeaboi/changelog.py
+++ b/src/yeaboi/changelog.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from importlib import resources
 
 logger = logging.getLogger(__name__)
@@ -39,13 +39,20 @@ AREA_COLORS: dict[str, str] = {
     "general": "rgb(160,160,180)",
 }
 
+# The surfaces a highlight applies to: the terminal app + CLI, the Electron
+# desktop app, and the browser-served share/board pages. A highlight with no
+# tag applies to all three — backend/engine work is the common case.
+VALID_SURFACES = frozenset({"tui", "desktop", "web"})
+ALL_SURFACES: tuple[str, ...] = ("tui", "desktop", "web")
+
 
 @dataclass(frozen=True)
 class ChangelogHighlight:
-    """One shipped change, tagged with the feature areas it touches."""
+    """One shipped change, tagged with the feature areas and surfaces it touches."""
 
     text: str = ""
     areas: tuple[str, ...] = ()
+    surfaces: tuple[str, ...] = ALL_SURFACES
 
 
 @dataclass(frozen=True)
@@ -72,6 +79,14 @@ def _coerce_areas(raw: object) -> tuple[str, ...]:
     return tuple(dict.fromkeys(areas)) or ("general",)
 
 
+def _coerce_surfaces(raw: object) -> tuple[str, ...]:
+    """Validate surface tags; missing, malformed, or empty means all surfaces."""
+    if not isinstance(raw, list):
+        return ALL_SURFACES
+    surfaces = [s for s in raw if isinstance(s, str) and s in VALID_SURFACES]
+    return tuple(dict.fromkeys(surfaces)) or ALL_SURFACES
+
+
 def _parse_entry(raw: object) -> ChangelogEntry | None:
     """Parse one raw JSON entry; None (skipped) when malformed."""
     if not isinstance(raw, dict) or not isinstance(raw.get("version"), str) or not raw.get("version"):
@@ -79,7 +94,13 @@ def _parse_entry(raw: object) -> ChangelogEntry | None:
     highlights = []
     for item in raw.get("highlights") or []:
         if isinstance(item, dict) and isinstance(item.get("text"), str) and item["text"]:
-            highlights.append(ChangelogHighlight(text=item["text"], areas=_coerce_areas(item.get("areas"))))
+            highlights.append(
+                ChangelogHighlight(
+                    text=item["text"],
+                    areas=_coerce_areas(item.get("areas")),
+                    surfaces=_coerce_surfaces(item.get("surfaces")),
+                )
+            )
     return ChangelogEntry(
         version=raw["version"],
         date=raw.get("date", "") if isinstance(raw.get("date"), str) else "",
@@ -101,6 +122,23 @@ def load_changelog() -> list[ChangelogEntry]:
     entries = [entry for entry in (_parse_entry(raw) for raw in raw_entries) if entry is not None]
     logger.debug("changelog loaded: %d entries", len(entries))
     return entries
+
+
+def filter_for_surface(entries: list[ChangelogEntry], surface: str) -> list[ChangelogEntry]:
+    """Keep only the entries and highlights that apply to ``surface``.
+
+    An entry with no highlights at all carries no surface information and is
+    kept whole — absence means everywhere, same as an untagged highlight.
+    """
+    filtered = []
+    for entry in entries:
+        if not entry.highlights:
+            filtered.append(entry)
+            continue
+        highlights = tuple(h for h in entry.highlights if surface in h.surfaces)
+        if highlights:
+            filtered.append(replace(entry, highlights=highlights))
+    return filtered
 
 
 def build_changelog_text(entries: list[ChangelogEntry] | None = None) -> str:

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -5489,11 +5489,12 @@ def _run_changelog_page(console: Console, live, read_key, frame_time: float, sup
     select. Data is the bundled ``changelog_data.json`` (no network); the upgrade
     banner reflects whatever the background PyPI check has found so far.
     """
-    from yeaboi.changelog import load_changelog
+    from yeaboi.changelog import filter_for_surface, load_changelog
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_changelog_screen
     from yeaboi.update_check import get_update_status
 
-    entries = load_changelog()
+    # Desktop- and web-only notes belong to those surfaces' own What's New views.
+    entries = filter_for_surface(load_changelog(), "tui")
     update_status = get_update_status()
     logger.info(
         "changelog: page opened (%d entries, update_available=%s)", len(entries), update_status["update_available"]

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -3426,7 +3426,8 @@ def _build_changelog_screen(
 ) -> Panel:
     """Build the Changelog page: per-version AI-written notes with area tags.
 
-    ``entries`` is ``changelog.load_changelog()`` output (newest-first). Each
+    ``entries`` is ``changelog.load_changelog()`` output, filtered by the caller
+    to the surface being shown (newest-first). Each
     highlight's feature-area tags render in that mode's accent colour
     (``changelog.AREA_COLORS``) so a change reads as the feature the user already
     knows by colour. ``update_status`` (``update_check.get_update_status()``)

--- a/tests/unit/test_app_server.py
+++ b/tests/unit/test_app_server.py
@@ -56,6 +56,7 @@ class TestMetaRoutes:
         payload = json.loads(request(app, "GET", "/api/meta/changelog").body)
         assert payload["entries"], "bundled changelog should never be empty"
         assert {"version", "date", "summary", "highlights"} <= set(payload["entries"][0])
+        assert {"text", "areas", "surfaces"} <= set(payload["entries"][0]["highlights"][0])
 
 
 class TestToolRoutes:

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -8,10 +8,13 @@ import pytest
 
 from yeaboi import changelog
 from yeaboi.changelog import (
+    ALL_SURFACES,
     AREA_COLORS,
     VALID_AREAS,
+    VALID_SURFACES,
     ChangelogEntry,
     ChangelogHighlight,
+    filter_for_surface,
     load_changelog,
 )
 
@@ -50,6 +53,12 @@ class TestBundledData:
             for hl in entry.highlights:
                 assert hl.areas, f"{entry.version}: highlight without areas"
                 assert set(hl.areas) <= VALID_AREAS
+
+    def test_all_surfaces_valid(self):
+        for entry in load_changelog():
+            for hl in entry.highlights:
+                assert hl.surfaces, f"{entry.version}: highlight without surfaces"
+                assert set(hl.surfaces) <= VALID_SURFACES
 
     def test_dates_iso(self):
         for entry in load_changelog():
@@ -95,6 +104,32 @@ class TestGracefulLoading:
         _patch_data(monkeypatch, '{"entries": [{"version": "1.0.0", "highlights": [{"text": "x"}]}]}')
         assert load_changelog()[0].highlights[0].areas == ("general",)
 
+    def test_missing_surfaces_defaults_to_all(self, monkeypatch):
+        _patch_data(monkeypatch, '{"entries": [{"version": "1.0.0", "highlights": [{"text": "x"}]}]}')
+        assert load_changelog()[0].highlights[0].surfaces == ALL_SURFACES
+
+    def test_unknown_surfaces_dropped(self, monkeypatch):
+        _patch_data(
+            monkeypatch,
+            '{"entries": [{"version": "1.0.0",'
+            ' "highlights": [{"text": "x", "surfaces": ["bogus", "tui", "tui", "desktop"]}]}]}',
+        )
+        assert load_changelog()[0].highlights[0].surfaces == ("tui", "desktop")
+
+    def test_all_unknown_surfaces_falls_back_to_all(self, monkeypatch):
+        _patch_data(
+            monkeypatch,
+            '{"entries": [{"version": "1.0.0", "highlights": [{"text": "x", "surfaces": ["bogus", 3]}]}]}',
+        )
+        assert load_changelog()[0].highlights[0].surfaces == ALL_SURFACES
+
+    def test_non_list_surfaces_falls_back_to_all(self, monkeypatch):
+        _patch_data(
+            monkeypatch,
+            '{"entries": [{"version": "1.0.0", "highlights": [{"text": "x", "surfaces": "tui"}]}]}',
+        )
+        assert load_changelog()[0].highlights[0].surfaces == ALL_SURFACES
+
     def test_highlight_without_text_skipped(self, monkeypatch):
         _patch_data(
             monkeypatch,
@@ -113,10 +148,57 @@ class TestAreaColors:
             assert re.fullmatch(r"rgb\(\d{1,3},\d{1,3},\d{1,3}\)", color)
 
 
+class TestFilterForSurface:
+    def _entries(self):
+        return [
+            ChangelogEntry(
+                version="2.0.0",
+                highlights=(
+                    ChangelogHighlight(text="everywhere"),
+                    ChangelogHighlight(text="terminal only", surfaces=("tui",)),
+                    ChangelogHighlight(text="web only", surfaces=("web",)),
+                ),
+            ),
+            ChangelogEntry(
+                version="1.0.0",
+                highlights=(ChangelogHighlight(text="desktop only", surfaces=("desktop",)),),
+            ),
+        ]
+
+    def test_keeps_matching_highlights_only(self):
+        filtered = filter_for_surface(self._entries(), "tui")
+        assert [e.version for e in filtered] == ["2.0.0"]
+        assert [h.text for h in filtered[0].highlights] == ["everywhere", "terminal only"]
+
+    def test_untagged_highlight_matches_every_surface(self):
+        filtered = filter_for_surface(self._entries(), "desktop")
+        assert [e.version for e in filtered] == ["2.0.0", "1.0.0"]
+        assert [h.text for h in filtered[1].highlights] == ["desktop only"]
+
+    def test_drops_entries_left_empty(self):
+        # 1.0.0's only highlight is desktop-tagged, so a web filter drops it.
+        filtered = filter_for_surface(self._entries(), "web")
+        assert [e.version for e in filtered] == ["2.0.0"]
+
+    def test_keeps_summary_only_entries(self):
+        entry = ChangelogEntry(version="3.0.0", summary="just words")
+        assert filter_for_surface([entry], "tui") == [entry]
+
+    def test_preserves_order_and_frozen(self):
+        filtered = filter_for_surface(self._entries(), "web")
+        assert [e.version for e in filtered] == ["2.0.0"]
+        with pytest.raises(AttributeError):
+            filtered[0].version = "9.9.9"  # type: ignore[misc]
+
+    def test_empty_input(self):
+        assert filter_for_surface([], "tui") == []
+
+
 class TestDataclasses:
     def test_defaults_for_backward_compat(self):
         assert ChangelogEntry().version == ""
         assert ChangelogHighlight().areas == ()
+        assert ChangelogHighlight().surfaces == ALL_SURFACES
 
     def test_frozen(self):
         entry = ChangelogEntry(version="1.0.0")


### PR DESCRIPTION
## Summary

The one bundled changelog served the TUI `c` page, the desktop's What's New page and GitHub release notes with no surface dimension, so web/packaging entries (e.g. 3.31.0) showed in the terminal and terminal-only notes showed in the desktop app. Highlights in `changelog_data.json` may now carry a `surfaces` tag (`tui`/`desktop`/`web`); a missing or invalid tag coerces to all three, which keeps every existing entry valid untouched.

- `changelog.py`: `VALID_SURFACES`/`ALL_SURFACES`, `surfaces` on `ChangelogHighlight`, `_coerce_surfaces`, and a `filter_for_surface()` helper (summary-only entries are kept whole — no highlights means no surface information).
- The TUI `c` page filters to `tui`; desktop- and web-only notes no longer appear in the terminal.
- `GET /api/meta/changelog` serializes the tag automatically (no handler change); `contracts/v1/app_http.md` documents the key and vocabulary. The desktop repo does not vendor this file, so the change is additive with no cross-repo red window — its What's New filters to `desktop` in a companion yeaboi-desktop PR.
- `auto-version.yml` prompt: tag surface-specific highlights, omit the key for everywhere-changes; also adds the `agents` area the prompt was missing (VALID_AREAS already had it).
- Release notes (`release_channel.py`) deliberately keep all surfaces — a GitHub release describes the whole backend release.

## Test plan

- `make ship-gate` (lint, format-check, full test suite on 3.11–3.14, security, preflight incl. actionlint) — green.
- New tests: `surfaces` coercion cases, `filter_for_surface` (keep/filter/drop/summary-only), bundled-data surface validity, wire-shape assertion in `test_app_server.py`.
- Independent fresh-context review: no blockers; its three nits (summary-only entry handling, a mis-aimed test, a stale docstring) are fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGy1wqY3nab7oWANmKD95W