### PR TITLE
add connection verify to the settings engine and app wire

### DIFF
--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -66,6 +66,7 @@ over this wire. Writes are allowlisted to the engine's field registry
 | POST | `/api/settings/data-dir` | body `{value, move?: bool}` → same write shape with `restart_required: true` |
 | POST | `/api/settings/provider/verify` | body `{provider, credential, model?}` → `{ok, message}` (network, up to ~8s) |
 | POST | `/api/settings/provider/models` | body `{provider, credential}` → `{models, default, hints}` (discovered-first merge) |
+| POST | `/api/settings/connection/verify` | body `{kind: github\|jira\|confluence\|notion\|elevenlabs\|tavus, token?, base_url?, email?, space_key?}` → `{ok, message}`; omitted fields fall back to saved values, so a stored credential can be re-checked without echoing it — but a stored token only travels to the stored host: a caller-supplied `base_url`/`email` requires `token` in the same request, and a supplied `base_url` must be https (400 otherwise; network, up to ~10s) |
 | POST | `/api/settings/signin/start` | spawn `claude setup-token` → `{started, message}` |
 | GET | `/api/settings/signin` | poll → `{active, url?, awaiting_code?, done?, ok?, saved?, message?}`; on first token sighting the credential is persisted before `saved: true` is reported — the token itself is never in the body |
 | POST | `/api/settings/signin/code` | body `{code}` → `{ok: true}`; 404 with no session |

--- a/src/yeaboi/app/registry.py
+++ b/src/yeaboi/app/registry.py
@@ -73,6 +73,7 @@ ROUTES: tuple[AppRoute, ...] = (
     AppRoute("POST", "/api/settings/data-dir", routes_settings.data_dir, "settings"),
     AppRoute("POST", "/api/settings/provider/verify", routes_settings.provider_verify, "settings"),
     AppRoute("POST", "/api/settings/provider/models", routes_settings.provider_models, "settings"),
+    AppRoute("POST", "/api/settings/connection/verify", routes_settings.connection_verify, "settings"),
     AppRoute("POST", "/api/settings/signin/start", routes_settings.signin_start, "settings"),
     AppRoute("GET", "/api/settings/signin", routes_settings.signin_status, "settings"),
     AppRoute("POST", "/api/settings/signin/code", routes_settings.signin_code, "settings"),

--- a/src/yeaboi/app/routes_settings.py
+++ b/src/yeaboi/app/routes_settings.py
@@ -85,6 +85,21 @@ def provider_models(app, request: Request) -> Response:
     return json_response(engine.discover_models(_required_str(payload, "provider"), str(payload.get("credential", ""))))
 
 
+def connection_verify(app, request: Request) -> Response:
+    """``POST /api/settings/connection/verify`` — live check for an optional integration.
+
+    Flat body ``{kind, token?, base_url?, email?, space_key?}``; omitted fields
+    fall back to stored values inside the engine, so a saved credential can be
+    re-checked without echoing it.
+    """
+    payload = request.json()
+    from yeaboi.settings import engine
+
+    kind = _required_str(payload, "kind")
+    fields = {k: "" if payload.get(k) is None else str(payload[k]) for k in ("token", "base_url", "email", "space_key")}
+    return json_response(engine.verify_connection(kind, fields))
+
+
 def _required_str(payload: dict, key: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str) or not value:

--- a/src/yeaboi/provider_verification.py
+++ b/src/yeaboi/provider_verification.py
@@ -685,6 +685,43 @@ def _verify_notion(token: str) -> tuple[bool, str]:
         return False, _connection_error(e)
 
 
+def _verify_elevenlabs(token: str) -> tuple[bool, str]:
+    """Verify an ElevenLabs API key against GET /v1/user — the cheapest authenticated endpoint."""
+    try:
+        import httpx
+
+        resp = httpx.get("https://api.elevenlabs.io/v1/user", headers={"xi-api-key": token}, timeout=10)
+        if resp.status_code == 200:
+            tier = ""
+            try:
+                tier = str(resp.json().get("subscription", {}).get("tier", ""))
+            except Exception:
+                pass
+            return True, f"ElevenLabs verified — {tier} tier" if tier else "ElevenLabs verified"
+        if resp.status_code == 401:
+            return False, "Invalid ElevenLabs API key"
+        if resp.status_code == 403:
+            return False, "ElevenLabs key is restricted or disabled"
+        return False, f"Unexpected response: {resp.status_code}"
+    except Exception as e:
+        return False, _connection_error(e)
+
+
+def _verify_tavus(token: str) -> tuple[bool, str]:
+    """Verify a Tavus API key by listing replicas — free, and the key's core permission."""
+    try:
+        import httpx
+
+        resp = httpx.get("https://tavusapi.com/v2/replicas", headers={"x-api-key": token}, timeout=10)
+        if resp.status_code == 200:
+            return True, "Tavus verified"
+        if resp.status_code in (401, 403):
+            return False, "Invalid Tavus API key"
+        return False, f"Unexpected response: {resp.status_code}"
+    except Exception as e:
+        return False, _connection_error(e)
+
+
 def _verify_azdevops(org_url: str, project: str, token: str) -> tuple[bool, str]:
     """Verify Azure DevOps credentials by listing work item types for the project."""
     try:

--- a/src/yeaboi/redaction.py
+++ b/src/yeaboi/redaction.py
@@ -77,6 +77,8 @@ SECRET_ENV_KEYS: tuple[str, ...] = (
     "NOTION_TOKEN",
     "STANDUP_SMTP_PASSWORD",
     "SLACK_WEBHOOK_URL",
+    "ELEVENLABS_API_KEY",
+    "TAVUS_API_KEY",
     # Deliberately NOT joined by SLACK_CHANNEL_ID or SLACK_ALLOWED_MEMBER_IDS:
     # neither is a secret, and redacting member ids would gut exactly the log
     # lines that answer "whose reaction was that".

--- a/src/yeaboi/settings/engine.py
+++ b/src/yeaboi/settings/engine.py
@@ -36,6 +36,8 @@ SECRET_ENVS: frozenset[str] = frozenset(
         "SLACK_WEBHOOK_URL",
         "SLACK_BOT_TOKEN",
         "STANDUP_SMTP_PASSWORD",
+        "ELEVENLABS_API_KEY",
+        "TAVUS_API_KEY",
     }
 )
 
@@ -148,6 +150,11 @@ def _build_fields() -> tuple[SettingField, ...]:
         SettingField("VOICE_INSTALL_OFFER", "Install Offer", "voice"),
         SettingField("VOICE_DEVICE", "Input Device", "voice", action="voice-device"),
         SettingField("VOICE_MODEL", "Model Size", "voice"),
+        # Cloud voice/video keys the desktop's call features read from the shared env.
+        SettingField("ELEVENLABS_API_KEY", "ElevenLabs Key", "voice", secret=True),
+        SettingField("ELEVENLABS_VOICE_ID", "ElevenLabs Voice", "voice"),
+        SettingField("ELEVENLABS_MODEL_ID", "ElevenLabs Model", "voice", default="eleven_turbo_v2_5"),
+        SettingField("TAVUS_API_KEY", "Tavus Key", "voice", secret=True),
         # -- advanced ------------------------------------------------------
         SettingField("LOG_LEVEL", "Log Level", "advanced", choices=VALID_LOG_LEVELS, default="WARNING"),
         SettingField("SESSION_PRUNE_DAYS", "Session Prune Days", "advanced", default="30"),
@@ -404,6 +411,80 @@ def _provider_card(provider: str) -> dict:
     if card is None:
         raise ValueError(f"unknown provider: {provider}")
     return card
+
+
+# Optional-integration verification: kind -> ((field name, env fallback), ...).
+# Confluence reuses the Jira Atlassian account (see tools/confluence.py).
+_CONNECTION_KINDS: dict[str, tuple[tuple[str, str], ...]] = {
+    "github": (("token", "GITHUB_TOKEN"),),
+    "jira": (("base_url", "JIRA_BASE_URL"), ("email", "JIRA_EMAIL"), ("token", "JIRA_API_TOKEN")),
+    "confluence": (
+        ("base_url", "JIRA_BASE_URL"),
+        ("email", "JIRA_EMAIL"),
+        ("token", "JIRA_API_TOKEN"),
+        ("space_key", "CONFLUENCE_SPACE_KEY"),
+    ),
+    "notion": (("token", "NOTION_TOKEN"),),
+    "elevenlabs": (("token", "ELEVENLABS_API_KEY"),),
+    "tavus": (("token", "TAVUS_API_KEY"),),
+}
+
+
+def verify_connection(kind: str, fields: dict[str, str]) -> dict:
+    """Live-check one optional integration's credentials.
+
+    Kinds: github/jira/confluence/notion, plus the desktop's voice & face keys
+    (elevenlabs/tavus).
+
+    A field omitted from ``fields`` falls back to the stored env value — secrets
+    are write-only over the wire, so this is how a caller re-checks a saved
+    credential without ever seeing it. A stored token only ever travels to the
+    stored host: pairing it with a caller-supplied ``base_url`` or ``email``
+    is refused (it would exfiltrate the saved secret in one request), and a
+    caller-supplied ``base_url`` must be https. Returns ``{ok, message}``;
+    network-bound (up to ~10s). Raises ValueError for an unknown kind or a
+    field that is neither provided nor stored. No credential appears in the
+    result or the log.
+    """
+    from yeaboi import provider_verification
+
+    spec = _CONNECTION_KINDS.get(kind)
+    if spec is None:
+        raise ValueError(f"unknown connection kind: {kind}")
+    resolved: dict[str, str] = {}
+    supplied: set[str] = set()
+    for name, env in spec:
+        value = (fields.get(name) or "").strip()
+        if value:
+            supplied.add(name)
+        else:
+            value = os.environ.get(env, "").strip()
+        if not value:
+            raise ValueError(f"{kind} verification needs {name}")
+        resolved[name] = value
+    if "token" not in supplied and supplied & {"base_url", "email"}:
+        raise ValueError(
+            f"{kind} verification with the stored token also uses the stored base_url and email — "
+            "supply the token to verify against other values"
+        )
+    if "base_url" in supplied and not resolved["base_url"].startswith("https://"):
+        raise ValueError(f"{kind} base_url must start with https://")
+    if kind == "github":
+        ok, message = provider_verification._verify_vc_token({"env_var": "GITHUB_TOKEN"}, resolved["token"])
+    elif kind == "jira":
+        ok, message = provider_verification._verify_jira(resolved["base_url"], resolved["email"], resolved["token"])
+    elif kind == "confluence":
+        ok, message = provider_verification._verify_confluence(
+            resolved["base_url"], resolved["email"], resolved["token"], resolved["space_key"]
+        )
+    elif kind == "notion":
+        ok, message = provider_verification._verify_notion(resolved["token"])
+    elif kind == "elevenlabs":
+        ok, message = provider_verification._verify_elevenlabs(resolved["token"])
+    else:
+        ok, message = provider_verification._verify_tavus(resolved["token"])
+    logger.info("settings: connection verify %s → ok=%s", kind, ok)
+    return {"ok": ok, "message": message}
 
 
 def verify_provider(provider: str, credential: str, model: str = "") -> dict:

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -1477,6 +1477,11 @@ def _collect_settings_data() -> dict:
         "TEAM_ANALYSIS_GITHUB_OWNERS",
         "VOICE_MODEL",
         "VOICE_DEVICE",
+        # Cloud voice/video keys the desktop's call features read from the shared env.
+        "ELEVENLABS_API_KEY",
+        "ELEVENLABS_VOICE_ID",
+        "ELEVENLABS_MODEL_ID",
+        "TAVUS_API_KEY",
         "AWS_REGION",
         "AWS_PROFILE",
         "LOG_LEVEL",

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -6909,6 +6909,21 @@ def _build_settings_screen(
             env="VOICE_DEVICE",
         )
         _row("Model Size", config_data.get("VOICE_MODEL", "") or "base (default)", env="VOICE_MODEL")
+        # Cloud voice/video keys — read by the desktop app's call features, kept
+        # here so every settings surface shows the same inventory.
+        _row("ElevenLabs Key", config_data.get("ELEVENLABS_API_KEY", ""), masked=True, env="ELEVENLABS_API_KEY")
+        _row(
+            "ElevenLabs Voice",
+            config_data.get("ELEVENLABS_VOICE_ID", "") or "provider default",
+            value_style="" if config_data.get("ELEVENLABS_VOICE_ID", "") else theme.dim,
+            env="ELEVENLABS_VOICE_ID",
+        )
+        _row(
+            "ElevenLabs Model",
+            config_data.get("ELEVENLABS_MODEL_ID", "") or "eleven_turbo_v2_5 (default)",
+            env="ELEVENLABS_MODEL_ID",
+        )
+        _row("Tavus Key", config_data.get("TAVUS_API_KEY", ""), masked=True, env="TAVUS_API_KEY")
 
     def _sec_advanced() -> None:
         """Everything here with a closed set of answers is a pick, not a text field.

--- a/src/yeaboi/ui/provider_select/_constants.py
+++ b/src/yeaboi/ui/provider_select/_constants.py
@@ -43,6 +43,14 @@ TOKEN_HELP: dict[str, dict[str, str]] = {
         "url": "https://id.atlassian.com/manage-profile/security/api-tokens",
         "scope": "Account needs view + create/update pages (and attachments) in the target space",
     },
+    "ELEVENLABS_API_KEY": {
+        "url": "https://elevenlabs.io/app/settings/api-keys",
+        "scope": "A default key works — restrict to 'Text to Speech' if scoping; powers the duck's spoken voice",
+    },
+    "TAVUS_API_KEY": {
+        "url": "https://platform.tavus.io",
+        "scope": "API key from the Tavus portal — powers avatar video in desktop calls",
+    },
 }
 
 # ---------------------------------------------------------------------------

--- a/src/yeaboi/voice.py
+++ b/src/yeaboi/voice.py
@@ -73,6 +73,9 @@ _SAMPLE_WIDTH_BYTES = 2  # int16
 # first transcription so the (potentially large) model download happens once.
 _MODEL_CACHE: dict = {}
 
+# The missing-optional-extra note is logged once per process, not per query.
+_sounddevice_missing_logged = False
+
 
 def voice_install_command() -> str:
     """Return the install command that will actually work for *this* install.
@@ -384,6 +387,7 @@ def list_input_devices() -> list[dict]:
     Returns an empty list if sounddevice is missing or the query fails, so
     callers can render "no microphones found" rather than crash.
     """
+    global _sounddevice_missing_logged
     try:
         import sounddevice as sd
 
@@ -392,7 +396,14 @@ def list_input_devices() -> list[dict]:
             default_index = sd.default.device[0]
         except Exception:  # noqa: BLE001 - no default configured on this host
             default_index = None
-    except Exception:  # noqa: BLE001 - sounddevice absent or PortAudio unhappy
+    except ImportError:
+        # The optional voice extra isn't installed — expected, so say it once
+        # quietly instead of a traceback on every settings fetch.
+        if not _sounddevice_missing_logged:
+            _sounddevice_missing_logged = True
+            logger.info("Voice input unavailable: sounddevice not installed (pip install 'yeaboi[voice]')")
+        return []
+    except Exception:  # noqa: BLE001 - PortAudio unhappy
         logger.warning("Could not list audio input devices", exc_info=True)
         return []
 

--- a/tests/unit/test_app_settings_routes.py
+++ b/tests/unit/test_app_settings_routes.py
@@ -95,6 +95,30 @@ class TestProviderProbes:
         assert json.loads(models.body)["models"][0] == "m1"
 
 
+class TestConnectionVerify:
+    def test_requires_auth_and_kind(self, app):
+        assert request(app, "POST", "/api/settings/connection/verify", {"kind": "github"}, authed=False).code == 401
+        assert request(app, "POST", "/api/settings/connection/verify", {"token": "t"}).code == 400
+
+    def test_unknown_kind_is_400(self, app):
+        resp = request(app, "POST", "/api/settings/connection/verify", {"kind": "gitlab"})
+        assert resp.code == 400
+        assert "unknown connection kind" in json.loads(resp.body)["error"]
+
+    def test_delegates_and_never_echoes_the_token(self, app, monkeypatch):
+        secret = "ghp_super-secret-raw-token-value"
+        monkeypatch.setattr("yeaboi.provider_verification._verify_vc_token", lambda vc, token: (True, "authenticated"))
+        resp = request(app, "POST", "/api/settings/connection/verify", {"kind": "github", "token": secret})
+        assert json.loads(resp.body) == {"ok": True, "message": "authenticated"}
+        assert secret not in resp.body.decode()
+
+    def test_missing_field_is_400(self, app, monkeypatch):
+        monkeypatch.delenv("NOTION_TOKEN", raising=False)
+        resp = request(app, "POST", "/api/settings/connection/verify", {"kind": "notion"})
+        assert resp.code == 400
+        assert "needs token" in json.loads(resp.body)["error"]
+
+
 class FakeSignIn:
     """A SubscriptionSignIn stand-in with a scriptable lifecycle."""
 

--- a/tests/unit/test_provider_verify_media.py
+++ b/tests/unit/test_provider_verify_media.py
@@ -1,0 +1,116 @@
+"""Tests for the ElevenLabs/Tavus key verification behind the voice & face setup."""
+
+from unittest.mock import MagicMock
+
+from yeaboi.provider_verification import _verify_elevenlabs, _verify_tavus
+
+
+def _resp(status_code: int, body: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = body or {}
+    return r
+
+
+class TestVerifyElevenlabs:
+    def test_200_ok_names_the_tier(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(200, {"subscription": {"tier": "free"}}))
+        ok, msg = _verify_elevenlabs("xi-key")
+        assert ok is True
+        assert "free tier" in msg.lower()
+
+    def test_200_without_tier_still_verifies(self, monkeypatch):
+        r = _resp(200)
+        r.json.side_effect = ValueError("not json")
+        monkeypatch.setattr("httpx.get", lambda *a, **k: r)
+        ok, msg = _verify_elevenlabs("xi-key")
+        assert ok is True
+        assert "verified" in msg.lower()
+
+    def test_401_invalid(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(401))
+        ok, msg = _verify_elevenlabs("bad")
+        assert ok is False
+        assert "invalid" in msg.lower()
+
+    def test_403_restricted(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(403))
+        ok, msg = _verify_elevenlabs("restricted")
+        assert ok is False
+        assert "restricted" in msg.lower()
+
+    def test_unexpected_status(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(500))
+        ok, msg = _verify_elevenlabs("t")
+        assert ok is False
+        assert "500" in msg
+
+    def test_sends_xi_api_key_header(self, monkeypatch):
+        captured = {}
+
+        def fake_get(url, headers=None, timeout=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return _resp(200)
+
+        monkeypatch.setattr("httpx.get", fake_get)
+        _verify_elevenlabs("xi-key")
+        assert captured["url"].endswith("/v1/user")
+        assert captured["headers"]["xi-api-key"] == "xi-key"
+
+    def test_connection_error_handled(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr("httpx.get", boom)
+        ok, msg = _verify_elevenlabs("t")
+        assert ok is False
+        assert "connection error" in msg.lower()
+
+
+class TestVerifyTavus:
+    def test_200_ok(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(200))
+        ok, msg = _verify_tavus("tv-key")
+        assert ok is True
+        assert "verified" in msg.lower()
+
+    def test_401_invalid(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(401))
+        ok, msg = _verify_tavus("bad")
+        assert ok is False
+        assert "invalid" in msg.lower()
+
+    def test_403_invalid(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(403))
+        ok, msg = _verify_tavus("bad")
+        assert ok is False
+        assert "invalid" in msg.lower()
+
+    def test_unexpected_status(self, monkeypatch):
+        monkeypatch.setattr("httpx.get", lambda *a, **k: _resp(500))
+        ok, msg = _verify_tavus("t")
+        assert ok is False
+        assert "500" in msg
+
+    def test_sends_x_api_key_header(self, monkeypatch):
+        captured = {}
+
+        def fake_get(url, headers=None, timeout=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return _resp(200)
+
+        monkeypatch.setattr("httpx.get", fake_get)
+        _verify_tavus("tv-key")
+        assert captured["url"].endswith("/v2/replicas")
+        assert captured["headers"]["x-api-key"] == "tv-key"
+
+    def test_connection_error_handled(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr("httpx.get", boom)
+        ok, msg = _verify_tavus("t")
+        assert ok is False
+        assert "connection error" in msg.lower()

--- a/tests/unit/test_settings_engine.py
+++ b/tests/unit/test_settings_engine.py
@@ -65,6 +65,18 @@ class TestMasking:
         assert github.help_url.startswith("https://")
         assert "repo" in github.help_scope
 
+    def test_voice_video_keys_are_masked_voice_fields(self, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "el-super-secret-123456")
+        monkeypatch.setenv("TAVUS_API_KEY", "tv-super-secret-123456")
+        snap = engine.get_settings()
+        for env in ("ELEVENLABS_API_KEY", "TAVUS_API_KEY"):
+            row = next(f for f in snap.fields if f.env == env)
+            assert row.section == "voice" and row.secret
+            assert "secret" not in row.value
+            assert row.help_url.startswith("https://")
+        model = next(f for f in snap.fields if f.env == "ELEVENLABS_MODEL_ID")
+        assert model.default == "eleven_turbo_v2_5"
+
 
 class TestChoiceResolution:
     def test_unset_resolves_to_the_asymmetric_defaults(self):
@@ -189,6 +201,98 @@ class TestProviderCatalog:
         )
         result = engine.discover_models("bedrock", "us-east-1")
         assert result["models"] == ["us.anthropic.claude-sonnet-4-6-v1:0"]
+
+
+class TestConnectionVerify:
+    def test_unknown_kind_is_refused(self):
+        with pytest.raises(ValueError, match="unknown connection kind"):
+            engine.verify_connection("gitlab", {})
+
+    def test_missing_field_with_empty_env_is_refused(self, monkeypatch):
+        monkeypatch.delenv("NOTION_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="notion verification needs token"):
+            engine.verify_connection("notion", {})
+
+    def test_explicit_fields_win_over_env(self, monkeypatch):
+        seen: dict[str, str] = {}
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_stored")
+        monkeypatch.setattr(
+            "yeaboi.provider_verification._verify_vc_token",
+            lambda vc, token: (seen.__setitem__("token", token), (True, "ok"))[1],
+        )
+        result = engine.verify_connection("github", {"token": "ghp_typed"})
+        assert result == {"ok": True, "message": "ok"}
+        assert seen["token"] == "ghp_typed"
+
+    def test_env_fallback_covers_omitted_fields(self, monkeypatch):
+        seen: dict[str, tuple] = {}
+        monkeypatch.setenv("JIRA_BASE_URL", "https://org.atlassian.net")
+        monkeypatch.setenv("JIRA_EMAIL", "dev@org.com")
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira-stored")
+        monkeypatch.setattr(
+            "yeaboi.provider_verification._verify_jira",
+            lambda base_url, email, token: (seen.__setitem__("args", (base_url, email, token)), (True, "jira ok"))[1],
+        )
+        result = engine.verify_connection("jira", {})
+        assert result["ok"] is True
+        assert seen["args"] == ("https://org.atlassian.net", "dev@org.com", "jira-stored")
+
+    def test_stored_token_refuses_a_caller_supplied_host(self, monkeypatch):
+        monkeypatch.setenv("JIRA_BASE_URL", "https://org.atlassian.net")
+        monkeypatch.setenv("JIRA_EMAIL", "dev@org.com")
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira-stored")
+        monkeypatch.setattr(
+            "yeaboi.provider_verification._verify_jira",
+            lambda *a: pytest.fail("the stored token must never travel to a caller-chosen host"),
+        )
+        with pytest.raises(ValueError, match="supply the token"):
+            engine.verify_connection("jira", {"base_url": "https://attacker.example"})
+        with pytest.raises(ValueError, match="supply the token"):
+            engine.verify_connection("jira", {"email": "attacker@example.com"})
+
+    def test_caller_supplied_base_url_must_be_https(self, monkeypatch):
+        monkeypatch.setattr(
+            "yeaboi.provider_verification._verify_jira",
+            lambda *a: pytest.fail("credentials must not go out over plain http"),
+        )
+        fields = {"base_url": "http://org.atlassian.net", "email": "dev@org.com", "token": "t"}
+        with pytest.raises(ValueError, match="https"):
+            engine.verify_connection("jira", fields)
+
+    def test_confluence_takes_the_atlassian_account_plus_space(self, monkeypatch):
+        seen: dict[str, tuple] = {}
+        monkeypatch.setattr(
+            "yeaboi.provider_verification._verify_confluence",
+            lambda base_url, email, token, space_key: (
+                seen.__setitem__("args", (base_url, email, token, space_key)),
+                (False, "space not found"),
+            )[1],
+        )
+        fields = {"base_url": "https://org.atlassian.net", "email": "dev@org.com", "token": "t", "space_key": "ENG"}
+        result = engine.verify_connection("confluence", fields)
+        assert result == {"ok": False, "message": "space not found"}
+        assert seen["args"] == ("https://org.atlassian.net", "dev@org.com", "t", "ENG")
+
+    def test_elevenlabs_dispatches_the_typed_key(self, monkeypatch):
+        seen: dict[str, str] = {}
+        monkeypatch.setattr(
+            "yeaboi.provider_verification._verify_elevenlabs",
+            lambda token: (seen.__setitem__("token", token), (True, "ElevenLabs verified"))[1],
+        )
+        result = engine.verify_connection("elevenlabs", {"token": "xi-typed"})
+        assert result == {"ok": True, "message": "ElevenLabs verified"}
+        assert seen["token"] == "xi-typed"
+
+    def test_tavus_falls_back_to_the_stored_key(self, monkeypatch):
+        seen: dict[str, str] = {}
+        monkeypatch.setenv("TAVUS_API_KEY", "tv-stored")
+        monkeypatch.setattr(
+            "yeaboi.provider_verification._verify_tavus",
+            lambda token: (seen.__setitem__("token", token), (False, "Invalid Tavus API key"))[1],
+        )
+        result = engine.verify_connection("tavus", {})
+        assert result == {"ok": False, "message": "Invalid Tavus API key"}
+        assert seen["token"] == "tv-stored"
 
 
 class TestTuiParity:

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -294,6 +294,7 @@ CAPABILITIES: dict[str, dict] = {
             ("yeaboi.settings.engine", "set_data_dir"),
             ("yeaboi.settings.engine", "provider_catalog"),
             ("yeaboi.settings.engine", "verify_provider"),
+            ("yeaboi.settings.engine", "verify_connection"),
             ("yeaboi.settings.engine", "discover_models"),
         },
         "mcp_tools": Exempt("MCP servers must not rewrite host credentials"),

--- a/tests/unit/test_voice.py
+++ b/tests/unit/test_voice.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.machinery
 import io
+import logging
 import sys
 import time
 import types
@@ -394,6 +395,16 @@ class TestListInputDevices:
     def test_missing_sounddevice_returns_empty(self, _inject):
         _inject(sounddevice=False)
         assert voice.list_input_devices() == []
+
+    def test_missing_sounddevice_logs_one_info_line_not_a_warning(self, _inject, caplog, monkeypatch):
+        _inject(sounddevice=False)
+        monkeypatch.setattr(voice, "_sounddevice_missing_logged", False)
+        with caplog.at_level(logging.INFO, logger="yeaboi.voice"):
+            assert voice.list_input_devices() == []
+            assert voice.list_input_devices() == []
+        notes = [r for r in caplog.records if "sounddevice not installed" in r.message]
+        assert len(notes) == 1
+        assert all(r.levelno < logging.WARNING for r in caplog.records)
 
 
 class TestResolveDevice:


### PR DESCRIPTION
## Summary

Backs the desktop app's first-run wizard (yeaboi-desktop#21, merged): one new wire route, `POST /api/settings/connection/verify`, live-checks a tool credential (github, jira, confluence, notion, elevenlabs, tavus). Omitted fields fall back to saved values so a stored credential can be re-checked without echoing it — secrets stay write-only over the wire.

Security posture, hardened after an independent review of the branch:

- **A stored token only travels to the stored host.** Pairing the saved Jira/Atlassian token with a caller-supplied `base_url` or `email` is refused with a 400 — the per-field fallback would otherwise let any loopback-authed caller exfiltrate the saved secret in one request.
- A caller-supplied `base_url` must be https.
- `ELEVENLABS_API_KEY` / `TAVUS_API_KEY` join both `SECRET_ENVS` (masked reads) and the redaction key list (log scrubbing); no credential appears in any response or log line.

Also: media verifiers for ElevenLabs (`GET /v1/user`, incl. 403 restricted-key handling) and Tavus, a `null`-field normalization fix in the route, the contract line in `contracts/v1/app_http.md`, TUI settings-table entries, and tests across every layer (route auth/400s, engine dispatch/fallback/precedence and both refusal paths, verifier status codes, surface-parity row).

## Test plan

- `make ship-gate` — lint, format-check, full test suite (14756 passed across 3.11–3.14), security, preflight — green
- Review fixes re-verified with `make lint` + `make test-scoped` (6567 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNmwQ25dwu9cLTAikoPMqH