### PR TITLE
tag every tip with the surfaces it is true on

### DIFF
--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -34,7 +34,7 @@ The token never appears in URLs. Missing/wrong token → `401 {"error":"unauthor
 | GET | `/api/health` | unauthenticated; `{ok, pid, version, schema}` |
 | GET | `/api/meta/version` | `{version, schema_version, python, platform}` |
 | GET | `/api/meta/capabilities` | the TUI card inventory verbatim: `{categories, modes, agents, intake}` |
-| GET | `/api/meta/tips` | `{tips: [{key, text, mode_key, is_new, is_beta}]}` |
+| GET | `/api/meta/tips` | `{tips: [{key, text, mode_key, is_new, is_beta, surfaces}]}` |
 | GET | `/api/meta/changelog` | `{entries: [{version, date, summary, highlights[{text, areas, surfaces}]}]}` |
 | GET | `/api/tools` | `{available, tools: [name…]}` — the MCP inventory the dispatcher serves |
 | POST | `/api/tool/{name}` | body `{"arguments": {...}, "op_id"?: "..."}` → the MCP envelope verbatim: `{ok, llm_mode, warnings, data}` or `{ok:false, error:{type,message}, hint?}`. 404 unknown tool, 503 when the `mcp` extra is missing |
@@ -49,6 +49,17 @@ A changelog highlight's `surfaces` names which product surfaces it applies to,
 from the fixed vocabulary `tui`, `desktop`, `web`. The key is always present on
 the wire — the loader coerces a missing or invalid tag in the bundled data to
 all three — and clients filter to their own surface.
+
+`/api/meta/tips` carries the same vocabulary but, unlike the changelog, filters
+at the source: the tip registry tags every tip with the surfaces it is true on,
+and this backend is the desktop app's, so the payload is **already** the
+`desktop` list. A tip naming a terminal keycap or a CLI flag never crosses the
+wire. `surfaces` is still serialised, so the tag is legible to a reader, but the
+client has nothing left to decide — filtering on it again is a no-op.
+
+Two consequences for a client. `key` is not unique: one capability may carry
+several tips. And the terminal's list is a different list, not a subset — so an
+index into this one means nothing anywhere else.
 
 ## Settings routes (M4)
 

--- a/scripts/test_scope.py
+++ b/scripts/test_scope.py
@@ -390,6 +390,10 @@ AREAS: tuple[Area, ...] = (
             "src/yeaboi/update_check.py",
             "src/yeaboi/changelog.py",
             "src/yeaboi/changelog_data.json",
+            # The tui/desktop/web vocabulary the changelog and the tips share.
+            # Its other consumer's guards (test_tips, test_surface_parity) are
+            # in ALWAYS, so they run whatever this selects.
+            "src/yeaboi/surfaces.py",
             "src/yeaboi/mcp/",
             # Cross-mode shared infrastructure, like config/paths above: the
             # tamper-evident decision chain every mode records into.
@@ -427,6 +431,7 @@ AREAS: tuple[Area, ...] = (
             "tests/unit/test_setup_wizard.py",
             "tests/unit/test_update_*.py",
             "tests/unit/test_changelog*.py",
+            "tests/unit/test_surfaces.py",
             "tests/unit/test_mcp_*.py",
             "tests/unit/test_provenance_*.py",
             "tests/unit/test_ceremonies_*.py",

--- a/src/yeaboi/app/routes_meta.py
+++ b/src/yeaboi/app/routes_meta.py
@@ -70,11 +70,16 @@ def capabilities(app, request: Request) -> Response:
 
 
 def tips(app, request: Request) -> Response:
-    """The rotating discoverability tips (voice/music availability resolved)."""
-    from yeaboi.ui.shared._tips import get_tips
+    """The desktop's discoverability tips (voice availability resolved).
+
+    Filtered at the source: the registry tags every tip with the surfaces it is
+    true on, and this backend is the desktop app's, so a tip naming a terminal
+    keycap or a CLI flag never crosses the wire.
+    """
+    from yeaboi.ui.shared._tips import tips_for_surface
 
     # to_jsonable flattens one dataclass, not a list of them — convert per item.
-    return json_response({"tips": [to_jsonable(tip) for tip in get_tips()]})
+    return json_response({"tips": [to_jsonable(tip) for tip in tips_for_surface("desktop")]})
 
 
 def changelog(app, request: Request) -> Response:

--- a/src/yeaboi/changelog.py
+++ b/src/yeaboi/changelog.py
@@ -14,6 +14,10 @@ import logging
 from dataclasses import dataclass, replace
 from importlib import resources
 
+# A highlight with no surface tag applies to all three — backend/engine work is
+# the common case. The vocabulary itself is shared with the tips registry.
+from yeaboi.surfaces import ALL_SURFACES, VALID_SURFACES
+
 logger = logging.getLogger(__name__)
 
 _DATA_FILENAME = "changelog_data.json"
@@ -38,12 +42,6 @@ AREA_COLORS: dict[str, str] = {
     "agents": "rgb(90,160,210)",
     "general": "rgb(160,160,180)",
 }
-
-# The surfaces a highlight applies to: the terminal app + CLI, the Electron
-# desktop app, and the browser-served share/board pages. A highlight with no
-# tag applies to all three — backend/engine work is the common case.
-VALID_SURFACES = frozenset({"tui", "desktop", "web"})
-ALL_SURFACES: tuple[str, ...] = ("tui", "desktop", "web")
 
 
 @dataclass(frozen=True)

--- a/src/yeaboi/surfaces.py
+++ b/src/yeaboi/surfaces.py
@@ -1,0 +1,13 @@
+"""The surfaces a piece of user-facing copy can be true on.
+
+One vocabulary, shared by the release notes (:mod:`yeaboi.changelog`) and the
+discoverability tips (:mod:`yeaboi.ui.shared._tips`): the terminal app + CLI, the
+Electron desktop app, and the browser-served share/board pages. Copy that names a
+gesture belongs to the surface that has it; copy that describes the product
+belongs to all of them.
+"""
+
+from __future__ import annotations
+
+VALID_SURFACES = frozenset({"tui", "desktop", "web"})
+ALL_SURFACES: tuple[str, ...] = ("tui", "desktop", "web")

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -5552,7 +5552,7 @@ def _run_all_tips_page(console: Console, live, read_key, frame_time: float, supp
 
     Read-only gallery of every tip: Up/Down scrolls, Enter/Esc/q returns to mode
     select. Mirrors ``_run_changelog_page`` — including having no actions of its
-    own; content comes live from ``get_tips()``.
+    own; content comes live from ``tips_for_surface("tui")``.
     """
     from yeaboi.ui.mode_select.screens._screens_secondary import _build_all_tips_screen
 

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -3573,7 +3573,7 @@ def _build_all_tips_screen(
     """Build the All Tips gallery page: every discoverability tip in one scroll.
 
     Same scrollable Panel skeleton as :func:`_build_changelog_screen`. Content is
-    the live ``get_tips()`` list, grouped into modes, workflows, and setup so the
+    the live ``tips_for_surface("tui")`` list, grouped into modes, workflows and setup so the
     gallery scans like the other sectioned pages. Freshly-shipped features get a
     gold ``NEW`` badge and tips that map to a home card note the mode they open.
     Read-only, with no actions of its own — going back is the app-wide back tab.
@@ -3582,7 +3582,7 @@ def _build_all_tips_screen(
 
     from yeaboi.ui.mode_select.screens._screens import _MODE_CARDS, _TIP_DOT_ON
     from yeaboi.ui.shared._components import CHANGELOG_THEME, build_reveal_subtitle, tips_title
-    from yeaboi.ui.shared._tips import get_tips
+    from yeaboi.ui.shared._tips import tips_for_surface
 
     theme = CHANGELOG_THEME
     title = tips_title(shimmer_tick, width=width)
@@ -3609,7 +3609,7 @@ def _build_all_tips_screen(
     tip_wrap_w = max(16, viewport_body_w - len(bullet_prefix) - 1)
     separator_w = max(8, min(viewport_body_w - len(_PAD) - 2, 40))
 
-    tips = get_tips()
+    tips = tips_for_surface("tui")
     grouped_tips = (
         ("Modes", [tip for tip in tips if tip.mode_key]),
         (

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -10,16 +10,17 @@ other screens want to surface a tip.
 Design notes:
 - **Feature-keyed tips.** Every tip that describes a real product capability is a
   :class:`FeatureTip` keyed by its ``CAPABILITIES`` key (see
-  ``tests/unit/test_surface_parity.py``). A parity test fails ``make test`` if a
-  capability ships without a tip — so the tips stay current as features land.
+  ``tests/unit/test_surface_parity.py``). One parity test per surface fails
+  ``make test`` if a capability reaches a surface without a tip there — so both
+  lists stay current as features land.
 - **Driven by the existing render tick.** The mode-select loop already re-renders
   at 60 FPS and threads a continuous ``shimmer_tick`` (seconds since the loop
   started) into the screen builder. :func:`current_tip` turns that float into a
   tip index with plain modulo arithmetic — no timer or background thread. The loop
   may also pass a manual ``override`` index (‹/› browsing) via :func:`resolve_index`.
 - **Availability-aware ambient tips.** The first tip adapts to whether the voice
-  extra is installed and the last to whether ffplay is present, mirroring
-  ``_voice_hint()`` in the input screens.
+  extra is installed, and the terminal's last to whether ffplay is present,
+  mirroring ``_voice_hint()`` in the input screens.
 - **Cached list.** Voice/music availability can't change during a process, so the
   tip list is memoised — this keeps the per-frame render from re-running the
   ``find_spec`` availability probe 60×/second.
@@ -31,6 +32,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 from yeaboi.beta import BETA_LABEL
+from yeaboi.surfaces import ALL_SURFACES, VALID_SURFACES
 
 # Seconds each tip stays on screen before the next one rotates in.
 TIP_ROTATE_SECONDS = 6.0
@@ -48,6 +50,12 @@ class FeatureTip:
     ``is_beta`` renders a BETA badge — the capability ships and works, but its
     output isn't verified yet. The two are different claims and must not be
     conflated; where both are set, BETA wins (see the render sites).
+
+    ``surfaces`` are the surfaces the tip is true on. Untagged means all of them,
+    which is the common case: a tip that describes what a feature does holds
+    everywhere, and only a tip that names a gesture — a keycap, a CLI flag, a
+    control that exists in one window and not the other — needs splitting. Two
+    tips may share a ``key`` and differ only by surface (see ``niko``).
     """
 
     key: str
@@ -55,6 +63,7 @@ class FeatureTip:
     mode_key: str | None = None
     is_new: bool = False
     is_beta: bool = False
+    surfaces: tuple[str, ...] = ALL_SURFACES
 
 
 # Feature tips — one per user-facing capability. Each is short (one line) and
@@ -123,13 +132,23 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
         mode_key="reporting",
         is_new=True,
     ),
+    # No mode_key on either: Niko is a keycap and the mascot, not a card, so
+    # there is no `g open` target. On the companion layout this tip renders
+    # inside the duck's own speech bubble, which makes him the one telling you
+    # to click.
     FeatureTip(
         "niko",
         "\U0001f986 Tip: click the duck — or press n — to ask Niko anything about yeaboi or your data",
-        # No mode_key: Niko is a keycap and the mascot, not a card, so there is
-        # no `g open` target. On the companion layout this tip renders inside the
-        # duck's own speech bubble, which makes him the one telling you to click.
         is_new=True,
+        surfaces=("tui",),
+    ),
+    FeatureTip(
+        "niko",
+        "\U0001f986 Tip: click the duck at the bottom of any screen to ask Niko about yeaboi or your data",
+        # No keycap: the shortcut is ⌘. on macOS and Ctrl+. elsewhere, and this
+        # is one static string for every platform the app ships on.
+        is_new=True,
+        surfaces=("desktop",),
     ),
     FeatureTip(
         "usage",
@@ -146,10 +165,18 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
     FeatureTip(
         "sessions",
         "\U0001f5c2️ Tip: every plan is saved — resume any past session with --resume",
+        surfaces=("tui",),
     ),
+    FeatureTip(
+        "sessions",
+        "\U0001f5c2️ Tip: every plan is saved — reopen any past run from Saved plans",
+        surfaces=("desktop",),
+    ),
+    # No desktop route (CAPABILITIES marks it exempt there), so no desktop tip.
     FeatureTip(
         "team-learning",
         "\U0001f9e0 Tip: yeaboi learns your team's velocity & estimation patterns over time",
+        surfaces=("tui",),
     ),
     FeatureTip(
         "roadmap",
@@ -158,11 +185,24 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
     FeatureTip(
         "anonymize",
         "\U0001f576️ Tip: press Anonymize on any result screen to mask names before sharing",
+        surfaces=("tui",),
+    ),
+    FeatureTip(
+        "anonymize",
+        "\U0001f576️ Tip: Anonymize a result before you share it — names are masked, numbers aren't",
+        surfaces=("desktop",),
     ),
     FeatureTip(
         "ceremonies",
         "\U0001f5d3️ Tip: press s to schedule a mode — it runs while yeaboi is closed and posts to your channels",
         is_new=True,
+        surfaces=("tui",),
+    ),
+    FeatureTip(
+        "ceremonies",
+        "\U0001f5d3️ Tip: Ceremonies schedules a mode — it runs while yeaboi is closed and posts to your channels",
+        is_new=True,
+        surfaces=("desktop",),
     ),
     FeatureTip(
         "slack-inbound",
@@ -209,6 +249,13 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
         "provenance",
         "\U0001f512 Tip: `yeaboi provenance audit` verifies the tamper-evident log behind every signal",
         is_new=True,
+        surfaces=("tui",),
+    ),
+    FeatureTip(
+        "provenance",
+        "\U0001f512 Tip: Provenance verifies the tamper-evident log behind every signal",
+        is_new=True,
+        surfaces=("desktop",),
     ),
     FeatureTip(
         "ship",
@@ -221,23 +268,62 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
 # Ambient tips — not tied to a capability, so exempt from parity. The generic
 # meta tips sit between the (dynamic) voice and music tips assembled in get_tips().
 _META_TIPS: tuple[FeatureTip, ...] = (
-    FeatureTip("meta:theme", "\U0001f4a1 Tip: switch between --theme dark and --theme light"),
-    FeatureTip("meta:headless", "\U0001f4a1 Tip: run headless with --non-interactive for scripts & pipelines"),
+    FeatureTip(
+        "meta:theme",
+        "\U0001f4a1 Tip: switch between --theme dark and --theme light",
+        surfaces=("tui",),
+    ),
+    FeatureTip(
+        "meta:theme",
+        "\U0001f4a1 Tip: Settings ▸ Themes — pick a theme or build your own",
+        surfaces=("desktop",),
+    ),
+    # No desktop counterpart: a window has no headless mode to offer.
+    FeatureTip(
+        "meta:headless",
+        "\U0001f4a1 Tip: run headless with --non-interactive for scripts & pipelines",
+        surfaces=("tui",),
+    ),
     FeatureTip("meta:export", "\U0001f4a1 Tip: export a plan to HTML or JSON for sharing and CI/CD"),
+)
+
+# The desktop app's own furniture: features with no terminal equivalent and so no
+# CAPABILITIES row. A `desktop:<slug>` key names the route it points at, which is
+# what TestDesktopOnlyTips checks against the desktop's own route manifest.
+_DESKTOP_TIPS: tuple[FeatureTip, ...] = (
+    FeatureTip(
+        "desktop:projects",
+        "\U0001f4c1 Tip: Projects holds every blueprint session, diagram and deliverable you've made",
+        surfaces=("desktop",),
+    ),
+    FeatureTip(
+        "desktop:board",
+        "\U0001f4cb Tip: Board shows every ticket across projects, waves and sprints in one place",
+        surfaces=("desktop",),
+    ),
+    FeatureTip(
+        "desktop:whats-new",
+        "\U0001f381 Tip: What's New lists everything that shipped in the version you're running",
+        surfaces=("desktop",),
+    ),
 )
 
 
 @lru_cache(maxsize=1)
 def get_tips() -> tuple[FeatureTip, ...]:
-    """Return the ordered tips shown on the welcome screen.
+    """Assemble every tip, for every surface, in rotation order.
 
-    The first entry is the voice tip and the last is the music tip; both adapt to
-    whether their optional dependency is installed (dictation extra / the ffplay
-    binary), showing an install hint otherwise. Between them come the feature tips
-    (one per capability) and the generic meta tips. Memoised because the tips are
-    rebuilt on every welcome-screen frame; the memo is dropped by
-    :func:`yeaboi.voice_install.refresh_imports` when an in-app install changes
-    the answer part-way through a run.
+    This is the assembly point, not the read API — a screen wants
+    :func:`tips_for_surface`, which is what keeps the terminal's keycaps out of
+    the desktop app and vice versa. Both lists still open on their voice tip, and
+    the terminal's still ends on the music tip.
+
+    The voice tip adapts to whether the dictation extra is installed and is built
+    once per surface, since the gesture differs (a double-tap in the terminal, a
+    mic button in the window) while the availability question does not. Memoised
+    because the tips are rebuilt on every welcome-screen frame; the memo is
+    dropped by :func:`yeaboi.voice_install.refresh_imports` when an in-app
+    install changes the answer part-way through a run.
     """
     from yeaboi.music import is_music_available
     from yeaboi.voice import unsupported_blocker, voice_install_command, voice_state
@@ -255,21 +341,59 @@ def get_tips() -> tuple[FeatureTip, ...]:
             # the user to a second terminal for something one keystroke does.
             "installable": "\U0001f3a4 Tip: double-tap Space in any text field — one keystroke sets dictation up",
         }.get(state, f"\U0001f3a4 Tip: enable dictation with — {voice_install_command()}")
-    voice_tip = FeatureTip("voice", voice_text)
+    voice_tip = FeatureTip("voice", voice_text, surfaces=("tui",))
+    # Same availability answer, the window's gesture. Every state is spelled out:
+    # the terminal's copy for a state the desktop has no sentence for would be a
+    # shell command in a window, which is the thing the surfaces split prevents.
+    # The mic opens the setup flow, so "declined" needs no install command.
+    desktop_voice_text = {
+        "ready": "\U0001f3a4 Tip: click the mic in any text field to dictate",
+        "installable": "\U0001f3a4 Tip: click the mic in any text field — one click sets dictation up",
+        "declined": "\U0001f3a4 Tip: click the mic in any text field to set dictation up",
+        # A machine fact, not a gesture: both surfaces say the same sentence.
+        "unsupported": voice_text,
+    }[state]
+    desktop_voice_tip = FeatureTip("voice", desktop_voice_text, surfaces=("desktop",))
     music_available, _music_reason = is_music_available()
+    # Terminal-only: focus music is a pair of keybindings there, and the desktop
+    # app ships no control for it.
     music_tip = FeatureTip(
         "music",
         "\U0001f3b5 Tip: press Ctrl+P for focus music · Ctrl+O to switch channel"
         if music_available
         else "\U0001f3b5 Tip: play focus music while you plan — brew install ffmpeg",
+        surfaces=("tui",),
     )
-    return (voice_tip, *_FEATURE_TIPS, *_META_TIPS, music_tip)
+    return (
+        voice_tip,
+        desktop_voice_tip,
+        *_FEATURE_TIPS,
+        *_META_TIPS,
+        *_DESKTOP_TIPS,
+        music_tip,
+    )
+
+
+def tips_for_surface(surface: str) -> tuple[FeatureTip, ...]:
+    """Return the tips that are true on ``surface``, in rotation order.
+
+    Not memoised on purpose: the cost :func:`get_tips` exists to avoid is the
+    availability probe, which stays behind its own memo, and filtering the
+    assembled tuple per frame is free.
+
+    Raises on an unknown surface rather than returning nothing: a typo would
+    otherwise leave a screen with an empty rotation, and :func:`tip_at` divides
+    by the length.
+    """
+    if surface not in VALID_SURFACES:
+        raise ValueError(f"unknown surface {surface!r}; expected one of {sorted(VALID_SURFACES)}")
+    return tuple(tip for tip in get_tips() if surface in tip.surfaces)
 
 
 def build_tips_text() -> str:
     """Render every tip as a copy-pasteable Markdown list.
 
-    Powers the "Copy all" action on the All Tips page, mirroring
+    Powers the "Copy all" action on the terminal's All Tips page, mirroring
     ``build_changelog_text``. Pure — :func:`get_tips` already resolves
     voice/music availability. Carded tips note the mode they open (by its
     friendly ``_MODE_CARDS`` title), freshly-shipped ones are marked ``(NEW)``
@@ -280,7 +404,7 @@ def build_tips_text() -> str:
 
     titles = {card["key"]: card["title"] for card in _MODE_CARDS}
     lines = ["# yeaboi — Tips", ""]
-    for tip in get_tips():
+    for tip in tips_for_surface("tui"):
         line = f"- {tip.text}"
         # BETA outranks NEW: a maturity caveat matters more than a freshness cue,
         # and a copied tip list that says both reads as neither.
@@ -295,13 +419,13 @@ def build_tips_text() -> str:
 
 
 def tip_count() -> int:
-    """Number of tips in rotation (used to render position dots)."""
-    return len(get_tips())
+    """Number of tips in the terminal's rotation (used to render position dots)."""
+    return len(tips_for_surface("tui"))
 
 
 def tip_at(index: int) -> FeatureTip:
-    """Return the tip at ``index`` (wrapped modulo the tip count)."""
-    tips = get_tips()
+    """Return the terminal tip at ``index`` (wrapped modulo the tip count)."""
+    tips = tips_for_surface("tui")
     return tips[index % len(tips)]
 
 
@@ -314,7 +438,7 @@ def resolve_index(tick: float, offset: int = 0, rotate_seconds: float = TIP_ROTA
     the list *and auto-rotation keeps running* from the new position — no pause,
     no pinned index that could get stuck.
     """
-    tips = get_tips()
+    tips = tips_for_surface("tui")
     if not tips:  # pragma: no cover - defensive; the list is always populated
         return 0
     period = rotate_seconds if rotate_seconds > 0 else TIP_ROTATE_SECONDS

--- a/tests/unit/test_app_server.py
+++ b/tests/unit/test_app_server.py
@@ -47,10 +47,18 @@ class TestMetaRoutes:
         assert [card["key"] for card in payload["modes"]] == [card["key"] for card in _MODE_CARDS]
         assert [card["key"] for card in payload["agents"]] == [card["key"] for card in _AGENT_CARDS]
 
-    def test_tips_serves_the_rotation(self, app):
+    def test_tips_serves_the_desktop_rotation(self, app):
+        # The registry holds both surfaces' tips; this endpoint is the desktop
+        # app's, so a terminal keycap or CLI flag must never reach it.
         payload = json.loads(request(app, "GET", "/api/meta/tips").body)
         keys = {tip["key"] for tip in payload["tips"]}
         assert "planning" in keys and "voice" in keys
+        assert "meta:headless" not in keys and "music" not in keys
+        assert "desktop:projects" in keys
+        assert not [t for t in payload["tips"] if "--" in t["text"] or "press " in t["text"]]
+        # Pin the shape: a field added to FeatureTip lands on the wire for free,
+        # so the contract doc only stays true if something notices.
+        assert set(payload["tips"][0]) == {"key", "text", "mode_key", "is_new", "is_beta", "surfaces"}
 
     def test_changelog_serves_entries(self, app):
         payload = json.loads(request(app, "GET", "/api/meta/changelog").body)

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -787,38 +787,110 @@ class TestTuiModes:
 
 
 # ---------------------------------------------------------------------------
-# 3b. Discoverability tips — every capability surfaces a rotating tip on the
-#     welcome screen, so tips stay current as features land. Model: the same
-#     two-way set-equality as the mode-card check above.
+# 3b. Discoverability tips — every capability surfaces a rotating tip, so tips
+#     stay current as features land. Model: the same two-way set-equality as the
+#     mode-card check above, once per surface.
+#
+#     Once per surface is the point: a tip names a gesture as often as it names a
+#     feature, and a keycap is not a thing the desktop app has. Each tip carries
+#     the surfaces it is true on (untagged means all of them), and each surface is
+#     checked against the capabilities that actually reached it.
 # ---------------------------------------------------------------------------
 
-# Capabilities that deliberately have no welcome-screen tip. Empty today — every
-# capability is worth surfacing. Add a `key: "reason (>10 chars)"` entry to opt a
-# capability out (TestTips enforces the reason length, like Exempt).
+# Capabilities that deliberately have no tip on a surface they do reach. Both
+# empty today — every capability is worth surfacing. Add a
+# `key: "reason (>10 chars)"` entry to opt one out.
 TIP_EXEMPT: dict[str, str] = {}
+DESKTOP_TIP_EXEMPT: dict[str, str] = {}
 
 _TIP_HOW_TO = (
     "Fix: add a FeatureTip for this capability in src/yeaboi/ui/shared/_tips.py "
-    "(_FEATURE_TIPS), or record a TIP_EXEMPT entry in tests/unit/test_surface_parity.py."
+    "(_FEATURE_TIPS) — tagged with the surface, or untagged if it is true on both — "
+    "or record a TIP_EXEMPT / DESKTOP_TIP_EXEMPT entry in tests/unit/test_surface_parity.py."
 )
+
+# Terminal gestures that must never appear in a tip the desktop app is served.
+# This is the guard that catches the real regression: a new tip written at a
+# terminal and tagged for both surfaces without anyone opening the window.
+_TERMINAL_GESTURES = ("--", "press ", "Ctrl+", "`yeaboi ", "double-tap")
 
 
 class TestTips:
-    def test_every_capability_has_a_tip(self):
+    def test_every_capability_has_a_tui_tip(self):
         from yeaboi.ui.shared._tips import _FEATURE_TIPS
 
-        actual = {t.key for t in _FEATURE_TIPS}
+        actual = {t.key for t in _FEATURE_TIPS if "tui" in t.surfaces}
         registered = set(CAPABILITIES) - set(TIP_EXEMPT)
         assert actual == registered, (
-            f"welcome-screen feature tips vs CAPABILITIES differ.\n"
+            f"terminal feature tips vs CAPABILITIES differ.\n"
             f"  capabilities with no tip: {sorted(registered - actual)}\n"
             f"  tips for an unknown/exempt capability: {sorted(actual - registered)}\n{_TIP_HOW_TO}"
         )
 
+    def test_every_desktop_capability_has_a_desktop_tip(self):
+        # The desktop column is itself checked against contracts/v1/routes_manifest.json
+        # further down, so this reads "the capabilities the app actually ships".
+        from yeaboi.ui.shared._tips import _FEATURE_TIPS
+
+        actual = {t.key for t in _FEATURE_TIPS if "desktop" in t.surfaces}
+        registered = set(_non_exempt("desktop")) - set(DESKTOP_TIP_EXEMPT)
+        assert actual == registered, (
+            f"desktop feature tips vs the desktop capabilities differ.\n"
+            f"  capabilities the app has but no tip mentions: {sorted(registered - actual)}\n"
+            f"  tips for something the app does not have: {sorted(actual - registered)}\n{_TIP_HOW_TO}"
+        )
+
     def test_tip_exempt_reasons_are_meaningful(self):
-        for cap, reason in TIP_EXEMPT.items():
-            assert cap in CAPABILITIES, f"TIP_EXEMPT names unknown capability {cap!r}"
-            assert len(reason) > 10, f"TIP_EXEMPT[{cap!r}] needs a real reason, got {reason!r}"
+        for name, exempt in (("TIP_EXEMPT", TIP_EXEMPT), ("DESKTOP_TIP_EXEMPT", DESKTOP_TIP_EXEMPT)):
+            for cap, reason in exempt.items():
+                assert cap in CAPABILITIES, f"{name} names unknown capability {cap!r}"
+                assert len(reason) > 10, f"{name}[{cap!r}] needs a real reason, got {reason!r}"
+
+    def test_every_tip_names_valid_surfaces(self):
+        from yeaboi.surfaces import VALID_SURFACES
+        from yeaboi.ui.shared._tips import get_tips
+
+        for tip in get_tips():
+            assert tip.surfaces, f"tip {tip.key!r} is tagged for no surface at all"
+            unknown = set(tip.surfaces) - VALID_SURFACES
+            assert not unknown, f"tip {tip.key!r} names unknown surface(s) {sorted(unknown)}"
+
+    @pytest.mark.parametrize("voice", ["ready", "installable", "declined", "unsupported"])
+    def test_desktop_tips_name_no_terminal_gesture(self, monkeypatch, voice):
+        # Driven over every voice state: the voice tip is the one built at run
+        # time, so leaving it on this machine's answer tests one branch of four.
+        from yeaboi.ui.shared import _tips
+
+        monkeypatch.setattr("yeaboi.voice.voice_state", lambda: voice)
+        monkeypatch.setattr("yeaboi.voice.unsupported_blocker", lambda: "no libportaudio2")
+        _tips.get_tips.cache_clear()
+        for tip in _tips.tips_for_surface("desktop"):
+            found = [g for g in _TERMINAL_GESTURES if g in tip.text]
+            assert not found, (
+                f"desktop tip {tip.key!r} names a terminal-only gesture {found}:\n"
+                f"  {tip.text}\n"
+                'Fix: reword it for the window, or tag this one surfaces=("tui",) and add a '
+                "desktop sibling under the same key."
+            )
+        _tips.get_tips.cache_clear()
+
+    def test_desktop_only_tips_name_a_real_route(self):
+        # `desktop:<slug>` names `/slug` in the app's own route manifest. These
+        # tips answer to no capability, so without this a renamed route leaves a
+        # tip pointing at a page that no longer exists.
+        import json
+
+        from yeaboi.ui.shared._tips import _DESKTOP_TIPS
+
+        paths = {r["path"] for r in json.loads(DESKTOP_MANIFEST.read_text(encoding="utf-8"))["routes"]}
+        for tip in _DESKTOP_TIPS:
+            prefix, _, slug = tip.key.partition(":")
+            assert prefix == "desktop" and slug, f"desktop-only tip {tip.key!r} must be keyed `desktop:<slug>`"
+            assert f"/{slug}" in paths, (
+                f"tip {tip.key!r} names route /{slug}, which is not in contracts/v1/routes_manifest.json.\n"
+                "Fix: rename the tip's key to the route it points at, or drop the tip."
+            )
+            assert tip.surfaces == ("desktop",), f"{tip.key!r} is desktop furniture and must be tagged so"
 
     def test_carded_capabilities_have_jump_targets(self):
         # Every capability that owns a mode card must have a tip whose mode_key
@@ -828,12 +900,12 @@ class TestTips:
         from yeaboi.ui.shared._tips import _FEATURE_TIPS
 
         card_keys = {card["key"] for card in (*_MODE_CARDS, *_AGENT_CARDS)}
-        by_key = {t.key: t for t in _FEATURE_TIPS}
         for cap, tui_mode in _non_exempt("tui_mode").items():
-            tip = by_key.get(cap)
-            assert tip is not None and tip.mode_key == tui_mode, (
-                f"capability {cap!r} has mode card {tui_mode!r} but its tip's mode_key is "
-                f"{getattr(tip, 'mode_key', None)!r} — jump-into-feature would miss.\n{_TIP_HOW_TO}"
+            # "some tip", not "the tip": several capabilities carry more than one.
+            tips = [t for t in _FEATURE_TIPS if t.key == cap and "tui" in t.surfaces]
+            assert any(t.mode_key == tui_mode for t in tips), (
+                f"capability {cap!r} has mode card {tui_mode!r} but no terminal tip points at it "
+                f"(got {sorted({t.mode_key for t in tips})}) — jump-into-feature would miss.\n{_TIP_HOW_TO}"
             )
         # No tip may point at a non-existent card.
         for tip in _FEATURE_TIPS:

--- a/tests/unit/test_surfaces.py
+++ b/tests/unit/test_surfaces.py
@@ -1,0 +1,22 @@
+"""Tests for the shared surface vocabulary (surfaces.py)."""
+
+from yeaboi.surfaces import ALL_SURFACES, VALID_SURFACES
+
+
+def test_all_surfaces_is_the_whole_vocabulary():
+    assert set(ALL_SURFACES) == VALID_SURFACES
+
+
+def test_all_surfaces_is_ordered_and_unique():
+    # It is a tuple rather than a set because it is a dataclass default: the
+    # order reaches a reader, and a duplicate would survive a set comparison.
+    assert len(ALL_SURFACES) == len(set(ALL_SURFACES))
+    assert ALL_SURFACES == ("tui", "desktop", "web")
+
+
+def test_changelog_still_re_exports_the_vocabulary():
+    # Moving these out of changelog.py must not break its importers.
+    from yeaboi import changelog
+
+    assert changelog.VALID_SURFACES is VALID_SURFACES
+    assert changelog.ALL_SURFACES is ALL_SURFACES

--- a/tests/unit/test_tips.py
+++ b/tests/unit/test_tips.py
@@ -1,5 +1,8 @@
 """Tests for the rotating welcome-screen tips (ui/shared/_tips.py)."""
 
+import pytest
+
+from yeaboi.surfaces import ALL_SURFACES
 from yeaboi.ui.shared import _tips
 from yeaboi.ui.shared._tips import (
     TIP_ROTATE_SECONDS,
@@ -11,6 +14,7 @@ from yeaboi.ui.shared._tips import (
     tip_at,
     tip_brightness,
     tip_count,
+    tips_for_surface,
 )
 from yeaboi.voice import voice_install_command
 
@@ -122,7 +126,7 @@ def test_current_tip_stable_within_window(monkeypatch):
 def test_current_tip_wraps_around(monkeypatch):
     _clear_cache()
     monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
-    n = len(get_tips())
+    n = len(tips_for_surface("tui"))
     # After a full cycle we return to the first tip.
     idx_first, _ = current_tip(0.0)
     idx_wrapped, _ = current_tip(n * TIP_ROTATE_SECONDS + 0.1)
@@ -168,9 +172,12 @@ def test_build_tips_text_lists_every_tip(monkeypatch):
     monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
     text = build_tips_text()
     assert text.startswith("# yeaboi — Tips")
-    # Every tip's text appears as a bullet.
-    for tip in get_tips():
+    # Every terminal tip's text appears as a bullet — and no other surface's.
+    for tip in tips_for_surface("tui"):
         assert tip.text in text
+    for tip in get_tips():
+        if "tui" not in tip.surfaces:
+            assert tip.text not in text
     assert text.endswith("\n")
     _clear_cache()
 
@@ -249,10 +256,12 @@ def test_module_constant_present():
     assert _tips.TIP_ROTATE_SECONDS > 0
 
 
-def test_tip_count_matches_get_tips(monkeypatch):
+def test_tip_count_matches_the_tui_rotation(monkeypatch):
     _clear_cache()
     monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
-    assert tip_count() == len(get_tips())
+    assert tip_count() == len(tips_for_surface("tui"))
+    # The terminal never counts the whole registry: it holds both surfaces.
+    assert tip_count() < len(get_tips())
     _clear_cache()
 
 
@@ -275,3 +284,72 @@ def test_tip_brightness_in_unit_range():
     for t in (0.0, 0.5, 2.9, 3.0, 5.9, 6.1, 42.0):
         b = tip_brightness(t)
         assert 0.0 <= b <= 1.0
+
+
+# --- per-surface split -----------------------------------------------------
+
+
+def test_untagged_tips_reach_every_surface():
+    tip = FeatureTip("x", "some text")
+    assert tip.surfaces == ALL_SURFACES
+
+
+def test_tips_for_surface_keeps_rotation_order(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
+    everything = get_tips()
+    tui = tips_for_surface("tui")
+    assert list(tui) == [t for t in everything if "tui" in t.surfaces]
+    _clear_cache()
+
+
+@pytest.mark.parametrize("state", ["ready", "installable", "declined", "unsupported"])
+def test_each_surface_opens_on_its_own_voice_tip(monkeypatch, state):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: state)
+    monkeypatch.setattr("yeaboi.voice.unsupported_blocker", lambda: "no libportaudio2")
+    tui, desktop = (tips_for_surface(s)[0] for s in ("tui", "desktop"))
+    assert tui.key == desktop.key == "voice"
+    if state == "unsupported":
+        # The one state that is a fact about the machine rather than a gesture.
+        assert tui.text == desktop.text
+    else:
+        assert "mic" in desktop.text and "mic" not in tui.text
+    _clear_cache()
+
+
+def test_the_two_surfaces_disagree(monkeypatch):
+    # The whole point of the split: neither list is the other's.
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
+    tui = {t.text for t in tips_for_surface("tui")}
+    desktop = {t.text for t in tips_for_surface("desktop")}
+    assert tui - desktop and desktop - tui
+    # …and they still share the tips that describe the product rather than a gesture.
+    assert len(tui & desktop) > 10
+    _clear_cache()
+
+
+def test_terminal_only_tips_never_reach_the_desktop(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
+    keys = {t.key for t in tips_for_surface("desktop")}
+    # Focus music has no desktop control, and a window has no headless mode.
+    assert "music" not in keys
+    assert "meta:headless" not in keys
+    _clear_cache()
+
+
+def test_desktop_only_tips_never_reach_the_terminal(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr("yeaboi.voice.voice_state", lambda: "ready")
+    assert not [t for t in tips_for_surface("tui") if t.key.startswith("desktop:")]
+    assert [t for t in tips_for_surface("desktop") if t.key.startswith("desktop:")]
+    _clear_cache()
+
+
+def test_tips_for_an_unknown_surface_raise():
+    # Not an empty tuple: a typo would leave a screen with nothing to rotate,
+    # and tip_at divides by the length.
+    with pytest.raises(ValueError, match="unknown surface"):
+        tips_for_surface("fax-machine")

--- a/tests/unit/test_tips_ui.py
+++ b/tests/unit/test_tips_ui.py
@@ -150,7 +150,7 @@ def test_tip_rows_open_hint_only_for_carded_tip(monkeypatch):
     monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
     _tips.get_tips.cache_clear()
-    tips = _tips.get_tips()
+    tips = _tips.tips_for_surface("tui")
     carded = next(i for i, t in enumerate(tips) if t.mode_key is not None)
     ambient = next(i for i, t in enumerate(tips) if t.mode_key is None)
     assert "open" in _tip_rows_text(shimmer_tick=0.0, tip_offset=carded)
@@ -162,7 +162,7 @@ def test_tip_rows_new_badge_when_flagged(monkeypatch):
     monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
     _tips.get_tips.cache_clear()
-    tips = _tips.get_tips()
+    tips = _tips.tips_for_surface("tui")
     new_idx = next(i for i, t in enumerate(tips) if t.is_new)
     plain_idx = next(i for i, t in enumerate(tips) if not t.is_new)
     assert "NEW" in _tip_rows_text(shimmer_tick=0.0, tip_offset=new_idx)
@@ -174,7 +174,7 @@ def test_tip_rows_beta_badge_when_flagged(monkeypatch):
     monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
     _tips.get_tips.cache_clear()
-    tips = _tips.get_tips()
+    tips = _tips.tips_for_surface("tui")
     beta_idx = next(i for i, t in enumerate(tips) if t.is_beta)
     plain_idx = next(i for i, t in enumerate(tips) if not t.is_beta and not t.is_new)
     assert "BETA" in _tip_rows_text(shimmer_tick=0.0, tip_offset=beta_idx)
@@ -200,7 +200,7 @@ def test_tip_offset_shifts_the_shown_tip(monkeypatch):
     monkeypatch.setattr("yeaboi.config.is_tips_enabled", lambda: True)
     monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
     _tips.get_tips.cache_clear()
-    tips = _tips.get_tips()
+    tips = _tips.tips_for_surface("tui")
     # At tick 0 the auto index is 0, so a browse offset selects tips[offset] —
     # and because it's an offset (not a pin) auto-rotation keeps advancing.
     assert tips[0].text in _tip_rows_text(shimmer_tick=0.0, tip_offset=0)
@@ -259,7 +259,7 @@ def test_all_tips_screen_groups_every_tip_once(monkeypatch):
         lambda *_args, **_kwargs: None,
     )
     _tips.get_tips.cache_clear()
-    tips = _tips.get_tips()
+    tips = _tips.tips_for_surface("tui")
     out = _all_tips_rendered(height=200, shimmer_tick=0.0, sub_reveal=99)
     assert out.index("Modes") < out.index("More workflows") < out.index("Shortcuts & setup")
     content_lines = [line.strip().strip("│").strip() for line in out.splitlines()[1:-1]]
@@ -268,6 +268,30 @@ def test_all_tips_screen_groups_every_tip_once(monkeypatch):
         _prefix, marker, display_text = tip.text.partition("Tip: ")
         expected = display_text if marker else tip.text
         assert normalized_out.count(" ".join(expected.split())) == 1
+    _tips.get_tips.cache_clear()
+
+
+def test_all_tips_screen_shows_no_desktop_tip(monkeypatch):
+    # The gallery is the terminal's, so the window's furniture — and the desktop
+    # wording of a tip the terminal words differently — must not appear in it.
+    monkeypatch.setattr("yeaboi.voice.is_voice_available", lambda: (True, ""))
+    monkeypatch.setattr(
+        "yeaboi.ui.mode_select.screens._screens_secondary.build_scrollbar",
+        lambda *_args, **_kwargs: None,
+    )
+    _tips.get_tips.cache_clear()
+    out = _all_tips_rendered(height=200, shimmer_tick=0.0, sub_reveal=99)
+    # Strip the panel's border glyphs the way the sibling test above does —
+    # wrapped text is interrupted by them, so an un-stripped haystack makes
+    # "not in" trivially true and the assertion vacuous.
+    content_lines = [line.strip().strip("│").strip() for line in out.splitlines()[1:-1]]
+    normalized = " ".join(" ".join(content_lines).split())
+    for tip in _tips.get_tips():
+        if "tui" in tip.surfaces:
+            continue
+        _prefix, marker, display_text = tip.text.partition("Tip: ")
+        expected = " ".join((display_text if marker else tip.text).split())
+        assert expected not in normalized, f"desktop tip {tip.key!r} leaked into the terminal gallery"
     _tips.get_tips.cache_clear()
 
 


### PR DESCRIPTION
## Summary

`GET /api/meta/tips` served the terminal's tip list verbatim, so the desktop app advertised gestures it does not have — `--resume`, "press s", "double-tap Space", `` `yeaboi provenance audit` `` — 11 of 31 tips. The reverse gap too: Projects and Board have no `CAPABILITIES` row, so the desktop's own front door had no tip at all.

Every tip now carries `surfaces`, defaulting to all of them, so the ~20 tips that describe a feature rather than a gesture stay a single entry serving both surfaces. `tips_for_surface()` is the read API; `get_tips()` becomes the assembly point. The `tui`/`desktop`/`web` vocabulary moves to `yeaboi.surfaces`, shared with `changelog.py`, which already owned it and still re-exports it.

**Filtered at the source, unlike the changelog.** The changelog is shared history served whole to two surfaces that both want all of it; a tip is copy for one surface, and this endpoint has exactly one consumer. So a tip naming a keycap never crosses the wire, and this stays a single-repo change.

Three things found while writing the copy, which changed the plan:

- **The `planning` tip was fine** — `/form` and `/finish` exist in the desktop chat identically (`routes.json` commands). It stays untagged.
- **Focus music has no desktop control** — `AmbienceState.music` is declared in a type and read by nothing, so that tip is terminal-only rather than reworded.
- **Recordings/clips are unwired** — `RecordingsList` has no caller, so no tip for it rather than advertising an unreachable feature.

## Enforcement

This is the half that keeps both lists current. `TestTips` was one two-way set equality against `CAPABILITIES`; it is now one **per surface**, the desktop side against the `desktop` column (itself already checked against `contracts/v1/routes_manifest.json`). Plus:

- `test_desktop_tips_name_no_terminal_gesture` — rejects `--`, `press `, `Ctrl+`, `` `yeaboi `` and `double-tap` in anything served to the app, **parametrised over all four `voice_state()` values** so it cannot pass by testing whichever state the machine happens to be in.
- `test_desktop_only_tips_name_a_real_route` — ties each `desktop:<slug>` tip to `/slug` in the desktop's route manifest, since those tips answer to no capability.

Both were verified to fail on a real regression, not just to pass.

Also fixes a latent bug in the existing jump-target check: it built `{t.key: t}`, so with three `planning` tips it only ever checked the last one.

## Review findings addressed

An independent review pass caught a **blocker I had shipped into the diff**: the desktop voice tip used `.get(state, voice_text)`, so for the `declined` and `unsupported` states it fell through to the terminal's string — emitting `uv sync --extra voice` to the desktop, the exact bug this branch exists to fix. Worse, neither guard stubbed `voice_state()`, so both ran on live state and passed locally while going red for anyone with `YEABOI_VOICE_OFFER` off. All four states are now spelled out and both guards are parametrised.

Also from that pass: the new gallery test was ~half vacuous (it never stripped the panel's `│` glyphs, so `not in` was trivially true), `tips_for_surface` now raises on an unknown surface rather than returning an empty rotation that would make `tip_at` divide by zero, war-note comments were trimmed per CLAUDE.md, and `tests/unit/test_surfaces.py` was added for the new module.

**Deferred to the paired desktop PR** (cross-repo, not fixable here): the client's `isAmbient()` does not know the `desktop:` prefix, so those tips group under "More workflows" rather than "Shortcuts & setup", and its `Tip` interface has no `surfaces` field.

## Test plan

- `make ship-gate` — green (lint, format-check, 14,768 tests on 3.11/3.12/3.13/3.14, security, preflight)
- `make test-scoped` after the review fixes — 14,780 passed
- Both new guards verified to **fail** on an injected regression before being trusted
- Endpoint driven directly: `/api/meta/tips` returns 31 tips, no terminal gesture, no `music`/`meta:headless`, `desktop:projects` present
- Payload keys pinned in `test_app_server.py` — adding a field to `FeatureTip` puts it on the wire for free, which is how `surfaces` reached the wire while the contract said it did not

🤖 Generated with [Claude Code](https://claude.com/claude-code)