### PR TITLE
give each worktree its own data home and pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Committed on purpose, and reached through a RELATIVE `core.hooksPath`.
+#
+# All worktrees share one common gitdir, so `pre-commit install` wrote a single
+# .git/hooks/pre-commit with INSTALL_PYTHON pinned to whichever worktree ran it
+# last — and removing that worktree broke `git commit` in every other one. Git
+# chdirs to the working-tree root before running a hook (githooks(5)), so one
+# relative `core.hooksPath = .githooks` in the shared config gives every
+# worktree, and the main checkout, its own copy of this file against its own venv.
+#
+# Tracked rather than generated so a worktree that has not been provisioned yet
+# still runs gitleaks and ruff instead of silently running nothing.
+
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+
+# `hook-impl` is pre-commit's own generated-hook entry point — the same contract
+# the file it used to write into .git/hooks called.
+if [ -x "$root/.venv/bin/pre-commit" ]; then
+  exec "$root/.venv/bin/pre-commit" hook-impl \
+    --config=.pre-commit-config.yaml --hook-type=pre-commit \
+    --hook-dir "$root/.githooks" -- "$@"
+elif command -v pre-commit >/dev/null 2>&1; then
+  exec pre-commit hook-impl \
+    --config=.pre-commit-config.yaml --hook-type=pre-commit \
+    --hook-dir "$root/.githooks" -- "$@"
+fi
+
+echo "pre-commit is not installed in this worktree ($root)." >&2
+echo "Run: bash scripts/provision.sh   (or: make install && make pre-commit)" >&2
+exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,13 @@ ENV/
 # Git worktrees (make wt-new / wt-open)
 .claude/worktrees/
 
+# This worktree's generated ports + data home (written by the shared wt.sh).
+/.worktree.env
+
+# The suite's own data home — conftest pins YEABOI_HOME here so tests never
+# touch the developer's real ~/.yeaboi.
+/.pytest-home/
+
 # The shared tooling, cloned on demand at the sha in .tooling-rev. Gitignored
 # and not a submodule because `git worktree add` does not populate submodules,
 # and this workflow lives in worktrees.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Terminal GIFs: `make demo` re-records `demo.cast.gz` + `demo.gif` from a scripte
 
 ## Parallel Development (worktrees)
 
-Each feature gets its own git worktree under `<main checkout>/.claude/worktrees/<name>` with its own branch, `.env`, uv venv, and pre-commit hooks. Never develop two features in one checkout. A new worktree is cut from latest `origin/main`; an existing local branch is left untouched, and a branch that exists only on `origin` is checked out tracking the remote — rebase it with `/sync-main`.
+Each feature gets its own git worktree under `<main checkout>/.claude/worktrees/<name>` with its own branch, `.env`, uv venv, port block and `~/.yeaboi` data home (`.worktree.env`, generated at creation; `make wt-repair NAME=…` retrofits an older tree). Hooks are one tracked `.githooks/pre-commit` reached through a relative `core.hooksPath`, so each worktree runs its own venv's. **Shared on purpose**: one `.git` (hence one stash stack — use `make stash`/`make unstash`, never a bare `pop`) and one set of credentials in `~/.yeaboi/.env`. Never develop two features in one checkout. A new worktree is cut from latest `origin/main`; an existing local branch is left untouched, and a branch that exists only on `origin` is checked out tracking the remote — rebase it with `/sync-main`.
 
 The venv and pre-commit half is this repo's `scripts/provision.sh`, which the shared worktree script runs inside the new tree; the rest lives in **[yeaboi-tooling](https://github.com/yeaboi-ai/yeaboi-tooling)** (see *Shared tooling* below).
 

--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,10 @@ BASE ?= origin/main
 ship-gate: lint format-check test security preflight ## The full local gate /ship runs — everything CI will check
 	@echo "✓ ship gate passed"
 
-pre-commit: ## Install pre-commit hooks
-	$(UV) run pre-commit install
+pre-commit: ## Point git at this worktree's own .githooks/ (repairs a stale shared hook)
+	git config core.hooksPath .githooks
+	@$(UV) run pre-commit uninstall >/dev/null 2>&1 || true
+	@echo "hooks: .githooks/ per worktree (was one shared .git/hooks pinned to one venv)"
 
 run: ## Run the yeaboi CLI (use ARGS="--flag" to pass arguments)
 	$(UV) run yeaboi $(ARGS)
@@ -248,16 +250,16 @@ web-types: ## Regenerate the contracts the front end vendors (enums + ui)
 site-contract: ## Regenerate contracts/site.json from pyproject (the facts the website vendors)
 	$(UV) run python scripts/gen_site_contract.py
 
-dev-board: ## Seeded retro board on :5173 for front-end development (prints the URL)
+dev-board: ## Seeded retro board for front-end development (prints the URL; :5173 unless the worktree has its own block)
 	$(UV) run python scripts/dev_board.py
 
-dev-poker: ## Seeded planning-poker board on :5273 for front-end development
+dev-poker: ## Seeded planning-poker board for front-end development (:5273 unless the worktree has its own block)
 	$(UV) run python scripts/dev_poker.py
 
-dev-deck: ## Seeded reporting slide deck on :5373 for front-end development
+dev-deck: ## Seeded reporting slide deck for front-end development (:5373 unless the worktree has its own block)
 	$(UV) run python scripts/dev_deck.py
 
-dev-editable: ## Seeded correctable standup document on :5473 for front-end development
+dev-editable: ## Seeded correctable standup document for front-end development (:5473 unless the worktree has its own block)
 	$(UV) run python scripts/dev_editable.py
 
 build: ## Build sdist + wheel into dist/

--- a/scripts/dev_board.py
+++ b/scripts/dev_board.py
@@ -22,6 +22,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from yeaboi.agent.state import RetroCard  # noqa: E402
+from yeaboi.config import get_retro_server_port  # noqa: E402
 from yeaboi.retro.board import RetroBoard  # noqa: E402
 from yeaboi.retro.server import RetroServer  # noqa: E402
 
@@ -123,7 +124,7 @@ def main() -> int:
             "carried": [],
         }
 
-    server = RetroServer(board)
+    server = RetroServer(board, port=get_retro_server_port())
     server.history_list, server.history_report = _listing, _one
     # Fixed credentials, as the poker dev board does it: a rebuild-and-restart
     # must not invalidate the token the tab you are looking at is holding.

--- a/scripts/dev_deck.py
+++ b/scripts/dev_deck.py
@@ -29,10 +29,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from yeaboi.agent.state import DeliveredItem, DeliveryReport, SupportingSignal  # noqa: E402
+from yeaboi.config import get_deck_server_port  # noqa: E402
 from yeaboi.reporting.presentation import build_presentation_html  # noqa: E402
 from yeaboi.reporting.style import DeckStyle  # noqa: E402
 
-PORT = 5373
+PORT = get_deck_server_port()
 
 REPORT = DeliveryReport(
     period_label="Last month (~2 sprints)",

--- a/scripts/dev_editable.py
+++ b/scripts/dev_editable.py
@@ -28,10 +28,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from yeaboi.agent.state import ActivityEvidence, MemberUpdate, StandupReport  # noqa: E402
+from yeaboi.config import get_ship_server_port  # noqa: E402
 from yeaboi.sharing.documents import editable_share, standup_document  # noqa: E402
 from yeaboi.sharing.server import OutputShareServer  # noqa: E402
 
-PORT = 5473
+PORT = get_ship_server_port()
 
 # Enough shape variety that the editing affordances get exercised properly: a
 # member with a blocker and one without, prose long enough to wrap, an outlook,

--- a/scripts/dev_poker.py
+++ b/scripts/dev_poker.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from yeaboi.config import load_user_config  # noqa: E402
+from yeaboi.config import get_poker_server_port, load_user_config  # noqa: E402
 from yeaboi.poker.board import PokerBoard  # noqa: E402
 from yeaboi.poker.server import PokerServer  # noqa: E402
 
@@ -132,7 +132,7 @@ def main() -> int:
     # seeded table that is not re-announced empties while you are looking at it.
     threading.Thread(target=_keep_seated, args=(board,), daemon=True).start()
 
-    server = PokerServer(board)
+    server = PokerServer(board, port=get_poker_server_port())
     # Fixed credentials so a rebuild-and-restart does not invalidate the token
     # already open tabs are holding. Dev only: in-memory board, loopback socket.
     server.token = "dev-token"  # noqa: S105

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -15,10 +15,19 @@ echo "[provision] creating venv + installing deps (uv)…"
 "$UV" venv >/dev/null
 "$UV" pip install -q -e ".[dev]"
 
-# pre-commit hooks land in the shared .git/hooks, so this is idempotent across
-# worktrees. A failure here is not worth losing the worktree over.
-if "$UV" run pre-commit install >/dev/null 2>&1; then
-  echo "[provision] pre-commit hooks installed"
-else
-  echo "[provision] note: pre-commit install failed — run \`make pre-commit\` in the worktree"
-fi
+# --- hooks: one per worktree, not one per .git -------------------------------
+# Every worktree shares a common gitdir, so `pre-commit install` wrote ONE
+# .git/hooks/pre-commit with INSTALL_PYTHON pinned to whichever worktree ran it
+# last, and deleting that worktree broke `git commit` in all the others. The
+# comment that used to sit here claimed it was idempotent; it was not.
+#
+# core.hooksPath is relative and git chdirs to the working-tree root before
+# running a hook, so this one shared setting gives every worktree its OWN
+# .githooks/ — including the main checkout and every worktree that already
+# exists, the moment any one of them runs this.
+git config core.hooksPath .githooks
+
+# The poisoned shared hook is inert once hooksPath is set, but a file naming a
+# venv that may not exist is a trap for whoever reads .git/hooks next.
+"$UV" run pre-commit uninstall >/dev/null 2>&1 || true
+echo "[provision] hooks: .githooks/ in this worktree"

--- a/scripts/record_demo.py
+++ b/scripts/record_demo.py
@@ -300,7 +300,10 @@ def _recording_env(home: Path) -> dict[str, str]:
         "YEABOI_NO_TUNNEL": "1",
         "YEABOI_TELEMETRY": "off",
     }
-    env.pop("YEABOI_HOME", None)
+    # Set, not popped: unset now falls through to the worktree's
+    # .worktree.env marker, which would land this run in the shared
+    # worktree tree instead of the temp HOME below it.
+    env["YEABOI_HOME"] = str(home / ".yeaboi")
     return env
 
 

--- a/scripts/test_scope.py
+++ b/scripts/test_scope.py
@@ -76,7 +76,7 @@ AREAS: tuple[Area, ...] = (
         # a sha) is `tests/unit/test_ship_gate.py`, which is in ALWAYS. CI's
         # `make tooling-check` covers the rest at runtime.
         "tooling",
-        src=(".tooling-rev", "scripts/tooling-sync.sh", "scripts/provision.sh"),
+        src=(".tooling-rev", "scripts/tooling-sync.sh", "scripts/provision.sh", ".githooks/"),
     ),
     Area(
         # The seam to yeaboi-site: the facts the website advertises about this

--- a/scripts/tui_fuzz.py
+++ b/scripts/tui_fuzz.py
@@ -167,7 +167,10 @@ def _child_env(home: Path) -> dict[str, str]:
         # runs instead, which is a path worth fuzzing anyway.
         "PATH": f"{home / 'shims'}{os.pathsep}{os.environ.get('PATH', '')}",
     }
-    env.pop("YEABOI_HOME", None)
+    # Set, not popped: unset now falls through to the worktree's
+    # .worktree.env marker, which would land this run in the shared
+    # worktree tree instead of the temp HOME below it.
+    env["YEABOI_HOME"] = str(home / ".yeaboi")
     env.pop("ANTHROPIC_BASE_URL", None)
     return env
 

--- a/src/yeaboi/config.py
+++ b/src/yeaboi/config.py
@@ -834,6 +834,19 @@ def get_poker_server_port() -> int:
         return 5273
 
 
+def get_deck_server_port() -> int:
+    """Return the port for the Reporting deck dev server (default 5373).
+
+    5373 sits clear of retro's 5173..5193 and poker's 5273..5293 walk ranges.
+    Unlike those two this server does not walk: a busy port is a hard failure,
+    which is right once each worktree has its own block.
+    """
+    try:
+        return int(os.getenv("DECK_PORT", "5373"))
+    except ValueError:
+        return 5373
+
+
 def get_ship_server_port() -> int:
     """Return the base port for the Ship board server (default 5473).
 

--- a/src/yeaboi/paths.py
+++ b/src/yeaboi/paths.py
@@ -59,8 +59,37 @@ from pathlib import Path
 DEFAULT_ROOT_DIR = Path.home() / ".yeaboi"
 
 
+def _checkout_home() -> Path | None:
+    """The data home pinned by the source checkout this package is imported from.
+
+    Git worktrees share a machine but must not share one sessions.db, one
+    exports tree or one log tree. `wt.sh` writes `.worktree.env` into each
+    worktree it cuts; this reads the one key out of it.
+
+    `parents[2]` is the repo root for an editable install and `lib/pythonX.Y`
+    for a wheel, so a released install has no such file and cannot acquire one.
+    Never raises: this runs at import, before logging exists, and a malformed
+    file must degrade to the default rather than make the package unimportable.
+    """
+    try:
+        marker = Path(__file__).resolve().parents[2] / ".worktree.env"
+        for line in marker.read_text(encoding="utf-8").splitlines():
+            key, _, value = line.removeprefix("export ").partition("=")
+            if key.strip() == "YEABOI_HOME":
+                value = value.strip().strip("'\"")
+                return Path(value).expanduser() if value else None
+    except (OSError, IndexError):
+        pass
+    return None
+
+
 def _resolve_root() -> Path:
-    """Resolve the data home: $YEABOI_HOME when set, else ~/.yeaboi.
+    """Resolve the data home, most specific source first.
+
+    1. $YEABOI_HOME            — explicit: a shell, a make recipe, a test
+    2. <checkout>/.worktree.env — this worktree's own tree, so parallel
+       worktrees do not write one another's data
+    3. ~/.yeaboi
 
     Read once at import time — every constant below derives from ROOT_DIR, so
     changing the setting mid-run takes effect on the next start (the Settings
@@ -68,7 +97,9 @@ def _resolve_root() -> Path:
     resolution with a monkeypatched environment.
     """
     raw = os.getenv("YEABOI_HOME", "").strip()
-    return Path(raw).expanduser() if raw else DEFAULT_ROOT_DIR
+    if raw:
+        return Path(raw).expanduser()
+    return _checkout_home() or DEFAULT_ROOT_DIR
 
 
 ROOT_DIR = _resolve_root()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,17 @@ import pytest
 # committed ones — passing or failing for a reason nothing in the output names.
 os.environ.pop("YEABOI_WEB_STATIC", None)
 
+# Same reason, one line further down: `paths.ROOT_DIR` is resolved at import, so
+# this cannot be a fixture either. Without it the suite writes the developer's
+# REAL ~/.yeaboi/data/sessions.db, and two worktrees running `make test-fast` at
+# once corrupt each other's ledger through it.
+#
+# Derived from this file's path rather than from the worktree marker, so it holds
+# for a non-editable install and a raw source tree too. `setdefault`, so CI or a
+# make recipe can still choose. Credentials are untouched on purpose:
+# ~/.yeaboi/.env is pinned outside YEABOI_HOME and is shared by design.
+os.environ.setdefault("YEABOI_HOME", str(Path(__file__).resolve().parent.parent / ".pytest-home"))
+
 
 @pytest.fixture(scope="session", autouse=True)
 def _sandbox_allows_test_dirs(tmp_path_factory):

--- a/tests/integration/test_tui_smoke.py
+++ b/tests/integration/test_tui_smoke.py
@@ -70,7 +70,10 @@ def _spawn_tui_in_pty(tmp_path: Path) -> tuple[subprocess.Popen, int]:
         # key from the developer environment leak into the subprocess.
         "ANTHROPIC_API_KEY": "test-key-dry-run-only",
     }
-    env.pop("YEABOI_HOME", None)
+    # Set, not popped: unset now falls through to the worktree's
+    # .worktree.env marker, which would land this run in the shared
+    # worktree tree instead of the temp HOME below it.
+    env["YEABOI_HOME"] = str(home / ".yeaboi")
 
     master_fd, slave_fd = os.openpty()
     # A generous size so no card/title is truncated by narrow-terminal fallbacks

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -1075,11 +1075,15 @@ class TestStandupReviewCommand:
         assert "no session found" in capsys.readouterr().err
 
     def test_list_gaps_reads_the_ledger(self, monkeypatch, tmp_path):
-        from yeaboi.paths import get_db_path
         from yeaboi.standup.store import StandupStore
 
+        # A tmp DB, like every sibling here: this wrote the developer's real
+        # ledger, and two worktrees running the suite at once corrupted each
+        # other's through it.
+        db = tmp_path / "sessions.db"
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
         monkeypatch.setattr("yeaboi.cli._resolve_cli_session", lambda s: "sid")
-        with StandupStore(get_db_path()) as store:
+        with StandupStore(db) as store:
             store.upsert_gap_issue("fp1", category="c", title="A tracked gap", issue_number=7, state="filed")
         buf = io.StringIO()
         assert _cmd_standup_review(self._args("--list-gaps"), _console(buf)) == 0

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -147,7 +147,16 @@ class TestGetDbPathPermissions:
 class TestResolveRoot:
     """YEABOI_HOME relocates the whole data tree (resolved once at import time)."""
 
-    def test_default_is_home_yeaboi(self, monkeypatch):
+    @pytest.fixture
+    def no_checkout_marker(self, monkeypatch):
+        """Ignore the worktree this suite is running inside.
+
+        These cases are about the env-var/default half of the resolution; the
+        checkout marker gets its own class below.
+        """
+        monkeypatch.setattr(paths, "_checkout_home", lambda: None)
+
+    def test_default_is_home_yeaboi(self, monkeypatch, no_checkout_marker):
         monkeypatch.delenv("YEABOI_HOME", raising=False)
         assert paths._resolve_root() == Path.home() / ".yeaboi"
 
@@ -160,7 +169,7 @@ class TestResolveRoot:
         monkeypatch.setenv("YEABOI_HOME", "~/yb-data")
         assert paths._resolve_root() == tmp_path / "yb-data"
 
-    def test_blank_override_ignored(self, monkeypatch):
+    def test_blank_override_ignored(self, monkeypatch, no_checkout_marker):
         monkeypatch.setenv("YEABOI_HOME", "   ")
         assert paths._resolve_root() == Path.home() / ".yeaboi"
 
@@ -168,6 +177,61 @@ class TestResolveRoot:
         # The bootstrap .env holds YEABOI_HOME itself, so it never moves.
         assert paths.ENV_FILE == paths.DEFAULT_ROOT_DIR / ".env"
         assert paths.DEFAULT_ROOT_DIR == Path.home() / ".yeaboi"
+
+
+class TestCheckoutHome:
+    """A worktree pins its own data home, so parallel worktrees do not share one.
+
+    `wt.sh` writes `.worktree.env` beside the source tree; `paths` is imported
+    before anything can load a dotenv, so this is the only place early enough
+    to read it.
+    """
+
+    def _marker(self, monkeypatch, tmp_path, body: str) -> None:
+        """Point _checkout_home() at a fake checkout root holding *body*."""
+        root = tmp_path / "checkout"
+        (root / "src" / "yeaboi").mkdir(parents=True)
+        (root / ".worktree.env").write_text(body)
+        monkeypatch.setattr(paths, "__file__", str(root / "src" / "yeaboi" / "paths.py"))
+
+    def test_the_marker_moves_the_root(self, monkeypatch, tmp_path):
+        self._marker(monkeypatch, tmp_path, "export YEABOI_HOME=/tmp/wt-home\n")
+        assert paths._checkout_home() == Path("/tmp/wt-home")
+
+    def test_a_bare_assignment_works_too(self, monkeypatch, tmp_path):
+        self._marker(monkeypatch, tmp_path, "YEABOI_HOME=/tmp/bare\n")
+        assert paths._checkout_home() == Path("/tmp/bare")
+
+    def test_an_explicit_env_var_still_wins(self, monkeypatch, tmp_path):
+        self._marker(monkeypatch, tmp_path, "export YEABOI_HOME=/tmp/wt-home\n")
+        monkeypatch.setenv("YEABOI_HOME", str(tmp_path / "explicit"))
+        assert paths._resolve_root() == tmp_path / "explicit"
+
+    def test_other_keys_are_ignored(self, monkeypatch, tmp_path):
+        self._marker(monkeypatch, tmp_path, "export RETRO_PORT=20100\nexport YEABOI_WT_SLOT=1\n")
+        assert paths._checkout_home() is None
+
+    def test_no_marker_means_no_opinion(self, monkeypatch, tmp_path):
+        root = tmp_path / "wheel-ish"
+        (root / "src" / "yeaboi").mkdir(parents=True)
+        monkeypatch.setattr(paths, "__file__", str(root / "src" / "yeaboi" / "paths.py"))
+        assert paths._checkout_home() is None
+
+    def test_an_unreadable_marker_never_raises(self, monkeypatch, tmp_path):
+        # This runs at import, before logging exists: a bad file must degrade
+        # to the default, not make the package unimportable.
+        root = tmp_path / "checkout"
+        (root / "src" / "yeaboi").mkdir(parents=True)
+        (root / ".worktree.env").mkdir()  # a directory where a file belongs
+        monkeypatch.setattr(paths, "__file__", str(root / "src" / "yeaboi" / "paths.py"))
+        assert paths._checkout_home() is None
+
+    def test_credentials_do_not_move_with_the_data(self, monkeypatch, tmp_path):
+        """The whole point: one set of API keys still serves every worktree."""
+        monkeypatch.delenv("YEABOI_HOME", raising=False)  # conftest pins one for the suite
+        self._marker(monkeypatch, tmp_path, "export YEABOI_HOME=/tmp/wt-home\n")
+        assert paths._resolve_root() == Path("/tmp/wt-home")
+        assert paths.ENV_FILE == Path.home() / ".yeaboi" / ".env"
 
 
 class TestMoveDataTree:

--- a/tests/unit/test_record_demo.py
+++ b/tests/unit/test_record_demo.py
@@ -326,8 +326,15 @@ class TestRecordingEnv:
         assert env["ANTHROPIC_API_KEY"] == "test-key-dry-run-only"
 
     def test_yeaboi_home_never_leaks_in(self, tmp_path, monkeypatch):
+        """The developer's real tree must not reach a recording — and nor must a worktree's.
+
+        This used to assert the variable was absent, which was the same thing
+        while unset meant ~/.yeaboi. It no longer is: unset now falls through to
+        the checkout's .worktree.env, so the recording has to pin the temp home
+        explicitly rather than by omission.
+        """
         monkeypatch.setenv("YEABOI_HOME", "/somewhere/real")
-        assert "YEABOI_HOME" not in record_demo._recording_env(tmp_path)
+        assert record_demo._recording_env(tmp_path)["YEABOI_HOME"] == str(tmp_path / ".yeaboi")
 
 
 class TestMain:

--- a/tests/unit/test_ship_gate.py
+++ b/tests/unit/test_ship_gate.py
@@ -235,6 +235,57 @@ class TestNoCommandTrustsLocalMain:
         )
 
 
+class TestWorktreeIsolation:
+    """What a worktree owns alone, and what it deliberately shares.
+
+    Worktrees share one common gitdir, so a hook installed into `.git/hooks`
+    is installed for all of them, pinned to whichever venv wrote it last. These
+    pin the arrangement that replaced it — nothing else in the suite implies it,
+    because it lives in git config and a shell script.
+    """
+
+    HOOK = ROOT / ".githooks" / "pre-commit"
+    PROVISION = ROOT / "scripts" / "provision.sh"
+
+    def test_the_hook_is_tracked_and_executable(self):
+        """A generated hook leaves an unprovisioned worktree running nothing at all."""
+        assert self.HOOK.is_file(), "the per-worktree pre-commit hook is missing"
+        assert self.HOOK.stat().st_mode & 0o111, f"chmod +x {self.HOOK.relative_to(ROOT)}"
+
+    def test_the_hook_resolves_the_venv_from_the_tree_being_committed(self):
+        text = self.HOOK.read_text()
+        assert "--show-toplevel" in text, "the hook must find the worktree it is running in"
+        assert "/.venv/bin/pre-commit" in text
+        assert "/Users/" not in text, "a baked absolute path is the bug this replaced"
+
+    def test_provisioning_points_git_at_the_per_worktree_hooks(self):
+        text = self.PROVISION.read_text()
+        assert "core.hooksPath .githooks" in text, (
+            "the path is relative on purpose: git chdirs to the working-tree root before "
+            "running a hook, so one shared setting gives every worktree its own"
+        )
+        # Prose may name it; nothing may run it — it writes into the SHARED
+        # .git/hooks, which is exactly what broke.
+        runs = [ln for ln in text.splitlines() if "pre-commit install" in ln and not ln.lstrip().startswith("#")]
+        assert not runs, runs
+
+    def test_the_repair_target_sets_it_too(self):
+        """The main checkout never runs provision.sh."""
+        _, body = _recipe("pre-commit")
+        assert "core.hooksPath .githooks" in body
+
+    def test_the_generated_port_block_is_never_committed(self):
+        ignored = (ROOT / ".gitignore").read_text()
+        assert "/.worktree.env" in ignored, "a worktree's ports would follow it into every diff"
+
+    def test_credentials_stay_machine_global(self):
+        """Data is per-worktree; API keys are the user's, not the branch's."""
+        text = (ROOT / "src" / "yeaboi" / "paths.py").read_text()
+        assert "ENV_FILE = DEFAULT_ROOT_DIR" in text, (
+            "the bootstrap .env must not move with YEABOI_HOME — it is what can set it"
+        )
+
+
 class TestTheSharedTooling:
     """The plugin's commands speak to this repo only through Make and repo-notes."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -4151,7 +4151,7 @@ wheels = [
 
 [[package]]
 name = "yeaboi"
-version = "3.32.0"
+version = "3.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Why

All worktrees share one common gitdir, so they share `.git/hooks`. `pre-commit install` wrote **one** hook with `INSTALL_PYTHON` baked to whichever worktree ran it last — verified live, it was pinned to a single worktree while ten others existed. Every other worktree committed through *that* worktree's venv, and deleting it would break `git commit` in all of them. The comment in `provision.sh` claimed this was idempotent. It was not.

## Hooks

`core.hooksPath` is **relative**, and git chdirs to the working-tree root before running a hook (`githooks(5)`), so one setting in the *shared* config gives every worktree its own `.githooks/` — the main checkout and every already-existing worktree included, with no per-worktree config to clean up on `wt-rm`. I verified this empirically in a throwaway two-worktree repo before building on it.

The hook is **tracked rather than generated**, so a worktree that has not been provisioned yet still runs gitleaks and ruff instead of silently running nothing. `pre-commit` refuses to install while `core.hooksPath` is set (`install_uninstall.py:123`), which is why it is no longer asked to.

No `extensions.worktreeConfig`: it makes older git refuse the repository outright, forever, and buys nothing here.

## Data home

`_resolve_root()` grows one fallback — with `YEABOI_HOME` unset, a source checkout may pin its own home via `.worktree.env`. `parents[2]` is the repo root for an editable install and `lib/pythonX.Y` for a wheel, so **a released install has no such file and cannot acquire one**.

**Credentials do not follow.** `ENV_FILE` stays pinned to `~/.yeaboi`, so one set of API keys still serves every worktree — that is the point, not an oversight.

The home is a **sibling** of `~/.yeaboi`, never a child: `move_data_tree()` relocates every *child* of the root when the Data Dir changes, and would have silently swept every worktree's data along with it, leaving each one pointing at nothing.

## Along the way

- The four dev scripts now go through `config.get_*_server_port()` — helpers that already existed and that they were bypassing. Only the deck needed a new one.
- `conftest` pins the suite's own home **at import**, because `ROOT_DIR` resolves at import and a fixture cannot move it. `TestStandupReviewCommand` was writing the developer's **real** `~/.yeaboi/data/sessions.db`, unlike its ~15 siblings; it now uses a tmp DB.
- The three launchers that *popped* `YEABOI_HOME` now **set** it. Popping used to mean "fall back to `~/.yeaboi` under the temp HOME"; it now means "fall back to the checkout marker", so a demo recording would have leaked the worktree's tree.

## Verification

`make ship-gate` passes: lint, format-check, **14,799 tests on Python 3.11–3.14**, security, preflight. End-to-end, two worktrees cut with the real scripts share **zero** ports, get distinct data homes, and each runs its own venv's hook.

`uv.lock`'s version line was stale against `pyproject.toml` (the known `auto-version.yml` drift in repo-notes) and is reconciled here.

## Ordering

Independent of the `.tooling-rev` bump and green without it — `paths.py` reads `.worktree.env` directly. The pin bump is a follow-up once yeaboi-ai/yeaboi-tooling#10 merges, and turns on the make-level port block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFyWp5MhFDn2hNwdkZxLVq