### PR TITLE
add first-class projects, per-run context toggles, and the solo world

### DIFF
--- a/claude-plugin/yeaboi/skills/niko/SKILL.md
+++ b/claude-plugin/yeaboi/skills/niko/SKILL.md
@@ -37,7 +37,7 @@ produces a new report.
   result to continue one. The thread is persisted locally, so it survives
   restarts and is the same thread the desktop panel and `yeaboi ask` see.
 - **`route`** — where the user is, as a desktop route (`/agents/usage`,
-  `/humans/retro`). It colours the answer toward that screen. Omit it rather
+  `/team/retro`). It colours the answer toward that screen. Omit it rather
   than guessing; Niko says it doesn't know which screen rather than inventing
   one.
 - **`max_rounds`** — tool rounds before Niko must answer. The default of 4 is

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -11,7 +11,7 @@ contract change — update both sides and this file in the same PR.
 stdout, then nothing else ever:
 
 ```
-YEABOI_APP_READY {"pid":12345,"schema":30,"token":"…","url":"http://127.0.0.1:52341","version":"3.25.0"}
+YEABOI_APP_READY {"pid":12345,"schema":31,"token":"…","url":"http://127.0.0.1:52341","version":"3.25.0"}
 ```
 
 - JSON keys: `url`, `token`, `pid`, `schema` (sessions.py `CURRENT_SCHEMA_VERSION`),

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -33,7 +33,7 @@ The token never appears in URLs. Missing/wrong token → `401 {"error":"unauthor
 |---|---|---|
 | GET | `/api/health` | unauthenticated; `{ok, pid, version, schema}` |
 | GET | `/api/meta/version` | `{version, schema_version, python, platform}` |
-| GET | `/api/meta/capabilities` | the TUI card inventory verbatim: `{categories, modes, agents, intake}` |
+| GET | `/api/meta/capabilities` | the TUI card inventory verbatim: `{categories, solo, modes, agents, intake}` — `modes` is the Team menu, `solo` the Solo menu |
 | GET | `/api/meta/tips` | `{tips: [{key, text, mode_key, is_new, is_beta, surfaces}]}` |
 | GET | `/api/meta/changelog` | `{entries: [{version, date, headline, summary, highlights[{text, areas, surfaces}]}], areas: [{name, color}]}` |
 | GET | `/api/meta/privacy` | `{headline, statement: [str…], groups: [{key, title}], switches: [{key, env, on_value}], egress: [{key, group, what, where, when, default, off_switch}]}` — the privacy statement and egress-disclosure table, serialized verbatim from `yeaboi.privacy` (the copy owner every surface renders). Carries no capability and is never gated behind one: disclosure must always answer |

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -246,9 +246,9 @@ The two run-and-read modes. Their read-only pieces are MCP tools already
 | GET | `/api/standup/schedule` | query `session_id` → the saved schedule plus the installed reminder offset |
 | POST | `/api/standup/schedule` | body `{session_id, enabled, time, weekdays, lead_minutes, delivery_channels, remind_after}` → `{message, schedule}`; saves the config **and** installs or removes the OS jobs |
 | GET | `/api/analysis/options` | what a setup wizard may offer on this machine |
-| POST | `/api/analysis/steps` | a partial selection → `{steps, grid, run}`: which steps still apply, the component rows they may offer, and the payload the answers would run |
+| POST | `/api/analysis/steps` | a partial selection → `{steps, grid, run}`: which steps still apply, the component rows they may offer, and the payload the answers would run. `solo: true` in the answers marks a Solo-world wizard: the `members` step never applies and stale member picks coerce out of `run` |
 | GET | `/api/analysis/profiles` | the saved team profiles |
-| GET | `/api/analysis/result/{team_id}` | one stored profile plus the cards it earned; 404 when unknown |
+| GET | `/api/analysis/result/{team_id}` | one stored profile plus the cards it earned; 404 when unknown. `?solo=1` drops the Team Members card from `cards` |
 | POST | `/api/analysis/run` | the setup wizard's payload → a chunked NDJSON run |
 
 The **standup dashboard** is

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -423,9 +423,14 @@ A **run** streams `op`, `progress`, then `done: {report, delivered}`; cancelling
 the op raises at the next stage boundary, before anything is persisted, and the
 stream ends `cancelled`. The run body also takes an optional `project_id`
 (a `proj-<8hex>` projects-table row id): a scoped run frames itself with
-that project's latest sprint plan; blank inherits the session's own link. The
-standup run needs no such field — its session is the scope (an unlinked session
-runs team-wide, exactly as before projects existed).
+that project's latest sprint plan; blank inherits the session's own link. It
+also takes an optional `context_deps` (a list drawn from retro, standup, plan,
+performance, analysis): the run's context-source toggles — omitted/null
+inherits the project default, `[]` is an incognito run (no cross-mode
+context). The standup run needs neither field — its session is the scope (an
+unlinked session runs team-wide, exactly as before projects existed), and its
+toggles live in the session's saved standup config (`standup_config_set`'s
+`context_deps`).
 
 `/api/reporting/fit` answers `{extra_slides, style}`. `extra_slides: 0` means
 there is nothing to ask — the style that comes back is the one to export with.

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -196,7 +196,7 @@ nothing to confirm.
 *archives* rather than purges: a conversation is a record of what the user was
 told. The terminal's saved-conversations hub does the permanent delete.
 
-`route` on `send` is where the user is (`/agents/usage`, `/humans/retro`) and
+`route` on `send` is where the user is (`/agents/usage`, `/team/retro`) and
 colours the answer toward that screen. Omit it rather than guessing — Niko says
 it does not know which screen rather than inventing one. `user_name` is what to
 call them; the shell reads it from its own identity file.

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -421,7 +421,11 @@ that the window never runs past today, are one answer on every surface.
 
 A **run** streams `op`, `progress`, then `done: {report, delivered}`; cancelling
 the op raises at the next stage boundary, before anything is persisted, and the
-stream ends `cancelled`.
+stream ends `cancelled`. The run body also takes an optional `project_id`
+(a `proj-<8hex>` projects-table row id): a scoped run frames itself with
+that project's latest sprint plan; blank inherits the session's own link. The
+standup run needs no such field — its session is the scope (an unlinked session
+runs team-wide, exactly as before projects existed).
 
 `/api/reporting/fit` answers `{extra_slides, style}`. `extra_slides: 0` means
 there is nothing to ask — the style that comes back is the one to export with.

--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -32,31 +32,6 @@
       "title": "Usage"
     },
     {
-      "path": "/humans/planning",
-      "capability": "planning",
-      "title": "Planning"
-    },
-    {
-      "path": "/humans/planning/chat",
-      "capability": "planning",
-      "title": "Planning · Chat"
-    },
-    {
-      "path": "/humans/planning/plan",
-      "capability": "planning",
-      "title": "The plan"
-    },
-    {
-      "path": "/humans/planning/sessions",
-      "capability": "sessions",
-      "title": "Saved plans"
-    },
-    {
-      "path": "/humans/planning/roadmap",
-      "capability": "roadmap",
-      "title": "Planning · Roadmap intake"
-    },
-    {
       "path": "/humans/analysis",
       "capability": "team-analysis",
       "title": "Analysis"
@@ -253,8 +228,18 @@
     },
     {
       "path": "/projects/:id/blueprint",
-      "capability": null,
+      "capability": "planning",
       "title": "Blueprint"
+    },
+    {
+      "path": "/projects/:id/plan",
+      "capability": "planning",
+      "title": "Project · Plan"
+    },
+    {
+      "path": "/projects/new/from-roadmap",
+      "capability": "roadmap",
+      "title": "New project · From roadmap"
     },
     {
       "path": "/projects/:id/sessions/new",
@@ -354,66 +339,5 @@
       ]
     }
   ],
-  "commands": [
-    {
-      "name": "help",
-      "tui": "help",
-      "help": "shortcuts and everything you can type"
-    },
-    {
-      "name": "export",
-      "tui": "export",
-      "help": "save the plan and/or chat transcript"
-    },
-    {
-      "name": "skip",
-      "tui": "skip",
-      "help": "skip the current question"
-    },
-    {
-      "name": "defaults",
-      "tui": "defaults",
-      "help": "accept defaults for all remaining questions"
-    },
-    {
-      "name": "form",
-      "tui": "form",
-      "help": "see every question in one panel and answer them in any order"
-    },
-    {
-      "name": "finish",
-      "tui": "finish",
-      "help": "answer the remaining questions with defaults"
-    },
-    {
-      "name": "summary",
-      "tui": "summary",
-      "help": "show your answers so far"
-    },
-    {
-      "name": "questions",
-      "tui": "questions",
-      "help": "see what I'll ask and what's already answered"
-    },
-    {
-      "name": "edit",
-      "tui": "edit",
-      "help": "browse your answers (/edit 6 re-asks one) or refine the last artifact"
-    },
-    {
-      "name": "small",
-      "tui": "small",
-      "help": "switch to a Small plan"
-    },
-    {
-      "name": "large",
-      "tui": "large",
-      "help": "switch to a Large plan"
-    },
-    {
-      "name": "duck",
-      "tui": "duck",
-      "help": "mute or unmute the duck's speech bubble"
-    }
-  ]
+  "commands": []
 }

--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -32,97 +32,97 @@
       "title": "Usage"
     },
     {
-      "path": "/humans/analysis",
+      "path": "/team/analysis",
       "capability": "team-analysis",
       "title": "Analysis"
     },
     {
-      "path": "/humans/analysis/new",
+      "path": "/team/analysis/new",
       "capability": "team-analysis",
       "title": "Analysis · New"
     },
     {
-      "path": "/humans/analysis/results",
+      "path": "/team/analysis/results",
       "capability": "team-analysis",
       "title": "Analysis · Results"
     },
     {
-      "path": "/humans/standup",
+      "path": "/team/standup",
       "capability": "standup",
       "title": "Standup"
     },
     {
-      "path": "/humans/standup/setup",
+      "path": "/team/standup/setup",
       "capability": "standup",
       "title": "Standup · Setup"
     },
     {
-      "path": "/humans/standup/schedule",
+      "path": "/team/standup/schedule",
       "capability": "standup",
       "title": "Standup · Schedule"
     },
     {
-      "path": "/humans/standup/review",
+      "path": "/team/standup/review",
       "capability": "standup",
       "title": "Standup · Transcript review"
     },
     {
-      "path": "/humans/retro",
+      "path": "/team/retro",
       "capability": "retro-board",
       "title": "Retro"
     },
     {
-      "path": "/humans/retro/board",
+      "path": "/team/retro/board",
       "capability": "retro-board",
       "title": "Retro · Board"
     },
     {
-      "path": "/humans/poker",
+      "path": "/team/poker",
       "capability": "scrum-poker",
       "title": "Poker"
     },
     {
-      "path": "/humans/poker/new",
+      "path": "/team/poker/new",
       "capability": "scrum-poker",
       "title": "Poker · New session"
     },
     {
-      "path": "/humans/poker/board",
+      "path": "/team/poker/board",
       "capability": "scrum-poker",
       "title": "Poker · Table"
     },
     {
-      "path": "/humans/performance",
+      "path": "/team/performance",
       "capability": "performance",
       "title": "Performance"
     },
     {
-      "path": "/humans/performance/engineer",
+      "path": "/team/performance/engineer",
       "capability": "performance",
       "title": "Performance · Engineer"
     },
     {
-      "path": "/humans/reporting",
+      "path": "/team/reporting",
       "capability": "reporting",
       "title": "Reporting"
     },
     {
-      "path": "/humans/reporting/new",
+      "path": "/team/reporting/new",
       "capability": "reporting",
       "title": "Reporting · New report"
     },
     {
-      "path": "/humans/reporting/style",
+      "path": "/team/reporting/style",
       "capability": "reporting",
       "title": "Reporting · Deck style"
     },
     {
-      "path": "/humans/ship",
+      "path": "/team/ship",
       "capability": "ship",
       "title": "Ship"
     },
     {
-      "path": "/humans/ship/run",
+      "path": "/team/ship/run",
       "capability": "ship",
       "title": "Ship · Run"
     },

--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -213,12 +213,12 @@
     },
     {
       "path": "/projects",
-      "capability": null,
+      "capability": "projects",
       "title": "Projects"
     },
     {
       "path": "/projects/:id",
-      "capability": null,
+      "capability": "projects",
       "title": "Project"
     },
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.37.0"
+version = "3.38.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/test_scope.py
+++ b/scripts/test_scope.py
@@ -89,8 +89,8 @@ AREAS: tuple[Area, ...] = (
     ),
     Area(
         "projects",
-        src=("src/yeaboi/projects/",),
-        tests=("tests/unit/test_projects_*.py",),
+        src=("src/yeaboi/projects/", "src/yeaboi/mcp/tools_projects.py"),
+        tests=("tests/unit/test_mcp_server.py", "tests/unit/test_projects_*.py"),
     ),
     Area(
         "standup",

--- a/scripts/test_scope.py
+++ b/scripts/test_scope.py
@@ -88,6 +88,11 @@ AREAS: tuple[Area, ...] = (
         src=("contracts/site.json", "scripts/gen_site_contract.py"),
     ),
     Area(
+        "projects",
+        src=("src/yeaboi/projects/",),
+        tests=("tests/unit/test_projects_*.py",),
+    ),
+    Area(
         "standup",
         src=("src/yeaboi/standup/", "src/yeaboi/mcp/tools_standup.py"),
         tests=("tests/unit/test_mcp_server.py", "tests/unit/test_standup_*.py", "tests/unit/prompts/test_standup_*.py"),

--- a/src/yeaboi/agent/ceremony_history.py
+++ b/src/yeaboi/agent/ceremony_history.py
@@ -242,12 +242,20 @@ def gather_ceremony_context(
 
     Retros are fetched project-first (matching ``project_name`` sort ahead of
     others); standups are recency-based (their table has no project column).
-    A ``scope`` hard-filters both reads to the project's own sessions instead.
-    Graceful: a missing DB / empty tables / any error yields an empty context —
-    planning/analysis then behave exactly as before.
+    A ``scope`` hard-filters both reads to the project's own sessions instead,
+    and its ``context_deps`` toggles gate each producer: the ``retro`` dep off
+    skips every retro read, ``standup`` likewise. Graceful: a missing DB /
+    empty tables / any error yields an empty context — planning/analysis then
+    behave exactly as before.
 
     # See docs: "Session Management" — SQLite persistence
     """
+    from yeaboi.projects.scope import wants
+
+    want_retro = wants(scope, "retro")
+    want_standup = wants(scope, "standup")
+    if not want_retro and not want_standup:
+        return CeremonyContext()
     try:
         from yeaboi.config import get_sessions_db
         from yeaboi.retro.store import RetroStore
@@ -258,12 +266,25 @@ def gather_ceremony_context(
             return CeremonyContext()
 
         session_ids = scope.session_ids if scope is not None else None
-        with RetroStore(db_path) as rstore:
-            retros = rstore.get_recent_reports(retro_limit, "" if scope else project_name, session_ids=session_ids)
-            retro_hist = rstore.get_all_history(100)
-        with StandupStore(db_path) as sstore:
-            standups = sstore.get_recent_reports(standup_limit, session_ids=session_ids)
-            standup_hist = sstore.get_all_history(100)
+        retros: list = []
+        retro_hist: list[dict] = []
+        standups: list = []
+        standup_hist: list[dict] = []
+        if want_retro:
+            with RetroStore(db_path) as rstore:
+                retros = rstore.get_recent_reports(
+                    retro_limit, project_name if session_ids is None else "", session_ids=session_ids
+                )
+                retro_hist = rstore.get_all_history(100)
+        if want_standup:
+            with StandupStore(db_path) as sstore:
+                standups = sstore.get_recent_reports(standup_limit, session_ids=session_ids)
+                standup_hist = sstore.get_all_history(100)
+        if session_ids is not None:
+            # Cadence/trend must not leak foreign sessions into a scoped run.
+            allowed = set(session_ids)
+            retro_hist = [h for h in retro_hist if h["session_id"] in allowed]
+            standup_hist = [h for h in standup_hist if h["session_id"] in allowed]
     except Exception:  # noqa: BLE001 — ceremony history is best-effort; never abort a plan
         logger.debug("gather_ceremony_context failed (non-fatal)", exc_info=True)
         return CeremonyContext()

--- a/src/yeaboi/agent/ceremony_history.py
+++ b/src/yeaboi/agent/ceremony_history.py
@@ -27,8 +27,12 @@ import logging
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from yeaboi.timeparse import parse_datetime
+
+if TYPE_CHECKING:
+    from yeaboi.projects.scope import ProjectScope
 
 logger = logging.getLogger(__name__)
 
@@ -232,12 +236,13 @@ def format_ceremony_history_md(ctx: CeremonyContext) -> str:
 
 
 def gather_ceremony_context(
-    project_name: str = "", *, retro_limit: int = 5, standup_limit: int = 10
+    project_name: str = "", *, retro_limit: int = 5, standup_limit: int = 10, scope: ProjectScope | None = None
 ) -> CeremonyContext:
     """Read the team's recent retros + standups and distil them (team-wide).
 
     Retros are fetched project-first (matching ``project_name`` sort ahead of
     others); standups are recency-based (their table has no project column).
+    A ``scope`` hard-filters both reads to the project's own sessions instead.
     Graceful: a missing DB / empty tables / any error yields an empty context —
     planning/analysis then behave exactly as before.
 
@@ -252,11 +257,12 @@ def gather_ceremony_context(
         if not db_path.exists():
             return CeremonyContext()
 
+        session_ids = scope.session_ids if scope is not None else None
         with RetroStore(db_path) as rstore:
-            retros = rstore.get_recent_reports(retro_limit, project_name)
+            retros = rstore.get_recent_reports(retro_limit, "" if scope else project_name, session_ids=session_ids)
             retro_hist = rstore.get_all_history(100)
         with StandupStore(db_path) as sstore:
-            standups = sstore.get_recent_reports(standup_limit)
+            standups = sstore.get_recent_reports(standup_limit, session_ids=session_ids)
             standup_hist = sstore.get_all_history(100)
     except Exception:  # noqa: BLE001 — ceremony history is best-effort; never abort a plan
         logger.debug("gather_ceremony_context failed (non-fatal)", exc_info=True)

--- a/src/yeaboi/agent/ceremony_history.py
+++ b/src/yeaboi/agent/ceremony_history.py
@@ -270,21 +270,18 @@ def gather_ceremony_context(
         retro_hist: list[dict] = []
         standups: list = []
         standup_hist: list[dict] = []
+        # Cadence/trend must not leak foreign sessions into a scoped run, and the
+        # filter goes in the query so the 100-row window is the project's own.
         if want_retro:
             with RetroStore(db_path) as rstore:
                 retros = rstore.get_recent_reports(
                     retro_limit, project_name if session_ids is None else "", session_ids=session_ids
                 )
-                retro_hist = rstore.get_all_history(100)
+                retro_hist = rstore.get_all_history(100, session_ids=session_ids)
         if want_standup:
             with StandupStore(db_path) as sstore:
                 standups = sstore.get_recent_reports(standup_limit, session_ids=session_ids)
-                standup_hist = sstore.get_all_history(100)
-        if session_ids is not None:
-            # Cadence/trend must not leak foreign sessions into a scoped run.
-            allowed = set(session_ids)
-            retro_hist = [h for h in retro_hist if h["session_id"] in allowed]
-            standup_hist = [h for h in standup_hist if h["session_id"] in allowed]
+                standup_hist = sstore.get_all_history(100, session_ids=session_ids)
     except Exception:  # noqa: BLE001 — ceremony history is best-effort; never abort a plan
         logger.debug("gather_ceremony_context failed (non-fatal)", exc_info=True)
         return CeremonyContext()

--- a/src/yeaboi/agent/headless.py
+++ b/src/yeaboi/agent/headless.py
@@ -28,6 +28,7 @@ export-only branch exactly:
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from collections.abc import Callable
@@ -183,6 +184,7 @@ def run_planning_pipeline(
     ac_format: str = "",
     architecture_spike: str = "auto",
     project_id: str = "",
+    context_deps: list[str] | None = None,
 ) -> dict:
     """Run the full planning pipeline headlessly and return the final graph state.
 
@@ -218,6 +220,12 @@ def run_planning_pipeline(
         project_id: Project to link the session to ("" = unscoped). A scoped
             run hard-filters ceremony context to the project's own sessions
             and seeds the analysis profile from the project's defaults.
+        context_deps: Context-source toggles for this run (see
+            ``projects.scope.CONTEXT_DEP_TOKENS``): ``retro``/``standup``
+            gate ceremony history, ``performance`` the 1:1 context,
+            ``analysis`` the team-profile calibration. ``None`` inherits the
+            project's ``default_context_deps``, then all-on; an empty list is
+            an incognito run (context isolation — the session still persists).
 
     Returns:
         The final graph state dict (analysis, features, stories, tasks,
@@ -275,20 +283,32 @@ def run_planning_pipeline(
             # A pre-made choice means the spike question is never asked;
             # "auto" leaves it unset so _next_auto_input's confidence rule answers.
             graph_state["spike_choice"] = architecture_spike
+        from yeaboi.projects.scope import normalize_context_deps
+
+        effective_deps = normalize_context_deps(context_deps)
         if project_id:
             graph_state["project_id"] = project_id
             try:
                 from yeaboi.projects.store import ProjectStore
 
                 with ProjectStore(db_path or get_db_path()) as projects:
-                    default_profile = str(projects.get_settings(project_id).get("default_analysis_profile_id", ""))
-                if default_profile:
+                    settings = projects.get_settings(project_id)
+                if effective_deps is None:
+                    effective_deps = normalize_context_deps(settings.get("default_context_deps"))
+                default_profile = str(settings.get("default_analysis_profile_id", ""))
+                if default_profile and (effective_deps is None or "analysis" in effective_deps):
                     # The analysis→planning edge: the project remembers which
-                    # team profile its last analysis produced.
+                    # team profile its last analysis produced. An off `analysis`
+                    # dep suppresses the seeding for this run.
                     graph_state["analysis_profile_id"] = default_profile
                     logger.info("Headless: seeded analysis profile %s from project %s", default_profile, project_id)
             except Exception:
                 logger.warning("Could not read project defaults for %s (continuing)", project_id, exc_info=True)
+        if effective_deps is not None:
+            # A JSON-list state key so the node reads (_wants_dep) and the saved
+            # session both carry the run's toggles.
+            graph_state["context_deps"] = json.dumps(sorted(effective_deps))
+            logger.info("Headless: context deps restricted to %s", sorted(effective_deps))
 
         store = SessionStore(db_path or get_db_path()) if save_session else None
         session_created = False

--- a/src/yeaboi/agent/headless.py
+++ b/src/yeaboi/agent/headless.py
@@ -182,6 +182,7 @@ def run_planning_pipeline(
     prior_art: list[str] | None = None,
     ac_format: str = "",
     architecture_spike: str = "auto",
+    project_id: str = "",
 ) -> dict:
     """Run the full planning pipeline headlessly and return the final graph state.
 
@@ -214,6 +215,9 @@ def run_planning_pipeline(
             "auto" (default) applies the confidence rule (validate unless the
             analyzer's confidence is high). Irrelevant when the architecture
             is pinned or has a single option — nothing is added then.
+        project_id: Project to link the session to ("" = unscoped). A scoped
+            run hard-filters ceremony context to the project's own sessions
+            and seeds the analysis profile from the project's defaults.
 
     Returns:
         The final graph state dict (analysis, features, stories, tasks,
@@ -271,6 +275,20 @@ def run_planning_pipeline(
             # A pre-made choice means the spike question is never asked;
             # "auto" leaves it unset so _next_auto_input's confidence rule answers.
             graph_state["spike_choice"] = architecture_spike
+        if project_id:
+            graph_state["project_id"] = project_id
+            try:
+                from yeaboi.projects.store import ProjectStore
+
+                with ProjectStore(db_path or get_db_path()) as projects:
+                    default_profile = str(projects.get_settings(project_id).get("default_analysis_profile_id", ""))
+                if default_profile:
+                    # The analysis→planning edge: the project remembers which
+                    # team profile its last analysis produced.
+                    graph_state["analysis_profile_id"] = default_profile
+                    logger.info("Headless: seeded analysis profile %s from project %s", default_profile, project_id)
+            except Exception:
+                logger.warning("Could not read project defaults for %s (continuing)", project_id, exc_info=True)
 
         store = SessionStore(db_path or get_db_path()) if save_session else None
         session_created = False
@@ -307,7 +325,7 @@ def run_planning_pipeline(
             if store is not None:
                 try:
                     if not session_created:
-                        store.create_session(session_id)
+                        store.create_session(session_id, project_id=project_id)
                         session_created = True
                     store.save_state(session_id, graph_state)
                     if not project_name_recorded:

--- a/src/yeaboi/agent/nodes.py
+++ b/src/yeaboi/agent/nodes.py
@@ -3937,6 +3937,11 @@ def _show_summary_or_pto(questionnaire: QuestionnaireState, prefix: str = "") ->
     # the repositories analysis found and let the user rule each in or out.
     # Same shape as the PTO sub-loop above: a stage flag on the questionnaire,
     # awaiting_confirmation set so the handler runs in the confirmation gate.
+    if not questionnaire._prior_art_stage and not questionnaire._analysis_enabled:
+        # Analysis is toggled off for this run: the shortlist would auto-detect
+        # a profile even with a blank id, so the stage settles without a scan.
+        logger.info("analysis dep off — skipping the prior-art offer")
+        questionnaire._prior_art_stage = "done"
     if not questionnaire._prior_art_stage and _prior_art_applies(questionnaire):
         prompt = _start_prior_art(questionnaire)
         if prompt is not None:
@@ -4294,7 +4299,9 @@ def project_intake(state: ScrumState) -> dict:
     if questionnaire is not None:
         # Refresh the stash on every invoke, so a resumed session — whose
         # transients were dropped — reaches the prior-art step with a profile.
-        questionnaire._analysis_profile_id = state.get("analysis_profile_id", "") or ""
+        # The analysis toggle beats the stash: off means no id and no prior art.
+        questionnaire._analysis_profile_id = _effective_analysis_profile_id(state)
+        questionnaire._analysis_enabled = _wants_dep(state, "analysis")
 
     # ── Tracker choice resolution ────────────────────────────────────
     # When both Jira and Azure DevOps are configured, the user picks one
@@ -4344,7 +4351,8 @@ def project_intake(state: ScrumState) -> dict:
         # The prior-art step runs from _show_summary_or_pto, which sees only the
         # questionnaire — stash the profile id rather than thread graph state
         # through eleven call sites. Same pattern as _repo_context.
-        qs._analysis_profile_id = state.get("analysis_profile_id", "") or ""
+        qs._analysis_profile_id = _effective_analysis_profile_id(state)
+        qs._analysis_enabled = _wants_dep(state, "analysis")
 
         # Apply tracker preference from the choice resolution above (if any).
         if _pending_tracker_pref:
@@ -4401,7 +4409,7 @@ def project_intake(state: ScrumState) -> dict:
         # ── Analysis profile auto-fill ────────────────────────────────
         # If the user selected an analysis profile in the profile picker,
         # extract Q6/Q8/Q9 from it. Priority: description > SCRUM.md > analysis.
-        _analysis_profile_id = state.get("analysis_profile_id", "")
+        _analysis_profile_id = _effective_analysis_profile_id(state)
         if _analysis_profile_id:
             _ap, _ap_ex = _load_profile_by_id(_analysis_profile_id)
             if _ap:
@@ -4499,7 +4507,7 @@ def project_intake(state: ScrumState) -> dict:
             # Q28 (bank holidays) choices are prepared so the user sees a confirmation.
             # See docs: "Scrum Standards" — capacity planning
             # ── Derive tracker preference from analysis profile if selected ──
-            _ap_id = state.get("analysis_profile_id", "")
+            _ap_id = _effective_analysis_profile_id(state)
             if _ap_id and not qs._preferred_tracker:
                 _ap_source = _ap_id.split("-", 1)[0]
                 if _ap_source in ("jira", "azdevops"):
@@ -4866,7 +4874,7 @@ def project_intake(state: ScrumState) -> dict:
                     questionnaire.answers[6] = f"{len(_sel_names)} ({_names_str})"
                     logger.info("Q6 member select: %d members: %s", len(_sel_names), _names_str)
 
-                    _ap_id = state.get("analysis_profile_id", "")
+                    _ap_id = _effective_analysis_profile_id(state)
                     if _ap_id:
                         try:
                             _, _ap_ex2 = _load_profile_by_id(_ap_id)
@@ -5067,7 +5075,7 @@ def project_intake(state: ScrumState) -> dict:
                 # Couldn't fetch active sprint from live tracker
                 logger.warning("Tracker sprint fetch failed: %s", jira_status)
                 # Try analysis sprint data as fallback
-                _ap_id = state.get("analysis_profile_id", "")
+                _ap_id = _effective_analysis_profile_id(state)
                 _used_analysis = False
                 if _ap_id:
                     try:
@@ -5777,7 +5785,7 @@ def project_intake(state: ScrumState) -> dict:
                 _names_str = ", ".join(_selected_names)
                 questionnaire.answers[6] = f"{len(_selected_names)} ({_names_str})"
                 # Calculate velocity from selected members
-                _ap_id = state.get("analysis_profile_id", "")
+                _ap_id = _effective_analysis_profile_id(state)
                 if _ap_id:
                     try:
                         _, _ap_ex2 = _load_profile_by_id(_ap_id)
@@ -6616,6 +6624,19 @@ def _state_scope(state):
     from yeaboi.projects.scope import resolve_scope
 
     return resolve_scope(state.get("project_id", ""), context_deps=state.get("context_deps") or None)
+
+
+def _effective_analysis_profile_id(state) -> str:
+    """The state's analysis profile id, unless the analysis toggle is off.
+
+    The toggle beats an explicit pick: with ``analysis`` off, a seeded or
+    resumed profile id is dropped (logged) so intake never auto-fills from it.
+    """
+    pid = state.get("analysis_profile_id", "") or ""
+    if pid and not _wants_dep(state, "analysis"):
+        logger.info("analysis dep off — dropping analysis profile %s for this run", pid)
+        return ""
+    return pid
 
 
 def project_analyzer(state: ScrumState) -> dict:

--- a/src/yeaboi/agent/nodes.py
+++ b/src/yeaboi/agent/nodes.py
@@ -6579,20 +6579,43 @@ def compute_prompt_quality(qs: QuestionnaireState, *, has_user_context: bool = F
     )
 
 
-def _gather_performance_summary() -> str:
+def _gather_performance_summary(scope=None) -> str:
     """Return the team's Performance signal as a markdown block (empty if unused).
 
     Thin, graceful wrapper around performance.gather_performance_context so the
     analyzer / planner stay decoupled from the Performance package internals and a
-    missing DB or unused mode never affects a plan. See README: "Performance Mode".
+    missing DB or unused mode never affects a plan. A ``scope`` with the
+    ``performance`` dep off yields "". See README: "Performance Mode".
     """
     try:
         from yeaboi.performance.context import gather_performance_context
 
-        return gather_performance_context().summary_md
+        return gather_performance_context(scope=scope).summary_md
     except Exception:  # noqa: BLE001 — performance context is best-effort
         logger.debug("_gather_performance_summary failed (non-fatal)", exc_info=True)
         return ""
+
+
+def _wants_dep(state, dep: str) -> bool:
+    """Whether this run's context toggles allow ``dep`` (absent key = all on).
+
+    Reads the ``context_deps`` state key seeded by run_planning_pipeline /
+    the TUI launch sites — a JSON list of projects.scope.CONTEXT_DEP_TOKENS.
+    """
+    raw = state.get("context_deps", "")
+    if not raw:
+        return True
+    from yeaboi.projects.scope import normalize_context_deps
+
+    deps = normalize_context_deps(raw)
+    return deps is None or dep in deps
+
+
+def _state_scope(state):
+    """The run's ProjectScope, built from the state's project + toggle keys."""
+    from yeaboi.projects.scope import resolve_scope
+
+    return resolve_scope(state.get("project_id", ""), context_deps=state.get("context_deps") or None)
 
 
 def project_analyzer(state: ScrumState) -> dict:
@@ -6692,10 +6715,13 @@ def project_analyzer(state: ScrumState) -> dict:
     # Load team profile for calibration-aware analysis.
     # Non-fatal — if no profile exists, the prompt runs without calibration context.
     # See docs: "Scrum Standards" — team learning, self-calibrating estimates
-    team_profile = _load_team_profile(state.get("analysis_profile_id", ""))
-    team_calibration_text = _format_team_calibration(
-        team_profile, examples=_load_team_examples(state.get("analysis_profile_id", ""))
-    )
+    if _wants_dep(state, "analysis"):
+        team_profile = _load_team_profile(state.get("analysis_profile_id", ""))
+        team_calibration_text = _format_team_calibration(
+            team_profile, examples=_load_team_examples(state.get("analysis_profile_id", ""))
+        )
+    else:
+        team_profile, team_calibration_text = None, ""
     team_profile_summary = team_calibration_text.strip()
 
     # Gather the team's recent Standup + Retro history (graceful — an empty
@@ -6705,15 +6731,15 @@ def project_analyzer(state: ScrumState) -> dict:
     # knows its project up front and hard-filters to its own sessions instead.
     # Action items are stashed for story_writer.
     # See docs: "Session Management" — SQLite persistence
-    from yeaboi.projects.scope import resolve_scope
-
-    ceremony = gather_ceremony_context(scope=resolve_scope(state.get("project_id", "")))
+    scope = _state_scope(state)
+    ceremony = gather_ceremony_context(scope=scope)
 
     # Gather per-engineer Performance signal (open 1:1 action items + review focus
     # areas) so the analysis is *person-aware* — e.g. flags an engineer's growth
     # area as a staffing consideration. Graceful: empty when Performance mode is
-    # unused. See README: "Performance Mode".
-    performance = _gather_performance_summary()
+    # unused, or when the run's `performance` toggle is off. See README:
+    # "Performance Mode".
+    performance = _gather_performance_summary(scope)
 
     # Build the formatted answers block for the prompt
     answers_block = _build_answers_block(questionnaire)
@@ -8496,10 +8522,13 @@ def story_writer(state: ScrumState) -> dict:
 
     # Load team calibration for team-specific estimation rules.
     # See docs: "Scrum Standards" — team learning, self-calibrating estimates
-    team_profile = _load_team_profile(state.get("analysis_profile_id", ""))
-    team_calibration_text = _format_team_calibration(
-        team_profile, examples=_load_team_examples(state.get("analysis_profile_id", ""))
-    )
+    if _wants_dep(state, "analysis"):
+        team_profile = _load_team_profile(state.get("analysis_profile_id", ""))
+        team_calibration_text = _format_team_calibration(
+            team_profile, examples=_load_team_examples(state.get("analysis_profile_id", ""))
+        )
+    else:
+        team_profile, team_calibration_text = None, ""
 
     # Resolve DoD items — custom from analysis or default 7
     from yeaboi.agent.state import resolve_ac_style, resolve_dod_items
@@ -8518,7 +8547,7 @@ def story_writer(state: ScrumState) -> dict:
     # The team's learned ticket-template section headings (naming conventions)
     # — persisted on state so exporters can adopt them on every surface.
     _tpl_sections: list[str] = []
-    _examples = _load_team_examples(state.get("analysis_profile_id", ""))
+    _examples = _load_team_examples(state.get("analysis_profile_id", "")) if _wants_dep(state, "analysis") else None
     if _examples:
         _naming = _examples.get("naming_conventions") or {}
         for entry in (_naming.get("template_sections") or [])[:8]:
@@ -9093,10 +9122,13 @@ def task_decomposer(state: ScrumState) -> dict:
 
     # Load team calibration for team-specific task patterns.
     # See docs: "Scrum Standards" — team learning, self-calibrating estimates
-    team_profile = _load_team_profile(state.get("analysis_profile_id", ""))
-    team_calibration_text = _format_team_calibration(
-        team_profile, examples=_load_team_examples(state.get("analysis_profile_id", ""))
-    )
+    if _wants_dep(state, "analysis"):
+        team_profile = _load_team_profile(state.get("analysis_profile_id", ""))
+        team_calibration_text = _format_team_calibration(
+            team_profile, examples=_load_team_examples(state.get("analysis_profile_id", ""))
+        )
+    else:
+        team_profile, team_calibration_text = None, ""
 
     # ── Parallel task decomposition by feature ────────────────────────────
     # Split stories into per-feature groups and decompose concurrently.
@@ -9901,10 +9933,13 @@ def sprint_planner(state: ScrumState) -> dict:
 
     # Load team calibration for velocity-aware sprint planning.
     # See docs: "Scrum Standards" — team learning, self-calibrating estimates
-    team_profile = _load_team_profile(state.get("analysis_profile_id", ""))
-    team_calibration_text = _format_team_calibration(
-        team_profile, examples=_load_team_examples(state.get("analysis_profile_id", ""))
-    )
+    if _wants_dep(state, "analysis"):
+        team_profile = _load_team_profile(state.get("analysis_profile_id", ""))
+        team_calibration_text = _format_team_calibration(
+            team_profile, examples=_load_team_examples(state.get("analysis_profile_id", ""))
+        )
+    else:
+        team_profile, team_calibration_text = None, ""
 
     prompt = get_sprint_planner_prompt(
         project_name=analysis.project_name,
@@ -9919,7 +9954,7 @@ def sprint_planner(state: ScrumState) -> dict:
         team_override_from=original_team_size if state.get("_capacity_team_override", 0) > 0 else None,
         team_calibration=team_calibration_text,
         ceremony_history=state.get("_ceremony_history", "") or "",
-        performance_context=state.get("_performance_context", "") or _gather_performance_summary(),
+        performance_context=state.get("_performance_context", "") or _gather_performance_summary(_state_scope(state)),
         review_feedback=review_feedback if review_mode else None,
         review_mode=review_mode,
         previous_output=previous_output,

--- a/src/yeaboi/agent/nodes.py
+++ b/src/yeaboi/agent/nodes.py
@@ -6698,12 +6698,16 @@ def project_analyzer(state: ScrumState) -> dict:
     )
     team_profile_summary = team_calibration_text.strip()
 
-    # Gather the team's recent Standup + Retro history (team-wide, graceful — an
-    # empty context when nothing has run). Recency-dominant here: pre-analysis we
-    # have no reliable project name to match on, so we pass "" and let the most
-    # recent ceremonies inform the plan. Action items are stashed for story_writer.
+    # Gather the team's recent Standup + Retro history (graceful — an empty
+    # context when nothing has run). Unscoped runs are recency-dominant:
+    # pre-analysis we have no reliable project name to match on, so we pass ""
+    # and let the most recent ceremonies inform the plan. A project-scoped run
+    # knows its project up front and hard-filters to its own sessions instead.
+    # Action items are stashed for story_writer.
     # See docs: "Session Management" — SQLite persistence
-    ceremony = gather_ceremony_context()
+    from yeaboi.projects.scope import resolve_scope
+
+    ceremony = gather_ceremony_context(scope=resolve_scope(state.get("project_id", "")))
 
     # Gather per-engineer Performance signal (open 1:1 action items + review focus
     # areas) so the analysis is *person-aware* — e.g. flags an engineer's growth

--- a/src/yeaboi/agent/state.py
+++ b/src/yeaboi/agent/state.py
@@ -2275,6 +2275,10 @@ class QuestionnaireState:
     # _repo_context is, so the summary path can reach it without threading
     # graph state through eleven call sites.
     _analysis_profile_id: str = ""
+    # Transient: whether this run's context toggles allow analysis reads at all.
+    # A blank _analysis_profile_id still auto-detects from configured trackers,
+    # so the prior-art step needs an explicit off switch, not just an empty id.
+    _analysis_enabled: bool = True
     # Transient: active sprint number from Jira (e.g. 104). Used to compute
     # the start date offset when the user selects a future sprint (e.g. Sprint 107).
     # Set during Q27 processing; None when Jira is not configured.

--- a/src/yeaboi/agent/state.py
+++ b/src/yeaboi/agent/state.py
@@ -2441,6 +2441,14 @@ class ScrumState(_RequiredState, total=False):
     # When set, intake auto-fills Q6/Q8/Q9 from the profile and nodes
     # use this profile for team calibration. Empty string = no profile selected.
     analysis_profile_id: str
+    # The run's project link and context toggles, read by _state_scope/_wants_dep
+    # to narrow every cross-mode read. Both are seeded by the caller, never by a
+    # node. Declared as ScrumState fields so LangGraph doesn't strip them —
+    # undeclared keys never reach a node, which silently unscopes the whole run.
+    # project_id is '' when unscoped; context_deps is a JSON array of dep tokens,
+    # absent when every source is on.
+    project_id: str
+    context_deps: str
     # Existing team repositories the user accepted as prior art for this plan.
     # Only greenfield projects are offered them. Feeds the analyzer and feature
     # prompts, and renders as a Prior Art section in the summary and exports.

--- a/src/yeaboi/analysis/dashboard.py
+++ b/src/yeaboi/analysis/dashboard.py
@@ -51,6 +51,7 @@ def visible_card_order(
     *,
     has_code_health: bool = False,
     analysis_features: list[str] | tuple[str, ...] | None = None,
+    solo: bool = False,
 ) -> tuple[str, ...]:
     """Which cards to show, composing delivery cards with the global ones.
 
@@ -58,11 +59,12 @@ def visible_card_order(
     delivery ``profile`` for the active tracker; ``ai-adoption`` iff the global
     Code scan ran; ``documentation`` iff the global Docs scan ran. The overview
     and the detail navigation share this, so a selection index and the rendered
-    card list can never drift apart.
+    card list can never drift apart. ``solo`` drops the Team Members card —
+    the one inherently multi-person card — from a run over your own history.
     """
     order: list[str] = []
     if profile is not None:
-        order.extend(k for k in DELIVERY_CARD_ORDER if k != "insights")
+        order.extend(k for k in DELIVERY_CARD_ORDER if k != "insights" and not (solo and k == "team"))
     features = set(analysis_features or ())
     explicit = analysis_features is not None
     # code-health first: it's deterministic, so it sits with the regular cards,
@@ -106,10 +108,11 @@ def component_presence(
     }
 
 
-def cards(profile, **kw) -> list[dict]:
+def cards(profile, *, solo: bool = False, **kw) -> list[dict]:
     """The visible cards as ``[{key, title}]`` — the desktop's card list.
 
-    Takes the same keywords as :func:`component_presence`.
+    Takes the same keywords as :func:`component_presence`, plus ``solo``
+    (forwarded to :func:`visible_card_order`).
     """
     features = kw.get("analysis_features")
     present = component_presence(profile, **kw)
@@ -119,5 +122,6 @@ def cards(profile, **kw) -> list[dict]:
         present["docs"],
         has_code_health=present["code_health"],
         analysis_features=features,
+        solo=solo,
     )
     return [{"key": key, "title": CARD_TITLES[key]} for key in order]

--- a/src/yeaboi/analysis/setup.py
+++ b/src/yeaboi/analysis/setup.py
@@ -165,13 +165,20 @@ def effective_depth(depth: str, features) -> str:
 
 
 def step_applies(
-    step: str, *, features, components=None, depth: str = DEFAULT_DEPTH, model_offered: bool = False
+    step: str,
+    *,
+    features,
+    components=None,
+    depth: str = DEFAULT_DEPTH,
+    model_offered: bool = False,
+    solo: bool = False,
 ) -> bool:
     """Does ``step`` apply, given what has been selected so far?
 
     A choice made for a step that later becomes inapplicable stays in the
     wizard's own state (so re-enabling a feature restores it) — it is here that
-    it is kept out of the run.
+    it is kept out of the run. ``solo`` is the Solo world: a run over your own
+    history has no roster to narrow, so the members step never applies.
     """
     chosen = set(features or ())
     comps = components or {}
@@ -187,23 +194,26 @@ def step_applies(
     if step == "window":
         return bool(chosen & (CODE_FEATURES | {"documentation"}))
     if step == "members":
-        return bool(chosen & (CODE_FEATURES | {"delivery"}))
+        return not solo and bool(chosen & (CODE_FEATURES | {"delivery"}))
     return False
 
 
-def run_config(state: dict, *, roster_fallback, model_offered: bool = False) -> dict:
+def run_config(state: dict, *, roster_fallback, model_offered: bool = False, solo: bool = False) -> dict:
     """Turn a completed wizard's answers into the run payload.
 
     Every host's scope is gated on its OWN applicability, so de-selecting a code
     host coerces its stale picks out of the payload — the same discipline that
-    keeps a stale ``deep`` out of a docs-only run.
+    keeps a stale ``deep`` out of a docs-only run (and, on a solo run, keeps a
+    stale member pick out of the payload entirely).
     """
     features = state.get("features")
     comps = state.get("components") or {}
     depth = state.get("depth") or DEFAULT_DEPTH
 
     def applies(step: str) -> bool:
-        return step_applies(step, features=features, components=comps, depth=depth, model_offered=model_offered)
+        return step_applies(
+            step, features=features, components=comps, depth=depth, model_offered=model_offered, solo=solo
+        )
 
     members = state.get("members") if applies("members") else None
     trackers = comps.get("delivery") or roster_fallback

--- a/src/yeaboi/app/awareness.py
+++ b/src/yeaboi/app/awareness.py
@@ -48,7 +48,7 @@ class Notice:
 NOTICES: dict[str, Notice] = {
     "ceremony_ran": Notice("ceremony_ran", "A ceremony fired!", route="/ceremonies"),
     "ceremony_failed": Notice("ceremony_failed", "A ceremony went wrong.", route="/ceremonies"),
-    "ship_gate": Notice("ship_gate", "A diff needs you.", sticky=True, route="/humans/ship/run"),
+    "ship_gate": Notice("ship_gate", "A diff needs you.", sticky=True, route="/team/ship/run"),
 }
 
 

--- a/src/yeaboi/app/routes_analysis.py
+++ b/src/yeaboi/app/routes_analysis.py
@@ -67,17 +67,20 @@ def steps(app, request: Request) -> Response:
     components = answers.get("components") or {}
     depth = str(answers.get("depth", setup.DEFAULT_DEPTH))
     model_offered = bool(answers.get("model_offered"))
+    solo = bool(answers.get("solo"))
     applicable = [
         step
         for step in setup.STEPS
-        if setup.step_applies(step, features=features, components=components, depth=depth, model_offered=model_offered)
+        if setup.step_applies(
+            step, features=features, components=components, depth=depth, model_offered=model_offered, solo=solo
+        )
     ]
     roster_fallback = answers.get("roster_fallback") or setup.available_trackers()
     return json_response(
         {
             "steps": applicable,
             "grid": setup.filtered_grid(answers.get("grid") or setup.available_grid(), features),
-            "run": setup.run_config(answers, roster_fallback=roster_fallback, model_offered=model_offered),
+            "run": setup.run_config(answers, roster_fallback=roster_fallback, model_offered=model_offered, solo=solo),
         }
     )
 
@@ -102,6 +105,7 @@ def result(app, request: Request) -> Response:
     from yeaboi.team_profile import TeamProfileStore
 
     team_id = request.params.get("team_id", "")
+    solo = request.query.get("solo") in ("1", "true")
     db_path = get_db_path()
     profile, examples = (None, None)
     if db_path.exists():
@@ -114,7 +118,7 @@ def result(app, request: Request) -> Response:
             "team_id": team_id,
             # A stored profile carries no top-level signals — the global scans
             # were persisted onto it, which is where the cards read them.
-            "cards": dashboard.cards(profile, examples=examples),
+            "cards": dashboard.cards(profile, examples=examples, solo=solo),
             "profile": to_jsonable(profile),
             "examples": to_jsonable(examples or {}),
         }

--- a/src/yeaboi/app/routes_meta.py
+++ b/src/yeaboi/app/routes_meta.py
@@ -52,15 +52,18 @@ def capabilities(app, request: Request) -> Response:
     """The card inventory, verbatim from the TUI's single source of truth.
 
     Served rather than re-declared so the desktop home screen can never drift
-    from ``_MODE_CARDS`` — the same dicts the welcome screen renders.
+    from ``_MODE_CARDS`` — the same dicts the welcome screen renders. ``modes``
+    is the Team menu (the key predates the Solo world and the desktop reads
+    it); ``solo`` is the Solo menu, additive.
     """
-    from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _INTAKE_CARDS, _MODE_CARDS
+    from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _INTAKE_CARDS, _MODE_CARDS, _SOLO_CARDS
     from yeaboi.ui.mode_select.screens._screens_category import _CATEGORY_CARDS
 
     return json_response(
         to_jsonable(
             {
                 "categories": _CATEGORY_CARDS,
+                "solo": _SOLO_CARDS,
                 "modes": _MODE_CARDS,
                 "agents": _AGENT_CARDS,
                 "intake": _INTAKE_CARDS,

--- a/src/yeaboi/app/routes_reporting.py
+++ b/src/yeaboi/app/routes_reporting.py
@@ -263,6 +263,7 @@ def _run(app, op, payload: dict, period: str, window_start: str, window_end: str
                 result_box[0] = run_delivery_report(
                     period,
                     session_id=str(payload.get("session_id", "")),
+                    project_id=str(payload.get("project_id", "")),
                     window_start=window_start,
                     window_end=window_end,
                     sprint_names=tuple(payload.get("sprint_names") or ()),

--- a/src/yeaboi/app/routes_reporting.py
+++ b/src/yeaboi/app/routes_reporting.py
@@ -264,6 +264,7 @@ def _run(app, op, payload: dict, period: str, window_start: str, window_end: str
                     period,
                     session_id=str(payload.get("session_id", "")),
                     project_id=str(payload.get("project_id", "")),
+                    context_deps=payload.get("context_deps"),
                     window_start=window_start,
                     window_end=window_end,
                     sprint_names=tuple(payload.get("sprint_names") or ()),

--- a/src/yeaboi/app/supervisor.py
+++ b/src/yeaboi/app/supervisor.py
@@ -227,8 +227,9 @@ class BoardSupervisor:
     def start_retro(self) -> BoardSession:
         """Open a retro board for the latest session, seeded with carried actions."""
         from yeaboi.config import get_retro_server_port
+        from yeaboi.projects.scope import resolve_scope
         from yeaboi.retro.board import RetroBoard
-        from yeaboi.retro.engine import carried_action_items_for_session, history_providers
+        from yeaboi.retro.engine import carried_action_items_for_session, history_providers, standup_blocker_cards
         from yeaboi.retro.server import RetroServer
         from yeaboi.retro.setup import resolve_session
 
@@ -237,10 +238,13 @@ class BoardSupervisor:
             raise ValueError("no project session yet")
         board = RetroBoard(target.session_id, project_name=target.project_name, sprint_name=target.sprint_name)
         # Seeded before the server starts, so the first browser poll already
-        # shows the "Last sprint's actions" column.
+        # shows the "Last sprint's actions" column. A project-linked session
+        # scopes the carry and adds the project's recent standup blockers.
+        scope = resolve_scope(session_id=target.session_id, db_path=self.db_path)
         carried = carried_action_items_for_session(
-            target.session_id, project_name=target.project_name, db_path=self.db_path
+            target.session_id, project_name=target.project_name, db_path=self.db_path, scope=scope
         )
+        carried = (*carried, *standup_blocker_cards(scope, db_path=self.db_path, existing=carried))
         if carried:
             board.seed_carried(list(carried))
         server = RetroServer(board, port=get_retro_server_port())

--- a/src/yeaboi/app/supervisor.py
+++ b/src/yeaboi/app/supervisor.py
@@ -276,6 +276,7 @@ class BoardSupervisor:
         from yeaboi.config import get_poker_server_port
         from yeaboi.poker.board import PokerBoard
         from yeaboi.poker.server import PokerServer
+        from yeaboi.projects.scope import resolve_scope
         from yeaboi.retro.setup import resolve_session
 
         if not tickets:
@@ -284,12 +285,16 @@ class BoardSupervisor:
         # A poker session does not need a planning session to exist — fall back
         # to a stable quick-session id so history still records and groups.
         session_id = target.session_id or "quick-poker"
+        # Same scope the retro board resolves above: a project-linked session
+        # narrows the AI perspective's cross-mode gather.
+        scope = resolve_scope(session_id=target.session_id, db_path=self.db_path)
         board = PokerBoard(
             session_id,
             project_name=target.project_name if target else "",
             source=source,
             scope_label=scope_label,
             tickets=tickets,
+            scope=scope,
         )
         server = PokerServer(board, port=get_poker_server_port())
         server.start()

--- a/src/yeaboi/app/supervisor.py
+++ b/src/yeaboi/app/supervisor.py
@@ -251,7 +251,7 @@ class BoardSupervisor:
         # Read lazily, so a store that cannot be opened costs a board with no
         # history rather than a board.
         server.history_list, server.history_report = history_providers(
-            project_name=target.project_name, db_path=self.db_path
+            project_name=target.project_name, db_path=self.db_path, scope=scope
         )
         server.start()
         session = BoardSession(

--- a/src/yeaboi/ceremonies/engine.py
+++ b/src/yeaboi/ceremonies/engine.py
@@ -180,6 +180,10 @@ def run_ceremony(
     ``CeremonyNotFoundError`` is the one exception, and it is raised before anything
     has happened: there is nothing to record a run against.
 
+    No project parameter, by design: a ceremony inherits project scope through
+    its session — the engine it drives resolves ``sessions_meta.project_id``
+    from the ``session_id`` it is invoked with (see projects/scope.py).
+
     ``suppress_terminal`` drops the terminal channel from the fan-out, for a
     caller that already owns the screen. The TUI runs a ceremony on a worker
     thread while the main thread repaints a ``Live`` every 100 ms, so a channel

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,26 @@
   "schema_version": 2,
   "entries": [
     {
+      "version": "3.38.0",
+      "date": "2026-08-31",
+      "headline": "Work by project and pick your working world",
+      "summary": "Every mode now scopes to your active project, narrowing standup, retro and reporting to that work alone. The landing shows three working worlds: Team for groups, Solo for shipping solo, Agents for monitoring your coding bots.",
+      "highlights": [
+        {
+          "text": "Scope standup, retro, poker, performance and reporting to a single project",
+          "areas": ["planning"]
+        },
+        {
+          "text": "Three landing worlds: Team for sprints, Solo for shipping, Agents for monitoring",
+          "areas": ["general"]
+        },
+        {
+          "text": "Toggle data sources off with incognito mode for sensitive analysis",
+          "areas": ["settings"]
+        }
+      ]
+    },
+    {
       "version": "3.37.0",
       "date": "2026-08-31",
       "headline": "Attach screenshots and logs to your feedback",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -836,6 +836,13 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="ID",
         help="Team profile a scoped plan seeds when the caller passes none",
     )
+    project_defaults_p.add_argument(
+        "--context",
+        default=None,
+        type=_context_spec,
+        metavar="SPEC",
+        help="Cross-mode sources a scoped run reads by default ('all', 'none', or a csv)",
+    )
 
     perf_p = subparsers.add_parser(
         "perf",
@@ -857,16 +864,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--project",
         default="",
         metavar="PROJ_ID",
-        help="Accepted for cross-mode uniformity; performance data is engineer-keyed, so this is a no-op",
+        help="Narrow the cross-mode evidence to one project; the engineer's own 1:1 history stays unscoped",
     )
     prep_p.add_argument(
         "--context",
         default=None,
         type=_context_spec,
         metavar="SPEC",
-        help="Accepted for cross-mode uniformity ('all', 'none', or a csv of sources); a no-op like --project",
+        help="Which cross-mode sources to read ('all', 'none', or a csv); a switched-off source says so",
     )
-    prep_p.add_argument("--incognito", action="store_true", help="Same as --context none (a no-op like --project)")
+    prep_p.add_argument("--incognito", action="store_true", help="Same as --context none")
     prep_p.add_argument("--jira-project", default="", metavar="KEY", help="Jira project key override")
     prep_p.add_argument("--azdo-project", default="", metavar="NAME", help="Azure DevOps project override")
     prep_p.add_argument(
@@ -901,16 +908,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--project",
         default="",
         metavar="PROJ_ID",
-        help="Accepted for cross-mode uniformity; performance data is engineer-keyed, so this is a no-op",
+        help="Narrow the cross-mode evidence to one project; the engineer's own review history stays unscoped",
     )
     review_p.add_argument(
         "--context",
         default=None,
         type=_context_spec,
         metavar="SPEC",
-        help="Accepted for cross-mode uniformity ('all', 'none', or a csv of sources); a no-op like --project",
+        help="Which cross-mode sources to read ('all', 'none', or a csv); a switched-off source says so",
     )
-    review_p.add_argument("--incognito", action="store_true", help="Same as --context none (a no-op like --project)")
+    review_p.add_argument("--incognito", action="store_true", help="Same as --context none")
     review_p.add_argument("--jira-project", default="", metavar="KEY", help="Jira project key override")
     review_p.add_argument("--azdo-project", default="", metavar="NAME", help="Azure DevOps project override")
     review_p.add_argument(
@@ -2458,6 +2465,13 @@ def _cmd_project(args: argparse.Namespace, console: Console) -> int:
     defaults: dict = {}
     if args.analysis_profile:
         defaults["default_analysis_profile_id"] = args.analysis_profile
+    if args.context is not None:
+        defaults["default_context_deps"] = args.context
+    if not defaults:
+        # Nothing to merge — say so rather than printing a success line for a
+        # call that changed nothing.
+        console.print("[yellow]Nothing to set — pass --analysis-profile and/or --context.[/yellow]")
+        return 2
     result = set_project_defaults(args.project_id, defaults)
     console.print(f"Defaults for {args.project_id}: {result['settings'] or '—'}")
     return 0

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -274,6 +274,21 @@ def _resolve_resume(console: Console, resume_arg: str) -> tuple[dict | None, str
         return state, resume_arg
 
 
+def _context_spec(spec: str) -> list[str] | None:
+    """argparse type for --context: 'all' | 'none' | csv of dep tokens."""
+    from yeaboi.projects.scope import parse_context_spec
+
+    try:
+        return parse_context_spec(spec)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def _cli_context_deps(args: argparse.Namespace) -> list[str] | None:
+    """Map --incognito/--context onto the engines' context_deps value."""
+    return [] if getattr(args, "incognito", False) else args.context
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(
@@ -580,6 +595,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Project to scope by (see `yeaboi project list`); default inherits the session's own link",
     )
     report_p.add_argument(
+        "--context",
+        default=None,
+        type=_context_spec,
+        metavar="SPEC",
+        help="Context sources for this run: 'all', 'none', or a comma-separated subset of "
+        "retro,standup,plan,performance,analysis (default: inherit the project setting)",
+    )
+    report_p.add_argument(
+        "--incognito", action="store_true", help="No cross-mode context (same as --context none; wins if both given)"
+    )
+    report_p.add_argument(
         "--window-start", default="", metavar="YYYY-MM-DD", help="Explicit window start (quarter/window periods)"
     )
     report_p.add_argument("--window-end", default="", metavar="YYYY-MM-DD", help="Explicit window end")
@@ -627,6 +653,17 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         metavar="PROJ_ID",
         help="Project to scope by (sprint/roster from its latest plan); default inherits the session's own link",
+    )
+    standup_p.add_argument(
+        "--context",
+        default=None,
+        type=_context_spec,
+        metavar="SPEC",
+        help="Context sources for this run: 'all', 'none', or a comma-separated subset of "
+        "retro,standup,plan,performance,analysis (default: inherit the saved config, then the project setting)",
+    )
+    standup_p.add_argument(
+        "--incognito", action="store_true", help="No cross-mode context (same as --context none; wins if both given)"
     )
     standup_p.add_argument("--deliver", action="store_true", help="Send to the configured channels (default: print)")
     standup_p.add_argument(
@@ -822,6 +859,14 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="PROJ_ID",
         help="Accepted for cross-mode uniformity; performance data is engineer-keyed, so this is a no-op",
     )
+    prep_p.add_argument(
+        "--context",
+        default=None,
+        type=_context_spec,
+        metavar="SPEC",
+        help="Accepted for cross-mode uniformity ('all', 'none', or a csv of sources); a no-op like --project",
+    )
+    prep_p.add_argument("--incognito", action="store_true", help="Same as --context none (a no-op like --project)")
     prep_p.add_argument("--jira-project", default="", metavar="KEY", help="Jira project key override")
     prep_p.add_argument("--azdo-project", default="", metavar="NAME", help="Azure DevOps project override")
     prep_p.add_argument(
@@ -858,6 +903,14 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="PROJ_ID",
         help="Accepted for cross-mode uniformity; performance data is engineer-keyed, so this is a no-op",
     )
+    review_p.add_argument(
+        "--context",
+        default=None,
+        type=_context_spec,
+        metavar="SPEC",
+        help="Accepted for cross-mode uniformity ('all', 'none', or a csv of sources); a no-op like --project",
+    )
+    review_p.add_argument("--incognito", action="store_true", help="Same as --context none (a no-op like --project)")
     review_p.add_argument("--jira-project", default="", metavar="KEY", help="Jira project key override")
     review_p.add_argument("--azdo-project", default="", metavar="NAME", help="Azure DevOps project override")
     review_p.add_argument(
@@ -2076,6 +2129,7 @@ def _cmd_report(args: argparse.Namespace, console: Console) -> int:
         jira_project=args.jira_project,
         azdo_project=args.azdo_project,
         project_id=args.project,
+        context_deps=_cli_context_deps(args),
         window_start=args.window_start,
         window_end=args.window_end,
         sprint_names=sprint_names,
@@ -2147,6 +2201,7 @@ def _cmd_standup_inner(args: argparse.Namespace, console: Console) -> int:
     report = run_standup(
         session_id,
         project_id=args.project,
+        context_deps=_cli_context_deps(args),
         deliver=args.deliver,
         days=args.days or None,
         channels=args.channels,
@@ -2434,6 +2489,7 @@ def _cmd_perf(args: argparse.Namespace, console: Console) -> int:
             azdo_project=args.azdo_project,
             deep_scan=args.deep_scan,
             project_id=args.project,
+            context_deps=_cli_context_deps(args),
         )
         for warning in prep.warnings:
             print(f"⚠ {warning}", file=sys.stderr)
@@ -2478,6 +2534,7 @@ def _cmd_perf(args: argparse.Namespace, console: Console) -> int:
             period_months=args.months,
             deep_scan=args.deep_scan,
             project_id=args.project,
+            context_deps=_cli_context_deps(args),
         )
         for warning in review.warnings:
             print(f"⚠ {warning}", file=sys.stderr)

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -574,6 +574,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     report_p.add_argument("--session", default="", metavar="ID", help="Session to use (default: most recent)")
     report_p.add_argument(
+        "--project",
+        default="",
+        metavar="PROJ_ID",
+        help="Project to scope by (see `yeaboi project list`); default inherits the session's own link",
+    )
+    report_p.add_argument(
         "--window-start", default="", metavar="YYYY-MM-DD", help="Explicit window start (quarter/window periods)"
     )
     report_p.add_argument("--window-end", default="", metavar="YYYY-MM-DD", help="Explicit window end")
@@ -616,6 +622,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     standup_p = subparsers.add_parser("standup", help="Run a Daily Standup (alias of --standup-run, more knobs)")
     standup_p.add_argument("--session", default="", metavar="ID", help="Session to use (default: most recent)")
+    standup_p.add_argument(
+        "--project",
+        default="",
+        metavar="PROJ_ID",
+        help="Project to scope by (sprint/roster from its latest plan); default inherits the session's own link",
+    )
     standup_p.add_argument("--deliver", action="store_true", help="Send to the configured channels (default: print)")
     standup_p.add_argument(
         "--channels", nargs="+", choices=["terminal", "desktop", "slack", "email"], help="Override delivery channels"
@@ -778,6 +790,12 @@ def build_parser() -> argparse.ArgumentParser:
     prep_p = perf_sub.add_parser("prep", help="Prepare a 1:1 for an engineer", description=PERFORMANCE_BETA_NOTICE)
     prep_p.add_argument("engineer", help="Engineer name (see `yeaboi perf roster`)")
     prep_p.add_argument("--session", default="", metavar="ID", help="Session for team context (default: most recent)")
+    prep_p.add_argument(
+        "--project",
+        default="",
+        metavar="PROJ_ID",
+        help="Accepted for cross-mode uniformity; performance data is engineer-keyed, so this is a no-op",
+    )
     prep_p.add_argument("--jira-project", default="", metavar="KEY", help="Jira project key override")
     prep_p.add_argument("--azdo-project", default="", metavar="NAME", help="Azure DevOps project override")
     prep_p.add_argument(
@@ -808,6 +826,12 @@ def build_parser() -> argparse.ArgumentParser:
     review_p.add_argument("engineer", help="Engineer name")
     review_p.add_argument("--months", type=int, default=6, help="Review period in months (default 6)")
     review_p.add_argument("--session", default="", metavar="ID", help="Session for team context")
+    review_p.add_argument(
+        "--project",
+        default="",
+        metavar="PROJ_ID",
+        help="Accepted for cross-mode uniformity; performance data is engineer-keyed, so this is a no-op",
+    )
     review_p.add_argument("--jira-project", default="", metavar="KEY", help="Jira project key override")
     review_p.add_argument("--azdo-project", default="", metavar="NAME", help="Azure DevOps project override")
     review_p.add_argument(
@@ -2024,6 +2048,7 @@ def _cmd_report(args: argparse.Namespace, console: Console) -> int:
         session_id=_resolve_cli_session(args.session) or "",
         jira_project=args.jira_project,
         azdo_project=args.azdo_project,
+        project_id=args.project,
         window_start=args.window_start,
         window_end=args.window_end,
         sprint_names=sprint_names,
@@ -2094,6 +2119,7 @@ def _cmd_standup_inner(args: argparse.Namespace, console: Console) -> int:
         return 0
     report = run_standup(
         session_id,
+        project_id=args.project,
         deliver=args.deliver,
         days=args.days or None,
         channels=args.channels,
@@ -2326,6 +2352,7 @@ def _cmd_perf(args: argparse.Namespace, console: Console) -> int:
             jira_project=args.jira_project,
             azdo_project=args.azdo_project,
             deep_scan=args.deep_scan,
+            project_id=args.project,
         )
         for warning in prep.warnings:
             print(f"⚠ {warning}", file=sys.stderr)
@@ -2369,6 +2396,7 @@ def _cmd_perf(args: argparse.Namespace, console: Console) -> int:
             azdo_project=args.azdo_project,
             period_months=args.months,
             deep_scan=args.deep_scan,
+            project_id=args.project,
         )
         for warning in review.warnings:
             print(f"⚠ {warning}", file=sys.stderr)

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -565,7 +565,7 @@ def build_parser() -> argparse.ArgumentParser:
     # See CLAUDE.md "REQUIRED: Surface Parity" — each mode needs a CLI path;
     # these run the same engines the TUI and the MCP server use.
     subparsers = parser.add_subparsers(
-        dest="command", metavar="{report,standup,standup-review,perf,retro,poker,analyze,agents}"
+        dest="command", metavar="{report,standup,standup-review,perf,project,retro,poker,analyze,agents}"
     )
 
     report_p = subparsers.add_parser("report", help="Generate a stakeholder delivery report (Reporting mode)")
@@ -773,6 +773,32 @@ def build_parser() -> argparse.ArgumentParser:
     )
     review_p.add_argument("--strict", action="store_true", help="Exit 3 on a degraded run (warnings present)")
     review_p.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
+
+    # ── project ───────────────────────────────────────────────────────────
+    project_p = subparsers.add_parser("project", help="Manage projects — the identity that links sessions across modes")
+    project_sub = project_p.add_subparsers(
+        dest="project_command", metavar="{create,list,show,link,set-defaults}", required=True
+    )
+    project_create_p = project_sub.add_parser("create", help="Create a project")
+    project_create_p.add_argument("name", help="Short human project name")
+    project_create_p.add_argument("--description", default="", metavar="TEXT", help="One-line description")
+    project_list_p = project_sub.add_parser("list", help="List projects (most recently active first)")
+    project_list_p.add_argument("--all", dest="include_archived", action="store_true", help="Include archived projects")
+    project_show_p = project_sub.add_parser("show", help="Show one project and its linked sessions")
+    project_show_p.add_argument("project_id", metavar="PROJ_ID", help="Project id (see `yeaboi project list`)")
+    project_link_p = project_sub.add_parser(
+        "link", help="Link a session to a project so its runs count toward the project's context"
+    )
+    project_link_p.add_argument("project_id", metavar="PROJ_ID", help="Project id")
+    project_link_p.add_argument("--session", default="", metavar="ID", help="Session to link (default: most recent)")
+    project_defaults_p = project_sub.add_parser("set-defaults", help="Set a project's default settings")
+    project_defaults_p.add_argument("project_id", metavar="PROJ_ID", help="Project id")
+    project_defaults_p.add_argument(
+        "--analysis-profile",
+        default="",
+        metavar="ID",
+        help="Team profile a scoped plan seeds when the caller passes none",
+    )
 
     perf_p = subparsers.add_parser(
         "perf",
@@ -1964,6 +1990,7 @@ def _run_subcommand(args: argparse.Namespace) -> int:
         "standup": _cmd_standup,
         "standup-review": _cmd_standup_review,
         "perf": _cmd_perf,
+        "project": _cmd_project,
         "retro": _cmd_retro,
         "poker": _cmd_poker,
         "analyze": _cmd_analyze,
@@ -2325,6 +2352,60 @@ def _cmd_standup_review_inner(args: argparse.Namespace, console: Console) -> int
 
     warnings = list(review.warnings) + list(filing.warnings if filing else [])
     return _strict_exit(args.strict, warnings)
+
+
+def _cmd_project(args: argparse.Namespace, console: Console) -> int:
+    logging.getLogger(__name__).info("project %s", args.project_command)
+
+    if args.project_command == "create":
+        from yeaboi.projects.engine import create_project
+
+        project = create_project(args.name, args.description)
+        console.print(f"Created [bold]{project['name']}[/bold] — {project['project_id']}")
+        return 0
+
+    if args.project_command == "list":
+        from yeaboi.projects.engine import list_projects
+
+        rows = list_projects(args.include_archived)
+        if not rows:
+            console.print("[yellow]No projects yet — `yeaboi project create <name>`.[/yellow]")
+            return 0
+        for project in rows:
+            suffix = " [dim](archived)[/dim]" if project["archived"] else ""
+            console.print(
+                f"  {project['project_id']}  [bold]{project['name']}[/bold]"
+                f"  {project['session_count']} session(s){suffix}"
+            )
+        return 0
+
+    if args.project_command == "show":
+        from yeaboi.projects.engine import get_project
+
+        project = get_project(args.project_id)
+        console.print(f"[bold]{project['name']}[/bold] — {project['project_id']}")
+        if project["description"]:
+            console.print(project["description"])
+        console.print(f"Settings: {project['settings'] or '—'}")
+        console.print(f"Sessions: {', '.join(project['session_ids']) or '—'}")
+        return 0
+
+    if args.project_command == "link":
+        from yeaboi.projects.engine import link_session
+
+        linked = link_session(args.project_id, _resolve_cli_session(args.session) or "")
+        console.print(f"Linked {linked['session_id']} → {linked['project_id']}")
+        return 0
+
+    # set-defaults
+    from yeaboi.projects.engine import set_project_defaults
+
+    defaults: dict = {}
+    if args.analysis_profile:
+        defaults["default_analysis_profile_id"] = args.analysis_profile
+    result = set_project_defaults(args.project_id, defaults)
+    console.print(f"Defaults for {args.project_id}: {result['settings'] or '—'}")
+    return 0
 
 
 def _cmd_perf(args: argparse.Namespace, console: Console) -> int:

--- a/src/yeaboi/config.py
+++ b/src/yeaboi/config.py
@@ -181,20 +181,23 @@ def set_tips_enabled(enabled: bool) -> None:
     logger.info("Tips %s (persisted to %s)", "enabled" if enabled else "disabled", config_file)
 
 
-# The landing split's two categories. Persisted so the next launch preselects
+# The landing split's three categories. Persisted so the next launch preselects
 # (never auto-skips) the category the user worked in last.
 LAST_CATEGORY_KEY = "YEABOI_LAST_CATEGORY"
-_VALID_CATEGORIES = ("humans", "agents")
+_VALID_CATEGORIES = ("solo", "team", "agents")
+# Values written by older releases, mapped on read; rewritten on the next set.
+_LEGACY_CATEGORIES = {"humans": "team"}
 
 
 def get_last_category() -> str:
-    """Return the last-chosen landing category ("humans"/"agents", default humans).
+    """Return the last-chosen landing category ("solo"/"team"/"agents", default team).
 
     Preselection only — the category screen always shows. Unknown values fall
-    back to "humans" so a hand-edited .env can't wedge the landing screen.
+    back to "team" so a hand-edited .env can't wedge the landing screen.
     """
-    value = os.getenv(LAST_CATEGORY_KEY, "humans").strip().lower()
-    return value if value in _VALID_CATEGORIES else "humans"
+    value = os.getenv(LAST_CATEGORY_KEY, "team").strip().lower()
+    value = _LEGACY_CATEGORIES.get(value, value)
+    return value if value in _VALID_CATEGORIES else "team"
 
 
 def set_last_category(category: str) -> None:

--- a/src/yeaboi/mcp/server.py
+++ b/src/yeaboi/mcp/server.py
@@ -65,6 +65,7 @@ def create_app():
         tools_performance,
         tools_planning,
         tools_poker,
+        tools_projects,
         tools_provenance,
         tools_reporting,
         tools_retro,
@@ -79,6 +80,7 @@ def create_app():
     modules = (
         tools_artifacts,
         tools_planning,
+        tools_projects,
         tools_sessions,
         tools_standup,
         tools_reporting,

--- a/src/yeaboi/mcp/tools_performance.py
+++ b/src/yeaboi/mcp/tools_performance.py
@@ -36,7 +36,9 @@ def _check_engineer(engineer: str, jira_project: str = "", azdo_project: str = "
         raise ValueError(f"Unknown engineer {engineer!r} — roster: {', '.join(sorted(names))} (see perf_roster).")
 
 
-def _one_on_one_prep(engineer: str, session_id: str, jira_project: str, azdo_project: str, deep_scan: bool):
+def _one_on_one_prep(
+    engineer: str, session_id: str, jira_project: str, azdo_project: str, deep_scan: bool, project_id: str
+):
     _check_engineer(engineer, jira_project, azdo_project)
     from yeaboi.performance.engine import run_one_on_one_prep
 
@@ -46,6 +48,7 @@ def _one_on_one_prep(engineer: str, session_id: str, jira_project: str, azdo_pro
         jira_project=jira_project,
         azdo_project=azdo_project,
         deep_scan=deep_scan,
+        project_id=project_id,
     )
 
 
@@ -81,7 +84,13 @@ def _note_add(engineer: str, note_text: str) -> dict:
 
 
 def _six_month_review(
-    engineer: str, period_months: int, session_id: str, jira_project: str, azdo_project: str, deep_scan: bool
+    engineer: str,
+    period_months: int,
+    session_id: str,
+    jira_project: str,
+    azdo_project: str,
+    deep_scan: bool,
+    project_id: str,
 ):
     _check_engineer(engineer, jira_project, azdo_project)
     from yeaboi.performance.engine import run_six_month_review
@@ -93,6 +102,7 @@ def _six_month_review(
         azdo_project=azdo_project,
         period_months=period_months,
         deep_scan=deep_scan,
+        project_id=project_id,
     )
 
 
@@ -140,18 +150,22 @@ def register(app) -> None:
         jira_project: str = "",
         azdo_project: str = "",
         deep_scan: bool = False,
+        project_id: str = "",
     ) -> dict:
         """BETA — Prepare a 1:1 for an engineer: talking points, feedback, goals and growth areas
         from every source that knows them — their tickets, the code/documentation/self-report
         evidence saved by past standups, their practice signals, team analysis metrics, retro and
         poker history, plus open action items from the previous 1:1. The result reports which
         sources were scanned and which were not. deep_scan=true additionally runs one capped live
-        scan of the stretch no saved standup covered — it costs API calls and is slower.
+        scan of the stretch no saved standup covered — it costs API calls and is slower. project_id
+        is accepted for cross-mode uniformity and unused: performance data is engineer-keyed.
 
         Performance mode is in beta — its output is not yet verified against real delivery data.
         Present it as a draft for the lead to edit, not a verdict."""
         return _with_beta(
-            await run_engine(ctx, _one_on_one_prep, engineer, session_id, jira_project, azdo_project, deep_scan)
+            await run_engine(
+                ctx, _one_on_one_prep, engineer, session_id, jira_project, azdo_project, deep_scan, project_id
+            )
         )
 
     @app.tool()
@@ -192,18 +206,28 @@ def register(app) -> None:
         jira_project: str = "",
         azdo_project: str = "",
         deep_scan: bool = False,
+        project_id: str = "",
     ) -> dict:
         """BETA — Draft an engineer's periodic performance review from past 1:1s, delivery history,
         the per-member code/documentation/self-report evidence saved by standups over the period,
         their practice signals, team analysis metrics, retro and poker history, and the competency
         framework (bundled default, or PERFORMANCE_FRAMEWORK_PATH). The result reports which
         sources were scanned and which were not — an unscanned source is unknown, not absent.
-        deep_scan=true additionally runs one capped live scan of the uncovered stretch.
+        deep_scan=true additionally runs one capped live scan of the uncovered stretch. project_id
+        is accepted for cross-mode uniformity and unused: performance data is engineer-keyed.
 
         Performance mode is in beta — its output is not yet verified against real delivery data.
         Present it as a draft for the lead to edit, not a verdict."""
         return _with_beta(
             await run_engine(
-                ctx, _six_month_review, engineer, period_months, session_id, jira_project, azdo_project, deep_scan
+                ctx,
+                _six_month_review,
+                engineer,
+                period_months,
+                session_id,
+                jira_project,
+                azdo_project,
+                deep_scan,
+                project_id,
             )
         )

--- a/src/yeaboi/mcp/tools_performance.py
+++ b/src/yeaboi/mcp/tools_performance.py
@@ -37,7 +37,13 @@ def _check_engineer(engineer: str, jira_project: str = "", azdo_project: str = "
 
 
 def _one_on_one_prep(
-    engineer: str, session_id: str, jira_project: str, azdo_project: str, deep_scan: bool, project_id: str
+    engineer: str,
+    session_id: str,
+    jira_project: str,
+    azdo_project: str,
+    deep_scan: bool,
+    project_id: str,
+    context_deps: list | None,
 ):
     _check_engineer(engineer, jira_project, azdo_project)
     from yeaboi.performance.engine import run_one_on_one_prep
@@ -49,6 +55,7 @@ def _one_on_one_prep(
         azdo_project=azdo_project,
         deep_scan=deep_scan,
         project_id=project_id,
+        context_deps=context_deps,
     )
 
 
@@ -91,6 +98,7 @@ def _six_month_review(
     azdo_project: str,
     deep_scan: bool,
     project_id: str,
+    context_deps: list | None,
 ):
     _check_engineer(engineer, jira_project, azdo_project)
     from yeaboi.performance.engine import run_six_month_review
@@ -103,6 +111,7 @@ def _six_month_review(
         period_months=period_months,
         deep_scan=deep_scan,
         project_id=project_id,
+        context_deps=context_deps,
     )
 
 
@@ -151,6 +160,7 @@ def register(app) -> None:
         azdo_project: str = "",
         deep_scan: bool = False,
         project_id: str = "",
+        context_deps: list[str] | None = None,
     ) -> dict:
         """BETA — Prepare a 1:1 for an engineer: talking points, feedback, goals and growth areas
         from every source that knows them — their tickets, the code/documentation/self-report
@@ -158,13 +168,22 @@ def register(app) -> None:
         poker history, plus open action items from the previous 1:1. The result reports which
         sources were scanned and which were not. deep_scan=true additionally runs one capped live
         scan of the stretch no saved standup covered — it costs API calls and is slower. project_id
-        is accepted for cross-mode uniformity and unused: performance data is engineer-keyed.
+        and context_deps are accepted for cross-mode uniformity and unused: performance data is
+        engineer-keyed.
 
         Performance mode is in beta — its output is not yet verified against real delivery data.
         Present it as a draft for the lead to edit, not a verdict."""
         return _with_beta(
             await run_engine(
-                ctx, _one_on_one_prep, engineer, session_id, jira_project, azdo_project, deep_scan, project_id
+                ctx,
+                _one_on_one_prep,
+                engineer,
+                session_id,
+                jira_project,
+                azdo_project,
+                deep_scan,
+                project_id,
+                context_deps,
             )
         )
 
@@ -207,6 +226,7 @@ def register(app) -> None:
         azdo_project: str = "",
         deep_scan: bool = False,
         project_id: str = "",
+        context_deps: list[str] | None = None,
     ) -> dict:
         """BETA — Draft an engineer's periodic performance review from past 1:1s, delivery history,
         the per-member code/documentation/self-report evidence saved by standups over the period,
@@ -214,7 +234,8 @@ def register(app) -> None:
         framework (bundled default, or PERFORMANCE_FRAMEWORK_PATH). The result reports which
         sources were scanned and which were not — an unscanned source is unknown, not absent.
         deep_scan=true additionally runs one capped live scan of the uncovered stretch. project_id
-        is accepted for cross-mode uniformity and unused: performance data is engineer-keyed.
+        and context_deps are accepted for cross-mode uniformity and unused: performance data is
+        engineer-keyed.
 
         Performance mode is in beta — its output is not yet verified against real delivery data.
         Present it as a draft for the lead to edit, not a verdict."""
@@ -229,5 +250,6 @@ def register(app) -> None:
                 azdo_project,
                 deep_scan,
                 project_id,
+                context_deps,
             )
         )

--- a/src/yeaboi/mcp/tools_performance.py
+++ b/src/yeaboi/mcp/tools_performance.py
@@ -168,8 +168,9 @@ def register(app) -> None:
         poker history, plus open action items from the previous 1:1. The result reports which
         sources were scanned and which were not. deep_scan=true additionally runs one capped live
         scan of the stretch no saved standup covered — it costs API calls and is slower. project_id
-        and context_deps are accepted for cross-mode uniformity and unused: performance data is
-        engineer-keyed.
+        and context_deps narrow the cross-mode evidence only: a switched-off source says so in its
+        coverage row. The engineer's own 1:1 history stays unscoped — it is engineer-keyed, and must
+        not shrink because a project is active.
 
         Performance mode is in beta — its output is not yet verified against real delivery data.
         Present it as a draft for the lead to edit, not a verdict."""
@@ -234,8 +235,9 @@ def register(app) -> None:
         framework (bundled default, or PERFORMANCE_FRAMEWORK_PATH). The result reports which
         sources were scanned and which were not — an unscanned source is unknown, not absent.
         deep_scan=true additionally runs one capped live scan of the uncovered stretch. project_id
-        and context_deps are accepted for cross-mode uniformity and unused: performance data is
-        engineer-keyed.
+        and context_deps narrow the cross-mode evidence and the ceremony summary only: a switched-off
+        source says so in its coverage row. The engineer's own review history stays unscoped — it is
+        engineer-keyed, and must not shrink because a project is active.
 
         Performance mode is in beta — its output is not yet verified against real delivery data.
         Present it as a draft for the lead to edit, not a verdict."""

--- a/src/yeaboi/mcp/tools_planning.py
+++ b/src/yeaboi/mcp/tools_planning.py
@@ -129,6 +129,7 @@ def _plan_generate(
     ac_format: str,
     architecture_spike: str,
     project_id: str,
+    context_deps: list | None,
     on_progress,
 ) -> dict:
     from yeaboi.agent.headless import run_planning_pipeline
@@ -142,6 +143,7 @@ def _plan_generate(
         ac_format=ac_format,
         architecture_spike=architecture_spike or "auto",
         project_id=project_id,
+        context_deps=context_deps,
     )
     plan = json.loads(export_plan_json(state))
     plan["session_id"] = state.get("_session_id", "")
@@ -332,6 +334,7 @@ def register(app) -> None:
         ac_format: str = "",
         architecture_spike: str = "auto",
         project_id: str = "",
+        context_deps: list[str] | None = None,
     ) -> dict:
         """Generate a full sprint plan (analysis, epics, stories, tasks, sprints) from a project
         description. Gather the intake_questions smart_essentials from the user first and pass
@@ -347,7 +350,10 @@ def register(app) -> None:
         unless the analyzer's confidence is high).
         `project_id`: link the session to a project (project_list shows them); a scoped run
         reads ceremony context from the project's own sessions and seeds the analysis profile
-        from the project's defaults. Empty = unscoped (team-wide context)."""
+        from the project's defaults. Empty = unscoped (team-wide context).
+        `context_deps`: toggle the run's cross-mode context sources (retro, standup, plan,
+        performance, analysis). Null inherits the project's default_context_deps then all-on;
+        an empty list is an incognito run — no cross-mode context, the session still persists."""
 
         def report(node_name: str, step: int) -> None:
             # Called from the engine's worker thread — bridge the async
@@ -369,6 +375,7 @@ def register(app) -> None:
             ac_format,
             architecture_spike,
             project_id,
+            context_deps,
             report,
         )
 

--- a/src/yeaboi/mcp/tools_planning.py
+++ b/src/yeaboi/mcp/tools_planning.py
@@ -128,6 +128,7 @@ def _plan_generate(
     prior_art: list[str] | None,
     ac_format: str,
     architecture_spike: str,
+    project_id: str,
     on_progress,
 ) -> dict:
     from yeaboi.agent.headless import run_planning_pipeline
@@ -140,6 +141,7 @@ def _plan_generate(
         prior_art=prior_art,
         ac_format=ac_format,
         architecture_spike=architecture_spike or "auto",
+        project_id=project_id,
     )
     plan = json.loads(export_plan_json(state))
     plan["session_id"] = state.get("_session_id", "")
@@ -329,6 +331,7 @@ def register(app) -> None:
         prior_art: list[str] | None = None,
         ac_format: str = "",
         architecture_spike: str = "auto",
+        project_id: str = "",
     ) -> dict:
         """Generate a full sprint plan (analysis, epics, stories, tasks, sprints) from a project
         description. Gather the intake_questions smart_essentials from the user first and pass
@@ -341,7 +344,10 @@ def register(app) -> None:
         (clear testable statements); empty follows the learned team profile.
         `architecture_spike`: when the analyzer's architecture decision is open (2+ options),
         whether to add a validation spike — 'include' / 'skip', or 'auto' (default: add it
-        unless the analyzer's confidence is high)."""
+        unless the analyzer's confidence is high).
+        `project_id`: link the session to a project (project_list shows them); a scoped run
+        reads ceremony context from the project's own sessions and seeds the analysis profile
+        from the project's defaults. Empty = unscoped (team-wide context)."""
 
         def report(node_name: str, step: int) -> None:
             # Called from the engine's worker thread — bridge the async
@@ -362,6 +368,7 @@ def register(app) -> None:
             prior_art,
             ac_format,
             architecture_spike,
+            project_id,
             report,
         )
 

--- a/src/yeaboi/mcp/tools_projects.py
+++ b/src/yeaboi/mcp/tools_projects.py
@@ -78,6 +78,8 @@ def register(app) -> None:
     async def project_set_defaults(project_id: str, defaults: dict | None = None) -> dict:
         """Merge default settings into a project. Accepted keys:
         default_analysis_profile_id (the team profile a scoped plan_generate seeds when the
-        caller passes none — set it after a team analysis) and default_context_deps
-        (reserved for the context-toggle work). Unknown keys are rejected."""
+        caller passes none — set it after a team analysis) and default_context_deps (the
+        context-source toggles a scoped run inherits when the caller passes none — a list of
+        retro/standup/plan/performance/analysis; [] makes the project's runs incognito by
+        default). Unknown keys are rejected."""
         return await run_readonly(_set_defaults, project_id, defaults)

--- a/src/yeaboi/mcp/tools_projects.py
+++ b/src/yeaboi/mcp/tools_projects.py
@@ -1,0 +1,83 @@
+"""MCP tools: projects (project_create/list/get/link_session/set_defaults)."""
+
+from __future__ import annotations
+
+import logging
+
+from yeaboi.mcp.runtime import run_readonly
+
+logger = logging.getLogger(__name__)
+
+
+def _create(name: str, description: str) -> dict:
+    from yeaboi.projects.engine import create_project
+
+    return create_project(name, description)
+
+
+def _list(include_archived: bool) -> list[dict]:
+    from yeaboi.projects.engine import list_projects
+
+    return list_projects(include_archived)
+
+
+def _get(project_id: str) -> dict:
+    if not project_id.strip():
+        raise ValueError("project_id is required — see project_list.")
+    from yeaboi.projects.engine import get_project
+
+    return get_project(project_id.strip())
+
+
+def _link_session(project_id: str, session_id: str) -> dict:
+    if not project_id.strip():
+        raise ValueError("project_id is required — see project_list.")
+    from yeaboi.mcp.tools_sessions import resolve_session_id
+    from yeaboi.projects.engine import link_session
+
+    return link_session(project_id.strip(), resolve_session_id(session_id))
+
+
+def _set_defaults(project_id: str, defaults: dict | None) -> dict:
+    if not project_id.strip():
+        raise ValueError("project_id is required — see project_list.")
+    from yeaboi.projects.engine import set_project_defaults
+
+    return set_project_defaults(project_id.strip(), defaults or {})
+
+
+def register(app) -> None:
+    """Attach the project tools to the FastMCP app."""
+
+    @app.tool()
+    async def project_create(name: str, description: str = "") -> dict:
+        """Create a project — the identity that links yeaboi sessions across modes (a plan's
+        analysis feeds its standups, standups feed its retros). Returns the row with its
+        project_id (proj-<8hex>); pass that id to plan_generate/standup_run/report_delivery
+        to scope a run to the project."""
+        return await run_readonly(_create, name, description)
+
+    @app.tool()
+    async def project_list(include_archived: bool = False) -> dict:
+        """List projects (id, name, last activity, linked-session count), most recently
+        active first."""
+        return await run_readonly(_list, include_archived)
+
+    @app.tool()
+    async def project_get(project_id: str) -> dict:
+        """Get one project: its row, settings/defaults, and the session ids linked to it."""
+        return await run_readonly(_get, project_id)
+
+    @app.tool()
+    async def project_link_session(project_id: str, session_id: str = "") -> dict:
+        """Link an existing session to a project so its runs and history count toward the
+        project's scoped context. Blank session_id = most recent session."""
+        return await run_readonly(_link_session, project_id, session_id)
+
+    @app.tool()
+    async def project_set_defaults(project_id: str, defaults: dict | None = None) -> dict:
+        """Merge default settings into a project. Accepted keys:
+        default_analysis_profile_id (the team profile a scoped plan_generate seeds when the
+        caller passes none — set it after a team analysis) and default_context_deps
+        (reserved for the context-toggle work). Unknown keys are rejected."""
+        return await run_readonly(_set_defaults, project_id, defaults)

--- a/src/yeaboi/mcp/tools_reporting.py
+++ b/src/yeaboi/mcp/tools_reporting.py
@@ -78,6 +78,7 @@ def _report_delivery(
     period_label_override: str,
     theme: str,
     sources: dict | None,
+    project_id: str,
 ):
     if period not in _PERIODS:
         raise ValueError(f"period must be one of {', '.join(_PERIODS)} — got {period!r}")
@@ -88,6 +89,7 @@ def _report_delivery(
         session_id=session_id,
         jira_project=jira_project,
         azdo_project=azdo_project,
+        project_id=project_id,
         window_start=window_start,
         window_end=window_end,
         sprint_names=tuple(sprint_names or ()),
@@ -113,6 +115,7 @@ def register(app) -> None:
         period_label_override: str = "",
         theme: str = "midnight",
         sources: dict[str, list[str]] | None = None,
+        project_id: str = "",
     ) -> dict:
         """Generate a stakeholder-friendly delivery report of completed work from the team's
         tracker (Jira/Azure DevOps): executive summary, outcome themes, metrics, highlights.
@@ -125,7 +128,8 @@ def register(app) -> None:
         'azuredevops'], 'docs': ['confluence','notion']} — delivery picks the tracker(s)
         tickets come from, code/docs add supporting PR/commit and doc-update context
         (azdevops/azure_devops accepted as aliases); omit for all configured. Blank
-        session_id = most recent session (sprint length/project name)."""
+        session_id = most recent session (sprint length/project name). project_id scopes the
+        sprint framing to a project's latest plan; blank inherits the session's own link."""
         return await run_engine(
             ctx,
             _report_delivery,
@@ -139,6 +143,7 @@ def register(app) -> None:
             period_label_override,
             theme,
             sources,
+            project_id,
         )
 
     @app.tool()

--- a/src/yeaboi/mcp/tools_reporting.py
+++ b/src/yeaboi/mcp/tools_reporting.py
@@ -79,6 +79,7 @@ def _report_delivery(
     theme: str,
     sources: dict | None,
     project_id: str,
+    context_deps: list | None,
 ):
     if period not in _PERIODS:
         raise ValueError(f"period must be one of {', '.join(_PERIODS)} — got {period!r}")
@@ -90,6 +91,7 @@ def _report_delivery(
         jira_project=jira_project,
         azdo_project=azdo_project,
         project_id=project_id,
+        context_deps=context_deps,
         window_start=window_start,
         window_end=window_end,
         sprint_names=tuple(sprint_names or ()),
@@ -116,6 +118,7 @@ def register(app) -> None:
         theme: str = "midnight",
         sources: dict[str, list[str]] | None = None,
         project_id: str = "",
+        context_deps: list[str] | None = None,
     ) -> dict:
         """Generate a stakeholder-friendly delivery report of completed work from the team's
         tracker (Jira/Azure DevOps): executive summary, outcome themes, metrics, highlights.
@@ -129,7 +132,9 @@ def register(app) -> None:
         tickets come from, code/docs add supporting PR/commit and doc-update context
         (azdevops/azure_devops accepted as aliases); omit for all configured. Blank
         session_id = most recent session (sprint length/project name). project_id scopes the
-        sprint framing to a project's latest plan; blank inherits the session's own link."""
+        sprint framing to a project's latest plan; blank inherits the session's own link.
+        context_deps toggles the run's cross-mode context sources — the 'plan' token gates
+        the sprint framing; null inherits the project default, an empty list is incognito."""
         return await run_engine(
             ctx,
             _report_delivery,
@@ -144,6 +149,7 @@ def register(app) -> None:
             theme,
             sources,
             project_id,
+            context_deps,
         )
 
     @app.tool()

--- a/src/yeaboi/mcp/tools_standup.py
+++ b/src/yeaboi/mcp/tools_standup.py
@@ -72,6 +72,7 @@ def _standup_run(
     azdo_repositories: list | None,
     documentation_sources: list | None,
     review_transcripts: bool,
+    project_id: str,
 ):
     from yeaboi.mcp.tools_sessions import resolve_session_id
     from yeaboi.standup.engine import run_standup
@@ -79,6 +80,7 @@ def _standup_run(
     resolved = resolve_session_id(session_id)
     return run_standup(
         resolved,
+        project_id=project_id,
         review_transcripts=review_transcripts,
         deliver=deliver,
         days=days or None,
@@ -446,6 +448,7 @@ def register(app) -> None:
         azdo_repositories: list[str] | None = None,
         documentation_sources: list[str] | None = None,
         review_transcripts: bool = True,
+        project_id: str = "",
     ) -> dict:
         """Run a Daily Standup: collect team activity (Jira/AzDO/GitHub/git/docs), score sprint
         confidence, and summarize per member. Returns the report for you to present; deliver=true
@@ -461,7 +464,9 @@ def register(app) -> None:
         Confluence/Notion providers without changing saved config. days overrides the activity look-back
         window. review_transcripts (default true) first reviews any unreviewed standup meeting
         transcripts covering earlier dates, so yesterday's corrections inform today's report; it
-        drafts issues locally and never writes to GitHub. Blank session_id = most recent session."""
+        drafts issues locally and never writes to GitHub. Blank session_id = most recent session.
+        project_id scopes the run to a project (project_list shows them): sprint and roster
+        context come from the project's latest plan; blank inherits the session's own link."""
         return await run_engine(
             ctx,
             _standup_run,
@@ -479,6 +484,7 @@ def register(app) -> None:
             azdo_repositories,
             documentation_sources,
             review_transcripts,
+            project_id,
         )
 
     @app.tool()

--- a/src/yeaboi/mcp/tools_standup.py
+++ b/src/yeaboi/mcp/tools_standup.py
@@ -43,6 +43,7 @@ _CONFIG_DEFAULTS = {
     "habit_detection": "on",
     "habit_rules": "",
     "habit_ai_match": "on",
+    "context_deps": None,
 }
 
 
@@ -73,6 +74,7 @@ def _standup_run(
     documentation_sources: list | None,
     review_transcripts: bool,
     project_id: str,
+    context_deps: list | None,
 ):
     from yeaboi.mcp.tools_sessions import resolve_session_id
     from yeaboi.standup.engine import run_standup
@@ -81,6 +83,7 @@ def _standup_run(
     return run_standup(
         resolved,
         project_id=project_id,
+        context_deps=context_deps,
         review_transcripts=review_transcripts,
         deliver=deliver,
         days=days or None,
@@ -305,9 +308,11 @@ def _standup_config_set(
     habit_detection: str | None,
     habit_rules: str | None,
     habit_ai_match: str | None,
+    context_deps: str,
 ) -> dict:
     from yeaboi.mcp.tools_sessions import resolve_session_id
     from yeaboi.paths import get_db_path
+    from yeaboi.projects.scope import parse_context_spec
     from yeaboi.standup.automation import VALID_AUTOMATION_HANDLING
     from yeaboi.standup.code_scope import validate_code_sources
     from yeaboi.standup.documentation_scope import validate_documentation_sources
@@ -422,6 +427,9 @@ def _standup_config_set(
             "habit_detection": (current.get("habit_detection", "on") if habit_detection is None else habit_detection),
             "habit_rules": (current.get("habit_rules", "") if normalized_rules is None else normalized_rules),
             "habit_ai_match": (current.get("habit_ai_match", "on") if habit_ai_match is None else habit_ai_match),
+            # "" = unchanged; "inherit"/"all"/"none"/csv per parse_context_spec
+            # (raises on a typo'd token rather than silently switching it off).
+            "context_deps": (current.get("context_deps") if not context_deps else parse_context_spec(context_deps)),
         }
         store.save_config(resolved, **merged)
     logger.info("Standup config updated via MCP: session=%s enabled=%s", resolved, merged["enabled"])
@@ -449,6 +457,7 @@ def register(app) -> None:
         documentation_sources: list[str] | None = None,
         review_transcripts: bool = True,
         project_id: str = "",
+        context_deps: list[str] | None = None,
     ) -> dict:
         """Run a Daily Standup: collect team activity (Jira/AzDO/GitHub/git/docs), score sprint
         confidence, and summarize per member. Returns the report for you to present; deliver=true
@@ -466,7 +475,10 @@ def register(app) -> None:
         transcripts covering earlier dates, so yesterday's corrections inform today's report; it
         drafts issues locally and never writes to GitHub. Blank session_id = most recent session.
         project_id scopes the run to a project (project_list shows them): sprint and roster
-        context come from the project's latest plan; blank inherits the session's own link."""
+        context come from the project's latest plan; blank inherits the session's own link.
+        context_deps toggles the run's cross-mode context sources (retro, standup, plan,
+        performance, analysis): null inherits the saved config then the project default,
+        an empty list is an incognito run (no cross-mode context; the session still persists)."""
         return await run_engine(
             ctx,
             _standup_run,
@@ -485,6 +497,7 @@ def register(app) -> None:
             documentation_sources,
             review_transcripts,
             project_id,
+            context_deps,
         )
 
     @app.tool()
@@ -612,6 +625,7 @@ def register(app) -> None:
         habit_detection: str | None = None,
         habit_rules: str | None = None,
         habit_ai_match: str | None = None,
+        context_deps: str = "",
     ) -> dict:
         """Update a session's standup configuration; omitted fields keep their current value.
         time is HH:MM (the meeting time), weekdays like '1-5' or '1,3,5', delivery_channels from
@@ -634,6 +648,9 @@ def register(app) -> None:
         wip-sprawl, large-change, no-pull-request, commit-messages (empty = all of them).
         habit_ai_match is 'on' (default) or 'off': when on, an LLM pass may excuse a change that
         belongs to a ticket it never names. It can only ever suppress a signal, never raise one.
+        context_deps sets the session's saved context-source toggles: '' leaves them unchanged,
+        'inherit' resets to the project default, 'all' enables everything, 'none' is incognito,
+        or a comma-separated subset of retro,standup,plan,performance,analysis.
         NOTE: this saves the config only — installing the OS schedule (launchd/cron) is
         machine-local and done from the yeaboi TUI. Blank session_id = most recent session."""
         return await run_readonly(
@@ -662,4 +679,5 @@ def register(app) -> None:
             habit_detection,
             habit_rules,
             habit_ai_match,
+            context_deps,
         )

--- a/src/yeaboi/mcp/tools_team.py
+++ b/src/yeaboi/mcp/tools_team.py
@@ -173,7 +173,8 @@ def register(app) -> None:
         members re-scopes each delivery tracker's velocity/contributors and is mandatory scope
         for code analysis, e.g. {"jira": ["Alice","Bob"]}. Code results contain only matched
         selected-user commits, authored PRs, activity, and changed files; a blank or unmatched
-        scope never falls back to whole-team code. Discover names with team_roster."""
+        scope never falls back to whole-team code. Discover names with team_roster.
+        A solo-world run is simply members=None — whole-history, no roster narrowing."""
         import asyncio
 
         try:

--- a/src/yeaboi/niko/suggestions.py
+++ b/src/yeaboi/niko/suggestions.py
@@ -7,7 +7,7 @@ rename a route and the mapping follows it; drop a capability and
 that no longer exists.
 
 Resolution order matches the surface's own specificity — exact route, then the
-capability that owns it, then the section (``/humans`` vs ``/agents``), then a
+capability that owns it, then the section (``/team`` vs ``/agents``), then a
 default set. A screen with nothing to say falls back rather than showing
 nothing: an empty chip list reads as a broken panel.
 
@@ -93,7 +93,7 @@ BY_CAPABILITY: dict[str, list[dict]] = {
 
 #: Section fallbacks, for a screen whose capability has no chips of its own.
 BY_SECTION: dict[str, list[dict]] = {
-    "/humans": [
+    "/team": [
         _chip("What should I do next?", "Based on my data, what should I work on next?", "compass"),
         _chip("What have I planned?", "List my saved planning sessions and how far each one got.", "layers"),
     ],
@@ -131,7 +131,7 @@ def route_index() -> dict[str, dict]:
 def screen_for(route: str) -> dict:
     """What the manifest says about ``route`` — longest matching prefix wins.
 
-    Prefix rather than exact so ``/humans/retro/board`` inherits the retro row
+    Prefix rather than exact so ``/team/retro/board`` inherits the retro row
     when the deeper path is not itself registered, which is how the renderer's
     own active-state works.
     """

--- a/src/yeaboi/niko/suggestions.py
+++ b/src/yeaboi/niko/suggestions.py
@@ -32,9 +32,6 @@ BY_CAPABILITY: dict[str, list[dict]] = {
         _chip("What have I planned?", "List my saved planning sessions and how far each one got.", "layers"),
         _chip("Where did this plan come from?", "Trace the decisions behind my most recent plan.", "compass"),
     ],
-    "sessions": [
-        _chip("What have I planned?", "List my saved planning sessions and how far each one got.", "layers"),
-    ],
     "roadmap": [
         _chip("What is roadmap intake?", "Explain what Roadmap intake does and when I should use it.", "info"),
     ],

--- a/src/yeaboi/niko/tools.py
+++ b/src/yeaboi/niko/tools.py
@@ -66,16 +66,18 @@ def _guard(what: str, fn: Callable, /, *args, **kwargs) -> dict:
 @tool
 def list_capabilities() -> dict:
     """List everything yeaboi can do: the Solo and Team menus, the Agents family, and the
-    two categories they sit under. Use this when the user asks what yeaboi is,
+    three categories they sit under. Use this when the user asks what yeaboi is,
     what it can do, where a feature lives, or what they should try next.
+    ``modes`` is the Team menu; ``solo`` is the Solo menu.
     """
 
     def _cards() -> dict:
-        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _INTAKE_CARDS, _MODE_CARDS
+        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _INTAKE_CARDS, _MODE_CARDS, _SOLO_CARDS
         from yeaboi.ui.mode_select.screens._screens_category import _CATEGORY_CARDS
 
         return {
             "categories": _CATEGORY_CARDS,
+            "solo": _SOLO_CARDS,
             "modes": _MODE_CARDS,
             "agents": _AGENT_CARDS,
             "intake": _INTAKE_CARDS,

--- a/src/yeaboi/niko/tools.py
+++ b/src/yeaboi/niko/tools.py
@@ -65,7 +65,7 @@ def _guard(what: str, fn: Callable, /, *args, **kwargs) -> dict:
 
 @tool
 def list_capabilities() -> dict:
-    """List everything yeaboi can do: the Humans modes, the Agents family, and the
+    """List everything yeaboi can do: the Solo and Team menus, the Agents family, and the
     two categories they sit under. Use this when the user asks what yeaboi is,
     what it can do, where a feature lives, or what they should try next.
     """
@@ -108,7 +108,7 @@ def known_routes() -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Humans
+# Team
 # ---------------------------------------------------------------------------
 
 
@@ -319,7 +319,7 @@ def provenance_trace(entity_id: str, depth: int = 2) -> dict:
 @tool
 def navigate(route: str) -> dict:
     """Take the user to a screen. Call this when the answer is "that lives over there"
-    — e.g. `/humans/retro` for a retro, `/agents/usage` for agent spend. The route
+    — e.g. `/team/retro` for a retro, `/agents/usage` for agent spend. The route
     must be one `list_routes` returned. This only moves the user; it starts nothing.
     """
     known = {row.get("path", "") for row in known_routes()}

--- a/src/yeaboi/performance/context.py
+++ b/src/yeaboi/performance/context.py
@@ -19,6 +19,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from yeaboi.projects.scope import ProjectScope
 
 logger = logging.getLogger(__name__)
 
@@ -47,12 +51,16 @@ def _bullets(items) -> str:
     return "\n".join(f"  - {it}" for it in items)
 
 
-def gather_performance_context() -> PerformanceContext:
+def gather_performance_context(*, scope: ProjectScope | None = None) -> PerformanceContext:
     """Read the team's recent 1:1 actions + reviews and distil them (team-wide).
 
+    ``scope`` is accepted for signature uniformity with the other gatherers and
+    deliberately ignored: performance data is keyed by engineer, not project —
+    an engineer's history must not shrink because a project is active.
     Graceful: a missing DB / empty tables / any error yields an empty context, so
     planning and analysis behave exactly as before Performance mode existed.
     """
+    del scope  # engineer-keyed; see docstring
     try:
         from yeaboi.config import get_sessions_db
         from yeaboi.performance.store import PerformanceStore

--- a/src/yeaboi/performance/context.py
+++ b/src/yeaboi/performance/context.py
@@ -54,13 +54,15 @@ def _bullets(items) -> str:
 def gather_performance_context(*, scope: ProjectScope | None = None) -> PerformanceContext:
     """Read the team's recent 1:1 actions + reviews and distil them (team-wide).
 
-    ``scope`` is accepted for signature uniformity with the other gatherers and
-    deliberately ignored: performance data is keyed by engineer, not project —
-    an engineer's history must not shrink because a project is active.
+    ``scope`` never narrows by session: performance data is keyed by engineer,
+    not project — an engineer's history must not shrink because a project is
+    active. Its ``performance`` context toggle IS honoured, though: a run with
+    the dep off gets an empty context.
     Graceful: a missing DB / empty tables / any error yields an empty context, so
     planning and analysis behave exactly as before Performance mode existed.
     """
-    del scope  # engineer-keyed; see docstring
+    if scope is not None and not scope.wants("performance"):
+        return PerformanceContext()
     try:
         from yeaboi.config import get_sessions_db
         from yeaboi.performance.store import PerformanceStore

--- a/src/yeaboi/performance/engine.py
+++ b/src/yeaboi/performance/engine.py
@@ -223,6 +223,7 @@ def run_one_on_one_prep(
     azdo_project: str = "",
     deep_scan: bool = False,
     project_id: str = "",
+    context_deps: list[str] | None = None,
     db_path=None,
     today: date | None = None,
     on_progress=None,
@@ -239,9 +240,11 @@ def run_one_on_one_prep(
     covered; it costs API calls, so it is off by default. ``on_progress`` takes
     one lifecycle event per phase (see ``analysis/progress.py``) so a caller can
     draw a live checklist; it is an injection seam, never a behaviour switch.
-    ``project_id`` is accepted for cross-mode uniformity and deliberately
-    unused: performance data is engineer-keyed, and a person's history must
-    not shrink because a project is active (see projects/scope.py).
+    ``project_id`` and ``context_deps`` are accepted for cross-mode uniformity
+    and deliberately unused: performance data is engineer-keyed, and a person's
+    history must not shrink because a project is active (see projects/scope.py).
+    The deferred leak follow-up wires ``context_deps`` to this engine's own
+    ceremony reads.
     """
     today = today or date.today()
     date_str = today.isoformat()
@@ -669,6 +672,7 @@ def run_six_month_review(
     period_months: int = 6,
     deep_scan: bool = False,
     project_id: str = "",
+    context_deps: list[str] | None = None,
     db_path=None,
     today: date | None = None,
     on_progress=None,
@@ -682,9 +686,11 @@ def run_six_month_review(
     framework, then asks the LLM for a structured review. Persists the review.
 
     ``deep_scan`` permits one capped live scan for the stretch no saved standup
-    covered; it costs API calls, so it is off by default. ``project_id`` is
-    accepted for cross-mode uniformity and deliberately unused: performance
-    data is engineer-keyed (see projects/scope.py).
+    covered; it costs API calls, so it is off by default. ``project_id`` and
+    ``context_deps`` are accepted for cross-mode uniformity and deliberately
+    unused: performance data is engineer-keyed (see projects/scope.py). The
+    deferred leak follow-up wires ``context_deps`` to this engine's own
+    ceremony reads.
     """
     today = today or date.today()
     period_end = today.isoformat()

--- a/src/yeaboi/performance/engine.py
+++ b/src/yeaboi/performance/engine.py
@@ -222,6 +222,7 @@ def run_one_on_one_prep(
     jira_project: str = "",
     azdo_project: str = "",
     deep_scan: bool = False,
+    project_id: str = "",
     db_path=None,
     today: date | None = None,
     on_progress=None,
@@ -238,6 +239,9 @@ def run_one_on_one_prep(
     covered; it costs API calls, so it is off by default. ``on_progress`` takes
     one lifecycle event per phase (see ``analysis/progress.py``) so a caller can
     draw a live checklist; it is an injection seam, never a behaviour switch.
+    ``project_id`` is accepted for cross-mode uniformity and deliberately
+    unused: performance data is engineer-keyed, and a person's history must
+    not shrink because a project is active (see projects/scope.py).
     """
     today = today or date.today()
     date_str = today.isoformat()
@@ -664,6 +668,7 @@ def run_six_month_review(
     azdo_project: str = "",
     period_months: int = 6,
     deep_scan: bool = False,
+    project_id: str = "",
     db_path=None,
     today: date | None = None,
     on_progress=None,
@@ -677,7 +682,9 @@ def run_six_month_review(
     framework, then asks the LLM for a structured review. Persists the review.
 
     ``deep_scan`` permits one capped live scan for the stretch no saved standup
-    covered; it costs API calls, so it is off by default.
+    covered; it costs API calls, so it is off by default. ``project_id`` is
+    accepted for cross-mode uniformity and deliberately unused: performance
+    data is engineer-keyed (see projects/scope.py).
     """
     today = today or date.today()
     period_end = today.isoformat()

--- a/src/yeaboi/performance/engine.py
+++ b/src/yeaboi/performance/engine.py
@@ -240,17 +240,20 @@ def run_one_on_one_prep(
     covered; it costs API calls, so it is off by default. ``on_progress`` takes
     one lifecycle event per phase (see ``analysis/progress.py``) so a caller can
     draw a live checklist; it is an injection seam, never a behaviour switch.
-    ``project_id`` and ``context_deps`` are accepted for cross-mode uniformity
-    and deliberately unused: performance data is engineer-keyed, and a person's
-    history must not shrink because a project is active (see projects/scope.py).
-    The deferred leak follow-up wires ``context_deps`` to this engine's own
-    ceremony reads.
+    ``project_id``/``context_deps`` resolve the run's ProjectScope, which gates
+    the evidence gather's cross-mode reads (standup/analysis/retro by token,
+    poker/delivery under full incognito). This engine's own PerformanceStore
+    reads stay engineer-keyed and unscoped: a person's history must not shrink
+    because a project is active (see projects/scope.py).
     """
+    from yeaboi.projects.scope import resolve_scope
+
     today = today or date.today()
     date_str = today.isoformat()
     db_path = _resolve_db_path(db_path)
     logger.info("run_one_on_one_prep: engineer=%s session=%s deep_scan=%s", engineer, session_id, deep_scan)
 
+    scope = resolve_scope(project_id, session_id, context_deps=context_deps, db_path=db_path)
     state = _load_state(session_id, db_path)
     evidence = evidence_mod.gather_engineer_evidence(
         engineer,
@@ -262,6 +265,7 @@ def run_one_on_one_prep(
         deep_scan=deep_scan,
         db_path=db_path,
         on_progress=on_progress,
+        scope=scope,
     )
     activity = evidence.activity
 
@@ -687,17 +691,20 @@ def run_six_month_review(
 
     ``deep_scan`` permits one capped live scan for the stretch no saved standup
     covered; it costs API calls, so it is off by default. ``project_id`` and
-    ``context_deps`` are accepted for cross-mode uniformity and deliberately
-    unused: performance data is engineer-keyed (see projects/scope.py). The
-    deferred leak follow-up wires ``context_deps`` to this engine's own
-    ceremony reads.
+    ``context_deps`` resolve the run's ProjectScope, which gates the evidence
+    gather's cross-mode reads and the team ceremony read below; this engine's
+    own PerformanceStore reads stay engineer-keyed and unscoped (see
+    projects/scope.py).
     """
+    from yeaboi.projects.scope import resolve_scope
+
     today = today or date.today()
     period_end = today.isoformat()
     period_start = (today - timedelta(days=period_months * 30)).isoformat()
     db_path = _resolve_db_path(db_path)
     logger.info("run_six_month_review: engineer=%s period=%s..%s", engineer, period_start, period_end)
 
+    scope = resolve_scope(project_id, session_id, context_deps=context_deps, db_path=db_path)
     state = _load_state(session_id, db_path)
 
     with PerformanceStore(db_path) as store:
@@ -716,6 +723,7 @@ def run_six_month_review(
         deep_scan=deep_scan,
         db_path=db_path,
         on_progress=on_progress,
+        scope=scope,
     )
     delivery = evidence.activity
 
@@ -725,7 +733,7 @@ def run_six_month_review(
     try:
         from yeaboi.agent.ceremony_history import gather_ceremony_context
 
-        ceremony_summary = gather_ceremony_context(state.get("project_name", "")).summary_md
+        ceremony_summary = gather_ceremony_context(state.get("project_name", ""), scope=scope).summary_md
     except Exception as e:  # noqa: BLE001 — ceremony context is best-effort
         logger.warning("run_six_month_review: ceremony context failed: %s", e)
         ceremony_failed = True

--- a/src/yeaboi/performance/evidence.py
+++ b/src/yeaboi/performance/evidence.py
@@ -97,6 +97,10 @@ _MAX_LINE = 220  # per-line truncation of free text
 _MAX_EVIDENCE_ROWS = 24  # structured rows kept per evidence group
 _MAX_GAP_DAYS = 45  # hard ceiling on a live gap-fill scan
 
+# Coverage detail for a source the run's context toggles switched off — the
+# anti-inference rule: silence must say why, never read as an idle period.
+_TOGGLED_OFF = "Switched off by this run's context toggles."
+
 
 @dataclass(frozen=True)
 class SourceCoverage:
@@ -601,16 +605,26 @@ def gather_engineer_evidence(
     deep_scan: bool = False,
     db_path=None,
     on_progress=None,
+    scope=None,
 ) -> EngineerEvidence:
     """Read every mode's history for one engineer. Never raises.
 
     Saved stores are read first (free); ``deep_scan`` additionally permits one
     capped live multi-source collection over the stretch no saved standup covered.
 
+    ``scope`` applies the run's context toggles: standup/analysis/retro obey
+    their dep tokens (a switched-off source settles its coverage row saying so,
+    so silence never reads as an idle period), the untokened poker/delivery
+    reads go quiet only under full incognito, and a session-scoped run narrows
+    the standup/retro reads. The live gap-fill borrows the saved standup config,
+    so it rides the ``standup`` toggle too.
+
     ``on_progress``: optional callable taking one lifecycle event per source
     (see ``analysis/progress.py``), so a caller can draw a live checklist. Each
     source reports ``running`` and then whatever its own SourceCoverage row says.
     """
+    from yeaboi.projects.scope import incognito, wants
+
     state = state or {}
     logger.info(
         "gather_engineer_evidence: engineer=%s period=%s..%s deep_scan=%s",
@@ -694,23 +708,29 @@ def gather_engineer_evidence(
 
     # ── Standup — per-member code, docs, self-reports, blockers, practices. ──
     _emit(on_progress, SOURCE_STANDUP, "running")
-    try:
-        from yeaboi.standup.store import StandupStore
+    if not wants(scope, "standup"):
+        coverage.append(SourceCoverage(SOURCE_STANDUP, NOT_CONFIGURED, _TOGGLED_OFF))
+        coverage.append(SourceCoverage(SOURCE_CODE, NOT_CONFIGURED, _TOGGLED_OFF))
+        coverage.append(SourceCoverage(SOURCE_DOCUMENTATION, NOT_CONFIGURED, _TOGGLED_OFF))
+    else:
+        try:
+            from yeaboi.standup.store import StandupStore
 
-        with StandupStore(db_path) as store:
-            reports = [
-                r
-                for r in store.get_recent_reports(_MAX_STANDUP_RUNS)
-                if _in_period(getattr(r, "date", ""), period_start, period_end)
-            ]
-        standup_stats = _standup_lines(reports, aliases)
-        standup_lines = standup_stats["standup"][:_MAX_STANDUP_LINES]
-        code_lines = standup_stats["code"][:_MAX_CODE_LINES]
-        doc_lines = standup_stats["documentation"][:_MAX_DOC_LINES]
-        practice_lines = standup_stats["practices"][:_MAX_PRACTICE_LINES]
-    except Exception:  # noqa: BLE001 — evidence is best-effort; never abort the run
-        logger.debug("performance evidence: standup read failed (non-fatal)", exc_info=True)
-        coverage.append(SourceCoverage(SOURCE_STANDUP, FAILED, "The standup history could not be read."))
+            session_ids = scope.session_ids if scope is not None else None
+            with StandupStore(db_path) as store:
+                reports = [
+                    r
+                    for r in store.get_recent_reports(_MAX_STANDUP_RUNS, session_ids=session_ids)
+                    if _in_period(getattr(r, "date", ""), period_start, period_end)
+                ]
+            standup_stats = _standup_lines(reports, aliases)
+            standup_lines = standup_stats["standup"][:_MAX_STANDUP_LINES]
+            code_lines = standup_stats["code"][:_MAX_CODE_LINES]
+            doc_lines = standup_stats["documentation"][:_MAX_DOC_LINES]
+            practice_lines = standup_stats["practices"][:_MAX_PRACTICE_LINES]
+        except Exception:  # noqa: BLE001 — evidence is best-effort; never abort the run
+            logger.debug("performance evidence: standup read failed (non-fatal)", exc_info=True)
+            coverage.append(SourceCoverage(SOURCE_STANDUP, FAILED, "The standup history could not be read."))
 
     if standup_stats:
         runs = standup_stats["runs"]
@@ -723,146 +743,172 @@ def gather_engineer_evidence(
 
     # ── Analysis — delivery stats + practice hygiene + AI markers. ───────────
     _emit(on_progress, SOURCE_ANALYSIS, "running")
-    try:
-        analysis_lines, analysis_metrics, profiles_seen = _read_analysis(db_path, aliases, jira_project, azdo_project)
-        metrics.extend(analysis_metrics)
-        # A profile that exists and names somebody else is an attribution gap,
-        # not an unconfigured source — the same distinction every other source
-        # here draws, and the reason ``partial`` is in the vocabulary at all.
-        if analysis_lines:
-            analysis_state, analysis_detail = COVERED, "Team analysis metrics for this engineer."
-        elif profiles_seen:
-            analysis_state = PARTIAL
-            analysis_detail = (
-                f"{profiles_seen} saved team analysis profile(s), none carrying a row for this engineer "
-                "— an attribution gap, not an idle period."
+    if not wants(scope, "analysis"):
+        coverage.append(SourceCoverage(SOURCE_ANALYSIS, NOT_CONFIGURED, _TOGGLED_OFF))
+    else:
+        try:
+            analysis_lines, analysis_metrics, profiles_seen = _read_analysis(
+                db_path, aliases, jira_project, azdo_project
             )
-        else:
-            analysis_state, analysis_detail = NOT_CONFIGURED, "No saved team analysis to read."
-        coverage.append(SourceCoverage(SOURCE_ANALYSIS, analysis_state, analysis_detail))
-    except Exception:  # noqa: BLE001
-        logger.debug("performance evidence: analysis read failed (non-fatal)", exc_info=True)
-        coverage.append(SourceCoverage(SOURCE_ANALYSIS, FAILED, "The team analysis profile could not be read."))
+            metrics.extend(analysis_metrics)
+            # A profile that exists and names somebody else is an attribution gap,
+            # not an unconfigured source — the same distinction every other source
+            # here draws, and the reason ``partial`` is in the vocabulary at all.
+            if analysis_lines:
+                analysis_state, analysis_detail = COVERED, "Team analysis metrics for this engineer."
+            elif profiles_seen:
+                analysis_state = PARTIAL
+                analysis_detail = (
+                    f"{profiles_seen} saved team analysis profile(s), none carrying a row for this engineer "
+                    "— an attribution gap, not an idle period."
+                )
+            else:
+                analysis_state, analysis_detail = NOT_CONFIGURED, "No saved team analysis to read."
+            coverage.append(SourceCoverage(SOURCE_ANALYSIS, analysis_state, analysis_detail))
+        except Exception:  # noqa: BLE001
+            logger.debug("performance evidence: analysis read failed (non-fatal)", exc_info=True)
+            coverage.append(SourceCoverage(SOURCE_ANALYSIS, FAILED, "The team analysis profile could not be read."))
     _emit_coverage(on_progress, coverage, SOURCE_ANALYSIS)
 
     # ── Retro — their cards, their action items, their attendance. ───────────
     _emit(on_progress, SOURCE_RETRO, "running")
-    try:
-        from yeaboi.retro.store import RetroStore
+    if not wants(scope, "retro"):
+        coverage.append(SourceCoverage(SOURCE_RETRO, NOT_CONFIGURED, _TOGGLED_OFF))
+    else:
+        try:
+            from yeaboi.retro.store import RetroStore
 
-        with RetroStore(db_path) as store:
-            reports = [
-                r
-                for r in store.get_recent_reports(_MAX_RETRO_RUNS, str(state.get("project_name", "")))
-                if _in_period(getattr(r, "date", ""), period_start, period_end)
-            ]
-        lines, participated, total = _retro_lines(reports, aliases)
-        retro_lines = lines[:_MAX_RETRO_LINES]
-        if participated and total:
-            retro_lines.insert(0, f"Took part in {participated} of {total} retro(s) in this period.")
-        if total:
-            metrics.append(
-                PerfMetric(
-                    key="retros_attended",
-                    label="Retros attended",
-                    value=float(participated),
-                    denominator=float(total),
-                    group="ceremony",
-                    source=SOURCE_RETRO,
+            session_ids = scope.session_ids if scope is not None else None
+            # The project-name sort bias only applies to a team-wide read; a hard
+            # session filter replaces it (same rule as gather_ceremony_context).
+            project_bias = str(state.get("project_name", "")) if session_ids is None else ""
+            with RetroStore(db_path) as store:
+                reports = [
+                    r
+                    for r in store.get_recent_reports(_MAX_RETRO_RUNS, project_bias, session_ids=session_ids)
+                    if _in_period(getattr(r, "date", ""), period_start, period_end)
+                ]
+            lines, participated, total = _retro_lines(reports, aliases)
+            retro_lines = lines[:_MAX_RETRO_LINES]
+            if participated and total:
+                retro_lines.insert(0, f"Took part in {participated} of {total} retro(s) in this period.")
+            if total:
+                metrics.append(
+                    PerfMetric(
+                        key="retros_attended",
+                        label="Retros attended",
+                        value=float(participated),
+                        denominator=float(total),
+                        group="ceremony",
+                        source=SOURCE_RETRO,
+                    )
                 )
-            )
-        state_ = COVERED if participated else (PARTIAL if total else NOT_CONFIGURED)
-        coverage.append(SourceCoverage(SOURCE_RETRO, state_, _coverage_detail(state_, "retro", participated, total)))
-    except Exception:  # noqa: BLE001
-        logger.debug("performance evidence: retro read failed (non-fatal)", exc_info=True)
-        coverage.append(SourceCoverage(SOURCE_RETRO, FAILED, "The retro history could not be read."))
+            state_ = COVERED if participated else (PARTIAL if total else NOT_CONFIGURED)
+            detail = _coverage_detail(state_, "retro", participated, total)
+            coverage.append(SourceCoverage(SOURCE_RETRO, state_, detail))
+        except Exception:  # noqa: BLE001
+            logger.debug("performance evidence: retro read failed (non-fatal)", exc_info=True)
+            coverage.append(SourceCoverage(SOURCE_RETRO, FAILED, "The retro history could not be read."))
     _emit_coverage(on_progress, coverage, SOURCE_RETRO)
 
     # ── Poker — how their estimates track where the team lands. ──────────────
+    # No dep token of its own — silenced only by a full-incognito run.
     _emit(on_progress, SOURCE_POKER, "running")
-    try:
-        from yeaboi.poker.store import PokerStore
+    if incognito(scope):
+        coverage.append(SourceCoverage(SOURCE_POKER, NOT_CONFIGURED, _TOGGLED_OFF))
+    else:
+        try:
+            from yeaboi.poker.store import PokerStore
 
-        with PokerStore(db_path) as store:
-            rows = store.get_all_history(_MAX_POKER_RUNS)
-            reports = []
-            for row in rows:
-                if not _in_period(str(row.get("poker_date", "")), period_start, period_end):
-                    continue
-                report = store.get_run_by_id(int(row.get("id", 0)))
-                if report is not None:
-                    reports.append(report)
-        lines, voted, total, attended = _poker_lines(reports, aliases)
-        poker_lines = lines[:_MAX_POKER_LINES]
-        if total:
-            metrics.append(
-                PerfMetric(
-                    key="poker_sessions",
-                    label="Estimation sessions joined",
-                    value=float(attended),
-                    denominator=float(total),
-                    group="ceremony",
-                    source=SOURCE_POKER,
-                    detail=f"Voted on {voted} ticket(s).",
+            with PokerStore(db_path) as store:
+                rows = store.get_all_history(_MAX_POKER_RUNS)
+                reports = []
+                for row in rows:
+                    if not _in_period(str(row.get("poker_date", "")), period_start, period_end):
+                        continue
+                    report = store.get_run_by_id(int(row.get("id", 0)))
+                    if report is not None:
+                        reports.append(report)
+            lines, voted, total, attended = _poker_lines(reports, aliases)
+            poker_lines = lines[:_MAX_POKER_LINES]
+            if total:
+                metrics.append(
+                    PerfMetric(
+                        key="poker_sessions",
+                        label="Estimation sessions joined",
+                        value=float(attended),
+                        denominator=float(total),
+                        group="ceremony",
+                        source=SOURCE_POKER,
+                        detail=f"Voted on {voted} ticket(s).",
+                    )
+                )
+            state_ = COVERED if voted else (PARTIAL if total else NOT_CONFIGURED)
+            coverage.append(
+                SourceCoverage(
+                    SOURCE_POKER,
+                    state_,
+                    f"Voted on {voted} ticket(s) across {total} session(s)."
+                    if voted
+                    else _coverage_detail(state_, "poker", 0, total),
                 )
             )
-        state_ = COVERED if voted else (PARTIAL if total else NOT_CONFIGURED)
-        coverage.append(
-            SourceCoverage(
-                SOURCE_POKER,
-                state_,
-                f"Voted on {voted} ticket(s) across {total} session(s)."
-                if voted
-                else _coverage_detail(state_, "poker", 0, total),
-            )
-        )
-    except Exception:  # noqa: BLE001
-        logger.debug("performance evidence: poker read failed (non-fatal)", exc_info=True)
-        coverage.append(SourceCoverage(SOURCE_POKER, FAILED, "The poker history could not be read."))
+        except Exception:  # noqa: BLE001
+            logger.debug("performance evidence: poker read failed (non-fatal)", exc_info=True)
+            coverage.append(SourceCoverage(SOURCE_POKER, FAILED, "The poker history could not be read."))
     _emit_coverage(on_progress, coverage, SOURCE_POKER)
 
     # ── Reporting — what actually shipped under their name. ──────────────────
+    # No dep token of its own — silenced only by a full-incognito run.
     _emit(on_progress, SOURCE_DELIVERY, "running")
-    try:
-        from yeaboi.reporting.store import ReportingStore
+    if incognito(scope):
+        coverage.append(SourceCoverage(SOURCE_DELIVERY, NOT_CONFIGURED, _TOGGLED_OFF))
+    else:
+        try:
+            from yeaboi.reporting.store import ReportingStore
 
-        with ReportingStore(db_path) as store:
-            report = store.get_latest_report()
-        delivered = getattr(report, "delivered_items", ()) or ()
-        shipped = [i for i in delivered if identity.matches(getattr(i, "assignee", ""), aliases)]
-        delivery_lines = _delivery_lines(delivered, aliases)[:_MAX_DELIVERY_LINES]
-        if shipped:
-            metrics.append(
-                PerfMetric(
-                    key="shipped_items",
-                    label="Items shipped",
-                    value=float(len(shipped)),
-                    group="delivery",
-                    source=SOURCE_DELIVERY,
+            with ReportingStore(db_path) as store:
+                report = store.get_latest_report()
+            delivered = getattr(report, "delivered_items", ()) or ()
+            shipped = [i for i in delivered if identity.matches(getattr(i, "assignee", ""), aliases)]
+            delivery_lines = _delivery_lines(delivered, aliases)[:_MAX_DELIVERY_LINES]
+            if shipped:
+                metrics.append(
+                    PerfMetric(
+                        key="shipped_items",
+                        label="Items shipped",
+                        value=float(len(shipped)),
+                        group="delivery",
+                        source=SOURCE_DELIVERY,
+                    )
                 )
-            )
-            groups.append(_delivery_group(shipped))
-        # Three different facts, three different words. ``shipped``, not the
-        # display list: ``delivery_lines`` is capped for the prompt, and counting
-        # the cap is how a tile saying 23 ended up beside a sentence saying 8.
-        if shipped:
-            delivery_state, delivery_detail = COVERED, f"{len(shipped)} shipped item(s) credited to this engineer."
-        elif delivered:
-            delivery_state = PARTIAL
-            delivery_detail = (
-                f"{len(delivered)} shipped item(s) in the latest delivery report, none credited to this "
-                "engineer — an attribution gap, not an idle period."
-            )
-        else:
-            delivery_state, delivery_detail = NOT_CONFIGURED, "No delivery report to read."
-        coverage.append(SourceCoverage(SOURCE_DELIVERY, delivery_state, delivery_detail))
-    except Exception:  # noqa: BLE001
-        logger.debug("performance evidence: reporting read failed (non-fatal)", exc_info=True)
-        coverage.append(SourceCoverage(SOURCE_DELIVERY, FAILED, "The delivery report could not be read."))
+                groups.append(_delivery_group(shipped))
+            # Three different facts, three different words. ``shipped``, not the
+            # display list: ``delivery_lines`` is capped for the prompt, and counting
+            # the cap is how a tile saying 23 ended up beside a sentence saying 8.
+            if shipped:
+                delivery_state, delivery_detail = COVERED, f"{len(shipped)} shipped item(s) credited to this engineer."
+            elif delivered:
+                delivery_state = PARTIAL
+                delivery_detail = (
+                    f"{len(delivered)} shipped item(s) in the latest delivery report, none credited to this "
+                    "engineer — an attribution gap, not an idle period."
+                )
+            else:
+                delivery_state, delivery_detail = NOT_CONFIGURED, "No delivery report to read."
+            coverage.append(SourceCoverage(SOURCE_DELIVERY, delivery_state, delivery_detail))
+        except Exception:  # noqa: BLE001
+            logger.debug("performance evidence: reporting read failed (non-fatal)", exc_info=True)
+            coverage.append(SourceCoverage(SOURCE_DELIVERY, FAILED, "The delivery report could not be read."))
     _emit_coverage(on_progress, coverage, SOURCE_DELIVERY)
 
     # ── Live gap-fill — only when asked, only over what nothing covered. ─────
-    if deep_scan:
+    if deep_scan and not wants(scope, "standup"):
+        # The live scan borrows the saved standup config (and hits the network),
+        # so it rides the standup toggle.
+        _emit(on_progress, PHASE_GAP_SCAN, "running")
+        _emit(on_progress, PHASE_GAP_SCAN, "no_data", detail=_TOGGLED_OFF)
+    elif deep_scan:
         _emit(on_progress, PHASE_GAP_SCAN, "running")
         extra_code, extra_docs, gap_note, gap_outcome = _gap_fill(
             aliases,

--- a/src/yeaboi/poker/board.py
+++ b/src/yeaboi/poker/board.py
@@ -162,11 +162,15 @@ class PokerBoard:
         source: str = "",
         scope_label: str = "",
         tickets: list[dict] | None = None,
+        scope=None,
     ) -> None:
         self.session_id = session_id
         self.project_name = project_name
         self.source = source
         self.scope_label = scope_label
+        # The run's ProjectScope (context toggles + session narrowing) for the
+        # AI perspective's history gather. Never serialized into a snapshot.
+        self.scope = scope
         self.created_at = _now_iso()
         self._tickets: list[dict] = []
         for t in tickets or []:

--- a/src/yeaboi/poker/context.py
+++ b/src/yeaboi/poker/context.py
@@ -273,7 +273,7 @@ def format_poker_context_md(ctx: PokerEstimationContext) -> str:
 # ---------------------------------------------------------------------------
 
 
-def gather_poker_context(ticket: dict, *, project_name: str = "") -> PokerEstimationContext:
+def gather_poker_context(ticket: dict, *, project_name: str = "", scope=None) -> PokerEstimationContext:
     """Read the other modes' history relevant to one poker ticket. Never raises.
 
     Each source sits in its own try/except so one broken store doesn't cost the
@@ -281,8 +281,14 @@ def gather_poker_context(ticket: dict, *, project_name: str = "") -> PokerEstima
     behaves exactly as before. Demo tickets skip gathering entirely — their
     fake assignees would only produce noise against real history.
 
+    ``scope`` applies the run's context toggles: each tokened source is gated
+    by its dep, the untokened delivery read goes silent only under full
+    incognito, and a session-scoped run narrows the standup/planning reads.
+
     # See docs: "Session Management" — SQLite persistence
     """
+    from yeaboi.projects.scope import incognito, wants
+
     ticket = ticket or {}
     source = str(ticket.get("source", ""))
     key = str(ticket.get("key", ""))
@@ -310,7 +316,7 @@ def gather_poker_context(ticket: dict, *, project_name: str = "") -> PokerEstima
 
     # Analysis mode: the team calibration profile for this tracker project.
     try:
-        project_key = _project_key_for(source, key)
+        project_key = _project_key_for(source, key) if wants(scope, "analysis") else ""
         if project_key:
             from yeaboi.team_profile import TeamProfileStore
 
@@ -326,7 +332,7 @@ def gather_poker_context(ticket: dict, *, project_name: str = "") -> PokerEstima
     try:
         from yeaboi.agent.ceremony_history import gather_ceremony_context
 
-        ceremony = gather_ceremony_context(project_name)
+        ceremony = gather_ceremony_context(project_name, scope=scope)
         if ceremony.confidence_trend:
             team_lines.append(f"Recent standup sprint confidence: {ceremony.confidence_trend}.")
         retro_lines = tuple(
@@ -338,35 +344,44 @@ def gather_poker_context(ticket: dict, *, project_name: str = "") -> PokerEstima
 
     # Standup: the ticket assignee's latest blockers + progress.
     try:
-        from yeaboi.standup.store import StandupStore
+        if wants(scope, "standup"):
+            from yeaboi.standup.store import StandupStore
 
-        with StandupStore(db_path) as sstore:
-            recent = sstore.get_recent_reports(1)
-        assignee_lines = _assignee_lines(recent[0] if recent else None, assignee)
+            session_ids = scope.session_ids if scope is not None else None
+            with StandupStore(db_path) as sstore:
+                recent = sstore.get_recent_reports(1, session_ids=session_ids)
+            assignee_lines = _assignee_lines(recent[0] if recent else None, assignee)
     except Exception:  # noqa: BLE001
         logger.debug("gather_poker_context: standup read failed (non-fatal)", exc_info=True)
 
     # Reporting: recently delivered tickets (real keys) for citable comparisons.
+    # No dep token of its own — silenced only by a full-incognito run.
     try:
-        from yeaboi.reporting.store import ReportingStore
+        if not incognito(scope):
+            from yeaboi.reporting.store import ReportingStore
 
-        with ReportingStore(db_path) as rstore:
-            delivery = rstore.get_latest_report()
-        if delivery is not None:
-            delivery_lines = _delivery_lines(delivery.delivered_items, assignee, summary, key)
+            with ReportingStore(db_path) as rstore:
+                delivery = rstore.get_latest_report()
+            if delivery is not None:
+                delivery_lines = _delivery_lines(delivery.delivered_items, assignee, summary, key)
     except Exception:  # noqa: BLE001
         logger.debug("gather_poker_context: reporting read failed (non-fatal)", exc_info=True)
 
     # Planning: similar stories this team already sized, with confidence.
     try:
-        from yeaboi.sessions import SessionStore
+        if wants(scope, "plan"):
+            from yeaboi.sessions import SessionStore
 
-        stories: list = []
-        with SessionStore(db_path) as sessions:
-            for meta in sessions.list_sessions()[:_MAX_SESSIONS_SCANNED]:
-                state = sessions.load_state(meta["session_id"]) or {}
-                stories.extend(state.get("stories") or [])
-        planning_lines = _planning_lines(stories, summary)
+            stories: list = []
+            with SessionStore(db_path) as sessions:
+                metas = sessions.list_sessions()
+                if scope is not None and scope.session_ids is not None:
+                    allowed = set(scope.session_ids)
+                    metas = [m for m in metas if m.get("session_id") in allowed]
+                for meta in metas[:_MAX_SESSIONS_SCANNED]:
+                    state = sessions.load_state(meta["session_id"]) or {}
+                    stories.extend(state.get("stories") or [])
+            planning_lines = _planning_lines(stories, summary)
     except Exception:  # noqa: BLE001
         logger.debug("gather_poker_context: planning read failed (non-fatal)", exc_info=True)
 

--- a/src/yeaboi/poker/engine.py
+++ b/src/yeaboi/poker/engine.py
@@ -144,6 +144,7 @@ def get_poker_perspective(
     project_name: str = "",
     context=None,
     debate_transcript: str = "",
+    scope=None,
 ) -> dict:
     """One LLM call commenting on a revealed vote spread. Never raises.
 
@@ -157,6 +158,8 @@ def get_poker_perspective(
         debate_transcript: the transcribed low-vs-high duel debate ("" when no
             duel ran). Passed through to the prompt, where the model is asked
             to judge which argument was stronger.
+        scope: an optional ``ProjectScope`` applying the run's context toggles
+            to the gather; ignored when ``context`` is injected.
 
     Returns ``{"note": str, "suggested_points": float | None, "confidence": str,
     "evidence": [str, ...], "llm_mode": "llm" | "fallback", "warnings": [str, ...]}``
@@ -179,7 +182,7 @@ def get_poker_perspective(
     if context is None:
         from yeaboi.poker.context import gather_poker_context
 
-        context = gather_poker_context(ticket or {}, project_name=project_name)
+        context = gather_poker_context(ticket or {}, project_name=project_name, scope=scope)
 
     def _fallback(warning: str) -> dict:
         note = _build_fallback_note(votes, context)

--- a/src/yeaboi/poker/server.py
+++ b/src/yeaboi/poker/server.py
@@ -229,6 +229,7 @@ def _run_ai(board: PokerBoard) -> None:
             votes,
             project_name=board.project_name,
             debate_transcript=board.current_duel_transcript(),
+            scope=board.scope,
         )
         # A fallback's note is the vote median in a sentence, and the decision
         # row already shows the median — so only the reason it fell back is

--- a/src/yeaboi/projects/__init__.py
+++ b/src/yeaboi/projects/__init__.py
@@ -1,0 +1,15 @@
+"""First-class projects — the identity that links sessions across modes.
+
+A project row lives in the shared sessions.db and sessions link to it through
+``sessions_meta.project_id``. Scoped context gathering resolves through
+``yeaboi.projects.scope``; the store below owns the rows themselves.
+
+Naming hazard: the legacy planning-TUI layer (``yeaboi.persistence``) also
+speaks of a "project_id" — a bare uuid4 in ``~/.yeaboi/data/projects.json``,
+a render cache in a disjoint id space. These ``proj-<8hex>`` ids never mix
+with it, and nothing here reads or writes that file.
+"""
+
+from yeaboi.projects.store import ProjectStore, new_project_id
+
+__all__ = ["ProjectStore", "new_project_id"]

--- a/src/yeaboi/projects/active.py
+++ b/src/yeaboi/projects/active.py
@@ -30,13 +30,30 @@ def set_active_project(project_id: str) -> None:
 
 _context_deps: tuple[str, ...] | None = None
 
+_solo_mode: bool = False
+
+
+#: The Solo world's default context toggles: everything but the retro feed —
+#: Solo has no retro mode, so a run should not go looking for retro history.
+#: Computed from the token vocabulary so a new token is on for Solo by default.
+def _solo_default_deps() -> tuple[str, ...]:
+    from yeaboi.projects.scope import CONTEXT_DEP_TOKENS
+
+    return tuple(t for t in CONTEXT_DEP_TOKENS if t != "retro")
+
 
 def get_context_deps() -> tuple[str, ...] | None:
     """The session's context-source toggles; ``None`` inherits (all on).
 
     Same contract as the engines' ``context_deps``: an empty tuple is an
     incognito run. Unpersisted for the same reason as the active project.
+    In the Solo world, "inherit" inherits the solo defaults (retro off)
+    rather than everything — an explicit choice still wins.
     """
+    if _context_deps is None and _solo_mode:
+        deps = _solo_default_deps()
+        logger.info("context deps defaulting for solo: %s", ", ".join(deps))
+        return deps
     return _context_deps
 
 
@@ -45,3 +62,16 @@ def set_context_deps(deps: tuple[str, ...] | None) -> None:
     global _context_deps
     _context_deps = deps
     logger.info("context deps set to %s", "inherit" if deps is None else (", ".join(deps) or "incognito"))
+
+
+def is_solo_mode() -> bool:
+    """True while the session is in the Solo world (set by the landing split)."""
+    return _solo_mode
+
+
+def set_solo_mode(solo: bool) -> None:
+    """Record which world the session is in; flips the inherit default above."""
+    global _solo_mode
+    if solo != _solo_mode:
+        logger.info("solo mode %s", "on" if solo else "off")
+    _solo_mode = solo

--- a/src/yeaboi/projects/active.py
+++ b/src/yeaboi/projects/active.py
@@ -26,3 +26,22 @@ def set_active_project(project_id: str) -> None:
     global _active_project_id
     _active_project_id = project_id
     logger.info("active project set to %s", project_id or "(none)")
+
+
+_context_deps: tuple[str, ...] | None = None
+
+
+def get_context_deps() -> tuple[str, ...] | None:
+    """The session's context-source toggles; ``None`` inherits (all on).
+
+    Same contract as the engines' ``context_deps``: an empty tuple is an
+    incognito run. Unpersisted for the same reason as the active project.
+    """
+    return _context_deps
+
+
+def set_context_deps(deps: tuple[str, ...] | None) -> None:
+    """Set the toggles for this process; ``()`` = incognito, ``None`` = inherit."""
+    global _context_deps
+    _context_deps = deps
+    logger.info("context deps set to %s", "inherit" if deps is None else (", ".join(deps) or "incognito"))

--- a/src/yeaboi/projects/active.py
+++ b/src/yeaboi/projects/active.py
@@ -1,6 +1,6 @@
 """The TUI's active project — in-process controller state.
 
-Set from the welcome screen's project switcher (``p``); read by mode launch
+Set from the welcome screen's project switcher (``P``); read by mode launch
 sites when they invoke an engine, so a standup or report started from the
 menu runs scoped without every screen learning about projects. Deliberately
 process-local and unpersisted: the active project is a *session* choice, and

--- a/src/yeaboi/projects/active.py
+++ b/src/yeaboi/projects/active.py
@@ -1,0 +1,28 @@
+"""The TUI's active project — in-process controller state.
+
+Set from the welcome screen's project switcher (``p``); read by mode launch
+sites when they invoke an engine, so a standup or report started from the
+menu runs scoped without every screen learning about projects. Deliberately
+process-local and unpersisted: the active project is a *session* choice, and
+a stale one silently rescoping next week's runs is worse than re-picking.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_active_project_id: str = ""
+
+
+def get_active_project() -> str:
+    """The active project id, '' when runs should stay team-wide."""
+    return _active_project_id
+
+
+def set_active_project(project_id: str) -> None:
+    """Set (or clear, with '') the active project for this process."""
+    global _active_project_id
+    _active_project_id = project_id
+    logger.info("active project set to %s", project_id or "(none)")

--- a/src/yeaboi/projects/engine.py
+++ b/src/yeaboi/projects/engine.py
@@ -20,7 +20,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # The settings keys set_project_defaults accepts. default_context_deps is the
-# context-toggle seam — reserved and stored now, read by the incognito work.
+# context-source toggle default a scoped run inherits (scope.resolve_scope).
 _DEFAULT_KEYS = ("default_analysis_profile_id", "default_context_deps")
 
 

--- a/src/yeaboi/projects/engine.py
+++ b/src/yeaboi/projects/engine.py
@@ -1,0 +1,112 @@
+"""Projects engine — the headless entry points every surface adapts.
+
+Five verbs over the ``projects`` table in the shared sessions.db: create,
+list, get, link a session, set defaults. Anything heavier (scoped context
+reads) lives in ``projects/scope.py``; the store itself in
+``projects/store.py``. Keep this module's public surface exactly these five
+functions — surface parity registers each one.
+
+Naming hazard: these ``proj-<8hex>`` ids are unrelated to the legacy
+planning-TUI uuid4 "project_id" in ``projects.json`` (persistence.py).
+
+# See docs: "Architecture" — engine-first, thin adapters
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# The settings keys set_project_defaults accepts. default_context_deps is the
+# context-toggle seam — reserved and stored now, read by the incognito work.
+_DEFAULT_KEYS = ("default_analysis_profile_id", "default_context_deps")
+
+
+def _db_path(db_path: Path | None) -> Path:
+    from yeaboi.paths import get_db_path
+
+    return db_path or get_db_path()
+
+
+def create_project(name: str, description: str = "", *, db_path: Path | None = None) -> dict:
+    """Create a project and return its row."""
+    name = name.strip()
+    if not name:
+        raise ValueError("name is required — a short human project name.")
+    from yeaboi.projects.store import ProjectStore
+
+    with ProjectStore(_db_path(db_path)) as store:
+        project = store.create(name, description.strip())
+    logger.info("create_project: %s (%s)", project["project_id"], name)
+    return project
+
+
+def list_projects(include_archived: bool = False, *, db_path: Path | None = None) -> list[dict]:
+    """All projects, most recently active first, with their session counts."""
+    from yeaboi.projects.store import ProjectStore
+    from yeaboi.sessions import SessionStore
+
+    path = _db_path(db_path)
+    with ProjectStore(path) as store:
+        projects = store.list_projects(include_archived=include_archived)
+    with SessionStore(path) as sessions:
+        for project in projects:
+            project["session_count"] = len(sessions.session_ids_for_project(project["project_id"]))
+    return projects
+
+
+def get_project(project_id: str, *, db_path: Path | None = None) -> dict:
+    """One project's row plus the ids of the sessions linked to it."""
+    from yeaboi.projects.store import ProjectStore
+    from yeaboi.sessions import SessionStore
+
+    path = _db_path(db_path)
+    with ProjectStore(path) as store:
+        project = store.get(project_id)
+    if project is None:
+        raise ValueError(f"unknown project {project_id!r} — see list_projects.")
+    with SessionStore(path) as sessions:
+        project["session_ids"] = sessions.session_ids_for_project(project_id)
+    return project
+
+
+def link_session(project_id: str, session_id: str, *, db_path: Path | None = None) -> dict:
+    """Link an existing session to a project (the post-hoc scoping lever)."""
+    from yeaboi.projects.store import ProjectStore
+    from yeaboi.sessions import SessionStore
+
+    path = _db_path(db_path)
+    with ProjectStore(path) as store:
+        if store.get(project_id) is None:
+            raise ValueError(f"unknown project {project_id!r} — see list_projects.")
+        with SessionStore(path) as sessions:
+            if sessions.get_session(session_id) is None:
+                raise ValueError(f"unknown session {session_id!r} — see sessions_list.")
+            sessions.set_session_project(session_id, project_id)
+        store.touch(project_id)
+    logger.info("link_session: %s -> %s", session_id, project_id)
+    return {"project_id": project_id, "session_id": session_id}
+
+
+def set_project_defaults(project_id: str, defaults: dict, *, db_path: Path | None = None) -> dict:
+    """Merge ``defaults`` into the project's settings and return them.
+
+    Accepts only the known keys (``default_analysis_profile_id``,
+    ``default_context_deps``) — an unknown key is a spelling mistake waiting
+    to become a silent no-op, so it raises instead.
+    """
+    unknown = sorted(set(defaults) - set(_DEFAULT_KEYS))
+    if unknown:
+        raise ValueError(f"unknown default(s) {unknown} — accepted: {', '.join(_DEFAULT_KEYS)}.")
+    from yeaboi.projects.store import ProjectStore
+
+    with ProjectStore(_db_path(db_path)) as store:
+        if store.get(project_id) is None:
+            raise ValueError(f"unknown project {project_id!r} — see list_projects.")
+        settings = store.get_settings(project_id)
+        settings.update(defaults)
+        store.set_settings(project_id, settings)
+    logger.info("set_project_defaults: %s keys=%s", project_id, sorted(defaults))
+    return {"project_id": project_id, "settings": settings}

--- a/src/yeaboi/projects/scope.py
+++ b/src/yeaboi/projects/scope.py
@@ -60,6 +60,40 @@ def resolve_scope(project_id: str = "", session_id: str = "", *, db_path: Path |
         return None
 
 
+def recent_standup_blockers(scope: ProjectScope | None, *, limit: int = 10, db_path: Path | None = None) -> list[str]:
+    """Blockers from the project's recent standups, newest first, deduped.
+
+    Feeds the standup→retro edge: a scoped retro board seeds these as
+    dismissible review cards. Unscoped (``None``) returns nothing — the
+    team-wide board keeps its carry-forward-only seeding. Never raises.
+    """
+    if scope is None or not scope.session_ids:
+        return []
+    try:
+        from yeaboi.paths import get_db_path
+        from yeaboi.standup.store import StandupStore
+
+        path = db_path or get_db_path()
+        if not Path(path).exists():
+            return []
+        with StandupStore(path) as store:
+            reports = store.get_recent_reports(limit, session_ids=scope.session_ids)
+    except Exception:  # noqa: BLE001 — same never-raise contract as resolve_scope
+        logger.debug("recent_standup_blockers failed (non-fatal)", exc_info=True)
+        return []
+    seen: set[str] = set()
+    blockers: list[str] = []
+    for report in reports:
+        for member in report.member_updates:
+            text = (member.blockers or "").strip()
+            if not text or text.lower() in seen:
+                continue
+            seen.add(text.lower())
+            blockers.append(f"{member.name}: {text}" if member.name else text)
+    logger.info("recent_standup_blockers: project=%s blockers=%d", scope.project_id, len(blockers))
+    return blockers
+
+
 def latest_planning_state(scope: ProjectScope | None, *, db_path: Path | None = None) -> tuple[str, dict] | None:
     """The project's newest planning session that carries a sprint plan.
 

--- a/src/yeaboi/projects/scope.py
+++ b/src/yeaboi/projects/scope.py
@@ -1,10 +1,18 @@
 """Project scope — the pull-based resolver that narrows cross-mode reads.
 
-A ``ProjectScope`` names a project and the sessions linked to it; gatherers
-(``gather_ceremony_context``, retro carry-forward, …) take an optional
-``scope=`` and hard-filter their store reads to those sessions. ``None`` is
-today's team-wide behavior, byte-for-byte — scoping is strictly an opt-in
-narrowing, and resolution never raises (a bad id degrades to unscoped).
+A ``ProjectScope`` names a project, the sessions linked to it, and which
+context dependencies the run may use; gatherers (``gather_ceremony_context``,
+retro carry-forward, …) take an optional ``scope=`` and hard-filter their
+store reads to those sessions. ``None`` is today's team-wide behavior,
+byte-for-byte — scoping is strictly an opt-in narrowing, and resolution never
+raises (a bad id degrades to unscoped).
+
+Context dependencies are the coarse per-producer toggles of
+``CONTEXT_DEP_TOKENS``. ``context_deps=None`` means every feed is enabled;
+an empty set is an incognito run (context isolation, not ephemerality —
+the session still persists). Precedence for a run: an explicit caller value,
+else the mode's own persisted config (standup only), else the project's
+``default_context_deps`` setting, else all-on.
 
 Deliberately unscoped: PerformanceStore reads. 1:1s and reviews are keyed by
 engineer, not project — an engineer's history must not shrink because a
@@ -16,47 +24,150 @@ not the legacy planning-TUI uuid4 "project_id" in ``projects.json``.
 
 from __future__ import annotations
 
+import json
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# The toggleable context feeds, one per producer mode:
+#   retro       — retro action items/themes/cadence into planning, retro→retro carry-over
+#   standup     — confidence trend/cadence into planning, blockers into retro
+#   plan        — latest-sprint-plan substitution into standup and reporting
+#   performance — open 1:1 actions and review focus into planning
+#   analysis    — analysis-profile seeding and team calibration into planning
+CONTEXT_DEP_TOKENS = ("retro", "standup", "plan", "performance", "analysis")
+
 
 @dataclass(frozen=True)
 class ProjectScope:
-    """The sessions a project's context reads are narrowed to."""
+    """The sessions and context dependencies a run's reads are narrowed to."""
 
     project_id: str
-    session_ids: tuple[str, ...]
-    # Context-toggle seam: None = every dependency enabled. resolve_scope
-    # always sets None today; the incognito/context_deps work assigns it.
+    # None = no session narrowing (team-wide reads); a tuple hard-filters.
+    session_ids: tuple[str, ...] | None
+    # None = every dependency enabled; an empty set = incognito.
     context_deps: frozenset[str] | None = None
 
+    def wants(self, dep: str) -> bool:
+        """Whether this scope allows the given context dependency."""
+        return self.context_deps is None or dep in self.context_deps
 
-def resolve_scope(project_id: str = "", session_id: str = "", *, db_path: Path | None = None) -> ProjectScope | None:
+
+def wants(scope: ProjectScope | None, dep: str) -> bool:
+    """Whether ``scope`` allows ``dep``; an absent scope allows everything."""
+    return scope is None or scope.wants(dep)
+
+
+def normalize_context_deps(value: object) -> frozenset[str] | None:
+    """Coerce a caller-supplied deps value to a frozenset of known tokens.
+
+    Accepts ``None`` (→ ``None`` = all on), an iterable of tokens, a JSON
+    list string, or a comma-separated string. Unknown tokens are dropped with
+    a warning rather than raised — same never-raise contract as the resolver.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.startswith("["):
+            try:
+                value = json.loads(text)
+            except ValueError:
+                logger.warning("normalize_context_deps: unparseable JSON %r — treating as all-on", text)
+                return None
+        else:
+            value = [part.strip() for part in text.split(",")]
+    if not isinstance(value, Iterable):
+        logger.warning("normalize_context_deps: unsupported value %r — treating as all-on", value)
+        return None
+    tokens = {str(item).strip() for item in value if str(item).strip()}
+    unknown = tokens - set(CONTEXT_DEP_TOKENS)
+    if unknown:
+        logger.warning("normalize_context_deps: dropping unknown token(s) %s", sorted(unknown))
+    return frozenset(tokens & set(CONTEXT_DEP_TOKENS))
+
+
+def parse_context_spec(spec: str) -> list[str] | None:
+    """Parse the surface grammar for context toggles into an engine value.
+
+    ``""``/``"inherit"`` → ``None`` (inherit), ``"all"`` → every token,
+    ``"none"`` → ``[]`` (incognito), else a comma-separated token list.
+    Raises ``ValueError`` on an unknown token — a surface typo must not read
+    as "that source is switched off".
+    """
+    word = spec.strip().lower()
+    if word in ("", "inherit"):
+        return None
+    if word == "all":
+        return list(CONTEXT_DEP_TOKENS)
+    if word == "none":
+        return []
+    tokens = [part.strip() for part in spec.split(",") if part.strip()]
+    unknown = [token for token in tokens if token not in CONTEXT_DEP_TOKENS]
+    if unknown:
+        raise ValueError(f"unknown context source(s) {unknown} — valid: {', '.join(CONTEXT_DEP_TOKENS)}")
+    return list(dict.fromkeys(tokens))
+
+
+def resolve_scope(
+    project_id: str = "",
+    session_id: str = "",
+    *,
+    context_deps: Iterable[str] | str | None = None,
+    db_path: Path | None = None,
+) -> ProjectScope | None:
     """Resolve the scope a run operates under. ``None`` = unscoped (team-wide).
 
     Precedence: an explicit ``project_id`` wins; otherwise the project is
-    inherited from ``session_id``'s ``sessions_meta`` row; an unlinked session
-    (or neither argument) resolves to ``None``. Never raises.
+    inherited from ``session_id``'s ``sessions_meta`` row. ``context_deps``
+    falls back to the project's ``default_context_deps`` setting when the
+    caller passes ``None``. Returns ``None`` only when there is neither a
+    project nor a deps restriction. Never raises.
     """
+    deps = normalize_context_deps(context_deps)
     try:
         from yeaboi.paths import get_db_path
         from yeaboi.sessions import SessionStore
 
         path = db_path or get_db_path()
         if not Path(path).exists():
-            return None
+            return ProjectScope(project_id="", session_ids=None, context_deps=deps) if deps is not None else None
         with SessionStore(path) as store:
             pid = project_id or (store.session_project_id(session_id) if session_id else "")
             if not pid:
-                return None
+                if deps is None:
+                    return None
+                return ProjectScope(project_id="", session_ids=None, context_deps=deps)
             ids = tuple(store.session_ids_for_project(pid))
-        logger.info("Resolved project scope: project=%s sessions=%d", pid, len(ids))
-        return ProjectScope(project_id=pid, session_ids=ids)
+        if deps is None:
+            deps = _project_default_deps(pid, db_path=path)
+        logger.info(
+            "Resolved project scope: project=%s sessions=%d deps=%s",
+            pid,
+            len(ids),
+            "all" if deps is None else sorted(deps),
+        )
+        return ProjectScope(project_id=pid, session_ids=ids, context_deps=deps)
     except Exception:  # noqa: BLE001 — scoping is best-effort; a bad id must not break a run
         logger.debug("resolve_scope failed (non-fatal)", exc_info=True)
+        return ProjectScope(project_id="", session_ids=None, context_deps=deps) if deps is not None else None
+
+
+def _project_default_deps(project_id: str, *, db_path: Path | None = None) -> frozenset[str] | None:
+    """The project's ``default_context_deps`` setting, or ``None`` (all on)."""
+    try:
+        from yeaboi.paths import get_db_path
+        from yeaboi.projects.store import ProjectStore
+
+        with ProjectStore(db_path or get_db_path()) as store:
+            return normalize_context_deps(store.get_settings(project_id).get("default_context_deps"))
+    except Exception:  # noqa: BLE001 — same never-raise contract as resolve_scope
+        logger.debug("_project_default_deps failed (non-fatal)", exc_info=True)
         return None
 
 
@@ -65,9 +176,10 @@ def recent_standup_blockers(scope: ProjectScope | None, *, limit: int = 10, db_p
 
     Feeds the standup→retro edge: a scoped retro board seeds these as
     dismissible review cards. Unscoped (``None``) returns nothing — the
-    team-wide board keeps its carry-forward-only seeding. Never raises.
+    team-wide board keeps its carry-forward-only seeding — and a scope with
+    the ``standup`` dep off returns nothing likewise. Never raises.
     """
-    if scope is None or not scope.session_ids:
+    if scope is None or not scope.session_ids or not scope.wants("standup"):
         return []
     try:
         from yeaboi.paths import get_db_path

--- a/src/yeaboi/projects/scope.py
+++ b/src/yeaboi/projects/scope.py
@@ -1,0 +1,88 @@
+"""Project scope — the pull-based resolver that narrows cross-mode reads.
+
+A ``ProjectScope`` names a project and the sessions linked to it; gatherers
+(``gather_ceremony_context``, retro carry-forward, …) take an optional
+``scope=`` and hard-filter their store reads to those sessions. ``None`` is
+today's team-wide behavior, byte-for-byte — scoping is strictly an opt-in
+narrowing, and resolution never raises (a bad id degrades to unscoped).
+
+Deliberately unscoped: PerformanceStore reads. 1:1s and reviews are keyed by
+engineer, not project — an engineer's history must not shrink because a
+project is active — and ``performance_notes`` has no session column at all.
+
+Naming hazard: this is the ``proj-<8hex>`` id space of ``projects/store.py``,
+not the legacy planning-TUI uuid4 "project_id" in ``projects.json``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProjectScope:
+    """The sessions a project's context reads are narrowed to."""
+
+    project_id: str
+    session_ids: tuple[str, ...]
+    # Context-toggle seam: None = every dependency enabled. resolve_scope
+    # always sets None today; the incognito/context_deps work assigns it.
+    context_deps: frozenset[str] | None = None
+
+
+def resolve_scope(project_id: str = "", session_id: str = "", *, db_path: Path | None = None) -> ProjectScope | None:
+    """Resolve the scope a run operates under. ``None`` = unscoped (team-wide).
+
+    Precedence: an explicit ``project_id`` wins; otherwise the project is
+    inherited from ``session_id``'s ``sessions_meta`` row; an unlinked session
+    (or neither argument) resolves to ``None``. Never raises.
+    """
+    try:
+        from yeaboi.paths import get_db_path
+        from yeaboi.sessions import SessionStore
+
+        path = db_path or get_db_path()
+        if not Path(path).exists():
+            return None
+        with SessionStore(path) as store:
+            pid = project_id or (store.session_project_id(session_id) if session_id else "")
+            if not pid:
+                return None
+            ids = tuple(store.session_ids_for_project(pid))
+        logger.info("Resolved project scope: project=%s sessions=%d", pid, len(ids))
+        return ProjectScope(project_id=pid, session_ids=ids)
+    except Exception:  # noqa: BLE001 — scoping is best-effort; a bad id must not break a run
+        logger.debug("resolve_scope failed (non-fatal)", exc_info=True)
+        return None
+
+
+def latest_planning_state(scope: ProjectScope | None, *, db_path: Path | None = None) -> tuple[str, dict] | None:
+    """The project's newest planning session that carries a sprint plan.
+
+    Returns ``(session_id, state)`` or ``None``; sessions without ``sprints``
+    are skipped (an intake that never reached sprint_planner feeds nothing).
+    Never raises.
+    """
+    if scope is None or not scope.project_id:
+        return None
+    try:
+        from yeaboi.paths import get_db_path
+        from yeaboi.sessions import SessionStore
+
+        path = db_path or get_db_path()
+        if not Path(path).exists():
+            return None
+        with SessionStore(path) as store:
+            for sid in store.session_ids_for_project(scope.project_id, mode="planning"):
+                state = store.load_state(sid)
+                if state and state.get("sprints"):
+                    logger.info("latest_planning_state: project=%s session=%s", scope.project_id, sid)
+                    return sid, state
+    except Exception:  # noqa: BLE001 — same never-raise contract as resolve_scope
+        logger.debug("latest_planning_state failed (non-fatal)", exc_info=True)
+        return None
+    return None

--- a/src/yeaboi/projects/scope.py
+++ b/src/yeaboi/projects/scope.py
@@ -82,6 +82,10 @@ def normalize_context_deps(value: object) -> frozenset[str] | None:
     Accepts ``None`` (→ ``None`` = all on), an iterable of tokens, a JSON
     list string, or a comma-separated string. Unknown tokens are dropped with
     a warning rather than raised — same never-raise contract as the resolver.
+
+    A value whose tokens are *all* unknown returns ``None`` (all on), never an
+    empty frozenset: only an explicitly empty value means incognito, and a
+    surface typo must not read as "every source is switched off".
     """
     if value is None:
         return None
@@ -101,10 +105,16 @@ def normalize_context_deps(value: object) -> frozenset[str] | None:
         logger.warning("normalize_context_deps: unsupported value %r — treating as all-on", value)
         return None
     tokens = {str(item).strip() for item in value if str(item).strip()}
+    known = tokens & set(CONTEXT_DEP_TOKENS)
     unknown = tokens - set(CONTEXT_DEP_TOKENS)
     if unknown:
         logger.warning("normalize_context_deps: dropping unknown token(s) %s", sorted(unknown))
-    return frozenset(tokens & set(CONTEXT_DEP_TOKENS))
+    if tokens and not known:
+        logger.warning(
+            "normalize_context_deps: no known token in %s — treating as all-on, not incognito", sorted(tokens)
+        )
+        return None
+    return frozenset(known)
 
 
 def parse_context_spec(spec: str) -> list[str] | None:

--- a/src/yeaboi/projects/scope.py
+++ b/src/yeaboi/projects/scope.py
@@ -55,10 +55,25 @@ class ProjectScope:
         """Whether this scope allows the given context dependency."""
         return self.context_deps is None or dep in self.context_deps
 
+    @property
+    def incognito(self) -> bool:
+        """True only for an explicit empty-deps run — every cross-mode read is off."""
+        return self.context_deps is not None and not self.context_deps
+
 
 def wants(scope: ProjectScope | None, dep: str) -> bool:
     """Whether ``scope`` allows ``dep``; an absent scope allows everything."""
     return scope is None or scope.wants(dep)
+
+
+def incognito(scope: ProjectScope | None) -> bool:
+    """Whether ``scope`` is a full-incognito run; an absent scope never is.
+
+    Gates the cross-mode reads that have no token of their own (poker votes,
+    the latest delivery report): they run for any partial toggle set and go
+    silent only when every source is switched off.
+    """
+    return scope is not None and scope.incognito
 
 
 def normalize_context_deps(value: object) -> frozenset[str] | None:

--- a/src/yeaboi/projects/store.py
+++ b/src/yeaboi/projects/store.py
@@ -12,7 +12,7 @@ gets the table.
 
 ``settings_json`` reserves two keys read elsewhere: ``default_analysis_profile_id``
 (seeds a scoped planning run's team profile) and ``default_context_deps``
-(the incognito/context-toggle default; defined ahead of that work, unread here).
+(the context-source toggles a scoped run inherits — read by scope.resolve_scope).
 
 # See docs: "Session Management" — SQLite persistence, schema versioning
 """

--- a/src/yeaboi/projects/store.py
+++ b/src/yeaboi/projects/store.py
@@ -1,0 +1,186 @@
+"""SQLite store for projects.
+
+Persists project rows in the shared ~/.yeaboi/data/sessions.db:
+- ``projects`` — one row per project; sessions link to it via
+  ``sessions_meta.project_id`` (owned by sessions.py, migration v31)
+
+Follows the exact patterns used by RetroStore (retro/store.py): a separate
+store class opening its own connection to the same DB, autocommit mode,
+context manager support, idempotent CREATE-IF-NOT-EXISTS schema. The schema
+constant is also referenced by sessions.py's v31 migration so an existing DB
+gets the table.
+
+``settings_json`` reserves two keys read elsewhere: ``default_analysis_profile_id``
+(seeds a scoped planning run's team profile) and ``default_context_deps``
+(the incognito/context-toggle default; defined ahead of that work, unread here).
+
+# See docs: "Session Management" — SQLite persistence, schema versioning
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Schema — referenced by sessions.py migration v31 AND created on store open
+# ---------------------------------------------------------------------------
+
+PROJECTS_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS projects (
+    project_id    TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    description   TEXT NOT NULL DEFAULT '',
+    settings_json TEXT NOT NULL DEFAULT '{}',
+    created_at    TEXT NOT NULL,
+    last_active   TEXT NOT NULL,
+    archived      INTEGER NOT NULL DEFAULT 0
+);"""
+
+
+def new_project_id() -> str:
+    """Mint a project id: ``proj-<8hex>``.
+
+    Not the legacy planning-TUI uuid4 "project_id" (persistence.py /
+    projects.json) — that is a disjoint id space this store never touches.
+    """
+    return f"proj-{secrets.token_hex(4)}"
+
+
+def _row_to_dict(row: tuple) -> dict:
+    settings: dict = {}
+    try:
+        parsed = json.loads(row[3] or "{}")
+        if isinstance(parsed, dict):
+            settings = parsed
+    except json.JSONDecodeError:
+        logger.warning("Corrupt settings_json for project %s; treating as empty", row[0])
+    return {
+        "project_id": row[0],
+        "name": row[1],
+        "description": row[2],
+        "settings": settings,
+        "created_at": row[4],
+        "last_active": row[5],
+        "archived": bool(row[6]),
+    }
+
+
+class ProjectStore:
+    """SQLite-backed store for project rows.
+
+    Uses the same database as SessionStore (sessions.db) with a dedicated
+    ``projects`` table. Follows the same patterns: autocommit mode,
+    context-manager support, explicit close.
+
+    # See docs: "Session Management" — SQLite persistence
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._conn.isolation_level = None  # autocommit
+        # Self-healing: the CLI and MCP tools open this store without ever
+        # constructing a SessionStore, so create the table here too.
+        self._conn.executescript(PROJECTS_SCHEMA)
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    def __enter__(self) -> ProjectStore:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    # ── Writes ────────────────────────────────────────────────────────────
+
+    def create(self, name: str, description: str = "") -> dict:
+        """Create a project and return its row as a dict."""
+        project_id = new_project_id()
+        now = self._now()
+        self._conn.execute(
+            """INSERT INTO projects (project_id, name, description, settings_json,
+                                     created_at, last_active, archived)
+               VALUES (?, ?, ?, '{}', ?, ?, 0)""",
+            (project_id, name, description, now, now),
+        )
+        logger.info("Created project %s (%s)", project_id, name)
+        return {
+            "project_id": project_id,
+            "name": name,
+            "description": description,
+            "settings": {},
+            "created_at": now,
+            "last_active": now,
+            "archived": False,
+        }
+
+    def touch(self, project_id: str) -> None:
+        """Bump ``last_active`` — called whenever a session links or runs."""
+        self._conn.execute(
+            "UPDATE projects SET last_active = ? WHERE project_id = ?",
+            (self._now(), project_id),
+        )
+
+    def archive(self, project_id: str) -> bool:
+        """Archive a project (hidden from default listings). True if a row changed."""
+        cursor = self._conn.execute(
+            "UPDATE projects SET archived = 1 WHERE project_id = ?",
+            (project_id,),
+        )
+        archived = (cursor.rowcount or 0) > 0
+        if archived:
+            logger.info("Archived project %s", project_id)
+        return archived
+
+    def set_settings(self, project_id: str, settings: dict) -> None:
+        """Replace the project's settings dict wholesale (callers merge)."""
+        self._conn.execute(
+            "UPDATE projects SET settings_json = ?, last_active = ? WHERE project_id = ?",
+            (json.dumps(settings, ensure_ascii=False), self._now(), project_id),
+        )
+        logger.info("Updated settings for project %s (%d key(s))", project_id, len(settings))
+
+    # ── Reads ─────────────────────────────────────────────────────────────
+
+    def get(self, project_id: str) -> dict | None:
+        """Return a project row as a dict, or None if not found."""
+        row = self._conn.execute(
+            "SELECT project_id, name, description, settings_json, created_at, last_active, archived "
+            "FROM projects WHERE project_id = ?",
+            (project_id,),
+        ).fetchone()
+        return None if row is None else _row_to_dict(row)
+
+    def list_projects(self, include_archived: bool = False) -> list[dict]:
+        """Return projects ordered by ``last_active`` descending."""
+        rows = self._conn.execute(
+            "SELECT project_id, name, description, settings_json, created_at, last_active, archived "
+            "FROM projects WHERE archived <= ? ORDER BY last_active DESC",
+            (1 if include_archived else 0,),
+        ).fetchall()
+        return [_row_to_dict(row) for row in rows]
+
+    def get_settings(self, project_id: str) -> dict:
+        """Return the project's settings dict; empty for a missing project."""
+        project = self.get(project_id)
+        return project["settings"] if project else {}

--- a/src/yeaboi/prompts/niko.py
+++ b/src/yeaboi/prompts/niko.py
@@ -8,7 +8,7 @@ Niko reads and points, and says so plainly when asked to do more.
 
 The Context section is rebuilt every turn from where the user actually is. That
 is the whole reason the answers read differently on ``/agents/usage`` than on
-``/humans/retro``, and it costs one dict lookup rather than an LLM call.
+``/team/retro``, and it costs one dict lookup rather than an LLM call.
 
 # See docs: "Prompt Construction" — ARC framework
 # See docs: "Guardrails" — the read-only tool surface is the guardrail
@@ -21,21 +21,24 @@ You are Niko, the duck's assistant for yeaboi — an AI Scrum Master that runs i
 terminal and a desktop window. You help people find their way around yeaboi and
 understand their own delivery data.
 
-yeaboi serves two audiences behind one split:
+yeaboi serves three audiences behind one split:
 
-- **Humans** — running your team's scrum. Planning (decompose a project into
-  epics, user stories, tasks and a sprint plan), Roadmap intake, Analysis (team
-  velocity and estimation patterns), Daily Standup, Retro boards, Planning Poker,
-  Performance (1:1 prep and six-month reviews), Reporting (delivery decks), and
-  Ship (a supervised story-to-PR pipeline).
+- **Solo** — running your own delivery, no team required. Planning (decompose a
+  project into epics, user stories, tasks and a sprint plan), Roadmap intake,
+  Analysis (your own velocity and estimation patterns, learned from your
+  history), Daily Standup (a personal "what did I do, am I on track" digest),
+  Reporting (delivery decks), and Ship (a supervised story-to-PR pipeline).
+- **Team** — running your team's scrum. Everything Solo has, analysed across
+  the whole roster, plus Retro boards, Planning Poker, and Performance (1:1
+  prep and six-month reviews).
 - **Agents** — watching the AI coding agents that work across your SDLC. Usage
   (what they cost), Advisor (how much of that was recoverable), Agent Standup
   (what they shipped), and Security (their posture). All computed locally from
   agent session logs.
 
-Alongside both: Ceremonies (the schedule the modes run on), Provenance (the
-tamper-evident record of what was decided and why), and Usage (yeaboi's own LLM
-spend).
+Alongside all three: Ceremonies (the schedule the modes run on), Provenance
+(the tamper-evident record of what was decided and why), and Usage (yeaboi's
+own LLM spend).
 """
 
 NIKO_PERSONALITY = """\

--- a/src/yeaboi/repl/__init__.py
+++ b/src/yeaboi/repl/__init__.py
@@ -1285,7 +1285,10 @@ def run_repl(
             _session_has_data = True
             try:
                 if not _session_created:
-                    _store.create_session(_session_id)
+                    # The run's project link, so a scoped Standup or Reporting
+                    # later finds this plan (graph state carries it; headless
+                    # passes its own).
+                    _store.create_session(_session_id, project_id=graph_state.get("project_id", "") or "")
                     _session_created = True
                 _store.save_state(_session_id, graph_state)
                 _pa = result.get("project_analysis")

--- a/src/yeaboi/reporting/engine.py
+++ b/src/yeaboi/reporting/engine.py
@@ -282,6 +282,7 @@ def run_delivery_report(
     session_id: str = "",
     jira_project: str = "",
     azdo_project: str = "",
+    project_id: str = "",
     db_path=None,
     today: date | None = None,
     window_start: str = "",
@@ -303,6 +304,9 @@ def run_delivery_report(
         period: one of activity's PERIOD_* constants (last_week / last_sprint /
             last_month / quarter / window).
         session_id: session to pull sprint length / project name from (best-effort).
+        project_id: project to scope by ("" inherits the session's own link).
+            A scoped report frames itself with the project's latest sprint
+            plan instead of the session's own saved state.
         window_start / window_end: explicit ISO date range (quarter or custom-window
             report). When ``window_start`` is set the look-back window is derived
             from it instead of ``period``.
@@ -334,6 +338,16 @@ def run_delivery_report(
 
     _emit(on_progress, "Loading session state")
     state = _load_state(session_id, db_path)
+    # Planning→reporting edge: a scoped run frames itself with the project's
+    # latest sprint plan, mirroring run_standup.
+    from yeaboi.projects.scope import latest_planning_state, resolve_scope
+
+    scope = resolve_scope(project_id, session_id, db_path=db_path)
+    if scope is not None:
+        planned = latest_planning_state(scope, db_path=db_path)
+        if planned is not None:
+            logger.info("run_delivery_report: sprint framing from project %s plan %s", scope.project_id, planned[0])
+            state = planned[1]
     project_name = str(state.get("project_name", "") or "")
     _check_cancel(cancel_event)
 

--- a/src/yeaboi/reporting/engine.py
+++ b/src/yeaboi/reporting/engine.py
@@ -283,6 +283,7 @@ def run_delivery_report(
     jira_project: str = "",
     azdo_project: str = "",
     project_id: str = "",
+    context_deps: list[str] | None = None,
     db_path=None,
     today: date | None = None,
     window_start: str = "",
@@ -307,6 +308,10 @@ def run_delivery_report(
         project_id: project to scope by ("" inherits the session's own link).
             A scoped report frames itself with the project's latest sprint
             plan instead of the session's own saved state.
+        context_deps: context-source toggles for this run (see
+            ``projects.scope.CONTEXT_DEP_TOKENS``). ``None`` inherits the
+            project default; an empty list is an incognito run. The ``plan``
+            dep gates the sprint-plan framing above.
         window_start / window_end: explicit ISO date range (quarter or custom-window
             report). When ``window_start`` is set the look-back window is derived
             from it instead of ``period``.
@@ -342,8 +347,8 @@ def run_delivery_report(
     # latest sprint plan, mirroring run_standup.
     from yeaboi.projects.scope import latest_planning_state, resolve_scope
 
-    scope = resolve_scope(project_id, session_id, db_path=db_path)
-    if scope is not None:
+    scope = resolve_scope(project_id, session_id, context_deps=context_deps, db_path=db_path)
+    if scope is not None and scope.wants("plan"):
         planned = latest_planning_state(scope, db_path=db_path)
         if planned is not None:
             logger.info("run_delivery_report: sprint framing from project %s plan %s", scope.project_id, planned[0])

--- a/src/yeaboi/retro/engine.py
+++ b/src/yeaboi/retro/engine.py
@@ -156,7 +156,7 @@ def _carried_from_report(prior_report: RetroReport) -> tuple[RetroCard, ...]:
 
 
 def history_providers(
-    *, project_name: str = "", db_path: Path | None = None
+    *, project_name: str = "", db_path: Path | None = None, scope: ProjectScope | None = None
 ) -> tuple[Callable[[], list[dict]], Callable[[int], dict | None]]:
     """Readers the browser board uses to step back through previous retros.
 
@@ -164,9 +164,14 @@ def history_providers(
     retro is persisted in, and a board with nothing behind it (a dev fixture, a
     retro run outside a session) simply reports no history.
 
+    ``scope`` narrows both readers: with the ``retro`` dependency off they
+    report nothing, and a session-scoped run only sees (and can only fetch by
+    id) the scope's own retros.
+
     Both are best-effort — a store that cannot be read is a board with no past,
     never a board that fails to load.
     """
+    from yeaboi.projects.scope import wants
 
     def _open() -> Any:
         from yeaboi.paths import get_db_path
@@ -175,6 +180,8 @@ def history_providers(
         return RetroStore(db_path or get_db_path())
 
     def listing() -> list[dict]:
+        if not wants(scope, "retro"):
+            return []
         # Across sessions, like the carry-forward reader above and for the same
         # reason: a retro runs under whatever quick session was open that day,
         # so a same-session history is almost always empty. Project-first, so a
@@ -185,6 +192,9 @@ def history_providers(
         except Exception as exc:  # pragma: no cover - defensive; history is best-effort
             logger.warning("retro: could not list previous retros: %s", exc)
             return []
+        if scope is not None and scope.session_ids is not None:
+            allowed = set(scope.session_ids)
+            runs = [r for r in runs if r.get("session_id") in allowed]
         # Already newest-first; a *stable* sort on the project match keeps it
         # that way inside each group.
         if project_name:
@@ -192,12 +202,17 @@ def history_providers(
         return runs[:24]
 
     def one(run_id: int) -> dict | None:
+        if not wants(scope, "retro"):
+            return None
         try:
             with _open() as store:
                 report = store.get_run_by_id(run_id)
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("retro: could not read retro id=%s: %s", run_id, exc)
             return None
+        if report and scope is not None and scope.session_ids is not None:
+            if report.session_id not in scope.session_ids:
+                return None
         return report_payload(report) if report else None
 
     return listing, one

--- a/src/yeaboi/retro/engine.py
+++ b/src/yeaboi/retro/engine.py
@@ -58,18 +58,21 @@ def carried_action_items_for_session(
 
     # See CLAUDE.md — Retro action-item carry-forward loop (mirrors Performance 1:1s)
     """
+    if scope is not None and not scope.wants("retro"):
+        return ()
     try:
         from yeaboi.paths import get_db_path
         from yeaboi.retro.store import RetroStore
 
         path = db_path or get_db_path()
+        session_ids = scope.session_ids if scope is not None else None
         with RetroStore(path) as store:
             # Project-first, newest-first across ALL sessions (see docstring).
-            # A scope replaces the name bias with a hard session filter.
+            # A session-narrowed scope replaces the name bias with a hard filter.
             reports = store.get_recent_reports(
                 limit=5,
-                project_name="" if scope else project_name,
-                session_ids=scope.session_ids if scope is not None else None,
+                project_name=project_name if session_ids is None else "",
+                session_ids=session_ids,
             )
     except Exception as exc:  # pragma: no cover - defensive; carry-forward is best-effort
         logger.warning("retro: could not load carried action items (session=%s): %s", session_id, exc)

--- a/src/yeaboi/retro/engine.py
+++ b/src/yeaboi/retro/engine.py
@@ -58,8 +58,6 @@ def carried_action_items_for_session(
 
     # See CLAUDE.md — Retro action-item carry-forward loop (mirrors Performance 1:1s)
     """
-    from dataclasses import replace
-
     try:
         from yeaboi.paths import get_db_path
         from yeaboi.retro.store import RetroStore
@@ -88,6 +86,48 @@ def carried_action_items_for_session(
     prior_report = reports[0] if reports else None
     if prior_report is None:
         return ()
+    return _carried_from_report(prior_report)
+
+
+def standup_blocker_cards(
+    scope: ProjectScope | None, *, db_path: Path | None = None, existing: tuple[RetroCard, ...] = ()
+) -> tuple[RetroCard, ...]:
+    """The standup→retro edge: the project's recent blockers as review cards.
+
+    Returns dismissible ``pending`` cards (text badged ``[Standup]``), deduped
+    against the ``existing`` carried cards they are seeded beside. Unscoped
+    boards (``scope=None``) get none — the team-wide board keeps its
+    carry-forward-only seeding. Never raises.
+    """
+    from yeaboi.projects.scope import recent_standup_blockers
+
+    blockers = recent_standup_blockers(scope, db_path=db_path)
+    if not blockers:
+        return ()
+    seen = {c.text.strip().lower() for c in existing}
+    cards: list[RetroCard] = []
+    for i, blocker in enumerate(blockers):
+        text = f"[Standup] {blocker}"
+        if text.lower() in seen:
+            continue
+        cards.append(
+            RetroCard(
+                id=f"standup-{i}",
+                grid="action_items",
+                text=text,
+                author="Standup",
+                origin="carryover",
+                status="pending",
+            )
+        )
+    if cards:
+        logger.info("retro: %d standup blocker card(s) for project %s", len(cards), scope.project_id if scope else "")
+    return tuple(cards)
+
+
+def _carried_from_report(prior_report: RetroReport) -> tuple[RetroCard, ...]:
+    from dataclasses import replace
+
     # Source = last retro's action_items grid PLUS any items it explicitly kept open in
     # its own review column (its carried_action_items with a still-open status). The
     # latter matters when the team marked something "Carried Over" but never clicked
@@ -105,10 +145,9 @@ def carried_action_items_for_session(
         combined.append(c)
     carried = tuple(replace(c, origin="carryover", status="pending") for c in combined)
     logger.info(
-        "retro: %d carried-over action item(s) available from session %s (current=%s)",
+        "retro: %d carried-over action item(s) available from session %s",
         len(carried),
         prior_report.session_id,
-        session_id,
     )
     return carried
 

--- a/src/yeaboi/retro/engine.py
+++ b/src/yeaboi/retro/engine.py
@@ -21,16 +21,19 @@ import logging
 from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from yeaboi.agent.state import RetroCard, RetroReport
 from yeaboi.retro.board import CARRIED_OPEN_STATUSES, RetroBoard
+
+if TYPE_CHECKING:
+    from yeaboi.projects.scope import ProjectScope
 
 logger = logging.getLogger(__name__)
 
 
 def carried_action_items_for_session(
-    session_id: str, *, project_name: str = "", db_path: Path | None = None
+    session_id: str, *, project_name: str = "", db_path: Path | None = None, scope: ProjectScope | None = None
 ) -> tuple[RetroCard, ...]:
     """Return the previous retro's action items for review, reset to ``pending``.
 
@@ -64,7 +67,12 @@ def carried_action_items_for_session(
         path = db_path or get_db_path()
         with RetroStore(path) as store:
             # Project-first, newest-first across ALL sessions (see docstring).
-            reports = store.get_recent_reports(limit=5, project_name=project_name)
+            # A scope replaces the name bias with a hard session filter.
+            reports = store.get_recent_reports(
+                limit=5,
+                project_name="" if scope else project_name,
+                session_ids=scope.session_ids if scope is not None else None,
+            )
     except Exception as exc:  # pragma: no cover - defensive; carry-forward is best-effort
         logger.warning("retro: could not load carried action items (session=%s): %s", session_id, exc)
         return ()

--- a/src/yeaboi/retro/engine.py
+++ b/src/yeaboi/retro/engine.py
@@ -186,15 +186,15 @@ def history_providers(
         # reason: a retro runs under whatever quick session was open that day,
         # so a same-session history is almost always empty. Project-first, so a
         # board for project X shows X's retros before anyone else's.
+        # Scoped in the query, so the 48-row window holds the project's own runs
+        # rather than whatever 48 happened to be newest team-wide.
+        scoped = scope.session_ids if scope is not None else None
         try:
             with _open() as store:
-                runs = store.get_all_history(limit=48)
+                runs = store.get_all_history(limit=48, session_ids=scoped)
         except Exception as exc:  # pragma: no cover - defensive; history is best-effort
             logger.warning("retro: could not list previous retros: %s", exc)
             return []
-        if scope is not None and scope.session_ids is not None:
-            allowed = set(scope.session_ids)
-            runs = [r for r in runs if r.get("session_id") in allowed]
         # Already newest-first; a *stable* sort on the project match keeps it
         # that way inside each group.
         if project_name:

--- a/src/yeaboi/retro/store.py
+++ b/src/yeaboi/retro/store.py
@@ -303,13 +303,30 @@ class RetroStore:
                 logger.warning("Failed to deserialize a retro report: %s", exc)
         return reports
 
-    def get_all_history(self, limit: int = 100) -> list[dict]:
-        """Return recent retro run metadata across ALL sessions (for cadence + the hub)."""
-        rows = self._conn.execute(
-            "SELECT id, session_id, run_at, retro_date, project_name, card_count FROM retro_history "
-            "ORDER BY run_at DESC LIMIT ?",
-            (limit,),
-        ).fetchall()
+    def get_all_history(self, limit: int = 100, session_ids: tuple[str, ...] | None = None) -> list[dict]:
+        """Return recent retro run metadata across ALL sessions (for cadence + the hub).
+
+        ``session_ids`` is the hard filter a ProjectScope resolves to; an empty
+        tuple means no rows, not all rows. Filtered in SQL so ``limit`` counts
+        the project's own runs — filtering after the limit would hide older ones
+        behind a window full of other projects'.
+        """
+        if session_ids is not None:
+            if not session_ids:
+                return []
+            slots = ", ".join("?" for _ in session_ids)
+            rows = self._conn.execute(
+                f"SELECT id, session_id, run_at, retro_date, project_name, card_count "  # noqa: S608 — placeholders, not values
+                f"FROM retro_history WHERE session_id IN ({slots}) "
+                "ORDER BY run_at DESC LIMIT ?",
+                (*session_ids, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT id, session_id, run_at, retro_date, project_name, card_count "
+                "FROM retro_history ORDER BY run_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
         return [
             {
                 "id": r[0],

--- a/src/yeaboi/retro/store.py
+++ b/src/yeaboi/retro/store.py
@@ -263,13 +263,26 @@ class RetroStore:
     #    Planning / Analysis with the team's recent retros regardless of which
     #    session they ran under. See docs: "Session Management".
 
-    def get_recent_reports(self, limit: int = 5, project_name: str = "") -> list[RetroReport]:
+    def get_recent_reports(
+        self, limit: int = 5, project_name: str = "", session_ids: tuple[str, ...] | None = None
+    ) -> list[RetroReport]:
         """Return recent RetroReports across ALL sessions, newest first.
 
         When ``project_name`` is given, rows matching it sort first (project-first),
         then by recency — so a plan for project X sees X's retros ahead of others'.
+        ``session_ids`` is the hard filter a ProjectScope resolves to: it replaces
+        the sort bias entirely, and an empty tuple means no rows, not all rows.
         """
-        if project_name:
+        if session_ids is not None:
+            if not session_ids:
+                return []
+            slots = ", ".join("?" for _ in session_ids)
+            rows = self._conn.execute(
+                f"SELECT report_json FROM retro_history WHERE session_id IN ({slots}) "  # noqa: S608 — placeholders, not values
+                "ORDER BY run_at DESC LIMIT ?",
+                (*session_ids, limit),
+            ).fetchall()
+        elif project_name:
             # (project_name = ?) is 1 for matches, 0 otherwise → matches sort first.
             rows = self._conn.execute(
                 "SELECT report_json FROM retro_history ORDER BY (project_name = ?) DESC, run_at DESC LIMIT ?",

--- a/src/yeaboi/sessions.py
+++ b/src/yeaboi/sessions.py
@@ -131,7 +131,7 @@ CREATE TABLE IF NOT EXISTS sessions_meta (
 #   stored < current → run migrations, UPDATE to current
 #   stored == current → schema_mismatch=False
 # See docs: "Memory & State" — session persistence
-CURRENT_SCHEMA_VERSION = 30  # v1=8A, v2=8B, v3=team_profiles, v4=session_mode, v5=token_usage, v6=standup, v7=retro, v8=performance, v9=reporting, v10=roadmap, v11=roadmap list, v12=token usage perf, v13=analysis ticket cache, v14=standup roster, v15=standup code scope, v16=standup documentation scope, v17=standup Azure project scope, v18=poker, v19=analysis enrichment cache, v20=analysis feature selection, v21=artifact edits, v22=standup transcript review, v23=standup practices, v24=standup practice AI matching, v25=standup practice feedback, v26=edit-provenance collision repair, v27=agentwatch, v28=standup GitHub owner scope, v29=standup GitHub repo exclusions, v30=planning prior-art feedback  # noqa: E501
+CURRENT_SCHEMA_VERSION = 31  # v1=8A, v2=8B, v3=team_profiles, v4=session_mode, v5=token_usage, v6=standup, v7=retro, v8=performance, v9=reporting, v10=roadmap, v11=roadmap list, v12=token usage perf, v13=analysis ticket cache, v14=standup roster, v15=standup code scope, v16=standup documentation scope, v17=standup Azure project scope, v18=poker, v19=analysis enrichment cache, v20=analysis feature selection, v21=artifact edits, v22=standup transcript review, v23=standup practices, v24=standup practice AI matching, v25=standup practice feedback, v26=edit-provenance collision repair, v27=agentwatch, v28=standup GitHub owner scope, v29=standup GitHub repo exclusions, v30=planning prior-art feedback, v31=projects  # noqa: E501
 
 _SCHEMA_INFO = """\
 CREATE TABLE IF NOT EXISTS schema_info (
@@ -178,6 +178,7 @@ _SCALAR_KEYS = {
     "_intake_mode",
     "output_format",
     "context_sources",
+    "project_id",
     "_chat_greeting_done",
     "_chat_preamble",
     "_chat_fast_forward",
@@ -890,6 +891,23 @@ class SessionStore:
             self._conn.execute(PRIOR_ART_FEEDBACK_SCHEMA)
             logger.info("Migration v30: created planning_prior_art_feedback table")
 
+        if from_version < 31:
+            # v31: first-class projects — the identity that links sessions
+            # across modes. Table schema lives in projects/store.py (also
+            # created on that store's open, for callers that never construct a
+            # SessionStore); the column links sessions to it, '' = unscoped.
+            from yeaboi.projects.store import PROJECTS_SCHEMA
+
+            self._conn.executescript(PROJECTS_SCHEMA)
+            added = True
+            try:
+                self._conn.execute("ALTER TABLE sessions_meta ADD COLUMN project_id TEXT NOT NULL DEFAULT ''")
+            except sqlite3.OperationalError:
+                added = False
+            self._conn.execute("CREATE INDEX IF NOT EXISTS idx_sessions_meta_project ON sessions_meta(project_id)")
+            if added:
+                logger.info("Migration v31: created projects table and sessions_meta.project_id")
+
     def _apply_edit_provenance(self) -> None:
         """The v21 migration body — idempotent, so v26 re-runs it verbatim.
 
@@ -1040,16 +1058,28 @@ class SessionStore:
         project_name: str = "",
         *,
         mode: str = "planning",
+        project_id: str = "",
     ) -> None:
-        """Insert a new session row. Silently ignores duplicate session IDs."""
-        logger.info("Creating session: %s (mode=%s)", session_id, mode)
+        """Insert a new session row. Silently ignores duplicate session IDs.
+
+        ``project_id`` links the session to a ``projects`` row; '' = unscoped.
+        """
+        logger.info("Creating session: %s (mode=%s, project=%s)", session_id, mode, project_id or "-")
         now = self._now()
         self._conn.execute(
             """INSERT OR IGNORE INTO sessions_meta
                (session_id, project_name, created_at, last_modified,
-                last_node_completed, session_state, session_mode)
-               VALUES (?, ?, ?, ?, '', '', ?)""",
-            (session_id, project_name, now, now, mode),
+                last_node_completed, session_state, session_mode, project_id)
+               VALUES (?, ?, ?, ?, '', '', ?, ?)""",
+            (session_id, project_name, now, now, mode, project_id),
+        )
+
+    def set_session_project(self, session_id: str, project_id: str) -> None:
+        """Link (or unlink, with '') a session to a project."""
+        logger.info("Linking session %s to project %s", session_id, project_id or "-")
+        self._conn.execute(
+            "UPDATE sessions_meta SET project_id = ?, last_modified = ? WHERE session_id = ?",
+            (project_id, self._now(), session_id),
         )
 
     def update_project_name(self, session_id: str, project_name: str) -> None:
@@ -1176,6 +1206,33 @@ class SessionStore:
             logger.error("Failed to deserialize state for session %s", session_id)
             return None
 
+    def session_project_id(self, session_id: str) -> str:
+        """The project a session is linked to, '' if unscoped or unknown."""
+        row = self._conn.execute(
+            "SELECT project_id FROM sessions_meta WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return row[0] if row else ""
+
+    def session_ids_for_project(self, project_id: str, *, mode: str = "") -> list[str]:
+        """Session ids linked to a project, newest first, optionally one mode.
+
+        Ids only, never the state blob — the same reasoning as
+        ``recent_session_ids``; scope resolution must stay cheap.
+        """
+        if mode:
+            rows = self._conn.execute(
+                "SELECT session_id FROM sessions_meta WHERE project_id = ? AND session_mode = ? "
+                "ORDER BY last_modified DESC",
+                (project_id, mode),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT session_id FROM sessions_meta WHERE project_id = ? ORDER BY last_modified DESC",
+                (project_id,),
+            ).fetchall()
+        return [r[0] for r in rows]
+
     def get_latest_session_id(self) -> str | None:
         """Return the session_id of the most recently modified session, or None."""
         row = self._conn.execute("SELECT session_id FROM sessions_meta ORDER BY last_modified DESC LIMIT 1").fetchone()
@@ -1230,8 +1287,10 @@ class SessionStore:
             return 0
         # SQLite datetime('now', '-N days') computes a UTC cutoff timestamp.
         # last_modified is stored as ISO-8601 UTC so string comparison works.
+        # Project-linked sessions are exempt: a project's old planning session
+        # is what its standups and retros resolve against.
         cursor = self._conn.execute(
-            "DELETE FROM sessions_meta WHERE last_modified < datetime('now', ?)",
+            "DELETE FROM sessions_meta WHERE last_modified < datetime('now', ?) AND project_id = ''",
             (f"-{max_age_days} days",),
         )
         if cursor.rowcount > 0:

--- a/src/yeaboi/sessions.py
+++ b/src/yeaboi/sessions.py
@@ -179,6 +179,7 @@ _SCALAR_KEYS = {
     "output_format",
     "context_sources",
     "project_id",
+    "context_deps",
     "_chat_greeting_done",
     "_chat_preamble",
     "_chat_fast_forward",

--- a/src/yeaboi/standup/engine.py
+++ b/src/yeaboi/standup/engine.py
@@ -1408,6 +1408,7 @@ def run_standup(
     deliver: bool = True,
     dry_run: bool = False,
     project_id: str = "",
+    context_deps: list[str] | None = None,
     db_path=None,
     today: date | None = None,
     on_progress=None,
@@ -1442,6 +1443,11 @@ def run_standup(
             an unlinked session stays team-wide). A scoped run reads sprint
             and roster context from the project's latest sprint plan rather
             than this session's own saved state.
+        context_deps: context-source toggles for this run (see
+            ``projects.scope.CONTEXT_DEP_TOKENS``). ``None`` inherits the
+            session's saved standup config, then the project default; an
+            empty list is an incognito run. The ``plan`` dep gates the
+            sprint-plan substitution above.
         db_path: override sessions.db path (tests); defaults to paths.get_db_path().
         today: override for the current date (tests).
         on_progress: optional ``callable(str)`` invoked (best-effort) as each
@@ -1473,18 +1479,6 @@ def run_standup(
     with SessionStore(db_path) as sessions:
         state = sessions.load_state(session_id) or {}
 
-    # Planning→standup edge: a project-scoped run reads the project's latest
-    # sprint plan instead of this session's own state, so a standup session
-    # created beside the plan still knows the sprint, capacity and roster.
-    from yeaboi.projects.scope import latest_planning_state, resolve_scope
-
-    scope = resolve_scope(project_id, session_id, db_path=db_path)
-    if scope is not None:
-        planned = latest_planning_state(scope, db_path=db_path)
-        if planned is not None:
-            plan_session_id, plan_state = planned
-            logger.info("run_standup: sprint context from project %s plan %s", scope.project_id, plan_session_id)
-            state = plan_state
     with StandupStore(db_path) as store:
         config = store.load_config(session_id)
         self_reported = store.get_my_updates(session_id, date_str)
@@ -1500,6 +1494,22 @@ def run_standup(
         # rather than taken as a parameter: it belongs to the session, so every
         # surface that runs a standup gets it without having to remember to.
         feedback_ledger = practice_feedback.load(store, session_id)
+
+    # Planning→standup edge: a project-scoped run reads the project's latest
+    # sprint plan instead of this session's own state, so a standup session
+    # created beside the plan still knows the sprint, capacity and roster.
+    # Context-deps precedence: explicit param, else the session's saved
+    # standup config, else the project default (applied inside resolve_scope).
+    from yeaboi.projects.scope import latest_planning_state, resolve_scope
+
+    effective_deps = context_deps if context_deps is not None else (config or {}).get("context_deps")
+    scope = resolve_scope(project_id, session_id, context_deps=effective_deps, db_path=db_path)
+    if scope is not None and scope.wants("plan"):
+        planned = latest_planning_state(scope, db_path=db_path)
+        if planned is not None:
+            plan_session_id, plan_state = planned
+            logger.info("run_standup: sprint context from project %s plan %s", scope.project_id, plan_session_id)
+            state = plan_state
 
     # What the team corrected on the previous standup, if they corrected it.
     # The corrected *text* already reaches this run for free — a corrected row

--- a/src/yeaboi/standup/engine.py
+++ b/src/yeaboi/standup/engine.py
@@ -1407,6 +1407,7 @@ def run_standup(
     review_transcripts: bool = True,
     deliver: bool = True,
     dry_run: bool = False,
+    project_id: str = "",
     db_path=None,
     today: date | None = None,
     on_progress=None,
@@ -1437,6 +1438,10 @@ def run_standup(
             writes to GitHub — issues are drafted, and filing is a separate act.
         deliver: when True, fan out to delivery channels (skipped if dry_run).
         dry_run: build the report but do not deliver (used by the TUI "Generate" preview).
+        project_id: project to scope by ("" inherits the session's own link;
+            an unlinked session stays team-wide). A scoped run reads sprint
+            and roster context from the project's latest sprint plan rather
+            than this session's own saved state.
         db_path: override sessions.db path (tests); defaults to paths.get_db_path().
         today: override for the current date (tests).
         on_progress: optional ``callable(str)`` invoked (best-effort) as each
@@ -1467,6 +1472,19 @@ def run_standup(
     # 1. Load session state + standup config.
     with SessionStore(db_path) as sessions:
         state = sessions.load_state(session_id) or {}
+
+    # Planning→standup edge: a project-scoped run reads the project's latest
+    # sprint plan instead of this session's own state, so a standup session
+    # created beside the plan still knows the sprint, capacity and roster.
+    from yeaboi.projects.scope import latest_planning_state, resolve_scope
+
+    scope = resolve_scope(project_id, session_id, db_path=db_path)
+    if scope is not None:
+        planned = latest_planning_state(scope, db_path=db_path)
+        if planned is not None:
+            plan_session_id, plan_state = planned
+            logger.info("run_standup: sprint context from project %s plan %s", scope.project_id, plan_session_id)
+            state = plan_state
     with StandupStore(db_path) as store:
         config = store.load_config(session_id)
         self_reported = store.get_my_updates(session_id, date_str)

--- a/src/yeaboi/standup/schedule.py
+++ b/src/yeaboi/standup/schedule.py
@@ -119,6 +119,7 @@ def apply_schedule(
             habit_detection=existing.get("habit_detection", "on"),
             habit_rules=existing.get("habit_rules", ""),
             habit_ai_match=existing.get("habit_ai_match", "on"),
+            context_deps=existing.get("context_deps"),
         )
     if enabled:
         message = install_schedule(session_id, time, weekdays, lead_minutes)

--- a/src/yeaboi/standup/sprint_context.py
+++ b/src/yeaboi/standup/sprint_context.py
@@ -15,6 +15,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from yeaboi.projects.scope import ProjectScope
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +76,16 @@ def _live_progress(jira_project: str, azdo_project: str) -> dict:
     return {}
 
 
-def gather(state: dict, *, jira_project: str = "", azdo_project: str = "") -> SprintContext:
-    """Assemble a SprintContext from saved plan state + live tracker progress."""
+def gather(
+    state: dict, *, jira_project: str = "", azdo_project: str = "", scope: ProjectScope | None = None
+) -> SprintContext:
+    """Assemble a SprintContext from saved plan state + live tracker progress.
+
+    ``scope`` is accepted for signature uniformity; the caller already chose
+    which plan ``state`` to pass (a scoped standup substitutes the project's
+    latest planning state), so nothing here reads it yet.
+    """
+    del scope  # the state argument carries the scoping decision
     state = state or {}
     length = state.get("sprint_length_weeks") or 2
     try:

--- a/src/yeaboi/standup/store.py
+++ b/src/yeaboi/standup/store.py
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS standup_config (
     habit_detection   TEXT NOT NULL DEFAULT 'on',
     habit_rules       TEXT NOT NULL DEFAULT '',
     habit_ai_match    TEXT NOT NULL DEFAULT 'on',
+    context_deps      TEXT NOT NULL DEFAULT '',
     created_at        TEXT NOT NULL,
     updated_at        TEXT NOT NULL
 );
@@ -528,6 +529,10 @@ class StandupStore:
                ADD COLUMN habit_rules TEXT NOT NULL DEFAULT ''""",
             """ALTER TABLE standup_config
                ADD COLUMN habit_ai_match TEXT NOT NULL DEFAULT 'on'""",
+            # Context-source toggles (projects/scope.py): a JSON list of dep
+            # tokens; '' inherits the project default, '[]' is incognito.
+            """ALTER TABLE standup_config
+               ADD COLUMN context_deps TEXT NOT NULL DEFAULT ''""",
             # Edit-provenance columns (sessions.py v21/v26): a v21 version-number
             # collision could leave a DB stamped past 21 without them, and
             # several entry points (--standup-run, the MCP tools) open this
@@ -598,6 +603,7 @@ class StandupStore:
         habit_detection: str = "on",
         habit_rules: str = "",
         habit_ai_match: str = "on",
+        context_deps: list[str] | None = None,
     ) -> None:
         """Insert or update the standup schedule/delivery config for a session.
 
@@ -618,7 +624,9 @@ class StandupStore:
         (standup/habits.py), and ``habit_ai_match`` switches off the
         language-model pass that excuses a change belonging to a ticket it never
         names (standup/adjudicate.py) — a separate switch because it is the only
-        part of practice detection that spends money.
+        part of practice detection that spends money. ``context_deps`` is the
+        session's context-source toggles (``None`` inherits the project
+        default, ``[]`` is incognito — see projects/scope.py).
 
         **This is a full upsert with defaulted keywords**, so a caller that omits
         a field resets it. Every call site must pass through the values it read.
@@ -651,8 +659,8 @@ class StandupStore:
                     documentation_sources, documentation_scope_configured,
                     automation_markers, automation_handling,
                     transcript_dir, transcript_review_enabled,
-                    habit_detection, habit_rules, habit_ai_match, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    habit_detection, habit_rules, habit_ai_match, context_deps, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(session_id) DO UPDATE SET
                    enabled = excluded.enabled,
                    time = excluded.time,
@@ -681,6 +689,7 @@ class StandupStore:
                    habit_detection = excluded.habit_detection,
                    habit_rules = excluded.habit_rules,
                    habit_ai_match = excluded.habit_ai_match,
+                   context_deps = excluded.context_deps,
                    updated_at = excluded.updated_at""",
             (
                 session_id,
@@ -711,6 +720,7 @@ class StandupStore:
                 habit_detection or "on",
                 habit_rules,
                 habit_ai_match or "on",
+                "" if context_deps is None else json.dumps(context_deps),
                 now,
                 now,
             ),
@@ -752,7 +762,8 @@ class StandupStore:
             "code_sources, github_repositories, azdo_projects, azdo_repositories, code_scope_configured, "
             "documentation_sources, documentation_scope_configured, automation_markers, automation_handling, "
             "transcript_dir, transcript_review_enabled, "
-            "habit_detection, habit_rules, habit_ai_match, github_owners, github_excluded_repositories "
+            "habit_detection, habit_rules, habit_ai_match, github_owners, github_excluded_repositories, "
+            "context_deps "
             "FROM standup_config WHERE session_id = ?",
             (session_id,),
         ).fetchone()
@@ -827,6 +838,9 @@ class StandupStore:
             "habit_detection": row[23] or "on",
             "habit_rules": row[24] or "",
             "habit_ai_match": row[25] or "on",
+            # None = inherit (project default / all-on); a list is the saved
+            # toggle set, [] being incognito.
+            "context_deps": _json_list(row[28]) if row[28] else None,
         }
 
     # ── Self-reported updates ─────────────────────────────────────────────

--- a/src/yeaboi/standup/store.py
+++ b/src/yeaboi/standup/store.py
@@ -1476,13 +1476,30 @@ class StandupStore:
                 out.append(entry)
         return out
 
-    def get_all_history(self, limit: int = 100) -> list[dict]:
-        """Return recent standup run metadata across ALL sessions (for cadence + the hub)."""
-        rows = self._conn.execute(
-            "SELECT id, session_id, run_at, standup_date, sprint_day, confidence_pct, status "
-            "FROM standup_history ORDER BY run_at DESC LIMIT ?",
-            (limit,),
-        ).fetchall()
+    def get_all_history(self, limit: int = 100, session_ids: tuple[str, ...] | None = None) -> list[dict]:
+        """Return recent standup run metadata across ALL sessions (for cadence + the hub).
+
+        ``session_ids`` is the hard filter a ProjectScope resolves to; an empty
+        tuple means no rows, not all rows. Filtered in SQL so ``limit`` counts
+        the project's own runs — filtering after the limit would hide older ones
+        behind a window full of other projects'.
+        """
+        if session_ids is not None:
+            if not session_ids:
+                return []
+            slots = ", ".join("?" for _ in session_ids)
+            rows = self._conn.execute(
+                f"SELECT id, session_id, run_at, standup_date, sprint_day, confidence_pct, status "  # noqa: S608 — placeholders, not values
+                f"FROM standup_history WHERE session_id IN ({slots}) "
+                "ORDER BY run_at DESC LIMIT ?",
+                (*session_ids, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT id, session_id, run_at, standup_date, sprint_day, confidence_pct, status "
+                "FROM standup_history ORDER BY run_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
         return [
             {
                 "id": r[0],

--- a/src/yeaboi/standup/store.py
+++ b/src/yeaboi/standup/store.py
@@ -1177,12 +1177,26 @@ class StandupStore:
     #    Planning / Analysis with the team's recent standups. standup_history has
     #    no project_name column, so these are recency-based (team-wide).
 
-    def get_recent_reports(self, limit: int = 10) -> list[StandupReport]:
-        """Return recent StandupReports across ALL sessions, newest first."""
-        rows = self._conn.execute(
-            "SELECT report_json FROM standup_history WHERE status = 'success' ORDER BY run_at DESC LIMIT ?",
-            (limit,),
-        ).fetchall()
+    def get_recent_reports(self, limit: int = 10, session_ids: tuple[str, ...] | None = None) -> list[StandupReport]:
+        """Return recent StandupReports across ALL sessions, newest first.
+
+        ``session_ids`` is the hard filter a ProjectScope resolves to; an
+        empty tuple means no rows, not all rows.
+        """
+        if session_ids is not None:
+            if not session_ids:
+                return []
+            slots = ", ".join("?" for _ in session_ids)
+            rows = self._conn.execute(
+                f"SELECT report_json FROM standup_history WHERE session_id IN ({slots}) "  # noqa: S608 — placeholders, not values
+                "AND status = 'success' ORDER BY run_at DESC LIMIT ?",
+                (*session_ids, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT report_json FROM standup_history WHERE status = 'success' ORDER BY run_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
         reports: list[StandupReport] = []
         for row in rows:
             if not row[0]:

--- a/src/yeaboi/tools/llm_tools.py
+++ b/src/yeaboi/tools/llm_tools.py
@@ -135,6 +135,9 @@ def generate_acceptance_criteria(
     try:
         from yeaboi.agent.nodes import _load_team_profile
 
+        # Deliberately outside the context-toggle gates (projects/scope.py):
+        # a @tool has no graph state to read the toggles from, and this only
+        # picks an AC *style* — it quotes no team history into the output.
         ac_style = resolve_ac_style({}, _load_team_profile(""))
     except Exception:
         ac_style = resolve_ac_style({})

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -343,6 +343,24 @@ def _confirm_ticket_generation(
             return False
 
 
+def _record_project_profile(profile) -> None:
+    """The analysis→planning edge: an active project remembers the profile its
+    analysis produced, so the next scoped plan seeds it automatically."""
+    from yeaboi.projects.active import get_active_project
+
+    project_id = get_active_project()
+    team_id = getattr(profile, "team_id", "") if profile else ""
+    if not project_id or not team_id:
+        return
+    try:
+        from yeaboi.projects.engine import set_project_defaults
+
+        set_project_defaults(project_id, {"default_analysis_profile_id": team_id})
+        logger.info("analysis: recorded profile %s as default for project %s", team_id, project_id)
+    except Exception:
+        logger.warning("analysis: could not record the project's default profile", exc_info=True)
+
+
 def _run_preview_flow(
     live,
     console,
@@ -705,6 +723,7 @@ def _run_preview_flow(
     global _ana_sid  # noqa: PLW0603
     if not _ana_sid:
         try:
+            from yeaboi.projects.active import get_active_project
             from yeaboi.sessions import SessionStore, make_session_id
 
             _ana_sid = make_session_id()
@@ -713,8 +732,10 @@ def _run_preview_flow(
                     _ana_sid,
                     project_name=getattr(ta_profile, "project_key", "") if ta_profile else "",
                     mode="analysis",
+                    project_id=get_active_project(),
                 )
             logger.info("Created analysis session for preview: %s", _ana_sid)
+            _record_project_profile(ta_profile)
         except Exception:
             logger.debug("Failed to create analysis session", exc_info=True)
 
@@ -14481,6 +14502,7 @@ def select_mode(
                                     subtitle=_ta_sub,
                                 ):
                                     from yeaboi.agent.nodes import _format_team_calibration
+                                    from yeaboi.projects.active import get_active_project as _gap
                                     from yeaboi.sessions import SessionStore as _AStore
                                     from yeaboi.sessions import make_session_id
 
@@ -14491,7 +14513,9 @@ def select_mode(
                                                 _ana_sid,
                                                 _ta_profile.project_key if _ta_profile else "",
                                                 mode="analysis",
+                                                project_id=_gap(),
                                             )
+                                        _record_project_profile(_ta_profile)
                                     except Exception:
                                         pass
 

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -9512,19 +9512,27 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
 
     def _run_action(label: str, engineer: str) -> None:
         """Run one AI/notes action for the selected engineer (blocks briefly)."""
+        # The active project + Context toggles scope the engines' cross-mode
+        # evidence/ceremony reads, like every other launch site.
+        from yeaboi.projects.active import get_active_project, get_context_deps
         from yeaboi.ui.mode_select.screens._screens_secondary import (
             PERF_COMPLETE_PHASES,
             PERF_PREP_PHASES,
             PERF_REVIEW_PHASES,
         )
 
+        _perf_deps = get_context_deps()
+        _perf_ctx = {
+            "project_id": get_active_project(),
+            "context_deps": None if _perf_deps is None else list(_perf_deps),
+        }
         try:
             if label == "1:1 Prep":
                 from yeaboi.performance.engine import run_one_on_one_prep
 
                 prep = _generate(
                     lambda on_progress: run_one_on_one_prep(
-                        engineer, session_id=session_id, db_path=_ana_dbp, on_progress=on_progress
+                        engineer, session_id=session_id, db_path=_ana_dbp, on_progress=on_progress, **_perf_ctx
                     ),
                     heading=f"1:1 Prep — {engineer}",
                     phases=PERF_PREP_PHASES,
@@ -9562,7 +9570,7 @@ def _run_performance_page(console: Console, live, read_key, frame_time: float, s
 
                 review = _generate(
                     lambda on_progress: run_six_month_review(
-                        engineer, session_id=session_id, db_path=_ana_dbp, on_progress=on_progress
+                        engineer, session_id=session_id, db_path=_ana_dbp, on_progress=on_progress, **_perf_ctx
                     ),
                     heading=f"6-Month Review — {engineer}",
                     phases=PERF_REVIEW_PHASES,

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -8544,6 +8544,7 @@ def _run_analysis_setup_wizard(
     roster_fallback: list[str],
     project_key: str = "",
     db_path=None,
+    solo: bool = False,
 ) -> dict | None:
     """Walk the Analysis setup steps with Esc-back navigation and state carry-over.
 
@@ -8602,10 +8603,13 @@ def _run_analysis_setup_wizard(
             components=state["components"],
             depth=state["depth"],
             model_offered=_model_offered(),
+            solo=solo,
         )
 
     def _config() -> dict:
-        return analysis_setup.run_config(state, roster_fallback=roster_fallback, model_offered=_model_offered())
+        return analysis_setup.run_config(
+            state, roster_fallback=roster_fallback, model_offered=_model_offered(), solo=solo
+        )
 
     def _members_step(direction: int) -> str:
         sources = (state["components"] or {}).get("delivery") or roster_fallback
@@ -8893,12 +8897,15 @@ def _run_team_analysis_results(
             examples=examples,
             analysis_features=analysis_features,
         )
+        from yeaboi.projects.active import is_solo_mode
+
         order = visible_card_order(
             profile,
             present["code"],
             present["docs"],
             has_code_health=present["code_health"],
             analysis_features=analysis_features,
+            solo=is_solo_mode(),
         )
 
         # When anonymized, render from a masked copy of the profile (and its sample
@@ -13264,6 +13271,23 @@ _CATEGORY_MENUS: dict[str, tuple[list[dict], str]] = {
 }
 
 
+def _tip_jump_target(mode_key: str, cards: list[dict]) -> tuple[str, int] | None:
+    """Where a cross-category tip jump lands: ``(category, card index)`` or None.
+
+    Team is searched first: Solo's keys are a subset of Team's, so a shared key
+    jumped from any other menu lands on the Team menu — and a retro/poker tip
+    fired while browsing Solo correctly jumps to the world that has the card.
+    """
+    for cat in ("team", "agents", "solo"):
+        other, _mascot = _CATEGORY_MENUS[cat]
+        if other is cards:
+            continue
+        j = next((i for i, m in enumerate(other) if m["key"] == mode_key), None)
+        if j is not None and other[j]["available"]:
+            return cat, j
+    return None
+
+
 def select_mode(
     console: Console | None = None, *, dry_run: bool = False, _read_key_fn=None
 ) -> tuple[str, str | None, str | None] | None:
@@ -13285,8 +13309,10 @@ def select_mode(
     # shows; the last choice is persisted and *preselected* on the next launch
     # (never auto-skipped). Esc from a menu returns here; q quits.
     from yeaboi.config import get_last_category, set_last_category
+    from yeaboi.projects.active import set_solo_mode
 
     category = get_last_category()
+    set_solo_mode(category == "solo")
     cards, mascot = _CATEGORY_MENUS[category]
     _category_pending = True  # show the split on the first pass through the loop
     _back_to_category = False
@@ -13364,6 +13390,7 @@ def select_mode(
                 if _pick != category:
                     set_last_category(_pick)
                 category = _pick
+                set_solo_mode(category == "solo")
                 cards, mascot = _CATEGORY_MENUS[category]
                 n = len(cards)
                 selected = 0
@@ -13519,25 +13546,15 @@ def select_mode(
                             logger.info("tip jump to mode: %s", _tip.mode_key)
                             selected = _j
                             break
-                        # Team first: Solo's keys are a subset of Team's, so a
-                        # shared key jumped from elsewhere lands on the Team menu.
-                        _jumped = False
-                        for _cat in ("team", "agents", "solo"):
-                            _other, _other_mascot = _CATEGORY_MENUS[_cat]
-                            if _other is cards:
-                                continue
-                            _j = next((i for i, m in enumerate(_other) if m["key"] == _tip.mode_key), None)
-                            if _j is not None and _other[_j]["available"]:
-                                category = _cat
-                                logger.info("tip jump across categories to %s (%s)", _tip.mode_key, category)
-                                set_last_category(category)
-                                cards = _other
-                                mascot = _other_mascot
-                                n = len(cards)
-                                selected = _j
-                                _jumped = True
-                                break
-                        if _jumped:
+                        _target = _tip_jump_target(_tip.mode_key, cards)
+                        if _target is not None:
+                            category, _j = _target
+                            set_solo_mode(category == "solo")
+                            logger.info("tip jump across categories to %s (%s)", _tip.mode_key, category)
+                            set_last_category(category)
+                            cards, mascot = _CATEGORY_MENUS[category]
+                            n = len(cards)
+                            selected = _j
                             break
                 elif key == "c":
                     # Open the Changelog page (bottom-left hint). Handled inline
@@ -14330,6 +14347,7 @@ def select_mode(
                             roster_fallback=available_trackers(),
                             project_key="",
                             db_path=_ana_dbp,
+                            solo=(category == "solo"),
                         )
                         if _ta_setup is None:
                             _ana_restart = True
@@ -16045,6 +16063,7 @@ def select_mode(
                         roster_fallback=_delivery_grid,
                         project_key=_ta_project_key,
                         db_path=_ana_dbp,
+                        solo=(category == "solo"),
                     )
                     if _ta_setup is None:
                         _restart_project_list = True

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -12157,13 +12157,19 @@ def _run_poker_page(console: Console, live, read_key, frame_time: float, support
     from yeaboi.poker.board import PokerBoard, board_to_report
     from yeaboi.poker.server import PokerServer
     from yeaboi.poker.store import PokerStore
+    from yeaboi.projects.active import get_active_project, get_context_deps
+    from yeaboi.projects.scope import resolve_scope
 
+    # The AI perspective's cross-mode gather honors the active project and the
+    # Context toggles, like the retro board's carry-forward above.
+    _poker_scope = resolve_scope(get_active_project(), session_id, context_deps=get_context_deps())
     board = PokerBoard(
         session_id,
         project_name=project_name,
         source=setup["source"],
         scope_label=setup["scope_label"],
         tickets=setup["tickets"],
+        scope=_poker_scope,
     )
     server = PokerServer(board, port=get_poker_server_port())
     try:

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -10762,6 +10762,14 @@ def _pick_analysis_profile(
     """
     if not board_configured:
         return ""
+    from yeaboi.projects.active import get_context_deps
+
+    _deps = get_context_deps()
+    if _deps is not None and "analysis" not in _deps:
+        # The Context toggles switched analysis off for this run — offering a
+        # profile that would then be dropped is worse than not asking.
+        logger.info("analysis dep off — skipping the analysis-profile picker")
+        return ""
     selected_profile_id = ""
     try:
         from yeaboi.team_profile import TeamProfileStore

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -12515,7 +12515,7 @@ def _sweep_menu_in(
     leaves that one title fully shown throughout (used after the return slide, when
     the mode you came from is already home and only the rest scroll in). A no-op
     wipe (straight to the final frame) when the terminal is too small.
-    ``cards``/``mascot`` pick the menu (Humans default, Agents when passed).
+    ``cards``/``mascot`` pick the menu (Team default, Agents when passed).
     """
     _iw, _ih = console.size
     if _iw >= _MIN_WIDTH and _ih >= _MIN_HEIGHT:
@@ -12585,7 +12585,7 @@ def _slide_menu_in(
     Phase 2 hands off to the diagonal wipe (``_sweep_menu_in`` with ``sweep_skip``)
     so every OTHER title reveals top-left → bottom-right while the one you picked
     stays put. A no-op (straight to the final frame) when the terminal is too small.
-    ``cards``/``mascot`` pick the menu (Humans default, Agents when passed).
+    ``cards``/``mascot`` pick the menu (Team default, Agents when passed).
     """
     _card_list = _MODE_CARDS if cards is None else cards
     w, h = console.size
@@ -12625,9 +12625,9 @@ def _run_category_screen(
     read_key,
     supports_timeout: bool,
     *,
-    preselected: str = "humans",
+    preselected: str = "team",
 ) -> str | None:
-    """Phase 0 — the Humans/Agents landing split. Returns a category key or
+    """Phase 0 — the landing split. Returns a category key or
     None to quit.
 
     Always shown on a fresh load (the last-used category is *preselected*,
@@ -13275,8 +13275,8 @@ def select_mode(
     from yeaboi.config import get_last_category, set_last_category
 
     category = get_last_category()
-    cards: list[dict] = _MODE_CARDS if category == "humans" else _AGENT_CARDS
-    mascot = "duck" if category == "humans" else "robo"
+    cards: list[dict] = _MODE_CARDS if category == "team" else _AGENT_CARDS
+    mascot = "duck" if category == "team" else "robo"
     _category_pending = True  # show the split on the first pass through the loop
     _back_to_category = False
 
@@ -13341,7 +13341,7 @@ def select_mode(
             _returning = _skip_fade_in
             _skip_fade_in = False
 
-            # ── Phase 0: the Humans/Agents landing split ─────────────────────
+            # ── Phase 0: the landing split ───────────────────────────────────
             # Shown on a fresh load and whenever Esc backs out of a menu; a
             # return from a sub-page keeps its category and skips straight to
             # the menu transition below.
@@ -13353,8 +13353,8 @@ def select_mode(
                 if _pick != category:
                     set_last_category(_pick)
                 category = _pick
-                cards = _MODE_CARDS if category == "humans" else _AGENT_CARDS
-                mascot = "duck" if category == "humans" else "robo"
+                cards = _MODE_CARDS if category == "team" else _AGENT_CARDS
+                mascot = "duck" if category == "team" else "robo"
                 n = len(cards)
                 selected = 0
                 # A category pick always sweeps its menu in fresh.
@@ -13512,11 +13512,11 @@ def select_mode(
                         _other = _AGENT_CARDS if cards is _MODE_CARDS else _MODE_CARDS
                         _j = next((i for i, m in enumerate(_other) if m["key"] == _tip.mode_key), None)
                         if _j is not None and _other[_j]["available"]:
-                            category = "agents" if _other is _AGENT_CARDS else "humans"
+                            category = "agents" if _other is _AGENT_CARDS else "team"
                             logger.info("tip jump across categories to %s (%s)", _tip.mode_key, category)
                             set_last_category(category)
                             cards = _other
-                            mascot = "duck" if category == "humans" else "robo"
+                            mascot = "duck" if category == "team" else "robo"
                             n = len(cards)
                             selected = _j
                             break

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -2685,9 +2685,12 @@ def _collect_standup_data(message: str = "") -> dict:
 def _standup_generate(session_id: str, on_progress=None) -> str:
     """Run a standup for preview (no delivery) and return a status message."""
     try:
+        from yeaboi.projects.active import get_active_project
         from yeaboi.standup.engine import run_standup
 
-        report = run_standup(session_id, deliver=False, dry_run=True, on_progress=on_progress)
+        report = run_standup(
+            session_id, deliver=False, dry_run=True, on_progress=on_progress, project_id=get_active_project()
+        )
         warn = f" · {len(report.warnings)} notice(s)" if report.warnings else ""
         logger.info(
             "standup: generated report — day %s/%s, %d notice(s) (session=%s)",
@@ -9832,6 +9835,13 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
     session_id = base["session_id"]
     session_name = base["session_name"]
 
+    def _active_project() -> str:
+        # Read at generate time, not page entry — the switcher can change it
+        # while this page is open.
+        from yeaboi.projects.active import get_active_project
+
+        return get_active_project()
+
     q_label, q_start, q_end = quarter_bounds()
     periods = [(o["key"], o["label"], o["description"]) for o in report_setup.period_options()]
     # Loaded once per page entry — custom palettes come from reporting_themes.json;
@@ -10092,6 +10102,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
             return run_delivery_report(
                 period_key,
                 session_id=session_id,
+                project_id=_active_project(),
                 db_path=_ana_dbp,
                 theme=state["theme"],
                 sources=state["sources"],
@@ -10116,6 +10127,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
             return run_delivery_report(
                 PERIOD_QUARTER,
                 session_id=session_id,
+                project_id=_active_project(),
                 db_path=_ana_dbp,
                 window_start=window_start,
                 window_end=window_end,
@@ -10178,6 +10190,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
             return run_delivery_report(
                 PERIOD_WINDOW,
                 session_id=session_id,
+                project_id=_active_project(),
                 db_path=_ana_dbp,
                 window_start=start_iso,
                 window_end=end_iso,
@@ -11338,7 +11351,9 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
     # carried_action_items_for_session returns () when there's no prior retro.
     # A project-linked session hard-filters the carry to its own project and adds
     # the project's recent standup blockers as dismissible review cards.
-    _retro_scope = resolve_scope(session_id=session_id, db_path=_ana_dbp)
+    from yeaboi.projects.active import get_active_project
+
+    _retro_scope = resolve_scope(get_active_project(), session_id, db_path=_ana_dbp)
     carried = carried_action_items_for_session(
         session_id, project_name=project_name, db_path=_ana_dbp, scope=_retro_scope
     )
@@ -13461,6 +13476,17 @@ def select_mode(
                     from yeaboi.ui.mode_select._ceremonies import run_ceremonies_page
 
                     run_ceremonies_page(console, live, read_key, _FRAME_TIME, _supports_timeout, dry_run=dry_run)
+                    _slide_menu_in(console, live, selected, n, cards=cards, mascot=mascot)
+                    select_time = time.monotonic()
+                elif key == "P":
+                    # Projects — the switcher for which project scoped runs read
+                    # their context through. A keycap rather than a mode card for
+                    # the same screen-budget reason as `s` and `n`; shifted because
+                    # lowercase `p` is the Privacy page.
+                    logger.info("projects opened from mode select")
+                    from yeaboi.ui.mode_select._projects import run_projects_page
+
+                    run_projects_page(console, live, read_key, _FRAME_TIME, _supports_timeout)
                     _slide_menu_in(console, live, selected, n, cards=cards, mascot=mascot)
                     select_time = time.monotonic()
                 elif key == "n":

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -11405,7 +11405,9 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
     server = RetroServer(board, port=get_retro_server_port())
     # Previous retros, for the board's back arrow. Read lazily, so a store that
     # cannot be opened costs a board with no history rather than a board.
-    server.history_list, server.history_report = history_providers(project_name=project_name, db_path=_ana_dbp)
+    server.history_list, server.history_report = history_providers(
+        project_name=project_name, db_path=_ana_dbp, scope=_retro_scope
+    )
     try:
         server.start()
         logger.info("retro: server started on port %s (session=%s)", server.port, session_id)

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -2706,11 +2706,16 @@ def _collect_standup_data(message: str = "") -> dict:
 def _standup_generate(session_id: str, on_progress=None) -> str:
     """Run a standup for preview (no delivery) and return a status message."""
     try:
-        from yeaboi.projects.active import get_active_project
+        from yeaboi.projects.active import get_active_project, get_context_deps
         from yeaboi.standup.engine import run_standup
 
         report = run_standup(
-            session_id, deliver=False, dry_run=True, on_progress=on_progress, project_id=get_active_project()
+            session_id,
+            deliver=False,
+            dry_run=True,
+            on_progress=on_progress,
+            project_id=get_active_project(),
+            context_deps=get_context_deps(),
         )
         warn = f" · {len(report.warnings)} notice(s)" if report.warnings else ""
         logger.info(
@@ -4161,6 +4166,7 @@ _STANDUP_SETUP_FIELDS = (
     "documentation_scope_configured",
     "automation_markers",
     "automation_handling",
+    "context_deps",
 )
 
 
@@ -4500,6 +4506,7 @@ def _standup_team_configure(
             habit_detection=merged.get("habit_detection", "on"),
             habit_rules=merged.get("habit_rules", ""),
             habit_ai_match=merged.get("habit_ai_match", "on"),
+            context_deps=merged.get("context_deps"),
         )
     logger.info(
         "standup team: saved session=%s sources=%s members=%d",
@@ -4786,6 +4793,7 @@ def _standup_code_configure(
             habit_detection=merged.get("habit_detection", "on"),
             habit_rules=merged.get("habit_rules", ""),
             habit_ai_match=merged.get("habit_ai_match", "on"),
+            context_deps=merged.get("context_deps"),
         )
     logger.info(
         "standup code: saved session=%s sources=%s github_owners=%d github_repos=%d excluded=%d azdo_projects=%d",
@@ -4903,6 +4911,7 @@ def _standup_documentation_configure(
             habit_detection=merged.get("habit_detection", "on"),
             habit_rules=merged.get("habit_rules", ""),
             habit_ai_match=merged.get("habit_ai_match", "on"),
+            context_deps=merged.get("context_deps"),
         )
     return True, f"Documentation scope saved — {len(selected)} provider(s); repository docs included."
 
@@ -5085,6 +5094,7 @@ def _standup_transcripts_configure(
             habit_detection=merged.get("habit_detection", "on"),
             habit_rules=merged.get("habit_rules", ""),
             habit_ai_match=merged.get("habit_ai_match", "on"),
+            context_deps=merged.get("context_deps"),
         )
     logger.info(
         "standup transcripts configured: session=%s dir=%s auto=%s",
@@ -5517,6 +5527,7 @@ def _standup_identity_configure(console: Console, live, read_key, frame_time, su
             habit_detection=existing.get("habit_detection", "on"),
             habit_rules=existing.get("habit_rules", ""),
             habit_ai_match=existing.get("habit_ai_match", "on"),
+            context_deps=existing.get("context_deps"),
         )
     logger.info("standup identity: saved (session=%s)", session_id)
     return "Identity saved."
@@ -9863,6 +9874,12 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
 
         return get_active_project()
 
+    def _active_context() -> tuple[str, ...] | None:
+        # Same read-at-generate-time rule as _active_project.
+        from yeaboi.projects.active import get_context_deps
+
+        return get_context_deps()
+
     q_label, q_start, q_end = quarter_bounds()
     periods = [(o["key"], o["label"], o["description"]) for o in report_setup.period_options()]
     # Loaded once per page entry — custom palettes come from reporting_themes.json;
@@ -10124,6 +10141,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
                 period_key,
                 session_id=session_id,
                 project_id=_active_project(),
+                context_deps=_active_context(),
                 db_path=_ana_dbp,
                 theme=state["theme"],
                 sources=state["sources"],
@@ -10149,6 +10167,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
                 PERIOD_QUARTER,
                 session_id=session_id,
                 project_id=_active_project(),
+                context_deps=_active_context(),
                 db_path=_ana_dbp,
                 window_start=window_start,
                 window_end=window_end,
@@ -10212,6 +10231,7 @@ def _run_reporting_page(console: Console, live, read_key, frame_time: float, sup
                 PERIOD_WINDOW,
                 session_id=session_id,
                 project_id=_active_project(),
+                context_deps=_active_context(),
                 db_path=_ana_dbp,
                 window_start=start_iso,
                 window_end=end_iso,
@@ -11372,9 +11392,9 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
     # carried_action_items_for_session returns () when there's no prior retro.
     # A project-linked session hard-filters the carry to its own project and adds
     # the project's recent standup blockers as dismissible review cards.
-    from yeaboi.projects.active import get_active_project
+    from yeaboi.projects.active import get_active_project, get_context_deps
 
-    _retro_scope = resolve_scope(get_active_project(), session_id, db_path=_ana_dbp)
+    _retro_scope = resolve_scope(get_active_project(), session_id, context_deps=get_context_deps(), db_path=_ana_dbp)
     carried = carried_action_items_for_session(
         session_id, project_name=project_name, db_path=_ana_dbp, scope=_retro_scope
     )

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -11326,8 +11326,9 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
         return
 
     from yeaboi.config import get_retro_server_port
+    from yeaboi.projects.scope import resolve_scope
     from yeaboi.retro.board import RetroBoard, board_to_report
-    from yeaboi.retro.engine import carried_action_items_for_session, history_providers
+    from yeaboi.retro.engine import carried_action_items_for_session, history_providers, standup_blocker_cards
     from yeaboi.retro.server import RetroServer
     from yeaboi.retro.store import RetroStore
 
@@ -11335,7 +11336,13 @@ def _run_retro_page(console: Console, live, read_key, frame_time: float, support
     # Seed last sprint's action items for review before the server starts, so the
     # first browser poll already shows the "Last sprint's actions" column. Best-effort:
     # carried_action_items_for_session returns () when there's no prior retro.
-    carried = carried_action_items_for_session(session_id, project_name=project_name, db_path=_ana_dbp)
+    # A project-linked session hard-filters the carry to its own project and adds
+    # the project's recent standup blockers as dismissible review cards.
+    _retro_scope = resolve_scope(session_id=session_id, db_path=_ana_dbp)
+    carried = carried_action_items_for_session(
+        session_id, project_name=project_name, db_path=_ana_dbp, scope=_retro_scope
+    )
+    carried = (*carried, *standup_blocker_cards(_retro_scope, db_path=_ana_dbp, existing=carried))
     if carried:
         board.seed_carried(list(carried))
         logger.info("retro: seeded %d carried-over action item(s) (session=%s)", len(carried), session_id)

--- a/src/yeaboi/ui/mode_select/__init__.py
+++ b/src/yeaboi/ui/mode_select/__init__.py
@@ -56,6 +56,7 @@ from yeaboi.ui.mode_select.screens._screens import (  # noqa: F401
     _MIN_WIDTH,
     _MODE_CARDS,
     _OFFLINE_CARDS,
+    _SOLO_CARDS,
     _SWEEP_ROW_WEIGHT,
     _build_mode_screen,
     _build_slide_frame,
@@ -12663,8 +12664,10 @@ def _run_category_screen(
             )
         )
         key = read_key(timeout=_FRAME_TIME) if supports_timeout else read_key()
-        if key in ("left", "right", "up", "down", "tab"):
-            selected = 1 - selected
+        if key in ("left", "up"):
+            selected = (selected - 1) % len(_CATEGORY_CARDS)
+        elif key in ("right", "down", "tab"):
+            selected = (selected + 1) % len(_CATEGORY_CARDS)
         elif key == "enter":
             chosen = _CATEGORY_CARDS[selected]["key"]
             logger.info("category chosen: %s", chosen)
@@ -13251,6 +13254,15 @@ SAVED_SESSION_HUBS = {
     "ship": _run_ship_hub,
 }
 
+#: Which menu (card list + companion mascot) each landing category opens.
+#: The one place the category key picks a menu — the Phase-0/Phase-1 loop and
+#: the tip jump all read this instead of hand-rolling ternaries.
+_CATEGORY_MENUS: dict[str, tuple[list[dict], str]] = {
+    "solo": (_SOLO_CARDS, "duck"),
+    "team": (_MODE_CARDS, "duck"),
+    "agents": (_AGENT_CARDS, "robo"),
+}
+
 
 def select_mode(
     console: Console | None = None, *, dry_run: bool = False, _read_key_fn=None
@@ -13275,8 +13287,7 @@ def select_mode(
     from yeaboi.config import get_last_category, set_last_category
 
     category = get_last_category()
-    cards: list[dict] = _MODE_CARDS if category == "team" else _AGENT_CARDS
-    mascot = "duck" if category == "team" else "robo"
+    cards, mascot = _CATEGORY_MENUS[category]
     _category_pending = True  # show the split on the first pass through the loop
     _back_to_category = False
 
@@ -13353,8 +13364,7 @@ def select_mode(
                 if _pick != category:
                     set_last_category(_pick)
                 category = _pick
-                cards = _MODE_CARDS if category == "team" else _AGENT_CARDS
-                mascot = "duck" if category == "team" else "robo"
+                cards, mascot = _CATEGORY_MENUS[category]
                 n = len(cards)
                 selected = 0
                 # A category pick always sweeps its menu in fresh.
@@ -13509,16 +13519,25 @@ def select_mode(
                             logger.info("tip jump to mode: %s", _tip.mode_key)
                             selected = _j
                             break
-                        _other = _AGENT_CARDS if cards is _MODE_CARDS else _MODE_CARDS
-                        _j = next((i for i, m in enumerate(_other) if m["key"] == _tip.mode_key), None)
-                        if _j is not None and _other[_j]["available"]:
-                            category = "agents" if _other is _AGENT_CARDS else "team"
-                            logger.info("tip jump across categories to %s (%s)", _tip.mode_key, category)
-                            set_last_category(category)
-                            cards = _other
-                            mascot = "duck" if category == "team" else "robo"
-                            n = len(cards)
-                            selected = _j
+                        # Team first: Solo's keys are a subset of Team's, so a
+                        # shared key jumped from elsewhere lands on the Team menu.
+                        _jumped = False
+                        for _cat in ("team", "agents", "solo"):
+                            _other, _other_mascot = _CATEGORY_MENUS[_cat]
+                            if _other is cards:
+                                continue
+                            _j = next((i for i, m in enumerate(_other) if m["key"] == _tip.mode_key), None)
+                            if _j is not None and _other[_j]["available"]:
+                                category = _cat
+                                logger.info("tip jump across categories to %s (%s)", _tip.mode_key, category)
+                                set_last_category(category)
+                                cards = _other
+                                mascot = _other_mascot
+                                n = len(cards)
+                                selected = _j
+                                _jumped = True
+                                break
+                        if _jumped:
                             break
                 elif key == "c":
                     # Open the Changelog page (bottom-left hint). Handled inline
@@ -15730,7 +15749,7 @@ def select_mode(
                         # Step 2: Slide Planning title from top down to its 3-item
                         # layout position. In the last ~40% of the slide, fade in
                         # the other two mode titles so they appear as Planning lands.
-                        chosen = _MODE_CARDS[selected]
+                        chosen = cards[selected]
                         base_r, base_g, base_b = COLOR_RGB.get(chosen["color"], (180, 180, 180))
                         base_style = f"bold rgb({base_r},{base_g},{base_b})"
                         others = [i for i in range(n) if i != selected]

--- a/src/yeaboi/ui/mode_select/_agents.py
+++ b/src/yeaboi/ui/mode_select/_agents.py
@@ -167,7 +167,7 @@ def _run_agent_page(
         status = ""
         refreshing = artifact is not None
         # duck_working_thread: the corner robo bobs for the engine's lifetime,
-        # same liveness cue the Humans pages give their worker runs.
+        # same liveness cue the Team pages give their worker runs.
         duck_working_thread(_work, name=label).start()
 
     _start_worker()

--- a/src/yeaboi/ui/mode_select/_projects.py
+++ b/src/yeaboi/ui/mode_select/_projects.py
@@ -1,0 +1,114 @@
+"""The Projects page loop: list, set active, archive.
+
+Reads are cheap and the page is short, so it re-reads the store on every
+action rather than caching. Creating a project is a terminal command
+(``yeaboi project create <name>``) and the page says so rather than offering
+a form — same argument as the Ceremonies page: the surface that installs a
+thing should be the one the resulting command is visible in.
+
+The one piece of state the page *writes* beyond the store is the active
+project (``projects/active.py``): the process-local choice every mode launch
+site reads so its runs are scoped.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from rich.console import Console
+
+from yeaboi.projects.active import get_active_project, set_active_project
+from yeaboi.ui.mode_select.screens._screens_projects import ACTIONS, _build_projects_screen
+from yeaboi.ui.shared._scroll import SCROLL_KEYS, coalesce_scroll
+
+logger = logging.getLogger(__name__)
+
+
+def _load() -> list[dict]:
+    from yeaboi.projects.engine import list_projects
+
+    try:
+        return list_projects()
+    except Exception:  # noqa: BLE001 — a broken store is an empty page, not a crash
+        logger.error("projects page: list_projects failed", exc_info=True)
+        return []
+
+
+def run_projects_page(
+    console: Console,
+    live,
+    read_key,
+    frame_time: float,
+    supports_timeout: bool,
+) -> None:
+    """Enter Projects from the menu; returns when the user backs out."""
+    projects = _load()
+    logger.info("Projects page opened: %d project(s), active=%s", len(projects), get_active_project() or "(none)")
+    selected = action_sel = scroll = 0
+    scroll_meta: dict = {}
+    message = ""
+    start = time.monotonic()
+
+    while True:
+        w, h = console.size
+        live.update(
+            _build_projects_screen(
+                projects,
+                selected=selected,
+                active_project_id=get_active_project(),
+                scroll_offset=scroll,
+                scroll_meta=scroll_meta,
+                width=w,
+                height=h,
+                action_sel=action_sel,
+                actions=list(ACTIONS),
+                shimmer_tick=time.monotonic() - start,
+                sub_reveal=(time.monotonic() - start) * 6.0,
+                message=message,
+            )
+        )
+        key = read_key(timeout=frame_time) if supports_timeout else read_key()
+
+        if key in SCROLL_KEYS:
+            scroll = coalesce_scroll(scroll, key, scroll_meta, read_key)
+            continue
+        if key in ("esc", "q"):
+            logger.info("Projects page closed")
+            return
+        if key == "left":
+            action_sel = (action_sel - 1) % len(ACTIONS)
+        elif key == "right":
+            action_sel = (action_sel + 1) % len(ACTIONS)
+        elif key in ("up", "down") and projects:
+            step = -1 if key == "up" else 1
+            selected = (selected + step) % len(projects)
+            message = ""
+        elif key == "enter":
+            choice = ACTIONS[action_sel]
+            if choice == "Back":
+                logger.info("Projects page closed from the buttons")
+                return
+            if not projects:
+                message = "No projects yet — yeaboi project create <name>"
+                continue
+            project = projects[selected]
+            if choice == "Set active":
+                if get_active_project() == project["project_id"]:
+                    set_active_project("")
+                    message = f"{project['name']} is no longer active — runs are team-wide again."
+                else:
+                    set_active_project(project["project_id"])
+                    message = f"{project['name']} is the active project — runs from the menu are scoped to it."
+            elif choice == "Archive":
+                from yeaboi.paths import get_db_path
+                from yeaboi.projects.store import ProjectStore
+
+                with ProjectStore(get_db_path()) as store:
+                    store.archive(project["project_id"])
+                if get_active_project() == project["project_id"]:
+                    set_active_project("")
+                logger.info("Projects: archived %s", project["project_id"])
+                message = f"Archived {project['name']}."
+            projects = _load()
+            selected = min(selected, max(0, len(projects) - 1))

--- a/src/yeaboi/ui/mode_select/_projects.py
+++ b/src/yeaboi/ui/mode_select/_projects.py
@@ -18,8 +18,14 @@ import time
 
 from rich.console import Console
 
-from yeaboi.projects.active import get_active_project, set_active_project
-from yeaboi.ui.mode_select.screens._screens_projects import ACTIONS, _build_projects_screen
+from yeaboi.projects.active import get_active_project, get_context_deps, set_active_project, set_context_deps
+from yeaboi.ui.mode_select.screens._screens_projects import (
+    ACTIONS,
+    CONTEXT_ACTIONS,
+    CONTEXT_ROWS,
+    _build_context_screen,
+    _build_projects_screen,
+)
 from yeaboi.ui.shared._scroll import SCROLL_KEYS, coalesce_scroll
 
 logger = logging.getLogger(__name__)
@@ -89,6 +95,12 @@ def run_projects_page(
             if choice == "Back":
                 logger.info("Projects page closed from the buttons")
                 return
+            if choice == "Context":
+                # Orthogonal to the project list — incognito works with no
+                # projects at all, so this sits before the empty-list guard.
+                run_context_page(console, live, read_key, frame_time, supports_timeout)
+                message = ""
+                continue
             if not projects:
                 message = "No projects yet — yeaboi project create <name>"
                 continue
@@ -112,3 +124,72 @@ def run_projects_page(
                 message = f"Archived {project['name']}."
             projects = _load()
             selected = min(selected, max(0, len(projects) - 1))
+
+
+def run_context_page(
+    console: Console,
+    live,
+    read_key,
+    frame_time: float,
+    supports_timeout: bool,
+) -> None:
+    """The context-toggles sub-page: Space flips a source, buttons batch it.
+
+    Writes only ``projects/active.py`` state — the process-local toggles every
+    launch site passes as ``context_deps``. ``None`` = inherit, ``()`` =
+    incognito, same contract as the engines.
+    """
+    logger.info("Context page opened: deps=%s", get_context_deps())
+    selected = action_sel = 0
+    message = ""
+    start = time.monotonic()
+
+    while True:
+        w, h = console.size
+        live.update(
+            _build_context_screen(
+                get_context_deps(),
+                selected=selected,
+                action_sel=action_sel,
+                width=w,
+                height=h,
+                shimmer_tick=time.monotonic() - start,
+                sub_reveal=(time.monotonic() - start) * 6.0,
+                message=message,
+            )
+        )
+        key = read_key(timeout=frame_time) if supports_timeout else read_key()
+
+        if key in ("esc", "q"):
+            logger.info("Context page closed: deps=%s", get_context_deps())
+            return
+        if key == "left":
+            action_sel = (action_sel - 1) % len(CONTEXT_ACTIONS)
+        elif key == "right":
+            action_sel = (action_sel + 1) % len(CONTEXT_ACTIONS)
+        elif key in ("up", "down"):
+            step = -1 if key == "up" else 1
+            selected = (selected + step) % len(CONTEXT_ROWS)
+            message = ""
+        elif key == " ":
+            token = CONTEXT_ROWS[selected][0]
+            deps = get_context_deps()
+            # Inherit materialises to the full set on the first toggle so
+            # switching one source off leaves the other four explicitly on.
+            current = set(token for token, _label, _hint in CONTEXT_ROWS) if deps is None else set(deps)
+            current.symmetric_difference_update({token})
+            ordered = tuple(t for t, _label, _hint in CONTEXT_ROWS if t in current)
+            set_context_deps(ordered)
+            logger.info("Context page: toggled %s -> %s", token, ordered or "incognito")
+            message = ""
+        elif key == "enter":
+            choice = CONTEXT_ACTIONS[action_sel]
+            if choice == "Back":
+                logger.info("Context page closed from the buttons: deps=%s", get_context_deps())
+                return
+            if choice == "All on":
+                set_context_deps(None)
+                message = "Every source on — runs inherit the project default when one is set."
+            elif choice == "Incognito":
+                set_context_deps(())
+                message = "Incognito — runs read no cross-mode context until this changes."

--- a/src/yeaboi/ui/mode_select/_projects.py
+++ b/src/yeaboi/ui/mode_select/_projects.py
@@ -18,7 +18,13 @@ import time
 
 from rich.console import Console
 
-from yeaboi.projects.active import get_active_project, get_context_deps, set_active_project, set_context_deps
+from yeaboi.projects.active import (
+    get_active_project,
+    get_context_deps,
+    is_solo_mode,
+    set_active_project,
+    set_context_deps,
+)
 from yeaboi.ui.mode_select.screens._screens_projects import (
     ACTIONS,
     CONTEXT_ACTIONS,
@@ -189,7 +195,13 @@ def run_context_page(
                 return
             if choice == "All on":
                 set_context_deps(None)
-                message = "Every source on — runs inherit the project default when one is set."
+                # Solo inherits the solo defaults, not everything — it has no
+                # retro mode, so saying "every source" there would be a lie.
+                message = (
+                    "Back to the Solo defaults — retro stays off."
+                    if is_solo_mode()
+                    else "Every source on — runs inherit the project default when one is set."
+                )
             elif choice == "Incognito":
                 set_context_deps(())
                 message = "Incognito — runs read no cross-mode context until this changes."

--- a/src/yeaboi/ui/mode_select/screens/_screens.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens.py
@@ -123,9 +123,9 @@ _MODE_CARDS: list[dict[str, Any]] = [
 ]
 
 # ---------------------------------------------------------------------------
-# Agents mode definitions — the second category on the landing split. Kept as a
+# Agents mode definitions — the third category on the landing split. Kept as a
 # SEPARATE list, never merged into _MODE_CARDS: the welcome tests pin exact
-# renders and hardcoded indices against _MODE_CARDS, and the two menus are
+# renders and hardcoded indices against _MODE_CARDS, and the menus are
 # separate screens sharing one builder (_build_mode_screen(cards=...)).
 # ---------------------------------------------------------------------------
 
@@ -698,7 +698,7 @@ def _build_mode_screen(
     sweep_skip: index of one title to leave fully shown while the sweep reveals the
     rest — used by the return transition (the mode you came from is already home).
     cards / mascot: the card list this menu shows (default ``_MODE_CARDS``) and the
-    companion sprite beside it ("duck" for Humans, "robo" for Agents). Only the
+    companion sprite beside it ("duck" for Solo/Team, "robo" for Agents). Only the
     *source* of the rows changes — every layout constant stays identical, and
     ``mode_at_row``/``selected_title_offset`` must be passed the same ``cards``.
     """

--- a/src/yeaboi/ui/mode_select/screens/_screens.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens.py
@@ -123,6 +123,75 @@ _MODE_CARDS: list[dict[str, Any]] = [
 ]
 
 # ---------------------------------------------------------------------------
+# Solo mode definitions — the first category on the landing split. Keys are
+# deliberately SHARED with _MODE_CARDS (same dispatch chains, saved-session
+# hubs, capabilities and colours); only the copy differs — solo-voiced, "your
+# history" rather than "your team's". Kept as copies, not references: the
+# welcome tests pin exact renders against each list, and a dict shared across
+# menus invites silent drift. No retro/poker (they host live multi-participant
+# boards) and no performance (it reviews *someone else* by construction).
+# ---------------------------------------------------------------------------
+
+_SOLO_CARDS: list[dict[str, Any]] = [
+    {
+        "key": "team-analysis",
+        "title": "Analysis",
+        "description": "Analyse your board history to learn your velocity, estimation patterns, and delivery signals.",
+        "available": True,
+        "color": "rgb(100,180,100)",
+    },
+    {
+        "key": "project-planning",
+        "title": "Planning",
+        "description": "Decompose your project into epics, user stories, tasks, and a sprint plan.",
+        "available": True,
+        "color": "rgb(110,140,220)",
+    },
+    {
+        "key": "daily-standup",
+        "title": "Standup",
+        "description": "Run your daily standup: what you did, sprint-day confidence, and a summary you can send.",
+        "available": True,
+        "color": "rgb(200,100,180)",
+    },
+    {
+        "key": "reporting",
+        "title": "Reporting",
+        "description": "Summarise your delivered work for the business — last sprint or month, as slides, HTML or MD.",
+        "available": True,
+        "color": "rgb(140,120,230)",
+    },
+    {
+        "key": "ship",
+        "title": "Ship",
+        "description": "Hand any epic, story or task to a coding agent: isolated branch, your approval, then a PR.",
+        # Beta for the same reason as the Team card — see _MODE_CARDS.
+        "available": True,
+        "badge": BETA_LABEL,
+        "color": "rgb(235,140,60)",
+    },
+    {
+        "key": "usage",
+        "title": "Usage",
+        "description": "View API token usage, session history, and cost estimates.",
+        "available": True,
+        "color": "rgb(220,160,60)",
+        # A local dashboard over the usage DB — no LLM call, so no credential gate.
+        "llm": False,
+    },
+    {
+        "key": "settings",
+        "title": "Settings",
+        "description": "Manage API keys, LLM provider, and board configuration.",
+        "available": True,
+        "color": "rgb(160,160,180)",
+        # Makes no LLM call, and is where a broken key gets fixed — gating it
+        # would lock the user out of the only screen that helps them.
+        "llm": False,
+    },
+]
+
+# ---------------------------------------------------------------------------
 # Agents mode definitions — the third category on the landing split. Kept as a
 # SEPARATE list, never merged into _MODE_CARDS: the welcome tests pin exact
 # renders and hardcoded indices against _MODE_CARDS, and the menus are

--- a/src/yeaboi/ui/mode_select/screens/_screens.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens.py
@@ -655,6 +655,7 @@ def _build_version_row(width: int, *, suppress_upgrade: bool = False, show_compa
         ("a", "all tips", False),
         ("s", "schedule", True),
         ("n", "niko", True),
+        ("P", "projects", True),
         ("p", "privacy", True),
         ("k", "system check", True),
     ):

--- a/src/yeaboi/ui/mode_select/screens/_screens_category.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_category.py
@@ -31,8 +31,9 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from yeaboi.beta import BETA_LABEL
 from yeaboi.ui.shared._ascii_font import render_ascii_text
-from yeaboi.ui.shared._components import AGENTS_THEME, SOLO_THEME, TEAM_THEME, build_page_panel
+from yeaboi.ui.shared._components import AGENTS_THEME, SOLO_THEME, TEAM_THEME, build_badge, build_page_panel
 from yeaboi.ui.shared._mascot import FRAMES, flock_cells, flock_head_cells, full_cells, mini_cells
 
 _CATEGORY_CARDS: list[dict[str, Any]] = [
@@ -46,6 +47,8 @@ _CATEGORY_CARDS: list[dict[str, Any]] = [
         "dim": "rgb(95,80,45)",  # the resting shade — no theme slot for it
         "tint": "rgb(30,25,15)",  # card-bg convention: a dark shade of the accent
         "mascot": "duck",
+        # A whole beta world, not just beta modes: the chip rides the card.
+        "badge": BETA_LABEL,
     },
     {
         "key": "team",
@@ -68,6 +71,7 @@ _CATEGORY_CARDS: list[dict[str, Any]] = [
         "dim": "rgb(50,88,115)",
         "tint": "rgb(15,24,32)",
         "mascot": "robo",
+        "badge": BETA_LABEL,
     },
 ]
 
@@ -301,6 +305,12 @@ def _card_half(
     verb.no_wrap = True
     verb.overflow = "ellipsis"
 
+    # A beta world wears the chip on the reserved row between wordmark and
+    # verb — the row is blank either way, so the card height never moves.
+    # Dim on the resting card, matching the mode-row treatment; it enters with
+    # the wordmark it annotates, not before it.
+    chip = build_badge(card["badge"], dim=not selected) if card.get("badge") and intro >= 0.5 else Text(" ")
+
     inner_budget = max(16, half_width - 2)  # card padding
     caps = _capability_rows(card, selected=selected, budget=inner_budget)
 
@@ -309,7 +319,7 @@ def _card_half(
         Align.center(mascot),
         Text(""),
         Align.center(title),
-        Text(""),
+        Align.center(chip),
         Align.center(verb),
         *[Align.center(row) for row in caps],
     )

--- a/src/yeaboi/ui/mode_select/screens/_screens_category.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_category.py
@@ -12,7 +12,7 @@ up, so the selection state needs no extra chrome. Pure builders only — the run
 loop lives in :mod:`yeaboi.ui.mode_select` (Phase 0 of ``select_mode``).
 
 Geometry note: the builder and :func:`category_at_pos` share one helper
-(:func:`_category_columns`) instead of hand-mirroring each other's maths — the
+(:func:`_category_bounds`) instead of hand-mirroring each other's maths — the
 lesson of ``mode_at_row``'s lock-step comment, applied from the start.
 
 # See docs: "TUI system" — shared component structure
@@ -32,10 +32,21 @@ from rich.table import Table
 from rich.text import Text
 
 from yeaboi.ui.shared._ascii_font import render_ascii_text
-from yeaboi.ui.shared._components import AGENTS_THEME, TEAM_THEME, build_page_panel
-from yeaboi.ui.shared._mascot import FRAMES, mini_cells, render_full
+from yeaboi.ui.shared._components import AGENTS_THEME, SOLO_THEME, TEAM_THEME, build_page_panel
+from yeaboi.ui.shared._mascot import FRAMES, flock_cells, flock_head_cells, full_cells, mini_cells
 
 _CATEGORY_CARDS: list[dict[str, Any]] = [
+    {
+        "key": "solo",
+        "title": "Solo",
+        "verb": "Run your own show",
+        "capabilities": ["planning", "standups", "analysis", "reports"],
+        "color": SOLO_THEME.accent,
+        "bright": SOLO_THEME.accent_bright,
+        "dim": "rgb(95,80,45)",  # the resting shade — no theme slot for it
+        "tint": "rgb(30,25,15)",  # card-bg convention: a dark shade of the accent
+        "mascot": "duck",
+    },
     {
         "key": "team",
         "title": "Team",
@@ -43,9 +54,9 @@ _CATEGORY_CARDS: list[dict[str, Any]] = [
         "capabilities": ["planning", "standups", "retros", "poker", "reviews"],
         "color": TEAM_THEME.accent,
         "bright": TEAM_THEME.accent_bright,
-        "dim": "rgb(55,95,58)",  # the resting shade — no theme slot for it
-        "tint": "rgb(17,28,20)",  # card-bg convention: a dark shade of the accent
-        "mascot": "duck",
+        "dim": "rgb(55,95,58)",
+        "tint": "rgb(17,28,20)",
+        "mascot": "flock",
     },
     {
         "key": "agents",
@@ -94,7 +105,7 @@ _WALK: dict[str, float] = {}
 
 
 def reset_category_walk() -> None:
-    """Put both mascots back where they started (tests, and a fresh entrance)."""
+    """Put every mascot back where it started (tests, and a fresh entrance)."""
     _WALK.clear()
 
 
@@ -145,7 +156,7 @@ def _walk_step(key: str, selected: bool) -> int:
 
 _CARD_ROWS = 28
 _HINT_ROWS = 4  # blank + the key-hint line + the two rows the footer note lands on
-_GUTTER_COLS = 2  # breathing room between the two cards
+_GUTTER_COLS = 1  # breathing room between the cards — one column, three-up is tight
 
 # The quiet layer around the living cards.
 _HEADING = "Who are we working with today?"
@@ -157,14 +168,24 @@ _CAPS_SELECTED = "rgb(168,172,184)"
 _CAPS_RESTING = "rgb(96,100,114)"
 
 
-def _category_columns(width: int) -> int:
-    """The 1-based terminal column where the right (Agents) half begins.
+def _category_bounds(width: int) -> list[tuple[int, int]]:
+    """The 1-based terminal column span (start, end) of each world-card.
 
-    The panel splits its inner width into two equal columns; borders and padding
-    are symmetric, so the midpoint of the full width is the boundary. Shared by
-    the builder's grid and the click hit-test so they cannot drift.
+    The panel splits its inner width (frame border + padding are 3 columns a
+    side) into equal card columns separated by ``_GUTTER_COLS``; the last card
+    absorbs the division remainder. Shared by the builder's grid and the click
+    hit-test so they cannot drift.
     """
-    return width // 2 + 1
+    n = len(_CATEGORY_CARDS)
+    inner_w = width - 6  # borders (2) + horizontal padding (4)
+    card_w = max(20, (inner_w - (n - 1) * _GUTTER_COLS) // n)
+    bounds: list[tuple[int, int]] = []
+    start = 4  # 1-based: border (1) + left padding (2) put the first card at col 4
+    for i in range(n):
+        w = card_w if i < n - 1 else max(card_w, inner_w - (card_w + _GUTTER_COLS) * (n - 1))
+        bounds.append((start, start + w - 1))
+        start += w + _GUTTER_COLS
+    return bounds
 
 
 def _capability_rows(card: dict[str, Any], *, selected: bool, budget: int) -> list[Text]:
@@ -216,11 +237,25 @@ def _card_half(
     # up the ground plane as well as making it smaller. Both occupy the same
     # _MASCOT_ROWS, so the card never changes height as the selection moves.
     # The mascot leads the entrance; the name follows him (see the title below).
+    # Three-up at narrow widths the full trace (34 cells) no longer fits the
+    # card, so the arrived state drops a tier: the mini trace, unshaded on the
+    # near ground — the walk still reads through size, light and position.
+    full_tier = half_width >= 34  # the card pads vertically only
     if True:
         step = _walk_step(card["key"], selected)
+        anim = int(shimmer_tick * 8) % FRAMES
         if step >= _MASCOT_WALK_STEPS - 1:
-            # Arrived: the full trace, wings going, feet on the near ground.
-            mascot: RenderableType = render_full(int(shimmer_tick * 8) % FRAMES, mascot=card["mascot"])
+            # Arrived: the biggest trace that fits, wings going, on the near ground.
+            if card["mascot"] == "flock":
+                cells = flock_cells(anim) if full_tier else flock_head_cells(anim)
+            else:
+                cells = (
+                    full_cells(anim, mascot=card["mascot"]) if full_tier else mini_cells(anim, mascot=card["mascot"])
+                )
+            mascot: RenderableType = Group(
+                *[Text("") for _ in range(_MASCOT_ROWS - len(cells))],
+                *_shaded_rows(cells, 1.0),
+            )
         else:
             # Still coming: the smaller trace, standing on the same ground the
             # full one does — his feet are on the title either way, and only
@@ -266,7 +301,7 @@ def _card_half(
     verb.no_wrap = True
     verb.overflow = "ellipsis"
 
-    inner_budget = max(16, half_width - 6)  # card borders + padding
+    inner_budget = max(16, half_width - 2)  # card padding
     caps = _capability_rows(card, selected=selected, budget=inner_budget)
 
     body = Group(
@@ -278,12 +313,12 @@ def _card_half(
         Align.center(verb),
         *[Align.center(row) for row in caps],
     )
-    # No frame, and no background wash. Two boxes side by side made the choice
+    # No frame, and no background wash. Boxes side by side made the choice
     # look like a form; the mascot walking forward is what marks the live one.
-    # The padding keeps the geometry the border used to occupy, so the card is
-    # the same height either way — ``test_card_height_matches_the_layout_constant``
-    # pins that to _CARD_ROWS.
-    return Padding(body, (1, 2))
+    # Vertical padding only — three-up the columns are the scarce dimension,
+    # and every row centres itself. The card stays the same height either way —
+    # ``test_card_height_matches_the_layout_constant`` pins it to _CARD_ROWS.
+    return Padding(body, (1, 0))
 
 
 def _build_category_screen(
@@ -295,18 +330,24 @@ def _build_category_screen(
     intro: float = 1.0,
 ) -> Panel:
     """Build the full-screen landing split."""
-    inner_w = width - 6  # borders (2) + horizontal padding (4)
-    half_w = max(20, (inner_w - _GUTTER_COLS) // 2)
+    bounds = _category_bounds(width)
+    widths = [end - start + 1 for start, end in bounds]
     halves = [
-        _card_half(card, selected=i == selected, shimmer_tick=shimmer_tick, intro=intro, half_width=half_w)
+        _card_half(card, selected=i == selected, shimmer_tick=shimmer_tick, intro=intro, half_width=widths[i])
         for i, card in enumerate(_CATEGORY_CARDS)
     ]
 
-    grid = Table.grid(expand=True)
-    grid.add_column(ratio=1)
-    grid.add_column(width=_GUTTER_COLS)
-    grid.add_column(ratio=1)
-    grid.add_row(halves[0], Text(""), halves[1])
+    # Explicit column widths from the shared bounds — a ratio grid rounds its
+    # own way, and the click hit-test must land where the cards actually are.
+    grid = Table.grid()
+    cells: list[RenderableType] = []
+    for i, w in enumerate(widths):
+        if i:
+            grid.add_column(width=_GUTTER_COLS)
+            cells.append(Text(""))
+        grid.add_column(width=w)
+        cells.append(halves[i])
+    grid.add_row(*cells)
 
     hint = Text(justify="center")
     for key, label in (("←/→", "switch"), ("enter", "choose"), ("q", "quit")):
@@ -353,12 +394,17 @@ def _build_category_screen(
 
 
 def category_at_pos(width: int, height: int, *, row: int, col: int) -> int | None:
-    """Map a 1-based terminal click to a category index (0=team, 1=agents).
+    """Map a 1-based terminal click to a category index (0=solo, 1=team, 2=agents).
 
-    Any click inside the content band counts for the half it lands in — the
-    cards are the whole screen, so precision clicking isn't required. The top
-    border row and the bottom hint row return None.
+    Any click inside the content band counts for the card region it lands in —
+    the cards are the whole screen, so precision clicking isn't required: a
+    gutter (and the frame padding either side) counts for the nearest card. The
+    top border row and the bottom hint row return None.
     """
     if row <= 2 or row >= height - 1:
         return None
-    return 0 if col < _category_columns(width) else 1
+    bounds = _category_bounds(width)
+    for i, (_start, end) in enumerate(bounds[:-1]):
+        if col <= end + _GUTTER_COLS:
+            return i
+    return len(bounds) - 1

--- a/src/yeaboi/ui/mode_select/screens/_screens_category.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_category.py
@@ -1,7 +1,7 @@
-"""The landing split — Humans vs Agents — shown between the splash and a menu.
+"""The landing split — Solo vs Team vs Agents — shown between the splash and a menu.
 
-Two rounded world-cards side by side, each carrying its FULL-BODY mascot (the
-duck for Humans, the robotic duck for Agents), a solid-accent block title, a
+Rounded world-cards side by side, each carrying its mascot (the OG duck for
+Solo, the duck trio for Team, the robotic duck for Agents), a solid-accent block title, a
 verb line, and an accent-middot capability list. The page's one question lives
 in the outer frame's border, not floating in space.
 
@@ -32,17 +32,17 @@ from rich.table import Table
 from rich.text import Text
 
 from yeaboi.ui.shared._ascii_font import render_ascii_text
-from yeaboi.ui.shared._components import AGENTS_THEME, HUMANS_THEME, build_page_panel
+from yeaboi.ui.shared._components import AGENTS_THEME, TEAM_THEME, build_page_panel
 from yeaboi.ui.shared._mascot import FRAMES, mini_cells, render_full
 
 _CATEGORY_CARDS: list[dict[str, Any]] = [
     {
-        "key": "humans",
-        "title": "Humans",
+        "key": "team",
+        "title": "Team",
         "verb": "Run your team's scrum",
         "capabilities": ["planning", "standups", "retros", "poker", "reviews"],
-        "color": HUMANS_THEME.accent,
-        "bright": HUMANS_THEME.accent_bright,
+        "color": TEAM_THEME.accent,
+        "bright": TEAM_THEME.accent_bright,
         "dim": "rgb(55,95,58)",  # the resting shade — no theme slot for it
         "tint": "rgb(17,28,20)",  # card-bg convention: a dark shade of the accent
         "mascot": "duck",
@@ -294,7 +294,7 @@ def _build_category_screen(
     shimmer_tick: float = 0.0,
     intro: float = 1.0,
 ) -> Panel:
-    """Build the full-screen Humans/Agents landing split."""
+    """Build the full-screen landing split."""
     inner_w = width - 6  # borders (2) + horizontal padding (4)
     half_w = max(20, (inner_w - _GUTTER_COLS) // 2)
     halves = [
@@ -353,7 +353,7 @@ def _build_category_screen(
 
 
 def category_at_pos(width: int, height: int, *, row: int, col: int) -> int | None:
-    """Map a 1-based terminal click to a category index (0=humans, 1=agents).
+    """Map a 1-based terminal click to a category index (0=team, 1=agents).
 
     Any click inside the content band counts for the half it lands in — the
     cards are the whole screen, so precision clicking isn't required. The top

--- a/src/yeaboi/ui/mode_select/screens/_screens_ceremonies.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_ceremonies.py
@@ -35,6 +35,7 @@ from yeaboi.ui.shared._components import (
     build_scrollbar,
     calc_viewport,
     ceremonies_title,
+    render_to_lines,
 )
 from yeaboi.ui.shared._scroll import publish_geometry
 
@@ -111,22 +112,6 @@ def _spend_cell(ceremony: Ceremony, spent: float, theme) -> Text:
     return _cell(f"${spent:.2f} / ${ceremony.monthly_cap_usd:.0f}", style)
 
 
-def _render_to_lines(renderable, render_w: int, left_pad: str) -> list:
-    """Flatten a renderable to one ``Text`` per rendered row.
-
-    A multi-row table breaks the "one body entry == one rendered row" assumption
-    the viewport math depends on, and an unflattened one renders at full height
-    regardless of the window — which pushes the action buttons off the bottom of
-    a fixed-height Panel. Same helper, same reason, as the usage page's grid.
-    """
-    from rich.console import Console as _Console
-
-    console = _Console(width=render_w, height=400)
-    with console.capture() as capture:
-        console.print(renderable)
-    return [Text.from_ansi(left_pad + line) for line in capture.get().splitlines()]
-
-
 def _build_rows(
     ceremonies: list[Ceremony],
     last_runs: dict[str, CeremonyRun | None],
@@ -169,7 +154,7 @@ def _build_rows(
             _spend_cell(ceremony, spend.get(ceremony.name, 0.0), theme),
         )
     indent = "  "
-    return [Text(""), *_render_to_lines(table, max(24, width - 4 - len(indent) - 2), indent)]
+    return [Text(""), *render_to_lines(table, max(24, width - 4 - len(indent) - 2), indent)]
 
 
 def _build_ceremonies_screen(

--- a/src/yeaboi/ui/mode_select/screens/_screens_projects.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_projects.py
@@ -1,0 +1,124 @@
+"""The Projects page — every project, and which one this session runs under.
+
+One list, one row per project: name, id, how many sessions it links, when it
+was last active. The active project is the row every scoped run reads its
+context through, so it wears the accent and a marker rather than hiding in a
+status line.
+
+# See docs: "Architecture" — TUI system; this page follows the shared blueprint
+"""
+
+from __future__ import annotations
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from yeaboi.ui.shared._components import (
+    PAD,
+    PROJECTS_THEME,
+    TITLE_ROWS,
+    build_action_buttons,
+    build_page_panel,
+    build_reveal_subtitle,
+    build_scrollbar,
+    calc_viewport,
+    projects_title,
+)
+from yeaboi.ui.shared._scroll import publish_geometry
+
+# Header = blank + title(TITLE_ROWS) + blank + subtitle.
+_HEADER_ROWS = 2 + TITLE_ROWS + 1
+# Actions = the spacer blank plus all three button rows (a fixed-height Panel
+# crops from the bottom, and buttons half off screen still answer Enter).
+_ACTION_ROWS = 4
+
+ACTIONS = ["Set active", "Archive", "Back"]
+
+
+def _cell(text: str, style: str) -> Text:
+    return Text(text, style=style, no_wrap=True, overflow="ellipsis")
+
+
+def _build_rows(projects: list[dict], selected: int, active_project_id: str, theme) -> list:
+    if not projects:
+        return [
+            Text(""),
+            Text(f"{PAD}No projects yet.", style=theme.muted),
+            Text(f"{PAD}Create one from the terminal: yeaboi project create <name>", style=theme.dim),
+        ]
+    table = Table(show_header=True, show_edge=False, box=None, padding=(0, 1), pad_edge=False, expand=True)
+    table.add_column(Text(f"{PAD}  project", style=theme.muted), ratio=3)
+    table.add_column(Text("id", style=theme.muted), ratio=2)
+    table.add_column(Text("sessions", style=theme.muted), ratio=1, justify="right")
+    table.add_column(Text("last active", style=theme.muted), ratio=2)
+    for i, project in enumerate(projects):
+        is_selected = i == selected
+        is_active = project["project_id"] == active_project_id
+        marker = "▸ " if is_selected else "  "
+        name_style = f"bold {theme.accent_bright}" if is_selected else (theme.accent if is_active else theme.value)
+        name = f"{PAD}{marker}{'● ' if is_active else ''}{project['name']}"
+        if project.get("archived"):
+            name += " (archived)"
+        table.add_row(
+            _cell(name, name_style),
+            _cell(project["project_id"], theme.id),
+            _cell(str(project.get("session_count", 0)), theme.muted),
+            _cell(project.get("last_active", "")[:10], theme.muted),
+        )
+    return [table]
+
+
+def _build_projects_screen(
+    projects: list[dict],
+    *,
+    selected: int = 0,
+    active_project_id: str = "",
+    scroll_offset: int = 0,
+    scroll_meta: dict | None = None,
+    width: int = 80,
+    height: int = 24,
+    action_sel: int = 0,
+    actions: list[str] | None = None,
+    shimmer_tick: float | None = None,
+    sub_reveal: float | None = None,
+    message: str = "",
+) -> Panel:
+    """Build the Projects page: the project list and the active marker."""
+    theme = PROJECTS_THEME
+    title = projects_title(shimmer_tick)
+    sub = build_reveal_subtitle("One project, every mode's context", sub_reveal, pad=PAD + "  ")
+
+    body: list = _build_rows(projects, selected, active_project_id, theme)
+    body.append(Text(""))
+    if active_project_id:
+        body.append(Text(f"{PAD}Scoped runs read context through the ● project.", style=theme.dim))
+    else:
+        body.append(Text(f"{PAD}No active project — runs stay team-wide until one is set.", style=theme.dim))
+    body.append(Text(f"{PAD}New projects come from the terminal: yeaboi project create <name>", style=theme.dim))
+    if message:
+        body.append(Text(""))
+        body.append(Text(f"{PAD}{message}", style=theme.accent))
+
+    viewport_h = calc_viewport(height, header_h=_HEADER_ROWS, action_h=_ACTION_ROWS)
+    total = len(body)
+    max_scroll = max(0, total - viewport_h)
+    offset = min(scroll_offset, max_scroll)
+    publish_geometry(scroll_meta, max_scroll, viewport_h)
+    visible = body[offset : offset + viewport_h]
+    padded = list(visible) + [Text("")] * max(0, viewport_h - len(visible))
+
+    scrollbar = build_scrollbar(viewport_h, total, offset, max_scroll)
+    if scrollbar is not None:
+        frame = Table(show_header=False, show_edge=False, box=None, padding=0, pad_edge=False, expand=True)
+        frame.add_column(ratio=1)
+        frame.add_column(width=1)
+        frame.add_row(Group(*padded), scrollbar)
+        viewport: object = frame
+    else:
+        viewport = Group(*padded)
+
+    btn_top, btn_mid, btn_bot = build_action_buttons(actions or list(ACTIONS), action_sel)
+    content = Group(Text(""), title, Text(""), sub, viewport, Text(""), btn_top, btn_mid, btn_bot)
+    return build_page_panel(content, theme=theme, height=height)

--- a/src/yeaboi/ui/mode_select/screens/_screens_projects.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_projects.py
@@ -25,6 +25,7 @@ from yeaboi.ui.shared._components import (
     build_scrollbar,
     calc_viewport,
     projects_title,
+    render_to_lines,
 )
 from yeaboi.ui.shared._scroll import publish_geometry
 
@@ -51,7 +52,7 @@ def _cell(text: str, style: str) -> Text:
     return Text(text, style=style, no_wrap=True, overflow="ellipsis")
 
 
-def _build_rows(projects: list[dict], selected: int, active_project_id: str, theme) -> list:
+def _build_rows(projects: list[dict], selected: int, active_project_id: str, theme, width: int) -> list:
     if not projects:
         return [
             Text(""),
@@ -77,7 +78,10 @@ def _build_rows(projects: list[dict], selected: int, active_project_id: str, the
             _cell(str(project.get("session_count", 0)), theme.muted),
             _cell(project.get("last_active", "")[:10], theme.muted),
         )
-    return [table]
+    # Flattened to one Text per rendered row: the table draws len(projects)+1
+    # lines but counts as a single body entry, which overshoots the viewport and
+    # crops the action buttons off the bottom.
+    return render_to_lines(table, max(24, width - 4))
 
 
 def _build_projects_screen(
@@ -100,7 +104,7 @@ def _build_projects_screen(
     title = projects_title(shimmer_tick)
     sub = build_reveal_subtitle("One project, every mode's context", sub_reveal, pad=PAD + "  ")
 
-    body: list = _build_rows(projects, selected, active_project_id, theme)
+    body: list = _build_rows(projects, selected, active_project_id, theme, width)
     body.append(Text(""))
     if active_project_id:
         body.append(Text(f"{PAD}Scoped runs read context through the ● project.", style=theme.dim))

--- a/src/yeaboi/ui/mode_select/screens/_screens_projects.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_projects.py
@@ -34,7 +34,17 @@ _HEADER_ROWS = 2 + TITLE_ROWS + 1
 # crops from the bottom, and buttons half off screen still answer Enter).
 _ACTION_ROWS = 4
 
-ACTIONS = ["Set active", "Archive", "Back"]
+ACTIONS = ["Set active", "Context", "Archive", "Back"]
+
+# The context sub-page: which cross-mode sources a run may read.
+CONTEXT_ACTIONS = ["All on", "Incognito", "Back"]
+CONTEXT_ROWS: tuple[tuple[str, str, str], ...] = (
+    ("retro", "Retro history", "action items, themes and carry-over"),
+    ("standup", "Standup history", "blockers, confidence trend and cadence"),
+    ("plan", "Latest sprint plan", "sprint framing and roster for standups and reports"),
+    ("performance", "Performance", "open 1:1 actions and review focus"),
+    ("analysis", "Analysis profile", "team calibration and AC style"),
+)
 
 
 def _cell(text: str, style: str) -> Text:
@@ -121,4 +131,57 @@ def _build_projects_screen(
 
     btn_top, btn_mid, btn_bot = build_action_buttons(actions or list(ACTIONS), action_sel)
     content = Group(Text(""), title, Text(""), sub, viewport, Text(""), btn_top, btn_mid, btn_bot)
+    return build_page_panel(content, theme=theme, height=height)
+
+
+def _build_context_screen(
+    deps: tuple[str, ...] | None,
+    *,
+    selected: int = 0,
+    action_sel: int = 0,
+    width: int = 80,
+    height: int = 24,
+    shimmer_tick: float | None = None,
+    sub_reveal: float | None = None,
+    message: str = "",
+) -> Panel:
+    """Build the context-toggles sub-page: one ●/○ row per source.
+
+    ``deps`` mirrors the engines' contract: ``None`` inherits (all sources
+    on, or the project default when one is set), ``()`` is incognito.
+    """
+    theme = PROJECTS_THEME
+    title = projects_title(shimmer_tick)
+    sub = build_reveal_subtitle("Which sources feed this session's runs", sub_reveal, pad=PAD + "  ")
+
+    body: list = [Text("")]
+    for i, (token, label, hint) in enumerate(CONTEXT_ROWS):
+        focused = i == selected
+        on = deps is None or token in deps
+        glyph = "●" if on else "○"
+        marker = "▸ " if focused else "  "
+        style = f"bold {theme.accent_bright}" if focused else (theme.value if on else theme.muted)
+        row = Text(f"{PAD}{marker}{glyph} {label}", style=style)
+        row.append(f"  ·  {hint}", style=theme.dim)
+        body.append(row)
+    body.append(Text(""))
+    if deps is None:
+        body.append(Text(f"{PAD}Inheriting — every source on (or the project's saved default).", style=theme.dim))
+    elif not deps:
+        body.append(Text(f"{PAD}Incognito — runs read no cross-mode context. Sessions still persist.", style=theme.dim))
+    else:
+        body.append(Text(f"{PAD}Only the ● sources feed runs started from the menu.", style=theme.dim))
+    body.append(Text(f"{PAD}Space toggles a source; changes last until yeaboi is closed.", style=theme.dim))
+    if message:
+        body.append(Text(""))
+        body.append(Text(f"{PAD}{message}", style=theme.accent))
+
+    viewport_h = calc_viewport(height, header_h=_HEADER_ROWS, action_h=_ACTION_ROWS)
+    total = len(body)
+    visible = body[:viewport_h]
+    padded = list(visible) + [Text("")] * max(0, viewport_h - len(visible))
+    publish_geometry(None, max(0, total - viewport_h), viewport_h)
+
+    btn_top, btn_mid, btn_bot = build_action_buttons(list(CONTEXT_ACTIONS), action_sel)
+    content = Group(Text(""), title, Text(""), sub, Group(*padded), Text(""), btn_top, btn_mid, btn_bot)
     return build_page_panel(content, theme=theme, height=height)

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -449,12 +449,17 @@ def _build_team_analysis_screen(
         examples=examples,
         analysis_features=analysis_features,
     )
+    from yeaboi.projects.active import is_solo_mode
+
+    # The results loop reads the same rule (its selection index and this
+    # rendered order share visible_card_order), so the two cannot drift.
     ctx.visible_order = visible_card_order(
         profile,
         present["code"],
         present["docs"],
         has_code_health=present["code_health"],
         analysis_features=analysis_features,
+        solo=is_solo_mode(),
     )
 
     if view == "overview":

--- a/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
+++ b/src/yeaboi/ui/mode_select/screens/_screens_secondary.py
@@ -4120,6 +4120,8 @@ def _build_all_tips_screen(
     theme = CHANGELOG_THEME
     title = tips_title(shimmer_tick, width=width)
     sub = build_reveal_subtitle("Everything yeaboi can do", sub_reveal, pad=_PAD + "  ")
+    # The Team menu carries every shared card key (Solo's keys are a subset),
+    # so it is the one list this gallery needs to resolve a tip's mode title.
     cards = {card["key"]: card for card in _MODE_CARDS}
     gold = f"rgb({_TIP_DOT_ON[0]},{_TIP_DOT_ON[1]},{_TIP_DOT_ON[2]})"
     beta_c = f"rgb({BETA_RGB[0]},{BETA_RGB[1]},{BETA_RGB[2]})"

--- a/src/yeaboi/ui/session/__init__.py
+++ b/src/yeaboi/ui/session/__init__.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 import logging
 import threading
 import time
@@ -180,6 +181,37 @@ def _intake_complete(graph_state: dict) -> bool:
     return isinstance(qs, QuestionnaireState) and qs.completed and graph_state.get("pending_review") != "project_intake"
 
 
+def _scope_state_keys() -> tuple[dict, frozenset[str] | None]:
+    """The scope keys a TUI planning run seeds, plus its effective deps.
+
+    The welcome screen's active project scopes this run's cross-mode reads, and
+    its context toggles (Projects → Context) gate them. ``resolve_scope`` applies
+    the precedence: the session's toggles win, else the project's saved
+    ``default_context_deps``. The deps are seeded into the ``context_deps`` state
+    key because ``agent/nodes._wants_dep`` reads only that — resolving them in
+    ``_state_scope`` alone would gate half the run and leave the other half on.
+    Best-effort: a failure here never blocks a session.
+    """
+    keys: dict = {}
+    try:
+        from yeaboi.projects.active import get_active_project, get_context_deps
+        from yeaboi.projects.scope import resolve_scope
+
+        project = get_active_project()
+        if project:
+            keys["project_id"] = project
+            logger.info("Planning session project: %s", project)
+        scope = resolve_scope(project, context_deps=get_context_deps())
+        deps = scope.context_deps if scope is not None else None
+        if deps is not None:
+            keys["context_deps"] = json.dumps(sorted(deps))
+            logger.info("Planning session context deps: %s", keys["context_deps"])
+        return keys, deps
+    except Exception:  # noqa: BLE001 — toggles are best-effort, never block a session
+        logger.debug("could not read the active project or context toggles", exc_info=True)
+        return keys, None
+
+
 def _run_session_body(
     live,
     console,
@@ -208,26 +240,9 @@ def _run_session_body(
     else:
         graph_state: dict = {"messages": []}
         graph_state["_intake_mode"] = intake_mode
+        _seed, _deps = _scope_state_keys()
+        graph_state.update(_seed)
         try:
-            from yeaboi.projects.active import get_active_project, get_context_deps
-
-            # The welcome screen's active project scopes this run's cross-mode
-            # reads, and its context toggles (Projects → Context) gate them —
-            # see agent/nodes._state_scope and _wants_dep.
-            if get_active_project():
-                graph_state["project_id"] = get_active_project()
-                logger.info("Planning session project: %s", graph_state["project_id"])
-            if get_context_deps() is not None:
-                import json as _json
-
-                graph_state["context_deps"] = _json.dumps(sorted(get_context_deps()))
-                logger.info("Planning session context deps: %s", graph_state["context_deps"])
-        except Exception:  # noqa: BLE001 — toggles are best-effort, never block a session
-            logger.debug("could not read the active project or context toggles", exc_info=True)
-        try:
-            from yeaboi.projects.active import get_context_deps as _get_deps
-
-            _deps = _get_deps()
             if analysis_profile_id and _deps is not None and "analysis" not in _deps:
                 # The toggle beats an explicit pick: analysis off means no
                 # profile seed and no DoD extraction for this run.

--- a/src/yeaboi/ui/session/__init__.py
+++ b/src/yeaboi/ui/session/__init__.py
@@ -220,6 +220,17 @@ def _run_session_body(
                 logger.info("Planning session context deps: %s", graph_state["context_deps"])
         except Exception:  # noqa: BLE001 — toggles are best-effort, never block a session
             logger.debug("could not read context toggles", exc_info=True)
+        try:
+            from yeaboi.projects.active import get_context_deps as _get_deps
+
+            _deps = _get_deps()
+            if analysis_profile_id and _deps is not None and "analysis" not in _deps:
+                # The toggle beats an explicit pick: analysis off means no
+                # profile seed and no DoD extraction for this run.
+                logger.info("analysis dep off — dropping picked analysis profile %s", analysis_profile_id)
+                analysis_profile_id = ""
+        except Exception:  # noqa: BLE001
+            logger.debug("could not apply the analysis toggle", exc_info=True)
         if analysis_profile_id:
             graph_state["analysis_profile_id"] = analysis_profile_id
             # Extract custom DoD items from the analysis profile

--- a/src/yeaboi/ui/session/__init__.py
+++ b/src/yeaboi/ui/session/__init__.py
@@ -209,17 +209,21 @@ def _run_session_body(
         graph_state: dict = {"messages": []}
         graph_state["_intake_mode"] = intake_mode
         try:
-            from yeaboi.projects.active import get_context_deps
+            from yeaboi.projects.active import get_active_project, get_context_deps
 
+            # The welcome screen's active project scopes this run's cross-mode
+            # reads, and its context toggles (Projects → Context) gate them —
+            # see agent/nodes._state_scope and _wants_dep.
+            if get_active_project():
+                graph_state["project_id"] = get_active_project()
+                logger.info("Planning session project: %s", graph_state["project_id"])
             if get_context_deps() is not None:
                 import json as _json
 
-                # The welcome screen's context toggles (Projects → Context)
-                # gate this run's cross-mode reads — see agent/nodes._wants_dep.
                 graph_state["context_deps"] = _json.dumps(sorted(get_context_deps()))
                 logger.info("Planning session context deps: %s", graph_state["context_deps"])
         except Exception:  # noqa: BLE001 — toggles are best-effort, never block a session
-            logger.debug("could not read context toggles", exc_info=True)
+            logger.debug("could not read the active project or context toggles", exc_info=True)
         try:
             from yeaboi.projects.active import get_context_deps as _get_deps
 

--- a/src/yeaboi/ui/session/__init__.py
+++ b/src/yeaboi/ui/session/__init__.py
@@ -208,6 +208,18 @@ def _run_session_body(
     else:
         graph_state: dict = {"messages": []}
         graph_state["_intake_mode"] = intake_mode
+        try:
+            from yeaboi.projects.active import get_context_deps
+
+            if get_context_deps() is not None:
+                import json as _json
+
+                # The welcome screen's context toggles (Projects → Context)
+                # gate this run's cross-mode reads — see agent/nodes._wants_dep.
+                graph_state["context_deps"] = _json.dumps(sorted(get_context_deps()))
+                logger.info("Planning session context deps: %s", graph_state["context_deps"])
+        except Exception:  # noqa: BLE001 — toggles are best-effort, never block a session
+            logger.debug("could not read context toggles", exc_info=True)
         if analysis_profile_id:
             graph_state["analysis_profile_id"] = analysis_profile_id
             # Extract custom DoD items from the analysis profile

--- a/src/yeaboi/ui/session/chat/_epic.py
+++ b/src/yeaboi/ui/session/chat/_epic.py
@@ -29,11 +29,20 @@ def load_epic_profile(graph_state: dict) -> tuple[str, dict | None]:
     """Resolve the analysis profile for the epic card banner and reformat.
 
     Returns (profile_id, examples). Explicit selection wins; otherwise
-    auto-detect from configured trackers (resumed sessions).
+    auto-detect from configured trackers (resumed sessions). With the run's
+    ``analysis`` toggle off, nothing loads — auto-detect included.
     """
-    profile_id = graph_state.get("analysis_profile_id", "")
     profile = None
     examples = None
+    try:
+        from yeaboi.agent.nodes import _wants_dep
+
+        if not _wants_dep(graph_state, "analysis"):
+            graph_state["_epic_profile"] = None
+            return "", None
+    except Exception:
+        logger.debug("Epic profile toggle check failed", exc_info=True)
+    profile_id = graph_state.get("analysis_profile_id", "")
     try:
         from yeaboi.agent.nodes import _load_profile_by_id, _load_team_examples, _load_team_profile
 

--- a/src/yeaboi/ui/session/phases/_phases.py
+++ b/src/yeaboi/ui/session/phases/_phases.py
@@ -840,11 +840,20 @@ def _phase_pipeline(
                 _ep_examples = None
                 _ep_profile = None
 
-                # Try to load profile — from explicit selection or auto-detect
+                # Try to load profile — from explicit selection or auto-detect.
+                # The analysis toggle gates both paths: auto-detect would find a
+                # profile even with no id, so an off dep must skip the load.
                 try:
-                    from yeaboi.agent.nodes import _load_profile_by_id, _load_team_examples, _load_team_profile
+                    from yeaboi.agent.nodes import (
+                        _load_profile_by_id,
+                        _load_team_examples,
+                        _load_team_profile,
+                        _wants_dep,
+                    )
 
-                    if _ep_profile_id:
+                    if not _wants_dep(graph_state, "analysis"):
+                        _ep_profile_id = ""
+                    elif _ep_profile_id:
                         _ep_profile, _ep_examples = _load_profile_by_id(_ep_profile_id)
                     else:
                         # Auto-detect from configured trackers (for resumed sessions)

--- a/src/yeaboi/ui/shared/_animations.py
+++ b/src/yeaboi/ui/shared/_animations.py
@@ -42,6 +42,7 @@ COLOR_RGB: dict[str, tuple[int, int, int]] = {
     "rgb(240,180,70)": (240, 180, 70),  # Agent Advisor accent (amber)
     "rgb(235,140,60)": (235, 140, 60),  # Ship accent (cargo orange)
     "rgb(120,150,175)": (120, 150, 175),  # Ceremonies accent (slate)
+    "rgb(150,170,90)": (150, 170, 90),  # Projects accent (olive)
     "rgb(229,166,48)": (229, 166, 48),  # Niko accent (duck gold — the desktop's own --primary)
 }
 

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -818,6 +818,23 @@ def calc_viewport(height: int, *, header_h: int = 7, action_h: int = 4) -> int:
     return max(3, inner_h - header_h - action_h)
 
 
+def render_to_lines(renderable, render_w: int, left_pad: str = "") -> list:
+    """Flatten a renderable to one ``Text`` per rendered row.
+
+    A multi-row renderable (a Table, a grid of boxes) breaks the "one body entry
+    == one rendered row" assumption :func:`calc_viewport` and the scroll math
+    depend on: it counts as a single entry while drawing many, so the page
+    overshoots its viewport and ``build_page_panel``'s fixed height crops the
+    action buttons off the bottom. Pass any such block through this first.
+    """
+    from rich.console import Console as _Console
+
+    console = _Console(width=render_w, height=400)
+    with console.capture() as capture:
+        console.print(renderable)
+    return [Text.from_ansi(left_pad + line) for line in capture.get().splitlines()]
+
+
 # Minimum terminal size for the TUI to function
 MIN_TERMINAL_HEIGHT = 10
 MIN_TERMINAL_WIDTH = 40

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -74,6 +74,7 @@ USAGE_THEME = Theme(accent="rgb(220,160,60)", accent_bright="rgb(255,200,80)")
 # Slate, deliberately the quietest accent on the menu: this page schedules the
 # other modes rather than being one, and a loud hue would compete with them.
 CEREMONIES_THEME = Theme(accent="rgb(120,150,175)", accent_bright="rgb(160,195,225)")
+PROJECTS_THEME = Theme(accent="rgb(150,170,90)", accent_bright="rgb(190,215,120)")
 SETTINGS_THEME = Theme(accent="rgb(160,160,180)", accent_bright="rgb(200,200,220)")
 STANDUP_THEME = Theme(accent="rgb(200,100,180)", accent_bright="rgb(255,150,220)")
 RETRO_THEME = Theme(accent="rgb(80,190,190)", accent_bright="rgb(120,230,230)")
@@ -146,6 +147,10 @@ _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
     "Jira": ("rgb(70,100,180)", "rgb(100,140,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
     "Azure DevOps": ("rgb(70,100,180)", "rgb(100,140,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
     "Configure": ("rgb(160,160,180)", "rgb(200,200,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
+    # Projects page. "Set active" is the affirmative action (green like Accept);
+    # Archive is amber (reversible, but it hides the row).
+    "Set active": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),
+    "Archive": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
     # Ceremonies page. "Run now" is the affirmative action (green like Accept);
     # Pause/Resume are neutral, because neither is the destructive one.
     "Run now": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),
@@ -371,6 +376,11 @@ def usage_title(shimmer_tick: float | None = None, *, width: int | None = None) 
 def ceremonies_title(shimmer_tick: float | None = None, *, width: int | None = None) -> Text:
     """Return the Ceremonies ASCII title (slate accent). Optionally shimmering."""
     return build_ascii_title("Ceremonies", "rgb(120,150,175)", shimmer_tick=shimmer_tick, width=width)
+
+
+def projects_title(shimmer_tick: float | None = None, *, width: int | None = None) -> Text:
+    """Return the Projects ASCII title (olive accent). Optionally shimmering."""
+    return build_ascii_title("Projects", "rgb(150,170,90)", shimmer_tick=shimmer_tick, width=width)
 
 
 def settings_title(shimmer_tick: float | None = None, *, width: int | None = None) -> Text:

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -92,16 +92,19 @@ FEEDBACK_THEME = Theme(accent="rgb(160,160,180)", accent_bright="rgb(200,200,220
 # App chrome like the changelog: neutral silver, no mode owns these pages.
 PRIVACY_THEME = Theme(accent="rgb(160,160,180)", accent_bright="rgb(200,200,220)")
 SYSTEM_CHECK_THEME = Theme(accent="rgb(160,160,180)", accent_bright="rgb(200,200,220)")
-# The two sides of the landing split. HUMANS_THEME is the Theme default palette
-# named, so the existing modes are unchanged; AGENTS_THEME opens the family's
-# "machine" palette, distinct per mode like the human modes: steel blue for the
-# category card, cyan/mint/rose per mode below it. The landing split reads its
-# card accents from these two — a card that hardcoded the same rgb() triples
-# would drift the moment either palette moved.
+# The three worlds of the landing split. TEAM_THEME is the Theme default
+# palette named, so the existing modes are unchanged; SOLO_THEME is a warm
+# amber for the one-duck world (distinct from Niko's duck gold and Usage's
+# ochre); AGENTS_THEME opens the family's "machine" palette, distinct per mode
+# like the team modes: steel blue for the category card, cyan/mint/rose per
+# mode below it. The landing split reads its card accents from these three — a
+# card that hardcoded the same rgb() triples would drift the moment a palette
+# moved.
 # The pre-mode credential gate. Alert rose, shared with Agent Security by
 # coincidence of meaning ("something is wrong here"), not by ownership.
 LLM_GATE_THEME = Theme(accent="rgb(230,90,120)", accent_bright="rgb(255,130,160)")
-HUMANS_THEME = Theme()
+SOLO_THEME = Theme(accent="rgb(210,168,80)", accent_bright="rgb(245,200,110)")
+TEAM_THEME = Theme()
 AGENTS_THEME = Theme(accent="rgb(90,160,210)", accent_bright="rgb(130,200,255)")
 AGENT_USAGE_THEME = Theme(accent="rgb(70,190,230)", accent_bright="rgb(110,225,255)")
 AGENT_STANDUP_THEME = Theme(accent="rgb(120,210,170)", accent_bright="rgb(160,245,205)")

--- a/src/yeaboi/ui/shared/_components.py
+++ b/src/yeaboi/ui/shared/_components.py
@@ -151,6 +151,11 @@ _BTN_COLORS: dict[str, tuple[str, str, str, str]] = {
     # Archive is amber (reversible, but it hides the row).
     "Set active": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),
     "Archive": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
+    # Context sub-page: All on restores every source (green); Incognito switches
+    # them all off, deliberate but reversible, so it wears the amber.
+    "Context": ("rgb(160,160,180)", "rgb(200,200,220)", "rgb(40,40,50)", "rgb(50,50,60)"),
+    "All on": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),
+    "Incognito": ("rgb(180,140,60)", "rgb(220,180,90)", "rgb(50,46,36)", "rgb(60,56,46)"),
     # Ceremonies page. "Run now" is the affirmative action (green like Accept);
     # Pause/Resume are neutral, because neither is the destructive one.
     "Run now": ("rgb(60,160,80)", "rgb(80,200,100)", "rgb(40,50,40)", "rgb(50,60,50)"),

--- a/src/yeaboi/ui/shared/_mascot.py
+++ b/src/yeaboi/ui/shared/_mascot.py
@@ -312,6 +312,47 @@ def mini_cells(frame: int = 0, *, flip: bool = False, mascot: str = "duck") -> l
     return _pack_cells(grid)
 
 
+def _at_x(grid: tuple[str, ...], x: int, total: int) -> tuple[str, ...]:
+    """Pad a pixel grid to ``total`` columns with the sprite starting at ``x``."""
+    return tuple("." * x + row + "." * (total - x - len(row)) for row in grid)
+
+
+def flock_cells(
+    frame: int = 0, *, count: int = 3, stride: int = 6, mascot: str = "duck"
+) -> list[list[tuple[str, str | None]]]:
+    """A row of ``count`` mini mascots as one cell grid — the Team card's trio.
+
+    Each neighbour stands ``stride`` pixels along, wings offset a few frames so
+    the group isn't flapping in lock-step, and the middle one is painted last so
+    it stands in front where the sprites overlap. At the defaults the trio is
+    22 + 2×6 = 34 pixels wide — the same footprint as the full-body sprite.
+    """
+    base, wing, glasses = _MINI_GRIDS.get(mascot, _MINI_GRIDS["duck"])
+    total = len(base[0]) + stride * (count - 1)
+    order = [i for i in range(count) if i != count // 2] + [count // 2]
+    layers = []
+    for i in order:
+        f = (frame + i * 3) % FRAMES
+        grid = _compose(base, _shift(wing, MINI_WING_OFF[f]), glasses)
+        layers.append(_at_x(grid, i * stride, total))
+    return _pack_cells(_compose(*layers))
+
+
+def flock_head_cells(
+    frame: int = 0, *, count: int = 3, stride: int = 3, mascot: str = "duck"
+) -> list[list[tuple[str, str | None]]]:
+    """The trio as overlapped heads — the Team card's crowd when a full-width
+    flock doesn't fit. At the defaults it is 16 + 2×3 = 22 pixels wide, the same
+    footprint as the mini sprite. The front head quacks on the ``frame`` clock so
+    the crowd reads as alive rather than a decal."""
+    head, quack = _HEADS.get(mascot, _HEADS["duck"])[:2]
+    total = len(head[0]) + stride * (count - 1)
+    order = [i for i in range(count) if i != count // 2] + [count // 2]
+    front = count // 2
+    layers = [_at_x(quack if i == front and frame % 4 < 2 else head, i * stride, total) for i in order]
+    return _pack_cells(_compose(*layers))
+
+
 def render_full(frame: int, *, mascot: str = "duck") -> Group:
     """Full-body idle duck: wing-flap + glasses-bob for the given frame."""
     f = frame % FRAMES

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -223,7 +223,7 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
         is_new=True,
     ),
     # The Agents family — cards live on the Agents menu (_AGENT_CARDS); the `g`
-    # jump switches category when the tip fires from the Humans menu.
+    # jump switches category when the tip fires from another menu.
     FeatureTip(
         "agent-usage",
         "\U0001f916 Tip: Agents → Usage shows what your AI agents cost — per model, project and day",

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -178,7 +178,7 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
     # No desktop route (CAPABILITIES marks it exempt there), so no desktop tip.
     FeatureTip(
         "team-learning",
-        "\U0001f9e0 Tip: yeaboi learns your team's velocity & estimation patterns over time",
+        "\U0001f9e0 Tip: yeaboi learns your velocity & estimation patterns over time",
         surfaces=("tui",),
     ),
     FeatureTip(

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -72,6 +72,12 @@ class FeatureTip:
 # ``mode_key`` (when set) MUST be a _MODE_CARDS key so the jump-into-feature key
 # lands on the right card.
 _FEATURE_TIPS: tuple[FeatureTip, ...] = (
+    # No mode_key: projects open from the welcome screen's `P` keycap, not a card.
+    FeatureTip(
+        "projects",
+        "\U0001f5c2️ Tip: Press P to pick a project — scoped runs feed each other's context",
+        is_new=True,
+    ),
     FeatureTip(
         "team-analysis",
         "\U0001f50d Tip: Analysis reads your board for velocity, estimation & delivery signals",

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -168,15 +168,12 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
     ),
     # Capabilities without a dedicated home-screen card (tui_mode Exempt) — they
     # still rotate to aid discovery, just with no jump target.
+    # TUI-only: on the desktop, saved plans surface through each project's plan
+    # panel (CAPABILITIES marks sessions exempt there), so no desktop tip.
     FeatureTip(
         "sessions",
         "\U0001f5c2️ Tip: every plan is saved — resume any past session with --resume",
         surfaces=("tui",),
-    ),
-    FeatureTip(
-        "sessions",
-        "\U0001f5c2️ Tip: every plan is saved — reopen any past run from Saved plans",
-        surfaces=("desktop",),
     ),
     # No desktop route (CAPABILITIES marks it exempt there), so no desktop tip.
     FeatureTip(

--- a/tests/test_mode_select.py
+++ b/tests/test_mode_select.py
@@ -453,6 +453,18 @@ class TestModeAtRow:
                 hit_order.append(idx)
         assert hit_order == list(range(len(_MODE_CARDS)))
 
+    def test_rows_are_contiguous_and_ordered_on_the_solo_menu(self):
+        # The seven-card Solo menu drives the same builder/hit-test pair.
+        from yeaboi.ui.mode_select.screens._screens import _SOLO_CARDS
+
+        w, h = 120, 40
+        hit_order = []
+        for row in range(1, h + 1):
+            idx = mode_at_row(3, width=w, height=h, row=row, col=10, cards=_SOLO_CARDS)
+            if idx is not None and (not hit_order or hit_order[-1] != idx):
+                hit_order.append(idx)
+        assert hit_order == list(range(len(_SOLO_CARDS)))
+
     def test_selected_mode_spans_more_rows_than_unselected(self):
         # The selected card also shows its description, so it owns extra rows.
         w, h = 120, 40

--- a/tests/unit/nodes/test_analyzer.py
+++ b/tests/unit/nodes/test_analyzer.py
@@ -1286,6 +1286,20 @@ class TestWantsDep:
 
         assert not _wants_dep({"context_deps": "[]"}, "retro")
 
+    def test_effective_profile_id_survives_when_analysis_is_on(self):
+        from yeaboi.agent.nodes import _effective_analysis_profile_id
+
+        assert _effective_analysis_profile_id({"analysis_profile_id": "jira-X"}) == "jira-X"
+        assert _effective_analysis_profile_id({"analysis_profile_id": "jira-X", "context_deps": ""}) == "jira-X"
+
+    def test_effective_profile_id_is_dropped_when_analysis_is_off(self):
+        # The toggle beats an explicit pick — incognito means incognito.
+        from yeaboi.agent.nodes import _effective_analysis_profile_id
+
+        assert _effective_analysis_profile_id({"analysis_profile_id": "jira-X", "context_deps": '["retro"]'}) == ""
+        assert _effective_analysis_profile_id({"analysis_profile_id": "jira-X", "context_deps": "[]"}) == ""
+        assert _effective_analysis_profile_id({"context_deps": "[]"}) == ""
+
 
 class TestAnalysisDepGatesCalibration:
     def _analyze(self, monkeypatch, state_extras):

--- a/tests/unit/nodes/test_analyzer.py
+++ b/tests/unit/nodes/test_analyzer.py
@@ -1265,3 +1265,73 @@ class TestComputePromptQuality:
         rating = compute_prompt_quality(qs)
         suggestion_text = " ".join(rating.suggestions)
         assert "Q14" in suggestion_text or "Q17" in suggestion_text
+
+
+class TestWantsDep:
+    def test_absent_key_allows_everything(self):
+        from yeaboi.agent.nodes import _wants_dep
+
+        assert _wants_dep({}, "analysis")
+        assert _wants_dep({"context_deps": ""}, "retro")
+
+    def test_json_list_gates_by_membership(self):
+        from yeaboi.agent.nodes import _wants_dep
+
+        state = {"context_deps": '["retro", "plan"]'}
+        assert _wants_dep(state, "retro")
+        assert not _wants_dep(state, "analysis")
+
+    def test_empty_list_is_incognito(self):
+        from yeaboi.agent.nodes import _wants_dep
+
+        assert not _wants_dep({"context_deps": "[]"}, "retro")
+
+
+class TestAnalysisDepGatesCalibration:
+    def _analyze(self, monkeypatch, state_extras):
+        from yeaboi.agent import nodes
+
+        fake_response = MagicMock()
+        fake_response.content = VALID_ANALYSIS_JSON
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = fake_response
+        monkeypatch.setattr("yeaboi.agent.nodes.get_llm", lambda **kw: mock_llm)
+        loads: list = []
+        monkeypatch.setattr(nodes, "_load_team_profile", lambda pid="": loads.append(("profile", pid)) or None)
+        monkeypatch.setattr(
+            nodes, "_load_team_examples", lambda pid="", db_path=None: loads.append(("examples", pid)) or None
+        )
+        qs = make_completed_questionnaire()
+        state = {
+            "messages": [HumanMessage(content="continue")],
+            "questionnaire": qs,
+            "team_size": 3,
+            "velocity_per_sprint": 15,
+            **state_extras,
+        }
+        project_analyzer(state)
+        return loads
+
+    def test_analysis_off_never_loads_a_profile(self, monkeypatch):
+        # The auto-detect fallback means the gate must sit at the call site:
+        # even a blank profile id would otherwise load a detected profile.
+        loads = self._analyze(monkeypatch, {"context_deps": "[]", "analysis_profile_id": "team-x"})
+        assert loads == []
+
+    def test_analysis_on_loads_as_before(self, monkeypatch):
+        loads = self._analyze(monkeypatch, {"analysis_profile_id": "team-x"})
+        assert ("profile", "team-x") in loads
+
+    def test_gather_performance_summary_honours_the_scope(self, monkeypatch, tmp_path):
+        from yeaboi.agent.nodes import _gather_performance_summary
+        from yeaboi.performance.store import PerformanceStore
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        from yeaboi.agent.state import OneOnOneRecord
+
+        with PerformanceStore(db) as store:
+            store.record_completion(OneOnOneRecord(engineer="Ada", date="2026-07-12", action_items=("write tests",)))
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        assert _gather_performance_summary() != ""
+        assert _gather_performance_summary(ProjectScope("", None, frozenset())) == ""

--- a/tests/unit/nodes/test_ceremony_history.py
+++ b/tests/unit/nodes/test_ceremony_history.py
@@ -263,3 +263,43 @@ class TestGather:
             _seed_standup(s, "s0", "2026-06-02T00:00:00+00:00", 0, status="error")
             reports = s.get_recent_reports(limit=10)
         assert len(reports) == 1
+
+
+class TestScopedGather:
+    """A ProjectScope hard-filters both store reads to the project's sessions."""
+
+    def _seed_two_projects(self, db):
+        with RetroStore(db) as r:
+            _seed_retro(r, "proj-sess", "2026-06-01T00:00:00+00:00", "Alpha", [_ac("Alpha item")])
+            _seed_retro(r, "other-sess", "2026-07-01T00:00:00+00:00", "Beta", [_ac("Beta item")])
+        with StandupStore(db) as s:
+            _seed_standup(s, "proj-sess", "2026-06-02T00:00:00+00:00", 70)
+            _seed_standup(s, "other-sess", "2026-07-02T00:00:00+00:00", 80)
+
+    def test_scope_filters_both_reads(self, tmp_path, monkeypatch):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        self._seed_two_projects(db)
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        ctx = gather_ceremony_context(scope=ProjectScope("proj-11112222", ("proj-sess",)))
+        assert ctx.retro_count == 1
+        assert ctx.standup_count == 1
+        assert ctx.action_items == ("Alpha item",)
+
+    def test_no_scope_is_the_legacy_teamwide_read(self, tmp_path, monkeypatch):
+        db = tmp_path / "sessions.db"
+        self._seed_two_projects(db)
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        ctx = gather_ceremony_context()
+        assert ctx.retro_count == 2
+        assert ctx.standup_count == 2
+
+    def test_empty_scope_reads_nothing(self, tmp_path, monkeypatch):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        self._seed_two_projects(db)
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        ctx = gather_ceremony_context(scope=ProjectScope("proj-11112222", ()))
+        assert ctx.retro_count == 0 and ctx.standup_count == 0

--- a/tests/unit/nodes/test_ceremony_history.py
+++ b/tests/unit/nodes/test_ceremony_history.py
@@ -303,3 +303,73 @@ class TestScopedGather:
         monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
         ctx = gather_ceremony_context(scope=ProjectScope("proj-11112222", ()))
         assert ctx.retro_count == 0 and ctx.standup_count == 0
+
+
+class TestContextDepGates:
+    """The retro/standup toggles gate each producer's reads; None-deps is byte-identical."""
+
+    def _seed(self, db):
+        with RetroStore(db) as r:
+            _seed_retro(r, "proj-sess", "2026-06-01T00:00:00+00:00", "Alpha", [_ac("Alpha item")])
+        with StandupStore(db) as s:
+            _seed_standup(s, "proj-sess", "2026-06-02T00:00:00+00:00", 70)
+
+    def test_retro_off_skips_every_retro_read(self, tmp_path, monkeypatch):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        self._seed(db)
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        ctx = gather_ceremony_context(scope=ProjectScope("proj-11112222", ("proj-sess",), frozenset({"standup"})))
+        assert ctx.retro_count == 0
+        assert ctx.action_items == ()
+        assert ctx.retro_cadence == "no retros recorded"
+        assert ctx.standup_count == 1
+
+    def test_standup_off_skips_every_standup_read(self, tmp_path, monkeypatch):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        self._seed(db)
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        ctx = gather_ceremony_context(scope=ProjectScope("proj-11112222", ("proj-sess",), frozenset({"retro"})))
+        assert ctx.standup_count == 0
+        assert ctx.confidence_trend == ""
+        assert ctx.standup_cadence == "no standups recorded"
+        assert ctx.retro_count == 1
+
+    def test_incognito_reads_nothing_at_all(self, tmp_path, monkeypatch):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        self._seed(db)
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        ctx = gather_ceremony_context(scope=ProjectScope("", None, frozenset()))
+        assert ctx.retro_count == 0 and ctx.standup_count == 0
+        assert ctx.summary_md == gather_ceremony_context(scope=ProjectScope("x", (), frozenset())).summary_md
+
+    def test_none_deps_scope_equals_no_scope(self, tmp_path, monkeypatch):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        self._seed(db)
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        unscoped = gather_ceremony_context()
+        carrier = gather_ceremony_context(scope=ProjectScope("", None, None))
+        assert asdict(unscoped) == asdict(carrier)
+
+    def test_scoped_cadence_and_trend_ignore_foreign_sessions(self, tmp_path, monkeypatch):
+        # The pre-existing leak: get_all_history is team-wide, so a scoped run's
+        # cadence/trend must post-filter to the project's own sessions.
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        with StandupStore(db) as s:
+            _seed_standup(s, "proj-sess", "2026-06-01T00:00:00+00:00", 40)
+            _seed_standup(s, "proj-sess", "2026-06-02T00:00:00+00:00", 80)
+            _seed_standup(s, "other-sess", "2026-06-03T00:00:00+00:00", 5)
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        scoped = gather_ceremony_context(scope=ProjectScope("proj-11112222", ("proj-sess",)))
+        # The foreign 5%-confidence run must not drag the trend: the scoped
+        # trend ends on the project's own 80% run (rising), not the outlier.
+        assert "5%" not in scoped.confidence_trend

--- a/tests/unit/nodes/test_intake.py
+++ b/tests/unit/nodes/test_intake.py
@@ -3907,3 +3907,45 @@ class TestGapModeSkipDefaults:
         qs.answers = {2: "a", 3: "b", 4: "c"}
         qs.skipped_questions.add(6)
         assert 6 not in _find_essential_gaps(qs, SMART_ESSENTIALS)
+
+
+class TestAnalysisToggleInIntake:
+    """The analysis context toggle beats a seeded profile id: with analysis off,
+    intake never reads the profile and the prior-art stash stays disabled."""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic(self, monkeypatch):
+        monkeypatch.setattr("yeaboi.agent.nodes._check_vague_answer", lambda q, a, n=0: None)
+        monkeypatch.setattr("yeaboi.agent.nodes._load_user_context", lambda *a, **kw: (None, {}))
+        monkeypatch.setattr("yeaboi.agent.nodes._extract_answers_from_description", lambda desc: {})
+
+    def _run(self, monkeypatch, extra_state):
+        from yeaboi.agent import nodes
+
+        loads: list = []
+        monkeypatch.setattr(nodes, "_load_profile_by_id", lambda pid: loads.append(pid) or (None, None))
+        state = {
+            "messages": [HumanMessage(content="Building a todo app for task management")],
+            "_intake_mode": "smart",
+            "analysis_profile_id": "jira-DEMO-1",
+            **extra_state,
+        }
+        result = project_intake(state)
+        return result["questionnaire"], loads
+
+    def test_analysis_off_drops_the_profile_and_never_loads_it(self, monkeypatch):
+        qs, loads = self._run(monkeypatch, {"context_deps": '["retro"]'})
+        assert loads == []
+        assert qs._analysis_profile_id == ""
+        assert qs._analysis_enabled is False
+
+    def test_incognito_behaves_the_same(self, monkeypatch):
+        qs, loads = self._run(monkeypatch, {"context_deps": "[]"})
+        assert loads == []
+        assert qs._analysis_profile_id == "" and qs._analysis_enabled is False
+
+    def test_without_toggles_the_profile_still_seeds_intake(self, monkeypatch):
+        qs, loads = self._run(monkeypatch, {})
+        assert loads == ["jira-DEMO-1"]  # the Q6/Q8/Q9 auto-fill read
+        assert qs._analysis_profile_id == "jira-DEMO-1"
+        assert qs._analysis_enabled is True

--- a/tests/unit/nodes/test_prior_art_subloop.py
+++ b/tests/unit/nodes/test_prior_art_subloop.py
@@ -471,3 +471,31 @@ class TestEmptyCardChoices:
         labels = [label for label, _ in view.choices]
         assert labels == [PRIOR_ART_CONTINUE]
         assert CONFIRM_ACCEPT not in labels
+
+
+class TestAnalysisToggleGate:
+    def test_analysis_off_settles_the_stage_without_a_scan(self, monkeypatch):
+        # A blank profile id still auto-detects inside the scan, so the toggle
+        # must stop the step before shortlist() runs at all.
+        def _boom(*a, **k):
+            raise AssertionError("the prior-art scan must not run with analysis off")
+
+        monkeypatch.setattr(prior_art, "shortlist", _boom)
+        qs = _qs()
+        qs._analysis_enabled = False
+        result = _show_summary_or_pto(qs)
+        assert result["pending_review"] == "project_intake"
+        assert qs._prior_art_stage == "done"
+
+    def test_analysis_on_still_offers_prior_art(self, monkeypatch):
+        called = {}
+
+        def _fake(*a, **k):
+            called["yes"] = True
+            return prior_art.Shortlist(empty_reason=prior_art.EMPTY_NO_PROFILE)
+
+        monkeypatch.setattr(prior_art, "shortlist", _fake)
+        qs = _qs()
+        assert qs._analysis_enabled is True
+        _show_summary_or_pto(qs)
+        assert called.get("yes")

--- a/tests/unit/test_agentwatch_store.py
+++ b/tests/unit/test_agentwatch_store.py
@@ -169,7 +169,7 @@ class TestMigration:
     def test_fresh_session_store_creates_agentwatch_tables(self, tmp_path):
         from yeaboi.sessions import CURRENT_SCHEMA_VERSION, SessionStore
 
-        assert CURRENT_SCHEMA_VERSION == 30
+        assert CURRENT_SCHEMA_VERSION == 31
         db = tmp_path / "sessions.db"
         with SessionStore(db) as s:
             assert s.schema_mismatch is False

--- a/tests/unit/test_analysis_dashboard.py
+++ b/tests/unit/test_analysis_dashboard.py
@@ -46,6 +46,17 @@ class TestVisibleCardOrder:
         # A blank results page would be worse than a card explaining itself.
         assert dashboard.visible_card_order(None, False, False) == ("ai-adoption",)
 
+    def test_a_solo_run_drops_the_team_members_card_and_nothing_else(self):
+        order = dashboard.visible_card_order(PROFILE, True, True, has_code_health=True, solo=True)
+        team_order = dashboard.visible_card_order(PROFILE, True, True, has_code_health=True)
+        assert "team" not in order
+        assert tuple(k for k in team_order if k != "team") == order
+
+    def test_solo_reaches_the_desktop_card_list(self):
+        keys = {card["key"] for card in dashboard.cards(PROFILE, solo=True)}
+        assert "team" not in keys
+        assert "velocity" in keys
+
 
 class TestComponentPresence:
     def test_a_fresh_run_reads_the_top_level_signals(self):

--- a/tests/unit/test_analysis_sessions.py
+++ b/tests/unit/test_analysis_sessions.py
@@ -63,7 +63,9 @@ class TestSchemaVersion:
         # an owner's expansion.
         # v30 adds planning_prior_art_feedback, the global ledger of which
         # existing repos the user ruled out as prior art.
-        assert CURRENT_SCHEMA_VERSION == 30
+        # v31 adds the projects table and sessions_meta.project_id, the
+        # identity that links sessions across modes.
+        assert CURRENT_SCHEMA_VERSION == 31
 
     def test_new_db_has_session_mode_column(self, store: SessionStore):
         """A freshly created DB should have the session_mode column."""

--- a/tests/unit/test_analysis_setup.py
+++ b/tests/unit/test_analysis_setup.py
@@ -69,6 +69,13 @@ class TestStepApplies:
     def test_an_unknown_step_never_applies(self):
         assert not setup.step_applies("astrology", features=["delivery"])
 
+    def test_a_solo_run_never_asks_for_members(self):
+        # The Solo world has no roster to narrow; every other step is untouched.
+        assert not setup.step_applies("members", features=["delivery"], solo=True)
+        assert not setup.step_applies("members", features=["ai_footprint"], solo=True)
+        assert setup.step_applies("features", features=["delivery"], solo=True)
+        assert setup.step_applies("window", features=["documentation"], solo=True)
+
 
 class TestRunConfig:
     def _state(self, **kw):
@@ -104,6 +111,12 @@ class TestRunConfig:
         config = setup.run_config(state, roster_fallback=["jira"])
         assert config["depth"] == "quick"
         assert config["members"] is None and config["members_map"] is None
+
+    def test_a_solo_run_coerces_a_stale_member_pick_out(self):
+        # A pick made before flipping to Solo must not narrow the run.
+        config = setup.run_config(self._state(), roster_fallback=["jira"], model_offered=True, solo=True)
+        assert config["members"] is None and config["members_map"] is None
+        assert config["depth"] == "deep"  # everything else is untouched
 
     def test_the_window_falls_back_when_nothing_scans(self):
         state = self._state(features=["delivery"], components={"delivery": ["jira"]})

--- a/tests/unit/test_app_dashboard_routes.py
+++ b/tests/unit/test_app_dashboard_routes.py
@@ -273,6 +273,18 @@ class TestAnalysisSteps:
         assert plan["run"]["depth"] == "deep"
         assert plan["run"]["members_map"] == {"jira": ["Ana"]}
 
+    def test_a_solo_wizard_never_asks_for_members(self, app):
+        plan = self._plan(
+            app,
+            features=["delivery"],
+            components={"delivery": ["jira"]},
+            members=["Ana"],
+            solo=True,
+        )
+        assert "members" not in plan["steps"]
+        # And a stale pick coerces out of the payload the answers would run.
+        assert plan["run"]["members"] is None and plan["run"]["members_map"] is None
+
 
 class TestAnalysisResult:
     def test_an_unknown_analysis_is_a_404(self, app, monkeypatch, tmp_path):

--- a/tests/unit/test_app_niko_routes.py
+++ b/tests/unit/test_app_niko_routes.py
@@ -162,9 +162,9 @@ class TestTheTurn:
         assert result == {"type": "tool_result", "tool_name": "ship_status", "ok": False, "error": "no runs yet"}
 
     def test_navigate_reaches_the_wire(self, app, scripted):
-        scripted([engine.Navigate("/humans/retro"), engine.Assistant("There.")])
+        scripted([engine.Navigate("/team/retro"), engine.Assistant("There.")])
         lines = turn(app, open_conversation(app))
-        assert {"type": "navigate", "route": "/humans/retro"} in lines
+        assert {"type": "navigate", "route": "/team/retro"} in lines
 
     def test_the_engines_own_done_is_not_a_second_terminator(self, app, scripted):
         scripted([engine.Assistant("ok"), engine.Done("c1")])

--- a/tests/unit/test_app_server.py
+++ b/tests/unit/test_app_server.py
@@ -40,10 +40,11 @@ class TestMetaRoutes:
         assert set(payload) == {"version", "schema_version", "python", "platform"}
 
     def test_capabilities_serves_the_card_inventory(self, app):
-        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _MODE_CARDS
+        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _MODE_CARDS, _SOLO_CARDS
 
         payload = json.loads(request(app, "GET", "/api/meta/capabilities").body)
-        assert set(payload) == {"categories", "modes", "agents", "intake"}
+        assert set(payload) == {"categories", "solo", "modes", "agents", "intake"}
+        assert [card["key"] for card in payload["solo"]] == [card["key"] for card in _SOLO_CARDS]
         assert [card["key"] for card in payload["modes"]] == [card["key"] for card in _MODE_CARDS]
         assert [card["key"] for card in payload["agents"]] == [card["key"] for card in _AGENT_CARDS]
 

--- a/tests/unit/test_beta_surfaces.py
+++ b/tests/unit/test_beta_surfaces.py
@@ -60,10 +60,10 @@ class TestBetaMarkersAgree:
     """
 
     def _badged_card_keys(self) -> set[str]:
-        # Badged cards span both category menus (Humans + Agents).
-        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _MODE_CARDS
+        # Badged cards span every category menu (Solo + Team + Agents).
+        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _MODE_CARDS, _SOLO_CARDS
 
-        return {card["key"] for card in (*_MODE_CARDS, *_AGENT_CARDS) if card.get("badge") == BETA_LABEL}
+        return {card["key"] for card in (*_SOLO_CARDS, *_MODE_CARDS, *_AGENT_CARDS) if card.get("badge") == BETA_LABEL}
 
     def test_every_badged_card_has_an_entry_notice(self):
         from yeaboi.ui.shared._beta_notice import _BETA_MODES
@@ -85,9 +85,9 @@ class TestBetaMarkersAgree:
     def test_a_badged_card_stays_selectable(self):
         # Beta labels a mode; it does not take it away. `available` gates Enter,
         # the click handler and the welcome screen's `g` jump key.
-        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _MODE_CARDS
+        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _MODE_CARDS, _SOLO_CARDS
 
-        for card in (*_MODE_CARDS, *_AGENT_CARDS):
+        for card in (*_SOLO_CARDS, *_MODE_CARDS, *_AGENT_CARDS):
             if card.get("badge") == BETA_LABEL:
                 assert card["available"] is True, card["key"]
 

--- a/tests/unit/test_category_screen.py
+++ b/tests/unit/test_category_screen.py
@@ -58,7 +58,7 @@ def _render(width=110, height=40, selected=0, **kwargs) -> str:
 
 class TestCards:
     def test_two_categories_in_order(self):
-        assert [c["key"] for c in _CATEGORY_CARDS] == ["humans", "agents"]
+        assert [c["key"] for c in _CATEGORY_CARDS] == ["team", "agents"]
 
     def test_core_keys_present(self):
         for card in _CATEGORY_CARDS:
@@ -80,7 +80,7 @@ class TestRender:
         shaded = ",".join(
             str(round(c * _MASCOT_SHADE + t * (1.0 - _MASCOT_SHADE))) for c, t in zip(steel, _SHADE_TOWARD, strict=True)
         )
-        resting = _render(selected=0)  # humans live, so the robo is at the back
+        resting = _render(selected=0)  # team live, so the robo is at the back
         assert "140;160;178" not in resting
         assert shaded.replace(",", ";") in resting, shaded
 
@@ -98,9 +98,9 @@ class TestRender:
 
         # No frame and no wash any more: the live card is marked by its wordmark
         # burning bright and by its mascot having walked to the front.
-        humans, agents = (_rgb(c["bright"]) for c in _CATEGORY_CARDS)
+        team, agents = (_rgb(c["bright"]) for c in _CATEGORY_CARDS)
         assert agents in right and agents not in left
-        assert humans in left and humans not in right
+        assert team in left and team not in right
         for tint in ("15;24;32", "17;28;20"):
             assert tint not in left and tint not in right, tint
 
@@ -244,7 +244,7 @@ class TestRender:
         # on its own still appears — in "Watch your AI agents work".)
         for line in plain.split("\n"):
             if "─" in line:
-                assert "humans" not in line and "agents" not in line, line
+                assert "team" not in line and "agents" not in line, line
         # And the cards themselves draw none. Counted on the CARD, not on the
         # page: the page's frame count depends on what else the chrome has been
         # asked to draw (an update box, a drawer), which is not this test's
@@ -294,7 +294,7 @@ class TestRender:
 
 
 class TestHitTest:
-    def test_left_half_is_humans(self):
+    def test_left_half_is_team(self):
         assert category_at_pos(100, 30, row=15, col=10) == 0
 
     def test_right_half_is_agents(self):
@@ -327,7 +327,7 @@ class TestSeedFrame:
     the tail of the splash — the flicker at the splash → landing-split boundary.
     """
 
-    def _seed(self, category="humans", width=110, height=40):
+    def _seed(self, category="team", width=110, height=40):
         from yeaboi.ui.mode_select import _landing_first_frame
 
         return _landing_first_frame(category, width=width, height=height)
@@ -369,7 +369,7 @@ class TestSeedFrame:
     def test_it_opens_on_the_remembered_category(self):
         from yeaboi.ui.mode_select.screens._screens_category import category_index
 
-        assert category_index("humans") == 0
+        assert category_index("team") == 0
         assert category_index("agents") == 1
         # An unknown key must not raise — a hand-edited config lands on Humans.
         assert category_index("nonsense") == 0

--- a/tests/unit/test_category_screen.py
+++ b/tests/unit/test_category_screen.py
@@ -64,6 +64,12 @@ class TestCards:
         for card in _CATEGORY_CARDS:
             assert {"key", "title", "verb", "capabilities", "color", "bright", "dim", "tint", "mascot"} <= set(card)
 
+    def test_solo_and_agents_are_the_beta_worlds(self):
+        from yeaboi.beta import BETA_LABEL
+
+        badged = {card["key"] for card in _CATEGORY_CARDS if card.get("badge") == BETA_LABEL}
+        assert badged == {"solo", "agents"}
+
 
 class TestRender:
     def test_both_mascots_render(self):
@@ -257,6 +263,22 @@ class TestRender:
                 with console.capture() as cap:
                     console.print(_card_half(card, selected=selected, shimmer_tick=0.0, intro=1.0))
                 assert "╭" not in cap.get(), (card["key"], selected)
+
+    def test_beta_worlds_wear_the_chip(self):
+        import re
+
+        plain = re.sub(r"\x1b\[[0-9;]*m", "", _render(width=110))
+        chip_rows = [line for line in plain.splitlines() if "BETA" in line]
+        assert chip_rows, "no BETA chip rendered"
+        # Two chips on one row — solo's and agents'; the team card carries none
+        # (its column between them stays blank).
+        assert chip_rows[0].count("BETA") == 2
+
+    def test_the_chip_enters_with_the_wordmark(self):
+        import re
+
+        early = re.sub(r"\x1b\[[0-9;]*m", "", _render(width=110, intro=0.0))
+        assert "BETA" not in early
 
     def test_headline_and_hints(self):
         out = _render_chromed()

--- a/tests/unit/test_category_screen.py
+++ b/tests/unit/test_category_screen.py
@@ -431,3 +431,33 @@ class TestFlock:
         from yeaboi.ui.shared._mascot import flock_head_cells
 
         assert flock_head_cells(0) != flock_head_cells(2)
+
+
+class TestTipJumpTarget:
+    """The cross-category jump rule: shared keys land on Team, never Solo."""
+
+    def test_a_retro_tip_from_solo_lands_on_team(self):
+        from yeaboi.ui.mode_select import _MODE_CARDS, _SOLO_CARDS, _tip_jump_target
+
+        cat, j = _tip_jump_target("retro", _SOLO_CARDS)
+        assert cat == "team"
+        assert _MODE_CARDS[j]["key"] == "retro"
+
+    def test_a_shared_key_from_agents_lands_on_team(self):
+        from yeaboi.ui.mode_select import _AGENT_CARDS, _MODE_CARDS, _tip_jump_target
+
+        cat, j = _tip_jump_target("daily-standup", _AGENT_CARDS)
+        assert cat == "team"
+        assert _MODE_CARDS[j]["key"] == "daily-standup"
+
+    def test_an_agent_tip_from_team_lands_on_agents(self):
+        from yeaboi.ui.mode_select import _AGENT_CARDS, _MODE_CARDS, _tip_jump_target
+
+        cat, j = _tip_jump_target("agent-security", _MODE_CARDS)
+        assert cat == "agents"
+        assert _AGENT_CARDS[j]["key"] == "agent-security"
+
+    def test_an_unknown_key_jumps_nowhere(self):
+        from yeaboi.ui.mode_select import _MODE_CARDS, _tip_jump_target
+
+        assert _tip_jump_target("astrology", _MODE_CARDS) is None

--- a/tests/unit/test_category_screen.py
+++ b/tests/unit/test_category_screen.py
@@ -1,4 +1,4 @@
-"""Tests for the Humans/Agents landing split (_screens_category.py)."""
+"""Tests for the Solo/Team/Agents landing split (_screens_category.py)."""
 
 import pytest
 from rich.console import Console
@@ -57,8 +57,8 @@ def _render(width=110, height=40, selected=0, **kwargs) -> str:
 
 
 class TestCards:
-    def test_two_categories_in_order(self):
-        assert [c["key"] for c in _CATEGORY_CARDS] == ["team", "agents"]
+    def test_three_categories_in_order(self):
+        assert [c["key"] for c in _CATEGORY_CARDS] == ["solo", "team", "agents"]
 
     def test_core_keys_present(self):
         for card in _CATEGORY_CARDS:
@@ -80,7 +80,7 @@ class TestRender:
         shaded = ",".join(
             str(round(c * _MASCOT_SHADE + t * (1.0 - _MASCOT_SHADE))) for c, t in zip(steel, _SHADE_TOWARD, strict=True)
         )
-        resting = _render(selected=0)  # team live, so the robo is at the back
+        resting = _render(selected=0)  # solo live, so the robo is at the back
         assert "140;160;178" not in resting
         assert shaded.replace(",", ";") in resting, shaded
 
@@ -88,21 +88,21 @@ class TestRender:
         out = _render(width=100, height=30)
         assert out.count("\n") == 30
 
-    def test_selected_half_carries_full_accent(self):
-        left = _render(selected=0)
-        right = _render(selected=1)
-        assert left != right
-
+    def test_selected_card_carries_full_accent(self):
         def _rgb(css):
             return css.removeprefix("rgb(").removesuffix(")").replace(",", ";")
 
         # No frame and no wash any more: the live card is marked by its wordmark
-        # burning bright and by its mascot having walked to the front.
-        team, agents = (_rgb(c["bright"]) for c in _CATEGORY_CARDS)
-        assert agents in right and agents not in left
-        assert team in left and team not in right
-        for tint in ("15;24;32", "17;28;20"):
-            assert tint not in left and tint not in right, tint
+        # burning bright and by its mascot having walked to the front. Each
+        # card's bright appears only in the render where that card is selected.
+        renders = [_render(selected=i) for i in range(len(_CATEGORY_CARDS))]
+        brights = [_rgb(c["bright"]) for c in _CATEGORY_CARDS]
+        for i, bright in enumerate(brights):
+            for j, out in enumerate(renders):
+                assert (bright in out) == (i == j), (i, j)
+        for out in renders:
+            for tint in ("15;24;32", "17;28;20", "30;25;15"):
+                assert tint not in out, tint
 
     def test_the_resting_mascot_stands_further_back(self):
         # Depth, not just dimming: the resting duck is the smaller trace and
@@ -198,9 +198,9 @@ class TestRender:
 
         def right_half(styled):
             plain = re.sub(r"\x1b\[[0-9;]*m", "", styled)
-            return "\n".join(row[len(row) // 2 :] for row in plain.splitlines())
+            return "\n".join(row[2 * len(row) // 3 :] for row in plain.splitlines())
 
-        # Humans selected → the agents half keeps its own, slower clock: it has
+        # Solo selected → the agents third keeps its own, slower clock: it has
         # an idle hop, but it does not flap frame for frame the way the live one
         # does. Ticks a quarter apart land in the same beat of it.
         a = _settled(selected=0, shimmer_tick=0.0)
@@ -244,7 +244,7 @@ class TestRender:
         # on its own still appears — in "Watch your AI agents work".)
         for line in plain.split("\n"):
             if "─" in line:
-                assert "team" not in line and "agents" not in line, line
+                assert "solo" not in line and "team" not in line and "agents" not in line, line
         # And the cards themselves draw none. Counted on the CARD, not on the
         # page: the page's frame count depends on what else the chrome has been
         # asked to draw (an update box, a drawer), which is not this test's
@@ -272,7 +272,7 @@ class TestRender:
 
         early = re.sub(r"\x1b\[[0-9;]*m", "", _render(intro=0.0))
         assert "34;158;122" in _render(intro=0.0)  # the duck is here
-        assert "HUMANS" not in early.replace(" ", "")  # his name is not
+        assert "SOLO" not in early.replace(" ", "")  # his name is not
         assert "working with today?" in _render_chromed(intro=0.0)  # the question is
         # Both sets of rows are reserved, so the card height never jumps.
         assert early.count("\n") == 40
@@ -294,15 +294,28 @@ class TestRender:
 
 
 class TestHitTest:
-    def test_left_half_is_team(self):
+    def test_left_third_is_solo(self):
         assert category_at_pos(100, 30, row=15, col=10) == 0
 
-    def test_right_half_is_agents(self):
-        assert category_at_pos(100, 30, row=15, col=90) == 1
+    def test_middle_third_is_team(self):
+        assert category_at_pos(100, 30, row=15, col=50) == 1
 
-    def test_midpoint_boundary(self):
-        assert category_at_pos(100, 30, row=15, col=50) == 0
-        assert category_at_pos(100, 30, row=15, col=51) == 1
+    def test_right_third_is_agents(self):
+        assert category_at_pos(100, 30, row=15, col=90) == 2
+
+    def test_region_boundaries_match_the_shared_bounds(self):
+        # The hit test and the builder read the same _category_bounds, so the
+        # boundary sits exactly one gutter past each card's last column.
+        from yeaboi.ui.mode_select.screens._screens_category import _GUTTER_COLS, _category_bounds
+
+        bounds = _category_bounds(100)
+        for i, (_start, end) in enumerate(bounds[:-1]):
+            assert category_at_pos(100, 30, row=15, col=end + _GUTTER_COLS) == i
+            assert category_at_pos(100, 30, row=15, col=end + _GUTTER_COLS + 1) == i + 1
+
+    def test_the_far_edges_count_for_the_outer_cards(self):
+        assert category_at_pos(100, 30, row=15, col=1) == 0
+        assert category_at_pos(100, 30, row=15, col=100) == 2
 
     def test_border_and_hint_rows_are_dead(self):
         assert category_at_pos(100, 30, row=1, col=50) is None
@@ -369,7 +382,52 @@ class TestSeedFrame:
     def test_it_opens_on_the_remembered_category(self):
         from yeaboi.ui.mode_select.screens._screens_category import category_index
 
-        assert category_index("team") == 0
-        assert category_index("agents") == 1
-        # An unknown key must not raise — a hand-edited config lands on Humans.
+        assert category_index("solo") == 0
+        assert category_index("team") == 1
+        assert category_index("agents") == 2
+        # An unknown key must not raise — a hand-edited config lands on Solo.
+        # (get_last_category sanitises before the key gets here.)
         assert category_index("nonsense") == 0
+
+
+class TestFlock:
+    """The Team card's trio — composed sprites, same footprint as the solo hero."""
+
+    def test_the_flock_shares_the_full_body_footprint(self):
+        from yeaboi.ui.shared._mascot import flock_cells, full_cells
+
+        flock = flock_cells(0)
+        full = full_cells(0)
+        assert len(flock[0]) == len(full[0]) == 34
+        assert len(flock) < len(full)  # minis are shorter; the card pads above
+
+    def test_the_head_trio_shares_the_mini_footprint(self):
+        from yeaboi.ui.shared._mascot import flock_head_cells, mini_cells
+
+        heads = flock_head_cells(0)
+        mini = mini_cells(0)
+        assert len(heads[0]) == len(mini[0]) == 22
+
+    def test_the_team_card_arrives_as_a_trio(self):
+        # Wider ink than one mini duck, and different ink from the solo hero at
+        # the same width — the trio is what marks the Team world.
+        blocks = "▀▄█"
+
+        def _sprite(card):
+            from yeaboi.ui.mode_select.screens._screens_category import reset_category_walk
+
+            reset_category_walk()
+            console = Console(width=60, force_terminal=False)
+            with console.capture() as cap:
+                console.print(_card_half(card, selected=True, shimmer_tick=0.0, intro=1.0))
+            rows = cap.get().split("\n")
+            return [r for r in rows[: _MASCOT_ROWS + 2] if any(ch in blocks for ch in r)]
+
+        solo = _sprite(_CATEGORY_CARDS[0])
+        team = _sprite(_CATEGORY_CARDS[1])
+        assert solo != team
+
+    def test_the_front_head_quacks(self):
+        from yeaboi.ui.shared._mascot import flock_head_cells
+
+        assert flock_head_cells(0) != flock_head_cells(2)

--- a/tests/unit/test_ceremonies_page.py
+++ b/tests/unit/test_ceremonies_page.py
@@ -12,6 +12,8 @@ a paused ceremony that still fires is the thing users report as a bug.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 
 from yeaboi.agent.state import Ceremony, CeremonyRun
@@ -118,6 +120,9 @@ class TestLoad:
 
     def test_the_last_run_and_the_months_spend_come_back(self, env):
         _save(env["db"])
+        # Fired this month, computed rather than hard-coded: month_spend defaults
+        # to the current month, so a pinned date fails the day the month rolls.
+        fired_at = datetime.now(timezone.utc).replace(day=17, hour=9, minute=0, second=0, microsecond=0).isoformat()
         with CeremonyStore(env["db"]) as store:
             store.record_run(
                 CeremonyRun(
@@ -125,7 +130,7 @@ class TestLoad:
                     session_id="s1",
                     outcome="ok",
                     cost_usd=0.25,
-                    fired_at="2026-08-17T09:00:00+00:00",
+                    fired_at=fired_at,
                 )
             )
         _, last, spend, _ = _ceremonies._load("s1")

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -301,9 +301,11 @@ class TestStandupCommand:
             azdo_repositories,
             documentation_sources,
             review_transcripts,
+            project_id,
         ):
             captured.update(
                 session_id=session_id,
+                project_id=project_id,
                 deliver=deliver,
                 days=days,
                 channels=channels,
@@ -326,6 +328,7 @@ class TestStandupCommand:
         assert _cmd_standup(args, _console()) == 0
         assert captured == {
             "session_id": "sid",
+            "project_id": "",
             "deliver": True,
             "days": 2,
             "channels": ["slack"],

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -302,10 +302,12 @@ class TestStandupCommand:
             documentation_sources,
             review_transcripts,
             project_id,
+            context_deps,
         ):
             captured.update(
                 session_id=session_id,
                 project_id=project_id,
+                context_deps=context_deps,
                 deliver=deliver,
                 days=days,
                 channels=channels,
@@ -329,6 +331,7 @@ class TestStandupCommand:
         assert captured == {
             "session_id": "sid",
             "project_id": "",
+            "context_deps": None,
             "deliver": True,
             "days": 2,
             "channels": ["slack"],
@@ -1573,3 +1576,56 @@ class TestProjectCommand:
         )
         assert _cmd_project(args, _console()) == 0
         assert get_project(project["project_id"], db_path=db)["settings"] == {"default_analysis_profile_id": "team-x"}
+
+
+class TestContextFlags:
+    """--context/--incognito map onto the engines' context_deps."""
+
+    def _capture(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_report(period, **kw):
+            captured.update(kw)
+            return DeliveryReport()
+
+        monkeypatch.setattr("yeaboi.reporting.engine.run_delivery_report", fake_report)
+        monkeypatch.setattr("yeaboi.cli._resolve_cli_session", lambda s: "sid")
+        return captured
+
+    def test_absent_flag_inherits(self, monkeypatch):
+        captured = self._capture(monkeypatch)
+        assert _cmd_report(build_parser().parse_args(["report"]), _console()) == 0
+        assert captured["context_deps"] is None
+
+    def test_csv_reaches_the_engine(self, monkeypatch):
+        captured = self._capture(monkeypatch)
+        args = build_parser().parse_args(["report", "--context", "retro,plan"])
+        assert _cmd_report(args, _console()) == 0
+        assert captured["context_deps"] == ["retro", "plan"]
+
+    def test_none_word_is_incognito(self, monkeypatch):
+        captured = self._capture(monkeypatch)
+        args = build_parser().parse_args(["report", "--context", "none"])
+        assert _cmd_report(args, _console()) == 0
+        assert captured["context_deps"] == []
+
+    def test_all_word_enables_everything(self, monkeypatch):
+        from yeaboi.projects.scope import CONTEXT_DEP_TOKENS
+
+        captured = self._capture(monkeypatch)
+        args = build_parser().parse_args(["report", "--context", "all"])
+        assert _cmd_report(args, _console()) == 0
+        assert captured["context_deps"] == list(CONTEXT_DEP_TOKENS)
+
+    def test_incognito_wins_over_context(self, monkeypatch):
+        captured = self._capture(monkeypatch)
+        args = build_parser().parse_args(["report", "--context", "all", "--incognito"])
+        assert _cmd_report(args, _console()) == 0
+        assert captured["context_deps"] == []
+
+    def test_a_typo_is_a_parse_error(self, capsys):
+        import pytest
+
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["report", "--context", "retro,bogus"])
+        assert "unknown context source" in capsys.readouterr().err

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -1521,3 +1521,55 @@ class TestShipCommand:
         args = build_parser().parse_args(["ship", "run", "US-001", "--repo", str(repo), "--strict"])
         assert _run_subcommand(args) == 3
         assert "⚠ boom" in capsys.readouterr().err
+
+
+class TestProjectCommand:
+    def test_create_list_show_round_trip(self, tmp_path, monkeypatch):
+        from yeaboi.cli import _cmd_project, build_parser
+
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: tmp_path / "sessions.db")
+        buf = io.StringIO()
+        args = build_parser().parse_args(["project", "create", "Apollo", "--description", "the big one"])
+        assert _cmd_project(args, _console(buf)) == 0
+        assert "Apollo" in buf.getvalue()
+
+        buf = io.StringIO()
+        args = build_parser().parse_args(["project", "list"])
+        assert _cmd_project(args, _console(buf)) == 0
+        out = buf.getvalue()
+        assert "Apollo" in out and "proj-" in out
+
+        project_id = next(w for w in out.split() if w.startswith("proj-"))
+        buf = io.StringIO()
+        args = build_parser().parse_args(["project", "show", project_id])
+        assert _cmd_project(args, _console(buf)) == 0
+        assert "Apollo" in buf.getvalue()
+
+    def test_link_uses_the_resolved_session(self, tmp_path, monkeypatch):
+        from yeaboi.cli import _cmd_project, build_parser
+        from yeaboi.projects.engine import create_project
+        from yeaboi.sessions import SessionStore
+
+        db = tmp_path / "sessions.db"
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
+        project = create_project("Apollo", db_path=db)
+        with SessionStore(db) as sessions:
+            sessions.create_session("s1")
+        buf = io.StringIO()
+        args = build_parser().parse_args(["project", "link", project["project_id"], "--session", "s1"])
+        assert _cmd_project(args, _console(buf)) == 0
+        with SessionStore(db) as sessions:
+            assert sessions.session_project_id("s1") == project["project_id"]
+
+    def test_set_defaults_assembles_the_dict(self, tmp_path, monkeypatch):
+        from yeaboi.cli import _cmd_project, build_parser
+        from yeaboi.projects.engine import create_project, get_project
+
+        db = tmp_path / "sessions.db"
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
+        project = create_project("Apollo", db_path=db)
+        args = build_parser().parse_args(
+            ["project", "set-defaults", project["project_id"], "--analysis-profile", "team-x"]
+        )
+        assert _cmd_project(args, _console()) == 0
+        assert get_project(project["project_id"], db_path=db)["settings"] == {"default_analysis_profile_id": "team-x"}

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -1577,6 +1577,30 @@ class TestProjectCommand:
         assert _cmd_project(args, _console()) == 0
         assert get_project(project["project_id"], db_path=db)["settings"] == {"default_analysis_profile_id": "team-x"}
 
+    def test_set_defaults_sets_the_context_deps(self, tmp_path, monkeypatch):
+        from yeaboi.cli import _cmd_project, build_parser
+        from yeaboi.projects.engine import create_project, get_project
+
+        db = tmp_path / "sessions.db"
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
+        project = create_project("Apollo", db_path=db)
+        args = build_parser().parse_args(["project", "set-defaults", project["project_id"], "--context", "retro"])
+        assert _cmd_project(args, _console()) == 0
+        assert get_project(project["project_id"], db_path=db)["settings"] == {"default_context_deps": ["retro"]}
+
+    def test_set_defaults_with_no_flags_changes_nothing(self, tmp_path, monkeypatch):
+        from yeaboi.cli import _cmd_project, build_parser
+        from yeaboi.projects.engine import create_project, get_project
+
+        db = tmp_path / "sessions.db"
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
+        project = create_project("Apollo", db_path=db)
+        buf = io.StringIO()
+        args = build_parser().parse_args(["project", "set-defaults", project["project_id"]])
+        assert _cmd_project(args, _console(buf)) == 2
+        assert "Nothing to set" in buf.getvalue()
+        assert get_project(project["project_id"], db_path=db)["settings"] == {}
+
 
 class TestContextFlags:
     """--context/--incognito map onto the engines' context_deps."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1024,35 +1024,51 @@ class TestVoiceExtraMarker:
 class TestLastCategory:
     """The landing split's persisted category preselection."""
 
-    def test_default_is_humans(self, monkeypatch):
+    def test_default_is_team(self, monkeypatch):
         monkeypatch.delenv("YEABOI_LAST_CATEGORY", raising=False)
         from yeaboi.config import get_last_category
 
-        assert get_last_category() == "humans"
+        assert get_last_category() == "team"
 
     def test_round_trip(self, monkeypatch, tmp_path):
         from yeaboi import config as cfg
 
-        monkeypatch.setenv("YEABOI_LAST_CATEGORY", "humans")
+        monkeypatch.setenv("YEABOI_LAST_CATEGORY", "team")
         monkeypatch.setattr(cfg, "get_config_file", lambda: tmp_path / ".env")
         cfg.set_last_category("agents")
         assert os.environ["YEABOI_LAST_CATEGORY"] == "agents"
         assert cfg.get_last_category() == "agents"
         assert "YEABOI_LAST_CATEGORY" in (tmp_path / ".env").read_text()
 
+    def test_solo_round_trips(self, monkeypatch, tmp_path):
+        from yeaboi import config as cfg
+
+        monkeypatch.setenv("YEABOI_LAST_CATEGORY", "team")
+        monkeypatch.setattr(cfg, "get_config_file", lambda: tmp_path / ".env")
+        cfg.set_last_category("solo")
+        assert cfg.get_last_category() == "solo"
+
+    def test_legacy_humans_maps_to_team(self, monkeypatch):
+        # Older releases persisted "humans"; it must read as "team", not fall
+        # back to the default by way of the unknown-value guard.
+        monkeypatch.setenv("YEABOI_LAST_CATEGORY", "humans")
+        from yeaboi.config import get_last_category
+
+        assert get_last_category() == "team"
+
     def test_unknown_value_falls_back(self, monkeypatch):
         monkeypatch.setenv("YEABOI_LAST_CATEGORY", "robots!!")
         from yeaboi.config import get_last_category
 
-        assert get_last_category() == "humans"
+        assert get_last_category() == "team"
 
     def test_setter_rejects_unknown(self, monkeypatch, tmp_path):
         from yeaboi import config as cfg
 
-        monkeypatch.setenv("YEABOI_LAST_CATEGORY", "humans")
+        monkeypatch.setenv("YEABOI_LAST_CATEGORY", "team")
         monkeypatch.setattr(cfg, "get_config_file", lambda: tmp_path / ".env")
         cfg.set_last_category("nonsense")
-        assert cfg.get_last_category() == "humans"
+        assert cfg.get_last_category() == "team"
         assert not (tmp_path / ".env").exists()
 
 

--- a/tests/unit/test_headless_pipeline.py
+++ b/tests/unit/test_headless_pipeline.py
@@ -291,3 +291,46 @@ class TestProjectScopedPipeline:
         qs = build_questionnaire_from_answers({1: "A test project", 6: "4", 8: "2"})
         state = run_planning_pipeline(qs, save_session=False)
         assert "project_id" not in state
+
+
+class TestContextDepsPipeline:
+    def _project(self, tmp_path, settings=None):
+        from yeaboi.projects.store import ProjectStore
+
+        db = tmp_path / "sessions.db"
+        with ProjectStore(db) as projects:
+            project = projects.create("Apollo")
+            if settings:
+                projects.set_settings(project["project_id"], settings)
+        return db, project["project_id"]
+
+    def _qs(self):
+        return build_questionnaire_from_answers({1: "A test project", 6: "4", 8: "2"})
+
+    def test_explicit_deps_land_on_state_as_a_json_list(self, fake_graph, tmp_path):
+        db, pid = self._project(tmp_path)
+        state = run_planning_pipeline(self._qs(), db_path=db, project_id=pid, context_deps=["retro", "plan"])
+        assert state["context_deps"] == '["plan", "retro"]'
+
+    def test_incognito_lands_as_an_empty_list(self, fake_graph):
+        state = run_planning_pipeline(self._qs(), save_session=False, context_deps=[])
+        assert state["context_deps"] == "[]"
+
+    def test_none_leaves_the_key_absent(self, fake_graph):
+        state = run_planning_pipeline(self._qs(), save_session=False)
+        assert "context_deps" not in state
+
+    def test_project_default_deps_apply_when_caller_passes_none(self, fake_graph, tmp_path):
+        db, pid = self._project(tmp_path, {"default_context_deps": ["standup"]})
+        state = run_planning_pipeline(self._qs(), db_path=db, project_id=pid)
+        assert state["context_deps"] == '["standup"]'
+
+    def test_analysis_dep_off_suppresses_the_profile_seed(self, fake_graph, tmp_path):
+        db, pid = self._project(tmp_path, {"default_analysis_profile_id": "team-apollo"})
+        state = run_planning_pipeline(self._qs(), db_path=db, project_id=pid, context_deps=["retro"])
+        assert "analysis_profile_id" not in state
+
+    def test_analysis_dep_on_still_seeds_the_profile(self, fake_graph, tmp_path):
+        db, pid = self._project(tmp_path, {"default_analysis_profile_id": "team-apollo"})
+        state = run_planning_pipeline(self._qs(), db_path=db, project_id=pid, context_deps=["analysis"])
+        assert state["analysis_profile_id"] == "team-apollo"

--- a/tests/unit/test_headless_pipeline.py
+++ b/tests/unit/test_headless_pipeline.py
@@ -256,3 +256,38 @@ class TestRunPlanningPipeline:
         qs = build_questionnaire_from_answers({1: "A test project"})
         run_planning_pipeline(qs, save_session=False)
         assert not db.exists()
+
+
+class TestProjectScopedPipeline:
+    def test_project_id_links_session_and_seeds_profile(self, fake_graph, tmp_path):
+        from yeaboi.projects.store import ProjectStore
+        from yeaboi.sessions import SessionStore
+
+        db = tmp_path / "sessions.db"
+        with ProjectStore(db) as projects:
+            project = projects.create("Apollo")
+            projects.set_settings(project["project_id"], {"default_analysis_profile_id": "team-apollo"})
+
+        qs = build_questionnaire_from_answers({1: "A test project", 6: "4", 8: "2"})
+        state = run_planning_pipeline(qs, db_path=db, project_id=project["project_id"])
+
+        assert state["project_id"] == project["project_id"]
+        # The analysis→planning edge: the project's default profile is seeded.
+        assert state["analysis_profile_id"] == "team-apollo"
+        with SessionStore(db) as store:
+            assert store.session_project_id(state["_session_id"]) == project["project_id"]
+
+    def test_project_without_defaults_seeds_no_profile(self, fake_graph, tmp_path):
+        from yeaboi.projects.store import ProjectStore
+
+        db = tmp_path / "sessions.db"
+        with ProjectStore(db) as projects:
+            project = projects.create("Apollo")
+        qs = build_questionnaire_from_answers({1: "A test project", 6: "4", 8: "2"})
+        state = run_planning_pipeline(qs, db_path=db, project_id=project["project_id"])
+        assert "analysis_profile_id" not in state
+
+    def test_unscoped_run_carries_no_project_state(self, fake_graph):
+        qs = build_questionnaire_from_answers({1: "A test project", 6: "4", 8: "2"})
+        state = run_planning_pipeline(qs, save_session=False)
+        assert "project_id" not in state

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1254,6 +1254,22 @@ class TestStandupConfigTools:
         assert payload["ok"] is False
         assert "habit_ai_match" in payload["error"]["message"]
 
+    def test_config_set_context_deps_grammar(self, seeded_session):
+        # '' = unchanged; csv narrows; 'none' = incognito; 'inherit' resets.
+        call_tool("standup_config_set", {"time": "09:15"})
+        assert call_tool("standup_config_get", {})["data"]["config"]["context_deps"] is None
+        config = call_tool("standup_config_set", {"context_deps": "retro,plan"})["data"]["config"]
+        assert config["context_deps"] == ["retro", "plan"]
+        # A merge that omits the field keeps the saved toggles.
+        assert call_tool("standup_config_set", {"enabled": True})["data"]["config"]["context_deps"] == ["retro", "plan"]
+        assert call_tool("standup_config_set", {"context_deps": "none"})["data"]["config"]["context_deps"] == []
+        assert call_tool("standup_config_set", {"context_deps": "inherit"})["data"]["config"]["context_deps"] is None
+
+    def test_config_set_rejects_a_context_deps_typo(self, seeded_session):
+        payload = call_tool("standup_config_set", {"context_deps": "retro,bogus"})
+        assert payload["ok"] is False
+        assert "unknown context source" in payload["error"]["message"]
+
 
 class TestServerEntry:
     def test_import_without_mcp_is_safe(self):

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -24,6 +24,11 @@ from yeaboi.mcp.server import create_app  # noqa: E402
 EXPECTED_TOOLS = {
     "artifact_edit_apply",
     "niko_ask",
+    "project_create",
+    "project_list",
+    "project_get",
+    "project_link_session",
+    "project_set_defaults",
     "ceremonies_list",
     "ceremonies_history",
     "artifact_edit_history",

--- a/tests/unit/test_mode_cards.py
+++ b/tests/unit/test_mode_cards.py
@@ -66,18 +66,22 @@ class TestPerformanceCardRegistration:
         assert _performance_card()["available"] is True
 
     def test_no_other_card_carries_a_badge(self):
-        # Performance and Ship are the two beta modes on the Humans menu;
-        # test_beta_surfaces.py keeps their three markers (badge, notice, tip)
-        # in agreement.
+        # Performance and Ship are the two beta modes on the Team menu (Ship
+        # also on Solo); test_beta_surfaces.py keeps their three markers
+        # (badge, notice, tip) in agreement.
+        from yeaboi.ui.mode_select.screens._screens import _SOLO_CARDS
+
         badged = [
             card["key"]
-            for card in (*_MODE_CARDS, *_INTAKE_CARDS, *_OFFLINE_CARDS)
+            for card in (*_MODE_CARDS, *_SOLO_CARDS, *_INTAKE_CARDS, *_OFFLINE_CARDS)
             if card.get("badge") and card.get("key") not in ("performance", "ship")
         ]
         assert badged == []
 
     def test_every_card_still_has_the_core_keys(self):
-        for card in (*_MODE_CARDS, *_INTAKE_CARDS, *_OFFLINE_CARDS):
+        from yeaboi.ui.mode_select.screens._screens import _SOLO_CARDS
+
+        for card in (*_MODE_CARDS, *_SOLO_CARDS, *_INTAKE_CARDS, *_OFFLINE_CARDS):
             assert {"title", "description", "available", "color"} <= set(card)
 
 
@@ -204,6 +208,11 @@ class TestNikoIsNotACard:
 
     def test_the_team_menu_does_not_carry_it(self):
         assert "niko" not in {card["key"] for card in _MODE_CARDS}
+
+    def test_the_solo_menu_does_not_carry_it(self):
+        from yeaboi.ui.mode_select.screens._screens import _SOLO_CARDS
+
+        assert "niko" not in {card["key"] for card in _SOLO_CARDS}
 
     def test_ten_cards_still_clear_the_enforced_minimum(self):
         from yeaboi.ui.mode_select.screens._screens import _MIN_HEIGHT, _MIN_WIDTH

--- a/tests/unit/test_mode_cards.py
+++ b/tests/unit/test_mode_cards.py
@@ -202,7 +202,7 @@ class TestNikoIsNotACard:
     is recorded in tests/unit/test_surface_parity.py's CAPABILITIES row.
     """
 
-    def test_the_humans_menu_does_not_carry_it(self):
+    def test_the_team_menu_does_not_carry_it(self):
         assert "niko" not in {card["key"] for card in _MODE_CARDS}
 
     def test_ten_cards_still_clear_the_enforced_minimum(self):

--- a/tests/unit/test_niko_engine.py
+++ b/tests/unit/test_niko_engine.py
@@ -190,14 +190,14 @@ class TestTheToolLoop:
 
 class TestNavigate:
     def test_the_route_reaches_the_answer_and_the_stream(self, wired, monkeypatch):
-        monkeypatch.setattr("yeaboi.niko.tools.call", lambda name, args: {"route": "/humans/retro"})
+        monkeypatch.setattr("yeaboi.niko.tools.call", lambda name, args: {"route": "/team/retro"})
         wired.install(
-            FakeModel([_tool_reply("navigate", {"route": "/humans/retro"}), AIMessage(content="Taking you there.")])
+            FakeModel([_tool_reply("navigate", {"route": "/team/retro"}), AIMessage(content="Taking you there.")])
         )
         seen = []
         answer = engine.ask("run a retro", db_path=wired.db, on_event=seen.append)
-        assert answer.route == "/humans/retro"
-        assert [e.route for e in seen if isinstance(e, engine.Navigate)] == ["/humans/retro"]
+        assert answer.route == "/team/retro"
+        assert [e.route for e in seen if isinstance(e, engine.Navigate)] == ["/team/retro"]
 
     def test_a_refused_route_is_not_suggested(self, wired, monkeypatch):
         monkeypatch.setattr("yeaboi.niko.tools.call", lambda name, args: {"error": "not a route", "route": ""})

--- a/tests/unit/test_niko_page.py
+++ b/tests/unit/test_niko_page.py
@@ -47,11 +47,11 @@ class TestTurnsFrom:
                 NikoMessage(
                     role="assistant",
                     content="there",
-                    tool_calls=(NikoToolCall(name="navigate", ok=True, result={"route": "/humans/retro"}),),
+                    tool_calls=(NikoToolCall(name="navigate", ok=True, result={"route": "/team/retro"}),),
                 )
             ]
         )
-        assert rows[0]["route"] == "/humans/retro"
+        assert rows[0]["route"] == "/team/retro"
 
     def test_a_refused_navigate_offers_no_route(self):
         rows = _turns_from(

--- a/tests/unit/test_niko_prompts.py
+++ b/tests/unit/test_niko_prompts.py
@@ -12,9 +12,9 @@ from yeaboi.prompts.niko import get_niko_system_prompt, get_niko_title_prompt
 
 
 class TestIdentity:
-    def test_it_names_both_audiences(self):
+    def test_it_names_all_three_audiences(self):
         prompt = get_niko_system_prompt()
-        assert "Humans" in prompt and "Agents" in prompt
+        assert "Solo" in prompt and "Team" in prompt and "Agents" in prompt
 
     def test_it_names_the_modes_a_user_would_ask_about(self):
         prompt = get_niko_system_prompt().lower()
@@ -49,8 +49,8 @@ class TestTheReadOnlyPromise:
 
 class TestContext:
     def test_the_route_and_its_capability_land_in_the_prompt(self):
-        prompt = get_niko_system_prompt(route="/humans/retro", capability="retro-board", screen_title="Retro")
-        assert "/humans/retro" in prompt
+        prompt = get_niko_system_prompt(route="/team/retro", capability="retro-board", screen_title="Retro")
+        assert "/team/retro" in prompt
         assert "retro-board" in prompt
         assert "Retro" in prompt
 

--- a/tests/unit/test_niko_store.py
+++ b/tests/unit/test_niko_store.py
@@ -89,8 +89,8 @@ class TestMessages:
     def test_route_is_snapshotted_per_turn(self, store):
         conversation = store.create()
         store.add_message(conversation.id, role="user", content="a", route="/agents/usage")
-        store.add_message(conversation.id, role="user", content="b", route="/humans/retro")
-        assert [m.route for m in store.messages(conversation.id)] == ["/agents/usage", "/humans/retro"]
+        store.add_message(conversation.id, role="user", content="b", route="/team/retro")
+        assert [m.route for m in store.messages(conversation.id)] == ["/agents/usage", "/team/retro"]
 
     def test_ordered_oldest_first_even_within_a_second(self, store):
         conversation = store.create()

--- a/tests/unit/test_niko_suggestions.py
+++ b/tests/unit/test_niko_suggestions.py
@@ -85,7 +85,9 @@ class TestScreenFor:
         assert suggestions.screen_for("/humans/retro/board/anything")["capability"] == "retro-board"
 
     def test_the_longest_prefix_wins(self):
-        assert suggestions.screen_for("/humans/planning/chat")["capability"] == "planning"
+        # /ceremonies and /ceremonies/slack both match; the deeper row's
+        # capability must win.
+        assert suggestions.screen_for("/ceremonies/slack/anything")["capability"] == "slack-inbound"
 
     def test_an_unknown_route_resolves_to_nothing_rather_than_guessing(self):
         assert suggestions.screen_for("/teleport") == {"capability": "", "title": ""}

--- a/tests/unit/test_niko_suggestions.py
+++ b/tests/unit/test_niko_suggestions.py
@@ -82,7 +82,7 @@ class TestScreenFor:
         assert suggestions.screen_for("/agents/usage") == {"capability": "agent-usage", "title": "Agent Usage"}
 
     def test_a_deeper_path_inherits_its_prefix(self):
-        assert suggestions.screen_for("/humans/retro/board/anything")["capability"] == "retro-board"
+        assert suggestions.screen_for("/team/retro/board/anything")["capability"] == "retro-board"
 
     def test_the_longest_prefix_wins(self):
         # /ceremonies and /ceremonies/slack both match; the deeper row's
@@ -93,8 +93,8 @@ class TestScreenFor:
         assert suggestions.screen_for("/teleport") == {"capability": "", "title": ""}
 
     def test_a_partial_segment_is_not_a_prefix_match(self):
-        # "/humans/retrospective" must not inherit "/humans/retro".
-        assert suggestions.screen_for("/humans/retrospective")["capability"] != "retro-board"
+        # "/team/retrospective" must not inherit "/team/retro".
+        assert suggestions.screen_for("/team/retrospective")["capability"] != "retro-board"
 
 
 class TestForRoute:
@@ -102,7 +102,7 @@ class TestForRoute:
         ("route", "expected"),
         [
             ("/agents/usage", "agents cost"),
-            ("/humans/ship/run", "waiting on me"),
+            ("/team/ship/run", "waiting on me"),
             ("/ceremonies", "scheduled"),
             ("/provenance", "decide"),
         ],
@@ -110,9 +110,9 @@ class TestForRoute:
     def test_a_screen_gets_its_own_chips(self, route, expected):
         assert any(expected in chip["label"].lower() for chip in suggestions.for_route(route))
 
-    def test_a_humans_screen_with_no_chips_falls_back_to_the_section(self):
-        chips = suggestions.for_route("/humans/planning/sessions/unmapped")
-        assert chips and chips == suggestions.for_route("/humans/planning/sessions/unmapped")
+    def test_a_team_screen_with_no_chips_falls_back_to_the_section(self):
+        chips = suggestions.for_route("/team/planning/sessions/unmapped")
+        assert chips and chips == suggestions.for_route("/team/planning/sessions/unmapped")
 
     def test_an_unknown_route_gets_the_default_rather_than_nothing(self):
         assert suggestions.for_route("/teleport") == suggestions.DEFAULT[: suggestions.MAX_CHIPS]

--- a/tests/unit/test_niko_tools.py
+++ b/tests/unit/test_niko_tools.py
@@ -178,7 +178,7 @@ class TestCapabilities:
     def test_list_capabilities_serves_the_real_cards(self):
         result = niko_tools.call("list_capabilities", {})
         assert {"categories", "modes", "agents", "intake"} <= set(result)
-        assert {"team", "agents"} <= {row["key"] for row in result["categories"]}
+        assert {"solo", "team", "agents"} <= {row["key"] for row in result["categories"]}
 
     def test_list_routes_names_the_capability_each_screen_belongs_to(self):
         rows = {row["path"]: row for row in niko_tools.call("list_routes", {})["routes"]}

--- a/tests/unit/test_niko_tools.py
+++ b/tests/unit/test_niko_tools.py
@@ -86,7 +86,7 @@ class TestNavigate:
         assert niko_tools.call("navigate", {"route": "/agents/usage"}) == {"route": "/agents/usage"}
 
     def test_refuses_an_invented_route(self):
-        result = niko_tools.call("navigate", {"route": "/humans/teleport"})
+        result = niko_tools.call("navigate", {"route": "/team/teleport"})
         assert result["route"] == ""
         assert "list_routes" in result["error"]
 
@@ -98,7 +98,7 @@ class TestNavigate:
 class TestKnownRoutes:
     def test_reads_the_committed_manifest(self):
         paths = {row["path"] for row in niko_tools.known_routes()}
-        assert {"/home", "/agents/usage", "/humans/retro"} <= paths
+        assert {"/home", "/agents/usage", "/team/retro"} <= paths
 
     def test_falls_back_to_the_repo_copy_when_unpackaged(self):
         # The wheel ships a copy under yeaboi/data/; a source checkout has none
@@ -178,7 +178,7 @@ class TestCapabilities:
     def test_list_capabilities_serves_the_real_cards(self):
         result = niko_tools.call("list_capabilities", {})
         assert {"categories", "modes", "agents", "intake"} <= set(result)
-        assert {"humans", "agents"} <= {row["key"] for row in result["categories"]}
+        assert {"team", "agents"} <= {row["key"] for row in result["categories"]}
 
     def test_list_routes_names_the_capability_each_screen_belongs_to(self):
         rows = {row["path"]: row for row in niko_tools.call("list_routes", {})["routes"]}

--- a/tests/unit/test_performance_context.py
+++ b/tests/unit/test_performance_context.py
@@ -33,3 +33,26 @@ class TestGatherPerformanceContext:
         monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
         ctx = context.gather_performance_context()
         assert ctx.engineers_with_actions == 0
+
+
+class TestPerformanceToggle:
+    def test_performance_dep_off_yields_an_empty_context(self, monkeypatch, tmp_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        with PerformanceStore(db) as store:
+            store.record_completion(OneOnOneRecord(engineer="Ada", date="2026-07-12", action_items=("write tests",)))
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        ctx = context.gather_performance_context(scope=ProjectScope("", None, frozenset()))
+        assert ctx.is_empty and ctx.summary_md == ""
+
+    def test_scope_without_a_restriction_never_narrows(self, monkeypatch, tmp_path):
+        # Engineer-keyed: session narrowing is deliberately ignored.
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        with PerformanceStore(db) as store:
+            store.record_completion(OneOnOneRecord(engineer="Ada", date="2026-07-12", action_items=("write tests",)))
+        monkeypatch.setattr("yeaboi.config.get_sessions_db", lambda: db)
+        ctx = context.gather_performance_context(scope=ProjectScope("proj-11112222", ("elsewhere",), None))
+        assert not ctx.is_empty

--- a/tests/unit/test_performance_engine.py
+++ b/tests/unit/test_performance_engine.py
@@ -532,3 +532,49 @@ class TestTheReviewReportsItsContextPhase:
         events: list = []
         engine.run_six_month_review("Ada", db_path=db_path, on_progress=events.append)
         assert [e for e in events if e["component_id"] == engine.PHASE_CONTEXT][-1]["status"] == "partial"
+
+
+class TestContextDepsReachTheGathers:
+    """The engines resolve project_id/context_deps into a ProjectScope and hand
+    it to the evidence gather and (for the review) the ceremony read."""
+
+    def _capture_evidence(self, monkeypatch):
+        from yeaboi.performance.evidence import EngineerEvidence
+
+        seen = {}
+
+        def _fake(engineer, **kw):
+            seen.update(kw)
+            return EngineerEvidence(engineer=engineer, activity=EngineerActivity(engineer=engineer))
+
+        monkeypatch.setattr(engine.evidence_mod, "gather_engineer_evidence", _fake)
+        return seen
+
+    def test_prep_builds_a_scope_from_context_deps(self, monkeypatch, db_path):
+        seen = self._capture_evidence(monkeypatch)
+        _patch_llm(monkeypatch, json.dumps({"talking_points": ["hi"]}))
+        engine.run_one_on_one_prep("Ada", db_path=db_path, context_deps=["retro"])
+        assert seen["scope"] is not None
+        assert seen["scope"].context_deps == frozenset({"retro"})
+
+    def test_prep_with_no_deps_passes_no_scope(self, monkeypatch, db_path):
+        seen = self._capture_evidence(monkeypatch)
+        _patch_llm(monkeypatch, json.dumps({"talking_points": ["hi"]}))
+        engine.run_one_on_one_prep("Ada", db_path=db_path)
+        assert seen["scope"] is None  # unlinked, all-on — today's behavior
+
+    def test_review_threads_the_scope_into_the_ceremony_read(self, monkeypatch, db_path):
+        seen_ev = self._capture_evidence(monkeypatch)
+        _patch_llm(monkeypatch, json.dumps({"strengths": ["ships"]}))
+        seen_cer = {}
+
+        def _fake_ceremony(project_name="", **kw):
+            seen_cer.update(kw)
+            from yeaboi.agent.ceremony_history import CeremonyContext
+
+            return CeremonyContext()
+
+        monkeypatch.setattr("yeaboi.agent.ceremony_history.gather_ceremony_context", _fake_ceremony)
+        engine.run_six_month_review("Ada", db_path=db_path, context_deps=[])
+        assert seen_ev["scope"] is not None and seen_ev["scope"].incognito
+        assert seen_cer["scope"] is seen_ev["scope"]

--- a/tests/unit/test_performance_evidence.py
+++ b/tests/unit/test_performance_evidence.py
@@ -652,3 +652,132 @@ class TestProgressReporting:
 
     def test_no_callback_is_the_default(self, db_path):
         assert evidence.gather_engineer_evidence(ENGINEER, db_path=db_path, **PERIOD).engineer == ENGINEER
+
+
+class TestContextScope:
+    """The run's context toggles on the evidence gather: tokened sources obey
+    their dep and settle a 'switched off' coverage row; the untokened poker and
+    delivery reads go quiet only under full incognito."""
+
+    def _seed_everything(self, db_path):
+        with StandupStore(db_path) as store:
+            store.record_run(_standup("2026-08-10", summary="Shipped it.", code_summary="3 commits."))
+        with RetroStore(db_path) as store:
+            store.record_run(
+                RetroReport(
+                    date="2026-08-12",
+                    session_id="perf-demo",
+                    participants=(ENGINEER,),
+                    cards=(RetroCard(id="1", grid="didnt_go_well", text="CI is flaky", author=ENGINEER, origin="web"),),
+                )
+            )
+        with PokerStore(db_path) as store:
+            store.record_run(
+                PokerReport(
+                    date="2026-08-13",
+                    session_id="perf-demo",
+                    tickets=(
+                        PokerTicketResult(
+                            key="PROJ-1",
+                            final_points=3.0,
+                            estimated=True,
+                            votes=(PokerVote(voter=ENGINEER, value="3"),),
+                        ),
+                    ),
+                )
+            )
+        with ReportingStore(db_path) as store:
+            store.record_run(
+                DeliveryReport(
+                    delivered_items=(DeliveredItem(key="P-9", title="Auth fix", status="Done", assignee=ENGINEER),)
+                )
+            )
+        with TeamProfileStore(db_path) as store:
+            store.save(
+                TeamProfile(team_id="jira-DEMO-1", source="jira", project_key="DEMO"),
+                examples={
+                    "contributor_stats": [
+                        {"name": ENGINEER, "stories_completed": 14, "stories_total": 16, "delivery_pts": 34}
+                    ]
+                },
+            )
+
+    def _scope(self, deps):
+        from yeaboi.projects.scope import ProjectScope
+
+        return ProjectScope("", None, None if deps is None else frozenset(deps))
+
+    def test_no_scope_and_all_on_are_identical(self, db_path):
+        self._seed_everything(db_path)
+        bare = _gather(db_path)
+        with_none = _gather(db_path, scope=None)
+        all_on = _gather(db_path, scope=self._scope(None))
+        assert bare == with_none == all_on
+        assert bare.standup_lines and bare.retro_lines and bare.poker_lines and bare.delivery_lines
+
+    def test_standup_off_silences_the_source_and_says_why(self, db_path):
+        self._seed_everything(db_path)
+        ev = _gather(db_path, scope=self._scope({"retro", "plan", "performance", "analysis"}))
+        assert ev.standup_lines == () and ev.code_lines == ()
+        for source in (evidence.SOURCE_STANDUP, evidence.SOURCE_CODE, evidence.SOURCE_DOCUMENTATION):
+            row = _coverage(ev, source)
+            assert row.state == evidence.NOT_CONFIGURED and "context toggles" in row.detail
+        assert ev.retro_lines and ev.poker_lines  # the others untouched
+
+    def test_analysis_off_silences_the_profile(self, db_path):
+        self._seed_everything(db_path)
+        ev = _gather(db_path, scope=self._scope({"retro", "standup", "plan", "performance"}))
+        assert ev.analysis_lines == ()
+        row = _coverage(ev, evidence.SOURCE_ANALYSIS)
+        assert row.state == evidence.NOT_CONFIGURED and "context toggles" in row.detail
+
+    def test_retro_off_silences_the_retro_read(self, db_path):
+        self._seed_everything(db_path)
+        ev = _gather(db_path, scope=self._scope({"standup", "plan", "performance", "analysis"}))
+        assert ev.retro_lines == ()
+        row = _coverage(ev, evidence.SOURCE_RETRO)
+        assert row.state == evidence.NOT_CONFIGURED and "context toggles" in row.detail
+
+    def test_incognito_silences_the_untokened_sources_too(self, db_path):
+        self._seed_everything(db_path)
+        ev = _gather(db_path, scope=self._scope(()))
+        assert ev.poker_lines == () and ev.delivery_lines == ()
+        for source in (evidence.SOURCE_POKER, evidence.SOURCE_DELIVERY):
+            row = _coverage(ev, source)
+            assert row.state == evidence.NOT_CONFIGURED and "context toggles" in row.detail
+        assert ev.standup_lines == () and ev.retro_lines == () and ev.analysis_lines == ()
+
+    def test_a_partial_toggle_set_keeps_poker_and_delivery(self, db_path):
+        self._seed_everything(db_path)
+        ev = _gather(db_path, scope=self._scope({"retro"}))
+        assert ev.poker_lines and ev.delivery_lines
+
+    def test_session_scope_narrows_standup_and_retro(self, db_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        self._seed_everything(db_path)
+        ev = _gather(db_path, scope=ProjectScope("proj-11112222", ("some-other-session",), None))
+        assert ev.standup_lines == () and ev.retro_lines == ()
+        assert ev.poker_lines  # untokened sources are not session-narrowed today
+
+    def test_standup_off_skips_the_live_gap_fill(self, db_path, monkeypatch):
+        self._seed_everything(db_path)
+
+        def _boom(*a, **k):
+            raise AssertionError("the live gap-fill must not run with the standup toggle off")
+
+        monkeypatch.setattr(evidence, "_gap_fill", _boom)
+        ev = _gather(db_path, deep_scan=True, scope=self._scope({"retro"}))
+        assert ev.standup_lines == ()
+
+    def test_the_gap_fill_still_runs_when_standup_is_on(self, db_path, monkeypatch):
+        self._seed_everything(db_path)
+        called = {}
+
+        def _fake(*a, **k):
+            called["yes"] = True
+            return [], [], "", "skipped"
+
+        monkeypatch.setattr(evidence, "_gap_fill", _fake)
+        _gather(db_path, deep_scan=True, scope=self._scope(None))
+        assert called.get("yes")

--- a/tests/unit/test_poker_board.py
+++ b/tests/unit/test_poker_board.py
@@ -636,3 +636,17 @@ class TestBoardToReport:
 class TestDeckConstant:
     def test_deck_shape(self):
         assert POKER_DECK == ("0", "1", "2", "3", "5", "8", "13", "21", "?", "☕")
+
+
+class TestScopeAttribute:
+    def test_scope_defaults_to_none_and_stays_out_of_the_snapshot(self):
+        b = _board()
+        assert b.scope is None
+        assert "scope" not in b.state_snapshot()
+
+    def test_scope_is_held_for_the_ai_worker(self):
+        from yeaboi.projects.scope import ProjectScope
+
+        scope = ProjectScope("proj-11112222", ("s",), frozenset({"retro"}))
+        b = PokerBoard("s", "Proj", source="demo", scope_label="Backlog", tickets=None, scope=scope)
+        assert b.scope is scope

--- a/tests/unit/test_poker_context.py
+++ b/tests/unit/test_poker_context.py
@@ -229,7 +229,7 @@ class TestGatherPokerContext:
         ctx = gather_poker_context({"source": "jira", "key": "PROJ-1", "summary": "x", "assignee": "Alex"})
         assert ctx.is_empty
 
-    def test_seeded_stores_produce_sections(self, tmp_path, monkeypatch):
+    def _seed_all(self, tmp_path, monkeypatch):
         db = self._seed_db(tmp_path, monkeypatch)
         from yeaboi.reporting.store import ReportingStore
         from yeaboi.sessions import SessionStore
@@ -265,6 +265,12 @@ class TestGatherPokerContext:
                     ),
                 )
             )
+        return db
+
+    _TICKET = {"source": "jira", "key": "PROJ-123", "summary": "Improve user login rate limit", "assignee": "Alex"}
+
+    def test_seeded_stores_produce_sections(self, tmp_path, monkeypatch):
+        self._seed_all(tmp_path, monkeypatch)
 
         ctx = gather_poker_context(
             {"source": "jira", "key": "PROJ-123", "summary": "Improve user login rate limit", "assignee": "Alex"},
@@ -296,6 +302,64 @@ class TestGatherPokerContext:
             {"source": "jira", "key": "PROJ-1", "summary": "Fix user login rate limit", "assignee": "Alex"}
         )
         assert any("similar story" in ln for ln in ctx.planning_lines)  # other sources still gathered
+
+
+class TestGatherContextDeps:
+    """Context toggles on the poker gather — each tokened source obeys its dep,
+    the untokened delivery read only goes silent under full incognito."""
+
+    _seed_db = TestGatherPokerContext._seed_db
+    _seed_all = TestGatherPokerContext._seed_all
+    _TICKET = TestGatherPokerContext._TICKET
+
+    def _scope(self, deps):
+        from yeaboi.projects.scope import ProjectScope
+
+        return ProjectScope("", None, None if deps is None else frozenset(deps))
+
+    def test_scope_none_matches_no_scope(self, tmp_path, monkeypatch):
+        self._seed_all(tmp_path, monkeypatch)
+        bare = gather_poker_context(dict(self._TICKET), project_name="Login")
+        with_none = gather_poker_context(dict(self._TICKET), project_name="Login", scope=None)
+        all_on = gather_poker_context(dict(self._TICKET), project_name="Login", scope=self._scope(None))
+        assert bare == with_none == all_on
+
+    def test_analysis_off_drops_the_profile(self, tmp_path, monkeypatch):
+        self._seed_all(tmp_path, monkeypatch)
+        deps = {"retro", "standup", "plan", "performance"}
+        ctx = gather_poker_context(dict(self._TICKET), project_name="Login", scope=self._scope(deps))
+        assert not ctx.calibration_lines and not ctx.calibration_by_value
+        assert not any("pts/sprint" in ln for ln in ctx.team_lines)
+        assert any("waiting on API keys" in ln for ln in ctx.assignee_lines)  # standup untouched
+
+    def test_standup_off_drops_assignee_and_confidence(self, tmp_path, monkeypatch):
+        self._seed_all(tmp_path, monkeypatch)
+        deps = {"retro", "plan", "performance", "analysis"}
+        ctx = gather_poker_context(dict(self._TICKET), project_name="Login", scope=self._scope(deps))
+        assert ctx.assignee_lines == ()
+        assert not any("confidence" in ln for ln in ctx.team_lines)
+        assert any("PROJ-87" in ln for ln in ctx.delivery_lines)  # delivery untouched
+
+    def test_plan_off_drops_similar_stories(self, tmp_path, monkeypatch):
+        self._seed_all(tmp_path, monkeypatch)
+        deps = {"retro", "standup", "performance", "analysis"}
+        ctx = gather_poker_context(dict(self._TICKET), project_name="Login", scope=self._scope(deps))
+        assert ctx.planning_lines == ()
+
+    def test_incognito_gathers_nothing(self, tmp_path, monkeypatch):
+        self._seed_all(tmp_path, monkeypatch)
+        ctx = gather_poker_context(dict(self._TICKET), project_name="Login", scope=self._scope(()))
+        assert ctx.is_empty and ctx.summary_md == ""
+
+    def test_session_scope_narrows_the_planning_scan(self, tmp_path, monkeypatch):
+        from yeaboi.projects.scope import ProjectScope
+
+        self._seed_all(tmp_path, monkeypatch)
+        scope = ProjectScope("proj-11112222", ("some-other-session",), None)
+        ctx = gather_poker_context(dict(self._TICKET), project_name="Login", scope=scope)
+        assert ctx.planning_lines == ()  # "plan-1" is outside the scope
+        wide = gather_poker_context(dict(self._TICKET), project_name="Login")
+        assert any("similar story" in ln for ln in wide.planning_lines)
 
     def test_context_is_frozen(self):
         with pytest.raises(dataclasses.FrozenInstanceError):

--- a/tests/unit/test_poker_engine.py
+++ b/tests/unit/test_poker_engine.py
@@ -216,8 +216,9 @@ class TestCrossModeContext:
         monkeypatch.setattr("yeaboi.config.is_llm_configured", lambda: (False, "no API key"))
         called = {}
 
-        def _gather(ticket, *, project_name=""):
+        def _gather(ticket, *, project_name="", scope=None):
             called["project_name"] = project_name
+            called["scope"] = scope
             from yeaboi.poker.context import PokerEstimationContext
 
             return PokerEstimationContext()
@@ -225,6 +226,24 @@ class TestCrossModeContext:
         monkeypatch.setattr("yeaboi.poker.context.gather_poker_context", _gather)
         engine.get_poker_perspective(_ticket(), {"Alex": "5"}, project_name="Login")
         assert called["project_name"] == "Login"
+        assert called["scope"] is None
+
+    def test_scope_is_forwarded_to_the_gather(self, monkeypatch):
+        from yeaboi.projects.scope import ProjectScope
+
+        monkeypatch.setattr("yeaboi.config.is_llm_configured", lambda: (False, "no API key"))
+        called = {}
+
+        def _gather(ticket, *, project_name="", scope=None):
+            called["scope"] = scope
+            from yeaboi.poker.context import PokerEstimationContext
+
+            return PokerEstimationContext()
+
+        monkeypatch.setattr("yeaboi.poker.context.gather_poker_context", _gather)
+        scope = ProjectScope("", None, frozenset())
+        engine.get_poker_perspective(_ticket(), {"Alex": "5"}, scope=scope)
+        assert called["scope"] is scope
 
     def test_fallback_note_includes_history_lines(self):
         note = engine._build_fallback_note({"Alex": "5", "Sam": "5"}, _history_context())

--- a/tests/unit/test_poker_server.py
+++ b/tests/unit/test_poker_server.py
@@ -565,8 +565,10 @@ class TestAiEndpoint:
             "evidence": ["5-pt stories avg 4.2 days"],
             "from_llm": True,
         }
-        # The worker scopes the cross-mode history gather to this session's project.
+        # The worker scopes the cross-mode history gather to this session's
+        # project and forwards the board's ProjectScope (context toggles).
         assert seen["project_name"] == b.project_name
+        assert "scope" in seen and seen["scope"] is b.scope
 
     def test_double_click_guard(self, running_server, monkeypatch):
         srv, b = running_server

--- a/tests/unit/test_projects_engine.py
+++ b/tests/unit/test_projects_engine.py
@@ -1,0 +1,87 @@
+"""Tests for projects/engine.py — the five headless entry points."""
+
+import pytest
+
+from yeaboi.projects import engine
+from yeaboi.sessions import SessionStore
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "sessions.db"
+
+
+class TestCreateAndList:
+    def test_create_returns_the_row(self, db_path):
+        project = engine.create_project("Apollo", "the big one", db_path=db_path)
+        assert project["name"] == "Apollo"
+        assert project["project_id"].startswith("proj-")
+
+    def test_blank_name_is_refused(self, db_path):
+        with pytest.raises(ValueError, match="name is required"):
+            engine.create_project("   ", db_path=db_path)
+
+    def test_list_carries_session_counts(self, db_path):
+        project = engine.create_project("Apollo", db_path=db_path)
+        with SessionStore(db_path) as sessions:
+            sessions.create_session("s1", project_id=project["project_id"])
+            sessions.create_session("s2")
+        rows = engine.list_projects(db_path=db_path)
+        assert [(p["name"], p["session_count"]) for p in rows] == [("Apollo", 1)]
+
+
+class TestGet:
+    def test_returns_row_with_linked_sessions(self, db_path):
+        project = engine.create_project("Apollo", db_path=db_path)
+        with SessionStore(db_path) as sessions:
+            sessions.create_session("s1", project_id=project["project_id"])
+        got = engine.get_project(project["project_id"], db_path=db_path)
+        assert got["name"] == "Apollo"
+        assert got["session_ids"] == ["s1"]
+
+    def test_unknown_project_raises(self, db_path):
+        engine.create_project("Apollo", db_path=db_path)
+        with pytest.raises(ValueError, match="unknown project"):
+            engine.get_project("proj-00000000", db_path=db_path)
+
+
+class TestLinkSession:
+    def test_links_and_reads_back(self, db_path):
+        project = engine.create_project("Apollo", db_path=db_path)
+        with SessionStore(db_path) as sessions:
+            sessions.create_session("s1")
+        linked = engine.link_session(project["project_id"], "s1", db_path=db_path)
+        assert linked == {"project_id": project["project_id"], "session_id": "s1"}
+        with SessionStore(db_path) as sessions:
+            assert sessions.session_project_id("s1") == project["project_id"]
+
+    def test_unknown_project_raises(self, db_path):
+        with SessionStore(db_path) as sessions:
+            sessions.create_session("s1")
+        with pytest.raises(ValueError, match="unknown project"):
+            engine.link_session("proj-00000000", "s1", db_path=db_path)
+
+    def test_unknown_session_raises(self, db_path):
+        project = engine.create_project("Apollo", db_path=db_path)
+        with pytest.raises(ValueError, match="unknown session"):
+            engine.link_session(project["project_id"], "nope", db_path=db_path)
+
+
+class TestSetDefaults:
+    def test_merges_and_returns_settings(self, db_path):
+        project = engine.create_project("Apollo", db_path=db_path)
+        first = engine.set_project_defaults(
+            project["project_id"], {"default_analysis_profile_id": "team-x"}, db_path=db_path
+        )
+        assert first["settings"] == {"default_analysis_profile_id": "team-x"}
+        second = engine.set_project_defaults(project["project_id"], {"default_context_deps": []}, db_path=db_path)
+        assert second["settings"] == {"default_analysis_profile_id": "team-x", "default_context_deps": []}
+
+    def test_unknown_key_is_rejected(self, db_path):
+        project = engine.create_project("Apollo", db_path=db_path)
+        with pytest.raises(ValueError, match="unknown default"):
+            engine.set_project_defaults(project["project_id"], {"default_analysis_profile": "typo"}, db_path=db_path)
+
+    def test_unknown_project_raises(self, db_path):
+        with pytest.raises(ValueError, match="unknown project"):
+            engine.set_project_defaults("proj-00000000", {}, db_path=db_path)

--- a/tests/unit/test_projects_page.py
+++ b/tests/unit/test_projects_page.py
@@ -41,8 +41,10 @@ def env(tmp_path, monkeypatch):
     db = tmp_path / "sessions.db"
     monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
     active.set_active_project("")
+    active.set_context_deps(None)
     yield {"db": db}
     active.set_active_project("")
+    active.set_context_deps(None)
 
 
 def _run(keys) -> _Live:
@@ -68,8 +70,8 @@ class TestClose:
 
     def test_the_back_button_closes_it(self, env):
         create_project("Apollo", db_path=env["db"])
-        # Set active → Archive → Back, then Enter.
-        live = _run(_keys("right", "right", "enter"))
+        # Set active → Context → Archive → Back, then Enter.
+        live = _run(_keys("right", "right", "right", "enter"))
         assert "Apollo" in _render(live.frames[-1])
 
 
@@ -93,5 +95,29 @@ class TestSetActive:
 class TestArchive:
     def test_archive_hides_the_row_and_clears_active(self, env):
         create_project("Apollo", db_path=env["db"])
-        _run(_keys("enter", "right", "enter", "esc"))  # set active, then archive it
+        _run(_keys("enter", "right", "right", "enter", "esc"))  # set active, then archive it
         assert active.get_active_project() == ""
+
+
+class TestContextPage:
+    def test_space_toggles_one_source_off(self, env):
+        # Open Context (button 1), Space the first row (retro) off, back out.
+        _run(_keys("right", "enter", " ", "esc", "esc"))
+        assert active.get_context_deps() == ("standup", "plan", "performance", "analysis")
+
+    def test_incognito_button_switches_everything_off(self, env):
+        _run(_keys("right", "enter", "right", "enter", "esc", "esc"))
+        assert active.get_context_deps() == ()
+
+    def test_all_on_restores_inherit(self, env):
+        active.set_context_deps(())
+        _run(_keys("right", "enter", "enter", "esc", "esc"))
+        assert active.get_context_deps() is None
+
+    def test_incognito_renders_its_own_state_line(self, env):
+        live = _run(_keys("right", "enter", "right", "enter", "esc", "esc"))
+        assert any("Incognito" in _render(f) for f in live.frames)
+
+    def test_context_works_with_no_projects(self, env):
+        _run(_keys("right", "enter", "right", "enter", "esc", "esc"))
+        assert active.get_context_deps() == ()

--- a/tests/unit/test_projects_page.py
+++ b/tests/unit/test_projects_page.py
@@ -1,0 +1,97 @@
+"""Tests for the Projects TUI page loop (ui/mode_select/_projects.py).
+
+Driven with a scripted ``read_key`` and a fake Live, the same shape the other
+page-loop tests use — no terminal, no threads of our own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from yeaboi.projects import active
+from yeaboi.projects.engine import create_project
+from yeaboi.ui.mode_select import _projects
+
+
+class _Live:
+    def __init__(self):
+        self.frames: list = []
+
+    def update(self, renderable):
+        self.frames.append(renderable)
+
+
+class _Console:
+    size = (84, 40)
+
+
+def _keys(*sequence):
+    remaining = list(sequence)
+
+    def _read(timeout=None):
+        if timeout == 0.0:
+            return ""
+        return remaining.pop(0) if remaining else "esc"
+
+    return _read
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    db = tmp_path / "sessions.db"
+    monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
+    active.set_active_project("")
+    yield {"db": db}
+    active.set_active_project("")
+
+
+def _run(keys) -> _Live:
+    live = _Live()
+    _projects.run_projects_page(_Console(), live, keys, 0.05, True)
+    return live
+
+
+def _render(panel) -> str:
+    import io
+
+    from rich.console import Console
+
+    console = Console(file=io.StringIO(), width=84, height=40)
+    console.print(panel)
+    return console.file.getvalue()
+
+
+class TestClose:
+    def test_esc_closes_the_page(self, env):
+        live = _run(_keys("esc"))
+        assert live.frames
+
+    def test_the_back_button_closes_it(self, env):
+        create_project("Apollo", db_path=env["db"])
+        # Set active → Archive → Back, then Enter.
+        live = _run(_keys("right", "right", "enter"))
+        assert "Apollo" in _render(live.frames[-1])
+
+
+class TestSetActive:
+    def test_enter_on_set_active_marks_the_project(self, env):
+        create_project("Apollo", db_path=env["db"])
+        _run(_keys("enter", "esc"))
+        assert active.get_active_project().startswith("proj-")
+
+    def test_enter_again_clears_it(self, env):
+        create_project("Apollo", db_path=env["db"])
+        _run(_keys("enter", "enter", "esc"))
+        assert active.get_active_project() == ""
+
+    def test_empty_page_offers_the_command_instead(self, env):
+        live = _run(_keys("enter", "esc"))
+        assert "yeaboi project create" in _render(live.frames[-1])
+        assert active.get_active_project() == ""
+
+
+class TestArchive:
+    def test_archive_hides_the_row_and_clears_active(self, env):
+        create_project("Apollo", db_path=env["db"])
+        _run(_keys("enter", "right", "enter", "esc"))  # set active, then archive it
+        assert active.get_active_project() == ""

--- a/tests/unit/test_projects_page.py
+++ b/tests/unit/test_projects_page.py
@@ -42,9 +42,11 @@ def env(tmp_path, monkeypatch):
     monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
     active.set_active_project("")
     active.set_context_deps(None)
+    active.set_solo_mode(False)
     yield {"db": db}
     active.set_active_project("")
     active.set_context_deps(None)
+    active.set_solo_mode(False)
 
 
 def _run(keys) -> _Live:
@@ -113,6 +115,32 @@ class TestContextPage:
         active.set_context_deps(())
         _run(_keys("right", "enter", "enter", "esc", "esc"))
         assert active.get_context_deps() is None
+
+
+class TestSoloMode:
+    """The Solo world's ambient session flag and its context-dep default."""
+
+    def test_solo_defaults_drop_the_retro_feed(self, env):
+        from yeaboi.projects.scope import CONTEXT_DEP_TOKENS
+
+        active.set_solo_mode(True)
+        deps = active.get_context_deps()
+        assert deps is not None and "retro" not in deps
+        assert set(deps) == set(CONTEXT_DEP_TOKENS) - {"retro"}
+
+    def test_an_explicit_choice_still_wins(self, env):
+        active.set_solo_mode(True)
+        active.set_context_deps(("retro", "plan"))
+        assert active.get_context_deps() == ("retro", "plan")
+        active.set_context_deps(())  # incognito is explicit too
+        assert active.get_context_deps() == ()
+
+    def test_leaving_the_solo_world_restores_inherit(self, env):
+        active.set_solo_mode(True)
+        assert active.get_context_deps() is not None
+        active.set_solo_mode(False)
+        assert active.get_context_deps() is None
+        assert active.is_solo_mode() is False
 
     def test_incognito_renders_its_own_state_line(self, env):
         live = _run(_keys("right", "enter", "right", "enter", "esc", "esc"))

--- a/tests/unit/test_projects_scope.py
+++ b/tests/unit/test_projects_scope.py
@@ -116,6 +116,22 @@ class TestContextDepsVocabulary:
     def test_normalize_drops_unknown_tokens_without_raising(self):
         assert normalize_context_deps(["retro", "bogus"]) == frozenset({"retro"})
 
+    def test_normalize_all_unknown_means_all_on_not_incognito(self):
+        # A wholly-typo'd value is a mistake, not a request for no context — an
+        # empty frozenset here would silently blank every cross-mode read.
+        assert normalize_context_deps(["retros"]) is None
+        assert normalize_context_deps("retros, standups") is None
+        assert normalize_context_deps('["bogus"]') is None
+        # Only an explicitly empty value is incognito.
+        assert normalize_context_deps([]) == frozenset()
+        assert normalize_context_deps(()) == frozenset()
+
+    def test_typo_does_not_resolve_to_an_incognito_scope(self):
+        from yeaboi.projects.scope import incognito, resolve_scope
+
+        assert incognito(resolve_scope("", context_deps=["retros"])) is False
+        assert incognito(resolve_scope("", context_deps=[])) is True
+
     def test_parse_spec_grammar(self):
         assert parse_context_spec("all") == list(CONTEXT_DEP_TOKENS)
         assert parse_context_spec("none") == []

--- a/tests/unit/test_projects_scope.py
+++ b/tests/unit/test_projects_scope.py
@@ -1,7 +1,18 @@
 """Tests for projects/scope.py — scope resolution and the planning-state pull."""
 
+import pytest
+
 from yeaboi.agent.state import Sprint
-from yeaboi.projects.scope import ProjectScope, latest_planning_state, resolve_scope
+from yeaboi.projects.scope import (
+    CONTEXT_DEP_TOKENS,
+    ProjectScope,
+    latest_planning_state,
+    normalize_context_deps,
+    parse_context_spec,
+    recent_standup_blockers,
+    resolve_scope,
+    wants,
+)
 from yeaboi.projects.store import ProjectStore
 from yeaboi.sessions import SessionStore
 
@@ -88,3 +99,80 @@ class TestLatestPlanningState:
             sessions.create_session("analysis-1", mode="analysis", project_id=pid)
             sessions.save_state("analysis-1", {"messages": [], "sprints": [_sprint("not a plan")]})
         assert latest_planning_state(ProjectScope(pid, ("analysis-1",)), db_path=db) is None
+
+
+class TestContextDepsVocabulary:
+    def test_normalize_accepts_iterables_csv_and_json(self):
+        assert normalize_context_deps(["retro", "plan"]) == frozenset({"retro", "plan"})
+        assert normalize_context_deps("retro, plan") == frozenset({"retro", "plan"})
+        assert normalize_context_deps('["standup"]') == frozenset({"standup"})
+        assert normalize_context_deps(()) == frozenset()
+
+    def test_normalize_none_and_blank_mean_all_on(self):
+        assert normalize_context_deps(None) is None
+        assert normalize_context_deps("") is None
+
+    def test_normalize_drops_unknown_tokens_without_raising(self):
+        assert normalize_context_deps(["retro", "bogus"]) == frozenset({"retro"})
+
+    def test_parse_spec_grammar(self):
+        assert parse_context_spec("all") == list(CONTEXT_DEP_TOKENS)
+        assert parse_context_spec("none") == []
+        assert parse_context_spec("") is None
+        assert parse_context_spec("inherit") is None
+        assert parse_context_spec("retro,plan") == ["retro", "plan"]
+
+    def test_parse_spec_raises_on_a_typo(self):
+        with pytest.raises(ValueError, match="unknown context source"):
+            parse_context_spec("retro,bogus")
+
+    def test_wants_helpers(self):
+        scope = ProjectScope("proj-11112222", ("s1",), frozenset({"retro"}))
+        assert scope.wants("retro") and not scope.wants("plan")
+        assert wants(None, "plan")
+        assert wants(ProjectScope("", None, None), "plan")
+        assert not wants(ProjectScope("", None, frozenset()), "plan")
+
+
+class TestResolveScopeContextDeps:
+    def test_explicit_deps_win_over_the_project_default(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        with ProjectStore(db) as projects:
+            projects.set_settings(pid, {"default_context_deps": ["plan"]})
+        scope = resolve_scope(pid, context_deps=["retro"], db_path=db)
+        assert scope is not None and scope.context_deps == frozenset({"retro"})
+
+    def test_project_default_applies_when_the_caller_passes_none(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        with ProjectStore(db) as projects:
+            projects.set_settings(pid, {"default_context_deps": ["plan", "retro"]})
+        scope = resolve_scope(pid, db_path=db)
+        assert scope is not None and scope.context_deps == frozenset({"plan", "retro"})
+
+    def test_no_default_means_all_on(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        scope = resolve_scope(pid, db_path=db)
+        assert scope is not None and scope.context_deps is None
+
+    def test_unscoped_incognito_gets_a_carrier_scope(self, tmp_path):
+        # No project, but a deps restriction: the scope exists, narrows no
+        # sessions (None, not ()), and carries the empty dep set.
+        db, _ = _linked_db(tmp_path)
+        scope = resolve_scope(session_id="loose-1", context_deps=[], db_path=db)
+        assert scope == ProjectScope("", None, frozenset())
+
+    def test_missing_db_still_carries_an_explicit_restriction(self, tmp_path):
+        scope = resolve_scope(context_deps=["retro"], db_path=tmp_path / "sessions.db")
+        assert scope == ProjectScope("", None, frozenset({"retro"}))
+
+    def test_explicit_empty_differs_from_absent(self, tmp_path):
+        db, _ = _linked_db(tmp_path)
+        assert resolve_scope(db_path=db) is None
+        assert resolve_scope(context_deps=[], db_path=db) is not None
+
+
+class TestBlockersRespectTheStandupToggle:
+    def test_standup_dep_off_returns_nothing(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        scope = resolve_scope(pid, context_deps=["retro", "plan"], db_path=db)
+        assert recent_standup_blockers(scope, db_path=db) == []

--- a/tests/unit/test_projects_scope.py
+++ b/tests/unit/test_projects_scope.py
@@ -6,6 +6,7 @@ from yeaboi.agent.state import Sprint
 from yeaboi.projects.scope import (
     CONTEXT_DEP_TOKENS,
     ProjectScope,
+    incognito,
     latest_planning_state,
     normalize_context_deps,
     parse_context_spec,
@@ -132,6 +133,18 @@ class TestContextDepsVocabulary:
         assert wants(None, "plan")
         assert wants(ProjectScope("", None, None), "plan")
         assert not wants(ProjectScope("", None, frozenset()), "plan")
+
+
+class TestIncognito:
+    def test_only_an_explicit_empty_set_is_incognito(self):
+        assert ProjectScope("", None, frozenset()).incognito
+        assert not ProjectScope("", None, None).incognito
+        assert not ProjectScope("proj-11112222", ("s1",), frozenset({"retro"})).incognito
+
+    def test_module_helper_treats_an_absent_scope_as_not_incognito(self):
+        assert not incognito(None)
+        assert incognito(ProjectScope("", None, frozenset()))
+        assert not incognito(ProjectScope("", None, frozenset({"plan"})))
 
 
 class TestResolveScopeContextDeps:

--- a/tests/unit/test_projects_scope.py
+++ b/tests/unit/test_projects_scope.py
@@ -1,0 +1,90 @@
+"""Tests for projects/scope.py — scope resolution and the planning-state pull."""
+
+from yeaboi.agent.state import Sprint
+from yeaboi.projects.scope import ProjectScope, latest_planning_state, resolve_scope
+from yeaboi.projects.store import ProjectStore
+from yeaboi.sessions import SessionStore
+
+
+def _sprint(name: str) -> Sprint:
+    return Sprint(id="SP-1", name=name, goal="", capacity_points=10, story_ids=())
+
+
+def _linked_db(tmp_path):
+    """A DB with one project and one linked planning session."""
+    db = tmp_path / "sessions.db"
+    with ProjectStore(db) as projects:
+        project = projects.create("Apollo")
+    with SessionStore(db) as sessions:
+        sessions.create_session("plan-1", "Apollo", project_id=project["project_id"])
+        sessions.create_session("loose-1")
+    return db, project["project_id"]
+
+
+class TestResolveScope:
+    def test_explicit_project_id_wins(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        scope = resolve_scope(pid, "loose-1", db_path=db)
+        assert scope is not None
+        assert scope.project_id == pid
+        assert scope.session_ids == ("plan-1",)
+        assert scope.context_deps is None
+
+    def test_inherits_from_a_linked_session(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        scope = resolve_scope(session_id="plan-1", db_path=db)
+        assert scope is not None and scope.project_id == pid
+
+    def test_unlinked_session_resolves_to_none(self, tmp_path):
+        db, _ = _linked_db(tmp_path)
+        assert resolve_scope(session_id="loose-1", db_path=db) is None
+
+    def test_no_arguments_resolves_to_none(self, tmp_path):
+        db, _ = _linked_db(tmp_path)
+        assert resolve_scope(db_path=db) is None
+
+    def test_missing_db_resolves_to_none(self, tmp_path):
+        # Never creates the DB file on a read path, and never raises.
+        db = tmp_path / "sessions.db"
+        assert resolve_scope("proj-11112222", db_path=db) is None
+        assert not db.exists()
+
+    def test_broken_db_path_never_raises(self, tmp_path):
+        assert resolve_scope("proj-11112222", db_path=tmp_path) is None  # a directory, not a file
+
+    def test_unknown_project_still_scopes_to_empty(self, tmp_path):
+        # A bad-but-set project id narrows to nothing rather than widening to
+        # everything: the caller asked for a project, they get its (zero) rows.
+        db, _ = _linked_db(tmp_path)
+        scope = resolve_scope("proj-00000000", db_path=db)
+        assert scope is not None and scope.session_ids == ()
+
+
+class TestLatestPlanningState:
+    def test_none_scope_is_none(self, tmp_path):
+        assert latest_planning_state(None, db_path=tmp_path / "sessions.db") is None
+
+    def test_picks_newest_session_with_sprints(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        with SessionStore(db) as sessions:
+            sessions.create_session("plan-2", "Apollo", project_id=pid)
+            sessions.save_state("plan-1", {"messages": [], "sprints": [], "team_size": 3})
+            sessions.save_state("plan-2", {"messages": [], "sprints": [_sprint("Sprint 1")], "team_size": 5})
+        found = latest_planning_state(resolve_scope(pid, db_path=db), db_path=db)
+        assert found is not None
+        sid, state = found
+        assert sid == "plan-2"
+        assert state["team_size"] == 5
+
+    def test_sprintless_project_yields_none(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        with SessionStore(db) as sessions:
+            sessions.save_state("plan-1", {"messages": [], "sprints": []})
+        assert latest_planning_state(resolve_scope(pid, db_path=db), db_path=db) is None
+
+    def test_non_planning_sessions_are_ignored(self, tmp_path):
+        db, pid = _linked_db(tmp_path)
+        with SessionStore(db) as sessions:
+            sessions.create_session("analysis-1", mode="analysis", project_id=pid)
+            sessions.save_state("analysis-1", {"messages": [], "sprints": [_sprint("not a plan")]})
+        assert latest_planning_state(ProjectScope(pid, ("analysis-1",)), db_path=db) is None

--- a/tests/unit/test_projects_screens.py
+++ b/tests/unit/test_projects_screens.py
@@ -10,7 +10,7 @@ import io
 
 from rich.console import Console
 
-from yeaboi.ui.mode_select.screens._screens_projects import _build_projects_screen
+from yeaboi.ui.mode_select.screens._screens_projects import _build_context_screen, _build_projects_screen
 
 _W, _H = 84, 40
 
@@ -70,3 +70,37 @@ class TestTheRow:
 class TestMessage:
     def test_a_message_reaches_the_page(self):
         assert "Archived Apollo." in _render(projects=[_project()], message="Archived Apollo.")
+
+
+def _render_context(deps, **kwargs) -> str:
+    panel = _build_context_screen(deps, width=_W, height=_H, **kwargs)
+    console = Console(file=io.StringIO(), width=_W, height=_H)
+    console.print(panel)
+    return console.file.getvalue()
+
+
+class TestContextScreen:
+    def test_inherit_shows_every_source_on(self):
+        out = _render_context(None)
+        assert "Retro history" in out
+        assert "Analysis profile" in out
+        assert "Inheriting" in out
+        assert "○" not in out
+
+    def test_a_disabled_source_wears_the_hollow_glyph(self):
+        out = _render_context(("standup", "plan", "performance", "analysis"))
+        assert "○" in out
+        assert "Only the ● sources" in out
+
+    def test_incognito_names_itself_and_keeps_sessions(self):
+        out = _render_context(())
+        assert "Incognito" in out
+        assert "Sessions still persist" in out
+
+    def test_draws_its_buttons(self):
+        out = _render_context(None)
+        assert "All on" in out
+        assert "Back" in out
+
+    def test_a_message_reaches_the_page(self):
+        assert "saved" in _render_context(None, message="saved")

--- a/tests/unit/test_projects_screens.py
+++ b/tests/unit/test_projects_screens.py
@@ -1,0 +1,72 @@
+"""Render tests for the Projects page (_screens_projects.py).
+
+Rendered at the app's enforced minimum terminal size (84x40), never the
+builder's own default — that hides exactly the crowding a real user would hit.
+"""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from yeaboi.ui.mode_select.screens._screens_projects import _build_projects_screen
+
+_W, _H = 84, 40
+
+
+def _render(**kwargs) -> str:
+    panel = _build_projects_screen(width=_W, height=_H, **kwargs)
+    console = Console(file=io.StringIO(), width=_W, height=_H)
+    console.print(panel)
+    return console.file.getvalue()
+
+
+def _project(**overrides) -> dict:
+    base = {
+        "project_id": "proj-11112222",
+        "name": "Apollo",
+        "description": "",
+        "settings": {},
+        "created_at": "2026-08-01T00:00:00+00:00",
+        "last_active": "2026-08-30T00:00:00+00:00",
+        "archived": False,
+        "session_count": 3,
+    }
+    return {**base, **overrides}
+
+
+class TestEmptyState:
+    def test_points_at_the_create_command_rather_than_saying_none(self):
+        out = _render(projects=[])
+        assert "No projects yet" in out
+        assert "yeaboi project create" in out
+
+    def test_still_draws_its_buttons(self):
+        assert "Back" in _render(projects=[])
+
+
+class TestTheRow:
+    def test_shows_name_id_and_session_count(self):
+        out = _render(projects=[_project()])
+        assert "Apollo" in out
+        assert "proj-11112222" in out
+        assert "3" in out
+
+    def test_the_active_project_wears_the_marker(self):
+        out = _render(projects=[_project()], active_project_id="proj-11112222")
+        assert "●" in out
+        assert "Scoped runs read context through" in out
+
+    def test_no_active_project_says_runs_stay_teamwide(self):
+        out = _render(projects=[_project()])
+        assert "team-wide" in out
+
+    def test_an_archived_row_says_so(self):
+        out = _render(projects=[_project(archived=True)])
+        assert "(archived)" in out
+
+
+class TestMessage:
+    def test_a_message_reaches_the_page(self):
+        assert "Archived Apollo." in _render(projects=[_project()], message="Archived Apollo.")

--- a/tests/unit/test_projects_screens.py
+++ b/tests/unit/test_projects_screens.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 
+import pytest
 from rich.console import Console
 
 from yeaboi.ui.mode_select.screens._screens_projects import _build_context_screen, _build_projects_screen
@@ -15,9 +16,9 @@ from yeaboi.ui.mode_select.screens._screens_projects import _build_context_scree
 _W, _H = 84, 40
 
 
-def _render(**kwargs) -> str:
-    panel = _build_projects_screen(width=_W, height=_H, **kwargs)
-    console = Console(file=io.StringIO(), width=_W, height=_H)
+def _render(*, width: int = _W, height: int = _H, **kwargs) -> str:
+    panel = _build_projects_screen(width=width, height=height, **kwargs)
+    console = Console(file=io.StringIO(), width=width, height=height)
     console.print(panel)
     return console.file.getvalue()
 
@@ -44,6 +45,30 @@ class TestEmptyState:
 
     def test_still_draws_its_buttons(self):
         assert "Back" in _render(projects=[])
+
+
+class TestTheListDoesNotCropTheButtons:
+    """The row block is flattened to one Text per line, so the viewport math holds.
+
+    A single multi-row Table counted as one body entry while drawing N+1 lines,
+    which pushed the action block off the bottom of the fixed-height Panel at
+    three projects or more — on any terminal height.
+    """
+
+    @staticmethod
+    def _many(n: int) -> list[dict]:
+        return [_project(project_id=f"proj-{i:08d}", name=f"Project {i}") for i in range(n)]
+
+    @pytest.mark.parametrize("count", [1, 3, 6, 12, 40])
+    def test_actions_survive_any_project_count(self, count):
+        out = _render(projects=self._many(count))
+        assert "Set active" in out
+        assert "Back" in out
+
+    def test_a_long_list_can_actually_scroll(self):
+        meta: dict = {}
+        _render(projects=self._many(40), scroll_meta=meta, height=24)
+        assert meta["max_offset"] > 0, "the page publishes no scroll room, so rows past the fold are unreachable"
 
 
 class TestTheRow:

--- a/tests/unit/test_projects_store.py
+++ b/tests/unit/test_projects_store.py
@@ -1,0 +1,105 @@
+"""Tests for projects/store.py — the first-class project rows."""
+
+import re
+import sqlite3
+
+import pytest
+
+from yeaboi.projects.store import PROJECTS_SCHEMA, ProjectStore, new_project_id
+
+
+@pytest.fixture
+def store(tmp_path):
+    with ProjectStore(tmp_path / "sessions.db") as s:
+        yield s
+
+
+class TestProjectId:
+    def test_format(self):
+        assert re.fullmatch(r"proj-[0-9a-f]{8}", new_project_id())
+
+    def test_unique(self):
+        assert len({new_project_id() for _ in range(50)}) == 50
+
+
+class TestCrud:
+    def test_create_and_get_round_trip(self, store):
+        created = store.create("Apollo", "the big one")
+        got = store.get(created["project_id"])
+        assert got == created
+        assert got["name"] == "Apollo"
+        assert got["description"] == "the big one"
+        assert got["settings"] == {}
+        assert got["archived"] is False
+
+    def test_get_missing_returns_none(self, store):
+        assert store.get("proj-00000000") is None
+
+    def test_list_orders_by_last_active(self, store):
+        first = store.create("First")
+        store.create("Second")
+        store.touch(first["project_id"])
+        # A touched project resurfaces ahead of a newer untouched one.
+        listed = store.list_projects()
+        assert [p["name"] for p in listed] == ["First", "Second"]
+        assert listed[0]["last_active"] >= listed[1]["last_active"]
+
+    def test_archive_hides_from_default_listing(self, store):
+        keep = store.create("Keep")
+        gone = store.create("Gone")
+        assert store.archive(gone["project_id"]) is True
+        assert [p["project_id"] for p in store.list_projects()] == [keep["project_id"]]
+        everything = store.list_projects(include_archived=True)
+        assert {p["project_id"] for p in everything} == {keep["project_id"], gone["project_id"]}
+
+    def test_archive_missing_returns_false(self, store):
+        assert store.archive("proj-00000000") is False
+
+
+class TestSettings:
+    def test_round_trip(self, store):
+        project = store.create("Apollo")
+        store.set_settings(project["project_id"], {"default_analysis_profile_id": "team-x"})
+        assert store.get_settings(project["project_id"]) == {"default_analysis_profile_id": "team-x"}
+
+    def test_unknown_keys_survive(self, store):
+        # The store is a dumb JSON round-trip; key policy lives in the engine.
+        project = store.create("Apollo")
+        store.set_settings(project["project_id"], {"default_context_deps": ["retro"], "future_key": 1})
+        assert store.get_settings(project["project_id"]) == {"default_context_deps": ["retro"], "future_key": 1}
+
+    def test_missing_project_reads_empty(self, store):
+        assert store.get_settings("proj-00000000") == {}
+
+    def test_corrupt_settings_read_as_empty(self, store):
+        project = store.create("Apollo")
+        store._conn.execute(
+            "UPDATE projects SET settings_json = 'not json' WHERE project_id = ?",
+            (project["project_id"],),
+        )
+        assert store.get_settings(project["project_id"]) == {}
+
+
+class TestLifecycle:
+    def test_self_heals_on_a_pre_existing_db(self, tmp_path):
+        # A DB that has never seen the projects table (opened by an older
+        # SessionStore, say) gets it on store open.
+        db = tmp_path / "sessions.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE other (x INT)")
+        conn.commit()
+        conn.close()
+        with ProjectStore(db) as store:
+            assert store.list_projects() == []
+
+    def test_schema_constant_is_idempotent(self, tmp_path):
+        db = tmp_path / "sessions.db"
+        ProjectStore(db).close()
+        conn = sqlite3.connect(str(db))
+        conn.executescript(PROJECTS_SCHEMA)  # IF NOT EXISTS — must not raise
+        conn.close()
+
+    def test_double_close_is_safe(self, tmp_path):
+        store = ProjectStore(tmp_path / "sessions.db")
+        store.close()
+        store.close()

--- a/tests/unit/test_reporting_engine.py
+++ b/tests/unit/test_reporting_engine.py
@@ -519,3 +519,37 @@ class TestProjectScopedReport:
         _patch_llm(monkeypatch, json.dumps({"headline": "h", "executive_summary": "s"}))
         report = engine.run_delivery_report("last_sprint", session_id="", db_path=db_path)
         assert report.project_name == ""
+
+
+class TestReportContextDeps:
+    def _seed(self, db_path):
+        from yeaboi.agent.state import Sprint
+        from yeaboi.projects.store import ProjectStore
+        from yeaboi.sessions import SessionStore
+
+        with ProjectStore(db_path) as projects:
+            pid = projects.create("Apollo")["project_id"]
+        with SessionStore(db_path) as s:
+            s.create_session("plan-1", "Apollo", mode="planning", project_id=pid)
+            s.save_state(
+                "plan-1",
+                {
+                    "project_name": "Apollo",
+                    "sprints": [Sprint(id="SP-1", name="Sprint 1", goal="", capacity_points=10, story_ids=())],
+                },
+            )
+        return pid
+
+    def test_plan_dep_off_skips_the_sprint_framing(self, monkeypatch, db_path):
+        pid = self._seed(db_path)
+        _patch_activity(monkeypatch, items=_items(1))
+        _patch_llm(monkeypatch, json.dumps({"headline": "h", "executive_summary": "s"}))
+        report = engine.run_delivery_report("last_sprint", project_id=pid, context_deps=[], db_path=db_path)
+        assert report.project_name == ""
+
+    def test_plan_dep_on_still_frames(self, monkeypatch, db_path):
+        pid = self._seed(db_path)
+        _patch_activity(monkeypatch, items=_items(1))
+        _patch_llm(monkeypatch, json.dumps({"headline": "h", "executive_summary": "s"}))
+        report = engine.run_delivery_report("last_sprint", project_id=pid, context_deps=["plan"], db_path=db_path)
+        assert report.project_name == "Apollo"

--- a/tests/unit/test_reporting_engine.py
+++ b/tests/unit/test_reporting_engine.py
@@ -488,3 +488,34 @@ class TestDeckStylePlumbing:
         monkeypatch.setattr("yeaboi.reporting.export.export_report", _capture)
         engine.run_delivery_report("last_sprint", db_path=db_path)
         assert seen["style"] == sentinel
+
+
+class TestProjectScopedReport:
+    """The planning→reporting edge: sprint framing from the project's plan."""
+
+    def test_scoped_report_frames_with_the_projects_plan(self, monkeypatch, db_path):
+        from yeaboi.agent.state import Sprint
+        from yeaboi.projects.store import ProjectStore
+        from yeaboi.sessions import SessionStore
+
+        with ProjectStore(db_path) as projects:
+            pid = projects.create("Apollo")["project_id"]
+        with SessionStore(db_path) as s:
+            s.create_session("plan-1", "Apollo", mode="planning", project_id=pid)
+            s.save_state(
+                "plan-1",
+                {
+                    "project_name": "Apollo",
+                    "sprints": [Sprint(id="SP-1", name="Sprint 1", goal="", capacity_points=10, story_ids=())],
+                },
+            )
+        _patch_activity(monkeypatch, items=_items(1))
+        _patch_llm(monkeypatch, json.dumps({"headline": "h", "executive_summary": "s"}))
+        report = engine.run_delivery_report("last_sprint", project_id=pid, db_path=db_path)
+        assert report.project_name == "Apollo"
+
+    def test_unscoped_report_is_unchanged(self, monkeypatch, db_path):
+        _patch_activity(monkeypatch, items=_items(1))
+        _patch_llm(monkeypatch, json.dumps({"headline": "h", "executive_summary": "s"}))
+        report = engine.run_delivery_report("last_sprint", session_id="", db_path=db_path)
+        assert report.project_name == ""

--- a/tests/unit/test_retro_engine.py
+++ b/tests/unit/test_retro_engine.py
@@ -269,3 +269,32 @@ class TestCarryForwardInGenerate:
         # Open item is handed to the LLM as STILL_OPEN context; the resolved one isn't.
         assert "in progress work" in captured["prompt"]
         assert "done thing" not in captured["prompt"]
+
+
+class TestCarriedActionItemsScope:
+    def test_scope_filters_to_the_projects_sessions(self, tmp_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        with RetroStore(db) as store:
+            store.record_run(_prior_report("proj-sess", date="2026-07-01"))
+            # Newer, but belongs to another project's session — must not win.
+            store.record_run(
+                RetroReport(
+                    session_id="other-sess",
+                    date="2026-07-09",
+                    cards=(RetroCard(id="o1", grid="action_items", text="other project's item", author="AI"),),
+                )
+            )
+        scope = ProjectScope("proj-11112222", ("proj-sess",))
+        carried = engine.carried_action_items_for_session("cur", db_path=db, scope=scope)
+        assert [c.text for c in carried] == ["ship the docs"]
+
+    def test_empty_scope_carries_nothing(self, tmp_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        with RetroStore(db) as store:
+            store.record_run(_prior_report("prev"))
+        scope = ProjectScope("proj-11112222", ())
+        assert engine.carried_action_items_for_session("cur", db_path=db, scope=scope) == ()

--- a/tests/unit/test_retro_engine.py
+++ b/tests/unit/test_retro_engine.py
@@ -298,3 +298,49 @@ class TestCarriedActionItemsScope:
             store.record_run(_prior_report("prev"))
         scope = ProjectScope("proj-11112222", ())
         assert engine.carried_action_items_for_session("cur", db_path=db, scope=scope) == ()
+
+
+class TestStandupBlockerCards:
+    def _seed_standup_report(self, db, session_id, blockers):
+        from dataclasses import asdict
+
+        from yeaboi.agent.state import MemberUpdate, StandupReport
+        from yeaboi.standup.store import StandupStore
+
+        report = StandupReport(
+            date="2026-07-10",
+            session_id=session_id,
+            member_updates=tuple(MemberUpdate(name=n, blockers=b) for n, b in blockers),
+        )
+        with StandupStore(db) as store:
+            store._conn.execute(
+                "INSERT INTO standup_history "
+                "(session_id, run_at, standup_date, sprint_day, confidence_pct, report_json, status) "
+                "VALUES (?, ?, ?, 1, 80, ?, 'success')",
+                (session_id, "2026-07-10T09:00:00+00:00", "2026-07-10", json.dumps(asdict(report))),
+            )
+
+    def test_scoped_board_gets_badged_blocker_cards(self, tmp_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        self._seed_standup_report(db, "proj-sess", [("Alice", "waiting on review"), ("Bob", "")])
+        self._seed_standup_report(db, "other-sess", [("Eve", "other project blocker")])
+        scope = ProjectScope("proj-11112222", ("proj-sess",))
+        cards = engine.standup_blocker_cards(scope, db_path=db)
+        assert [c.text for c in cards] == ["[Standup] Alice: waiting on review"]
+        assert cards[0].status == "pending" and cards[0].origin == "carryover"
+
+    def test_dedupes_against_existing_carried_cards(self, tmp_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        self._seed_standup_report(db, "proj-sess", [("Alice", "waiting on review")])
+        existing = (RetroCard(id="c1", grid="action_items", text="[Standup] Alice: waiting on review"),)
+        scope = ProjectScope("proj-11112222", ("proj-sess",))
+        assert engine.standup_blocker_cards(scope, db_path=db, existing=existing) == ()
+
+    def test_unscoped_board_gets_none(self, tmp_path):
+        db = tmp_path / "sessions.db"
+        self._seed_standup_report(db, "proj-sess", [("Alice", "waiting on review")])
+        assert engine.standup_blocker_cards(None, db_path=db) == ()

--- a/tests/unit/test_retro_engine.py
+++ b/tests/unit/test_retro_engine.py
@@ -367,3 +367,55 @@ class TestCarryRespectsTheRetroToggle:
         scope = ProjectScope("", None, frozenset({"retro"}))
         carried = engine.carried_action_items_for_session("cur", db_path=db, scope=scope)
         assert [c.text for c in carried] == ["ship the docs"]
+
+
+class TestHistoryProviders:
+    def _seed(self, tmp_path):
+        db = tmp_path / "sessions.db"
+        with RetroStore(db) as store:
+            store.record_run(_prior_report("proj-sess", project_name="Alpha", date="2026-07-01"))
+            store.record_run(_prior_report("other-sess", project_name="Beta", date="2026-07-09"))
+        return db
+
+    def test_unscoped_listing_matches_scope_none(self, tmp_path):
+        db = self._seed(tmp_path)
+        listing_bare, one_bare = engine.history_providers(db_path=db)
+        listing_none, one_none = engine.history_providers(db_path=db, scope=None)
+        assert listing_bare() == listing_none()
+        first_id = listing_bare()[0]["id"]
+        assert one_bare(first_id) == one_none(first_id)
+
+    def test_retro_dep_off_reports_no_history(self, tmp_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = self._seed(tmp_path)
+        listing, one = engine.history_providers(db_path=db, scope=ProjectScope("", None, frozenset()))
+        assert listing() == []
+        run_id = engine.history_providers(db_path=db)[0]()[0]["id"]
+        assert one(run_id) is None
+
+    def test_session_scope_filters_the_listing(self, tmp_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = self._seed(tmp_path)
+        scope = ProjectScope("proj-11112222", ("proj-sess",))
+        listing, _one = engine.history_providers(db_path=db, scope=scope)
+        runs = listing()
+        assert [r["session_id"] for r in runs] == ["proj-sess"]
+
+    def test_a_foreign_id_cannot_be_fetched_through_a_scoped_reader(self, tmp_path):
+        # The listing hides foreign runs; the id endpoint must not be a bypass.
+        from yeaboi.projects.scope import ProjectScope
+
+        db = self._seed(tmp_path)
+        all_runs = engine.history_providers(db_path=db)[0]()
+        foreign = next(r["id"] for r in all_runs if r["session_id"] == "other-sess")
+        own = next(r["id"] for r in all_runs if r["session_id"] == "proj-sess")
+        _listing, one = engine.history_providers(db_path=db, scope=ProjectScope("p", ("proj-sess",)))
+        assert one(foreign) is None
+        assert one(own) is not None
+
+    def test_a_broken_store_is_a_board_with_no_past(self, tmp_path):
+        listing, one = engine.history_providers(db_path=tmp_path / "not-a-dir" / "nope.db")
+        assert listing() == []
+        assert one(1) is None

--- a/tests/unit/test_retro_engine.py
+++ b/tests/unit/test_retro_engine.py
@@ -344,3 +344,26 @@ class TestStandupBlockerCards:
         db = tmp_path / "sessions.db"
         self._seed_standup_report(db, "proj-sess", [("Alice", "waiting on review")])
         assert engine.standup_blocker_cards(None, db_path=db) == ()
+
+
+class TestCarryRespectsTheRetroToggle:
+    def test_retro_dep_off_carries_nothing_even_unscoped(self, tmp_path):
+        # The scope object is the sentinel: an unscoped incognito run (no
+        # project, session_ids=None) must still suppress the carry-forward.
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        with RetroStore(db) as store:
+            store.record_run(_prior_report("prev"))
+        scope = ProjectScope("", None, frozenset())
+        assert engine.carried_action_items_for_session("cur", project_name="Apollo", db_path=db, scope=scope) == ()
+
+    def test_retro_dep_on_still_carries(self, tmp_path):
+        from yeaboi.projects.scope import ProjectScope
+
+        db = tmp_path / "sessions.db"
+        with RetroStore(db) as store:
+            store.record_run(_prior_report("prev"))
+        scope = ProjectScope("", None, frozenset({"retro"}))
+        carried = engine.carried_action_items_for_session("cur", db_path=db, scope=scope)
+        assert [c.text for c in carried] == ["ship the docs"]

--- a/tests/unit/test_retro_store.py
+++ b/tests/unit/test_retro_store.py
@@ -115,6 +115,17 @@ class TestSavedRunsHub:
             rows = store.get_all_history()
         assert rows and "id" in rows[0] and rows[0]["session_id"] == "sess-1"
 
+    def test_get_all_history_filters_by_session_ids(self, tmp_path):
+        other = RetroReport(session_id="sess-2", date="2026-07-12", cards=(RetroCard(text="x"),))
+        with RetroStore(tmp_path / "sessions.db") as store:
+            store.record_run(_report())
+            store.record_run(other)
+            assert {r["session_id"] for r in store.get_all_history(session_ids=("sess-1",))} == {"sess-1"}
+            # Filtered in SQL, so the limit counts the scoped rows, not the newest overall.
+            assert [r["session_id"] for r in store.get_all_history(limit=1, session_ids=("sess-1",))] == ["sess-1"]
+            # An empty tuple means no rows, never all rows.
+            assert store.get_all_history(session_ids=()) == []
+
     def test_get_run_by_id_round_trips_and_missing(self, tmp_path):
         with RetroStore(tmp_path / "sessions.db") as store:
             rid = store.record_run(_report())

--- a/tests/unit/test_retro_store.py
+++ b/tests/unit/test_retro_store.py
@@ -165,3 +165,29 @@ class TestProvenanceSelfHeal:
             cols = {r[1] for r in store._conn.execute("PRAGMA table_info(retro_history)")}
             assert {"origin", "edited_from_id"} <= cols
             assert store.record_run(_report()) > 0  # the INSERT that names origin
+
+
+class TestScopedRecentReports:
+    """The session_ids hard filter a ProjectScope resolves to."""
+
+    def test_none_is_the_legacy_read(self, tmp_path):
+        with RetroStore(tmp_path / "sessions.db") as store:
+            store.record_run(_report("sess-1"))
+            store.record_run(RetroReport(session_id="sess-2", date="2026-07-12", cards=(RetroCard(text="x"),)))
+            legacy = store.get_recent_reports(limit=5)
+            explicit = store.get_recent_reports(limit=5, session_ids=None)
+        assert [r.session_id for r in legacy] == [r.session_id for r in explicit]
+        assert len(legacy) == 2
+
+    def test_filters_to_the_given_sessions(self, tmp_path):
+        with RetroStore(tmp_path / "sessions.db") as store:
+            store.record_run(_report("sess-1"))
+            store.record_run(RetroReport(session_id="sess-2", date="2026-07-12", cards=(RetroCard(text="x"),)))
+            scoped = store.get_recent_reports(limit=5, session_ids=("sess-2",))
+        assert [r.session_id for r in scoped] == ["sess-2"]
+
+    def test_empty_scope_means_no_rows(self, tmp_path):
+        # () is "a project with no sessions yet", never "everything".
+        with RetroStore(tmp_path / "sessions.db") as store:
+            store.record_run(_report("sess-1"))
+            assert store.get_recent_reports(limit=5, session_ids=()) == []

--- a/tests/unit/test_session_handoff.py
+++ b/tests/unit/test_session_handoff.py
@@ -166,3 +166,67 @@ class TestChatToPipelineHandoff:
     def test_quit_during_the_greeting_returns_none(self, monkeypatch):
         calls = self._run_body(monkeypatch, chat_result=None)
         assert calls == ["chat"]
+
+
+class TestScopeStateKeys:
+    """_scope_state_keys seeds the run's project and its effective context deps.
+
+    Both must land on the graph state: `_state_scope` resolves the project's
+    default on its own, but `_wants_dep` reads only the `context_deps` key, so
+    leaving it absent gates half a run and leaves the other half all-on.
+    """
+
+    @staticmethod
+    def _project(tmp_path, settings=None) -> tuple:
+        from yeaboi.projects.store import ProjectStore
+
+        db = tmp_path / "sessions.db"
+        with ProjectStore(db) as projects:
+            project = projects.create("Apollo")
+            if settings:
+                projects.set_settings(project["project_id"], settings)
+        return db, project["project_id"]
+
+    @staticmethod
+    def _seed(monkeypatch, db, project="", deps=None):
+        from yeaboi.ui.session import _scope_state_keys
+
+        monkeypatch.setattr("yeaboi.paths.get_db_path", lambda: db)
+        monkeypatch.setattr("yeaboi.projects.active.get_active_project", lambda: project)
+        monkeypatch.setattr("yeaboi.projects.active.get_context_deps", lambda: deps)
+        return _scope_state_keys()
+
+    def test_no_project_and_no_toggles_seeds_nothing(self, tmp_path, monkeypatch):
+        db, _ = self._project(tmp_path)
+        keys, deps = self._seed(monkeypatch, db)
+        assert keys == {} and deps is None
+
+    def test_the_active_project_lands_on_the_state(self, tmp_path, monkeypatch):
+        db, pid = self._project(tmp_path)
+        keys, _ = self._seed(monkeypatch, db, project=pid)
+        assert keys["project_id"] == pid
+
+    def test_session_toggles_land_as_a_json_list(self, tmp_path, monkeypatch):
+        db, pid = self._project(tmp_path)
+        keys, deps = self._seed(monkeypatch, db, project=pid, deps=("retro", "plan"))
+        assert keys["context_deps"] == '["plan", "retro"]'
+        assert deps == frozenset({"retro", "plan"})
+
+    def test_the_projects_default_applies_when_the_session_inherits(self, tmp_path, monkeypatch):
+        db, pid = self._project(tmp_path, {"default_context_deps": ["standup"]})
+        keys, deps = self._seed(monkeypatch, db, project=pid)
+        assert keys["context_deps"] == '["standup"]'
+        assert deps == frozenset({"standup"})
+
+    def test_a_projects_incognito_default_reaches_the_state_key(self, tmp_path, monkeypatch):
+        # The gap this closes: `_wants_dep` saw no key and answered "all on",
+        # so a project documented as incognito-by-default still loaded context.
+        db, pid = self._project(tmp_path, {"default_context_deps": []})
+        keys, deps = self._seed(monkeypatch, db, project=pid)
+        assert keys["context_deps"] == "[]"
+        assert deps == frozenset()
+
+    def test_session_toggles_beat_the_projects_default(self, tmp_path, monkeypatch):
+        db, pid = self._project(tmp_path, {"default_context_deps": ["standup"]})
+        keys, _ = self._seed(monkeypatch, db, project=pid, deps=("retro",))
+        assert keys["context_deps"] == '["retro"]'

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -279,3 +279,12 @@ class TestProjectIdStateRoundTrip:
             store.save_state("s1", {"messages": [], "project_id": "proj-11112222"})
             loaded = store.load_state("s1")
         assert loaded["project_id"] == "proj-11112222"
+
+
+class TestContextDepsStateRoundTrip:
+    def test_context_deps_survives_save_and_load(self, tmp_path):
+        with SessionStore(tmp_path / "sessions.db") as store:
+            store.create_session("s1", "Test")
+            store.save_state("s1", {"messages": [], "context_deps": '["retro", "plan"]'})
+            loaded = store.load_state("s1")
+        assert loaded["context_deps"] == '["retro", "plan"]'

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -270,3 +270,12 @@ class TestPruneSparesProjects:
             assert store.prune_old_sessions(30) == 1
             remaining = {row["session_id"] for row in store.list_sessions()}
             assert remaining == {"stale-linked", "fresh-unscoped"}
+
+
+class TestProjectIdStateRoundTrip:
+    def test_project_id_survives_save_and_load(self, tmp_path):
+        with SessionStore(tmp_path / "sessions.db") as store:
+            store.create_session("s1", "Test", project_id="proj-11112222")
+            store.save_state("s1", {"messages": [], "project_id": "proj-11112222"})
+            loaded = store.load_state("s1")
+        assert loaded["project_id"] == "proj-11112222"

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -160,3 +160,113 @@ class TestArchitectureRoundTrip:
         task = _dict_to_task({"id": "T-1", "story_id": "US-1", "title": "t", "description": "d"})
         assert task.label is TaskLabel.CODE
         assert task.test_plan == ""
+
+
+class TestProjectsMigration:
+    """Migration v31 — the projects table and sessions_meta.project_id."""
+
+    def _v30_db(self, tmp_path):
+        db = tmp_path / "sessions.db"
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """CREATE TABLE sessions_meta (
+                   session_id          TEXT PRIMARY KEY,
+                   project_name        TEXT NOT NULL DEFAULT '',
+                   created_at          TEXT NOT NULL,
+                   last_modified       TEXT NOT NULL,
+                   last_node_completed TEXT NOT NULL DEFAULT '',
+                   session_state       TEXT NOT NULL DEFAULT '',
+                   session_mode        TEXT NOT NULL DEFAULT 'planning'
+               );
+               CREATE TABLE schema_info (schema_version INT NOT NULL);"""
+        )
+        conn.execute("INSERT INTO schema_info VALUES (30)")
+        conn.execute("INSERT INTO sessions_meta (session_id, created_at, last_modified) VALUES ('old-1', 't', 't')")
+        conn.commit()
+        conn.close()
+        return db
+
+    def _columns(self, db, table):
+        conn = sqlite3.connect(str(db))
+        try:
+            return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+        finally:
+            conn.close()
+
+    def test_v30_db_gains_table_column_and_index(self, tmp_path):
+        db = self._v30_db(tmp_path)
+        with SessionStore(db) as store:
+            assert store.schema_mismatch is False
+        assert "project_id" in self._columns(db, "sessions_meta")
+        conn = sqlite3.connect(str(db))
+        try:
+            names = {r[0] for r in conn.execute("SELECT name FROM sqlite_master")}
+            assert "projects" in names
+            assert "idx_sessions_meta_project" in names
+            # Pre-existing rows read as unscoped, not NULL.
+            (pid,) = conn.execute("SELECT project_id FROM sessions_meta WHERE session_id = 'old-1'").fetchone()
+            assert pid == ""
+        finally:
+            conn.close()
+
+    def test_reopen_is_idempotent(self, tmp_path):
+        db = self._v30_db(tmp_path)
+        SessionStore(db).close()
+        with SessionStore(db) as store:
+            assert store.schema_mismatch is False
+
+
+class TestSessionProjectLink:
+    def test_create_session_defaults_to_unscoped(self, tmp_path):
+        with SessionStore(tmp_path / "sessions.db") as store:
+            store.create_session("s1", "Test")
+            assert store.session_project_id("s1") == ""
+
+    def test_create_session_persists_project_id(self, tmp_path):
+        with SessionStore(tmp_path / "sessions.db") as store:
+            store.create_session("s1", "Test", project_id="proj-11112222")
+            assert store.session_project_id("s1") == "proj-11112222"
+
+    def test_set_session_project_links_and_unlinks(self, tmp_path):
+        with SessionStore(tmp_path / "sessions.db") as store:
+            store.create_session("s1", "Test")
+            store.set_session_project("s1", "proj-11112222")
+            assert store.session_project_id("s1") == "proj-11112222"
+            store.set_session_project("s1", "")
+            assert store.session_project_id("s1") == ""
+
+    def test_unknown_session_reads_as_unscoped(self, tmp_path):
+        with SessionStore(tmp_path / "sessions.db") as store:
+            assert store.session_project_id("nope") == ""
+
+    def test_session_ids_for_project_filters_and_orders(self, tmp_path):
+        with SessionStore(tmp_path / "sessions.db") as store:
+            store.create_session("plan-a", project_id="proj-11112222")
+            store.create_session("analysis-a", mode="analysis", project_id="proj-11112222")
+            store.create_session("plan-other", project_id="proj-33334444")
+            store.create_session("plan-unscoped")
+            # Distinct timestamps so the newest-first ordering is decidable.
+            for i, sid in enumerate(("plan-a", "analysis-a")):
+                store._conn.execute(
+                    "UPDATE sessions_meta SET last_modified = ? WHERE session_id = ?",
+                    (f"2026-08-0{i + 1}T00:00:00+00:00", sid),
+                )
+            assert store.session_ids_for_project("proj-11112222") == ["analysis-a", "plan-a"]
+            assert store.session_ids_for_project("proj-11112222", mode="planning") == ["plan-a"]
+            assert store.session_ids_for_project("proj-99990000") == []
+
+
+class TestPruneSparesProjects:
+    def test_only_unscoped_stale_sessions_are_pruned(self, tmp_path):
+        with SessionStore(tmp_path / "sessions.db") as store:
+            store.create_session("stale-unscoped")
+            store.create_session("stale-linked", project_id="proj-11112222")
+            store.create_session("fresh-unscoped")
+            for sid in ("stale-unscoped", "stale-linked"):
+                store._conn.execute(
+                    "UPDATE sessions_meta SET last_modified = ? WHERE session_id = ?",
+                    ("2020-01-01T00:00:00+00:00", sid),
+                )
+            assert store.prune_old_sessions(30) == 1
+            remaining = {row["session_id"] for row in store.list_sessions()}
+            assert remaining == {"stale-linked", "fresh-unscoped"}

--- a/tests/unit/test_standup_engine.py
+++ b/tests/unit/test_standup_engine.py
@@ -2812,3 +2812,59 @@ class TestConflictAndProvenanceWiring:
         monkeypatch.setattr(provenance_log, "record_run", _boom)
         report = engine.run_standup(seeded_session, deliver=False, db_path=db_path, today=date(2026, 7, 10))
         assert any("Audit trail not recorded" in w for w in report.warnings)
+
+
+class TestProjectScopedStandup:
+    """The planning→standup edge: sprint/roster context from the project's plan."""
+
+    def _seed_project(self, db_path, *, link_standup: bool):
+        from yeaboi.agent.state import Sprint
+        from yeaboi.projects.store import ProjectStore
+
+        sprint = Sprint(id="SP-1", name="Sprint 1", goal="", capacity_points=10, story_ids=())
+        with ProjectStore(db_path) as projects:
+            project = projects.create("Apollo")
+        pid = project["project_id"]
+        with SessionStore(db_path) as s:
+            s.create_session("plan-1", "Apollo", mode="planning", project_id=pid)
+            s.save_state(
+                "plan-1",
+                {
+                    "selected_team_members": ("Carol",),
+                    "sprint_length_weeks": 3,
+                    "sprints": [sprint],
+                },
+            )
+            s.create_session("standup-1", "Apollo", project_id=pid if link_standup else "")
+            s.save_state("standup-1", {"selected_team_members": ("Alice",), "sprint_length_weeks": 2})
+        return pid
+
+    def _run(self, monkeypatch, db_path, *, project_id=""):
+        captured = {}
+
+        def _capture_gather(state, **kw):
+            captured["state"] = state
+            return SprintContext(sprint_name="S", sprint_length_weeks=2)
+
+        _patch_common(monkeypatch, items=[], counts=[])
+        monkeypatch.setattr(engine.sprint_context, "gather", _capture_gather)
+        monkeypatch.setattr("yeaboi.config.is_llm_configured", lambda: (False, "no key"))
+        engine.run_standup("standup-1", deliver=False, db_path=db_path, today=date(2026, 7, 10), project_id=project_id)
+        return captured["state"]
+
+    def test_explicit_project_uses_the_plans_state(self, monkeypatch, db_path):
+        pid = self._seed_project(db_path, link_standup=False)
+        state = self._run(monkeypatch, db_path, project_id=pid)
+        assert state.get("sprint_length_weeks") == 3
+        assert tuple(state.get("selected_team_members", ())) == ("Carol",)
+
+    def test_linked_session_inherits_the_project(self, monkeypatch, db_path):
+        self._seed_project(db_path, link_standup=True)
+        state = self._run(monkeypatch, db_path)
+        assert state.get("sprint_length_weeks") == 3
+
+    def test_unlinked_session_keeps_its_own_state(self, monkeypatch, db_path):
+        self._seed_project(db_path, link_standup=False)
+        state = self._run(monkeypatch, db_path)
+        assert state.get("sprint_length_weeks") == 2
+        assert tuple(state.get("selected_team_members", ())) == ("Alice",)

--- a/tests/unit/test_standup_engine.py
+++ b/tests/unit/test_standup_engine.py
@@ -2868,3 +2868,72 @@ class TestProjectScopedStandup:
         state = self._run(monkeypatch, db_path)
         assert state.get("sprint_length_weeks") == 2
         assert tuple(state.get("selected_team_members", ())) == ("Alice",)
+
+
+class TestStandupContextDeps:
+    """The plan toggle gates the sprint-plan substitution; the config column feeds it."""
+
+    _seed_project = TestProjectScopedStandup._seed_project
+
+    def _run(self, monkeypatch, db_path, *, project_id="", context_deps=None):
+        captured = {}
+
+        def _capture_gather(state, **kw):
+            captured["state"] = state
+            return SprintContext(sprint_name="S", sprint_length_weeks=2)
+
+        _patch_common(monkeypatch, items=[], counts=[])
+        monkeypatch.setattr(engine.sprint_context, "gather", _capture_gather)
+        monkeypatch.setattr("yeaboi.config.is_llm_configured", lambda: (False, "no key"))
+        engine.run_standup(
+            "standup-1",
+            deliver=False,
+            db_path=db_path,
+            today=date(2026, 7, 10),
+            project_id=project_id,
+            context_deps=context_deps,
+        )
+        return captured["state"]
+
+    def test_plan_dep_off_keeps_the_sessions_own_state(self, monkeypatch, db_path):
+        pid = self._seed_project(db_path, link_standup=False)
+        state = self._run(monkeypatch, db_path, project_id=pid, context_deps=["retro", "standup"])
+        assert state.get("sprint_length_weeks") == 2
+
+    def test_incognito_keeps_the_sessions_own_state(self, monkeypatch, db_path):
+        pid = self._seed_project(db_path, link_standup=False)
+        state = self._run(monkeypatch, db_path, project_id=pid, context_deps=[])
+        assert state.get("sprint_length_weeks") == 2
+
+    def test_explicit_deps_including_plan_still_substitute(self, monkeypatch, db_path):
+        pid = self._seed_project(db_path, link_standup=False)
+        state = self._run(monkeypatch, db_path, project_id=pid, context_deps=["plan"])
+        assert state.get("sprint_length_weeks") == 3
+
+    def test_saved_config_deps_apply_when_the_caller_passes_none(self, monkeypatch, db_path):
+        self._seed_project(db_path, link_standup=True)
+        with StandupStore(db_path) as store:
+            store.save_config(
+                "standup-1",
+                enabled=False,
+                time="10:00",
+                weekdays="1-5",
+                delivery_channels=["terminal"],
+                context_deps=["retro"],
+            )
+        state = self._run(monkeypatch, db_path)
+        assert state.get("sprint_length_weeks") == 2
+
+    def test_explicit_param_beats_the_saved_config(self, monkeypatch, db_path):
+        self._seed_project(db_path, link_standup=True)
+        with StandupStore(db_path) as store:
+            store.save_config(
+                "standup-1",
+                enabled=False,
+                time="10:00",
+                weekdays="1-5",
+                delivery_channels=["terminal"],
+                context_deps=["retro"],
+            )
+        state = self._run(monkeypatch, db_path, context_deps=["plan"])
+        assert state.get("sprint_length_weeks") == 3

--- a/tests/unit/test_standup_store.py
+++ b/tests/unit/test_standup_store.py
@@ -1305,3 +1305,28 @@ class TestScopedRecentReports:
         with StandupStore(db_path) as store:
             store.record_run(_make_report(session_id="s1"))
             assert store.get_recent_reports(limit=5, session_ids=()) == []
+
+
+class TestContextDepsColumn:
+    def test_round_trips_none_list_and_incognito(self, tmp_path):
+        db = tmp_path / "sessions.db"
+        with StandupStore(db) as store:
+            base = dict(enabled=False, time="10:00", weekdays="1-5", delivery_channels=["terminal"])
+            store.save_config("inherit", **base)
+            store.save_config("subset", **base, context_deps=["retro", "plan"])
+            store.save_config("incognito", **base, context_deps=[])
+            assert (store.load_config("inherit") or {})["context_deps"] is None
+            assert (store.load_config("subset") or {})["context_deps"] == ["retro", "plan"]
+            assert (store.load_config("incognito") or {})["context_deps"] == []
+
+    def test_alter_heals_a_pre_column_table(self, tmp_path):
+        import sqlite3
+
+        db = tmp_path / "sessions.db"
+        with StandupStore(db) as store:
+            store.save_config("s1", enabled=True, time="09:00", weekdays="1-5", delivery_channels=["terminal"])
+        with sqlite3.connect(db) as conn:
+            conn.execute("ALTER TABLE standup_config DROP COLUMN context_deps")
+        with StandupStore(db) as store:
+            loaded = store.load_config("s1") or {}
+        assert loaded["context_deps"] is None

--- a/tests/unit/test_standup_store.py
+++ b/tests/unit/test_standup_store.py
@@ -369,6 +369,16 @@ class TestSavedRunsHub:
             rows = store.get_all_history()
         assert rows and "id" in rows[0] and rows[0]["session_id"] == "s1"
 
+    def test_get_all_history_filters_by_session_ids(self, db_path):
+        with StandupStore(db_path) as store:
+            store.record_run(_make_report(date="2026-07-09"))
+            store.record_run(_make_report(date="2026-07-10", session_id="s2"))
+            assert {r["session_id"] for r in store.get_all_history(session_ids=("s1",))} == {"s1"}
+            # Filtered in SQL, so the limit counts the scoped rows, not the newest overall.
+            assert [r["session_id"] for r in store.get_all_history(limit=1, session_ids=("s1",))] == ["s1"]
+            # An empty tuple means no rows, never all rows.
+            assert store.get_all_history(session_ids=()) == []
+
     def test_get_run_by_id_round_trips_and_missing(self, db_path):
         report = _make_report(date="2026-07-10")
         with StandupStore(db_path) as store:

--- a/tests/unit/test_standup_store.py
+++ b/tests/unit/test_standup_store.py
@@ -1279,3 +1279,29 @@ class TestConflictsRoundTrip:
             )
             loaded = store.get_latest_report("s1")
         assert loaded.conflicts == ()
+
+
+class TestScopedRecentReports:
+    """The session_ids hard filter a ProjectScope resolves to."""
+
+    def test_none_is_the_legacy_read(self, db_path):
+        with StandupStore(db_path) as store:
+            store.record_run(_make_report(session_id="s1"))
+            store.record_run(_make_report(session_id="s2", date="2026-07-11"))
+            legacy = store.get_recent_reports(limit=5)
+            explicit = store.get_recent_reports(limit=5, session_ids=None)
+        assert [r.session_id for r in legacy] == [r.session_id for r in explicit]
+        assert len(legacy) == 2
+
+    def test_filters_to_the_given_sessions_and_skips_failures(self, db_path):
+        with StandupStore(db_path) as store:
+            store.record_run(_make_report(session_id="s1"))
+            store.record_run(_make_report(session_id="s2", date="2026-07-11"))
+            store.record_run(_make_report(session_id="s2", date="2026-07-12"), status="error")
+            scoped = store.get_recent_reports(limit=5, session_ids=("s2",))
+        assert [r.session_id for r in scoped] == ["s2"]
+
+    def test_empty_scope_means_no_rows(self, db_path):
+        with StandupStore(db_path) as store:
+            store.record_run(_make_report(session_id="s1"))
+            assert store.get_recent_reports(limit=5, session_ids=()) == []

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -903,6 +903,29 @@ class TestStateGraphCompatibility:
         graph = StateGraph(ScrumState)
         assert graph is not None
 
+    def test_scope_keys_reach_a_node(self):
+        """project_id/context_deps must survive the graph, not just the input dict.
+
+        LangGraph drops keys the state schema does not declare, so an undeclared
+        scope key silently unscopes every cross-mode read inside the run.
+        """
+        from langgraph.graph import END
+
+        seen = {}
+
+        def probe(state):
+            seen.update(project_id=state.get("project_id"), context_deps=state.get("context_deps"))
+            return {}
+
+        graph = StateGraph(ScrumState)
+        graph.add_node("probe", probe)
+        graph.set_entry_point("probe")
+        graph.add_edge("probe", END)
+        out = graph.compile().invoke({"messages": [], "project_id": "p-1", "context_deps": '["retro"]'})
+
+        assert seen == {"project_id": "p-1", "context_deps": '["retro"]'}
+        assert (out["project_id"], out["context_deps"]) == ("p-1", '["retro"]')
+
 
 # ── _merge_dicts reducer ────────────────────────────────────────────────
 

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -596,14 +596,24 @@ CLI_PARAM_PAIRS: dict[str, tuple[str, str]] = {
 
 # CLI dest → engine param renames (the CLI keeps short ergonomic flag names).
 CLI_RENAMES: dict[str, dict[str, str]] = {
-    "report": {"session": "session_id", "label": "period_label_override", "project": "project_id"},
-    "standup": {"session": "session_id", "project": "project_id"},
+    "report": {
+        "session": "session_id",
+        "label": "period_label_override",
+        "project": "project_id",
+        "context": "context_deps",
+    },
+    "standup": {"session": "session_id", "project": "project_id", "context": "context_deps"},
     # --transcript/--date carry explicit dest= in cli.py, so only --session
     # needs a rename here.
     "standup-review": {"session": "session_id"},
-    "perf prep": {"session": "session_id", "project": "project_id"},
+    "perf prep": {"session": "session_id", "project": "project_id", "context": "context_deps"},
     "perf complete": {"session": "session_id"},
-    "perf review": {"session": "session_id", "months": "period_months", "project": "project_id"},
+    "perf review": {
+        "session": "session_id",
+        "months": "period_months",
+        "project": "project_id",
+        "context": "context_deps",
+    },
     "ship run": {"session": "session_id", "check": "check_command"},
     "ship resume": {"check": "check_command"},
     "project link": {"session": "session_id"},
@@ -624,12 +634,14 @@ CLI_RENAMES: dict[str, dict[str, str]] = {
 CLI_ONLY_DESTS: dict[str, set[str]] = {
     # source/code_sources/documentation_sources are assembled into the engine's
     # `sources` dict (component → source list), mirroring analyze's components flags.
-    "report": {"format", "strict", "source", "code_sources", "documentation_sources"},
+    # incognito is sugar over context_deps=[] (see _cli_context_deps), not an engine param.
+    "report": {"format", "strict", "source", "code_sources", "documentation_sources", "incognito"},
     "standup": {
         "format",
         "strict",
         "schedule",
         "list_members",
+        "incognito",
     },  # schedule/list-members are adapters, not run_standup params
     # file-issues drives the separate file_transcript_issues entry point;
     # list-gaps is a store read. `paths` is the bare positional form of
@@ -637,9 +649,9 @@ CLI_ONLY_DESTS: dict[str, set[str]] = {
     # produces) — the handler folds it into transcript_paths, and a lone "-" into
     # transcript_text.
     "standup-review": {"format", "strict", "file_issues", "list_gaps", "paths"},
-    "perf prep": {"strict"},
+    "perf prep": {"strict", "incognito"},
     "perf complete": {"strict"},
-    "perf review": {"strict"},
+    "perf review": {"strict", "incognito"},
     "agents cost": {"format", "strict"},
     "agents standup": {"format", "strict"},
     "agents security": {"format", "strict"},

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -104,6 +104,32 @@ CAPABILITIES: dict[str, dict] = {
         # the intake and /projects/:id/plan renders the finished plan.
         "desktop": {"/projects/:id/blueprint", "/projects/:id/plan"},
     },
+    "projects": {
+        "engines": {
+            ("yeaboi.projects.engine", "create_project"),
+            ("yeaboi.projects.engine", "list_projects"),
+            ("yeaboi.projects.engine", "get_project"),
+            ("yeaboi.projects.engine", "link_session"),
+            ("yeaboi.projects.engine", "set_project_defaults"),
+        },
+        "mcp_tools": {
+            "project_create",
+            "project_list",
+            "project_get",
+            "project_link_session",
+            "project_set_defaults",
+        },
+        "tui_mode": Exempt(
+            "a welcome-screen keycap (p) opening the project switcher, not a card — "
+            "an eleventh card breaks the 84x40 layout, the ceremonies/niko argument"
+        ),
+        "cli": {"project"},
+        "skill": Exempt(
+            "a scoping primitive, not a guided workflow — modes gain --project/project_id, "
+            "and agents call the project_* tools directly"
+        ),
+        "desktop": {"/projects", "/projects/:id"},
+    },
     "sessions": {
         "engines": Exempt("thin SessionStore reads — no pipeline to extract"),
         "mcp_tools": {"sessions_list", "session_get", "session_delete"},
@@ -489,6 +515,11 @@ PARAM_PAIRS: dict[str, tuple[str, str]] = {
     "provenance_audit": ("yeaboi.provenance.engine", "run_provenance_audit"),
     "provenance_trace": ("yeaboi.provenance.engine", "trace_entity"),
     "niko_ask": ("yeaboi.niko.engine", "ask"),
+    "project_create": ("yeaboi.projects.engine", "create_project"),
+    "project_list": ("yeaboi.projects.engine", "list_projects"),
+    "project_get": ("yeaboi.projects.engine", "get_project"),
+    "project_link_session": ("yeaboi.projects.engine", "link_session"),
+    "project_set_defaults": ("yeaboi.projects.engine", "set_project_defaults"),
 }
 
 # Injection/test seams that are never exposed on any wire surface.
@@ -556,6 +587,11 @@ CLI_PARAM_PAIRS: dict[str, tuple[str, str]] = {
     "agents security": ("yeaboi.agentwatch.engine", "run_agent_security"),
     "ship run": ("yeaboi.ship.engine", "run_ship"),
     "ship resume": ("yeaboi.ship.engine", "resume_ship"),
+    "project create": ("yeaboi.projects.engine", "create_project"),
+    "project list": ("yeaboi.projects.engine", "list_projects"),
+    "project show": ("yeaboi.projects.engine", "get_project"),
+    "project link": ("yeaboi.projects.engine", "link_session"),
+    "project set-defaults": ("yeaboi.projects.engine", "set_project_defaults"),
 }
 
 # CLI dest → engine param renames (the CLI keeps short ergonomic flag names).
@@ -570,6 +606,7 @@ CLI_RENAMES: dict[str, dict[str, str]] = {
     "perf review": {"session": "session_id", "months": "period_months", "project": "project_id"},
     "ship run": {"session": "session_id", "check": "check_command"},
     "ship resume": {"check": "check_command"},
+    "project link": {"session": "session_id"},
     "analyze": {
         # NOT project_id: analysis's --project is the tracker key (Jira/AzDO),
         # a different id space from the projects table's proj-<8hex> ids.
@@ -609,6 +646,12 @@ CLI_ONLY_DESTS: dict[str, set[str]] = {
     # --split picks the entry point (run_ship_batch) rather than a run_ship param.
     "ship run": {"format", "strict", "split"},
     "ship resume": {"format", "strict"},
+    "project create": set(),
+    "project list": set(),
+    "project show": set(),
+    "project link": set(),
+    # --analysis-profile is one key of the engine's `defaults` dict.
+    "project set-defaults": {"analysis_profile"},
     # delivery/code/docs are assembled into the engine's `components` dict (component
     # → sub-source map); each flag names a component's sub-sources, not an engine param.
     "analyze": {
@@ -650,6 +693,9 @@ CLI_HIDDEN: dict[str, dict[str, str]] = {
     "ship resume": {
         "cancel_event": "in-process threading.Event cancel seam for the TUI worker; the CLI cancels via Ctrl-C",
         "driver": "AgentDriver injection seam for tests; every wire surface runs the real Claude Code driver",
+    },
+    "project set-defaults": {
+        "defaults": "assembled from the per-key flags (--analysis-profile); a raw dict flag invites typos",
     },
 }
 

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -100,7 +100,9 @@ CAPABILITIES: dict[str, dict] = {
             "--architecture-spike",
         },
         "skill": "plan-sprint",
-        "desktop": {"/humans/planning", "/humans/planning/chat", "/humans/planning/plan"},
+        # Planning folded into the desktop's project flow: the blueprint is
+        # the intake and /projects/:id/plan renders the finished plan.
+        "desktop": {"/projects/:id/blueprint", "/projects/:id/plan"},
     },
     "sessions": {
         "engines": Exempt("thin SessionStore reads — no pipeline to extract"),
@@ -108,7 +110,10 @@ CAPABILITIES: dict[str, dict] = {
         "tui_mode": Exempt("sessions are surfaced inside the planning-mode screens, no dedicated card"),
         "cli": {"--list-sessions", "--resume", "--clear-sessions"},
         "skill": Exempt("agents call the session tools directly — no guided workflow needed"),
-        "desktop": {"/humans/planning/sessions"},
+        "desktop": Exempt(
+            "saved plans surface through each project's plan panel (the iteration carries its "
+            "session id) — a raw session browser would be a second door to the same room"
+        ),
     },
     "standup": {
         "engines": {
@@ -238,7 +243,7 @@ CAPABILITIES: dict[str, dict] = {
         # carrying a milestone that has shipped: the intake tile needs a
         # roadmap path that is not TUI-only, and no surface has one yet — the
         # same gap the four rows above already track.
-        "desktop": {"/humans/planning/roadmap"},
+        "desktop": {"/projects/new/from-roadmap"},
     },
     "anonymize": {
         # Post-processing action, not a mode of its own: an "Anonymize" button on every

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -841,17 +841,29 @@ class TestMcpTools:
 
 class TestTuiModes:
     def test_mode_cards_registered(self):
-        # The union of both category menus — Humans (_MODE_CARDS) and Agents
-        # (_AGENT_CARDS) — must equal the registered tui_mode column.
-        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _MODE_CARDS
+        # The union of every category menu — Solo (_SOLO_CARDS), Team
+        # (_MODE_CARDS) and Agents (_AGENT_CARDS) — must equal the registered
+        # tui_mode column.
+        from yeaboi.ui.mode_select.screens._screens import _AGENT_CARDS, _MODE_CARDS, _SOLO_CARDS
 
-        actual = {card["key"] for card in (*_MODE_CARDS, *_AGENT_CARDS)}
+        actual = {card["key"] for card in (*_SOLO_CARDS, *_MODE_CARDS, *_AGENT_CARDS)}
         registered = set(_non_exempt("tui_mode").values())
         assert actual == registered, (
-            f"_MODE_CARDS/_AGENT_CARDS keys vs CAPABILITIES differ.\n"
+            f"_SOLO_CARDS/_MODE_CARDS/_AGENT_CARDS keys vs CAPABILITIES differ.\n"
             f"  new unregistered cards: {sorted(actual - registered)}\n"
             f"  registered but card removed: {sorted(registered - actual)}\n{_HOW_TO}"
         )
+
+    def test_solo_cards_are_a_subset_of_the_team_menu(self):
+        # Solo introduces no capability of its own: every solo card shares a
+        # Team card's key (dispatch, hubs, tips and this registry all key on
+        # it), and the complement is exactly the deliberately team-only modes.
+        from yeaboi.ui.mode_select.screens._screens import _MODE_CARDS, _SOLO_CARDS
+
+        solo = {card["key"] for card in _SOLO_CARDS}
+        team = {card["key"] for card in _MODE_CARDS}
+        assert solo <= team, sorted(solo - team)
+        assert team - solo == {"retro", "poker", "performance"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -193,11 +193,14 @@ CAPABILITIES: dict[str, dict] = {
     "retro-board": {
         # carried_action_items_for_session: the headless carry-forward load (prior
         # retro's action items) the TUI/browser adapt for the review column.
+        # standup_blocker_cards: its project-scoped sibling — the standup→retro
+        # edge, seeding a scoped board with the project's recent blockers.
         # history_providers/report_payload: the board's step-back through previous
         # retros — the same runs `retro_history` already reads, shaped as cards.
         "engines": {
             ("yeaboi.retro.engine", "generate_action_items"),
             ("yeaboi.retro.engine", "carried_action_items_for_session"),
+            ("yeaboi.retro.engine", "standup_blocker_cards"),
             ("yeaboi.retro.engine", "history_providers"),
             ("yeaboi.retro.engine", "report_payload"),
         },
@@ -557,17 +560,19 @@ CLI_PARAM_PAIRS: dict[str, tuple[str, str]] = {
 
 # CLI dest → engine param renames (the CLI keeps short ergonomic flag names).
 CLI_RENAMES: dict[str, dict[str, str]] = {
-    "report": {"session": "session_id", "label": "period_label_override"},
-    "standup": {"session": "session_id"},
+    "report": {"session": "session_id", "label": "period_label_override", "project": "project_id"},
+    "standup": {"session": "session_id", "project": "project_id"},
     # --transcript/--date carry explicit dest= in cli.py, so only --session
     # needs a rename here.
     "standup-review": {"session": "session_id"},
-    "perf prep": {"session": "session_id"},
+    "perf prep": {"session": "session_id", "project": "project_id"},
     "perf complete": {"session": "session_id"},
-    "perf review": {"session": "session_id", "months": "period_months"},
+    "perf review": {"session": "session_id", "months": "period_months", "project": "project_id"},
     "ship run": {"session": "session_id", "check": "check_command"},
     "ship resume": {"check": "check_command"},
     "analyze": {
+        # NOT project_id: analysis's --project is the tracker key (Jira/AzDO),
+        # a different id space from the projects table's proj-<8hex> ids.
         "project": "project_key",
         "sprints": "sprint_count",
         "depth": "analysis_depth",

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -171,10 +171,10 @@ CAPABILITIES: dict[str, dict] = {
         },
         "skill": "standup",
         "desktop": {
-            "/humans/standup",
-            "/humans/standup/setup",
-            "/humans/standup/schedule",
-            "/humans/standup/review",
+            "/team/standup",
+            "/team/standup/setup",
+            "/team/standup/schedule",
+            "/team/standup/review",
         },
     },
     "reporting": {
@@ -185,7 +185,7 @@ CAPABILITIES: dict[str, dict] = {
         "tui_mode": "reporting",
         "cli": {"report"},
         "skill": "delivery-report",
-        "desktop": {"/humans/reporting", "/humans/reporting/new", "/humans/reporting/style"},
+        "desktop": {"/team/reporting", "/team/reporting/new", "/team/reporting/style"},
     },
     "performance": {
         "engines": {
@@ -203,7 +203,7 @@ CAPABILITIES: dict[str, dict] = {
         "tui_mode": "performance",
         "cli": {"perf"},
         "skill": "performance",
-        "desktop": {"/humans/performance", "/humans/performance/engineer"},
+        "desktop": {"/team/performance", "/team/performance/engineer"},
     },
     "scrum-poker": {
         # get_poker_perspective: the one LLM call (AI take on a revealed vote
@@ -214,7 +214,7 @@ CAPABILITIES: dict[str, dict] = {
         "tui_mode": "poker",
         "cli": {"poker"},  # history read-back + export; the live voting board stays TUI-hosted
         "skill": Exempt("live voting session is TUI-hosted by design; history stays readable via poker_history"),
-        "desktop": {"/humans/poker", "/humans/poker/new", "/humans/poker/board"},
+        "desktop": {"/team/poker", "/team/poker/new", "/team/poker/board"},
     },
     "retro-board": {
         # carried_action_items_for_session: the headless carry-forward load (prior
@@ -234,7 +234,7 @@ CAPABILITIES: dict[str, dict] = {
         "tui_mode": "retro",
         "cli": {"retro"},  # history read-back + export; the live board itself stays TUI-hosted
         "skill": Exempt("live board is TUI-only by design; history stays readable via retro_history"),
-        "desktop": {"/humans/retro", "/humans/retro/board"},
+        "desktop": {"/team/retro", "/team/retro/board"},
     },
     "team-learning": {
         "engines": Exempt("lives in tools/team_learning.py as @tool functions — covered by test_tools_registry"),
@@ -254,7 +254,7 @@ CAPABILITIES: dict[str, dict] = {
         "tui_mode": "team-analysis",
         "cli": {"analyze", "--learn"},
         "skill": "team-analysis",
-        "desktop": {"/humans/analysis", "/humans/analysis/new", "/humans/analysis/results"},
+        "desktop": {"/team/analysis", "/team/analysis/new", "/team/analysis/results"},
     },
     "roadmap": {
         # Landed on main (TUI-only) before both this parity framework and the
@@ -479,7 +479,7 @@ CAPABILITIES: dict[str, dict] = {
         # or a task, nor split an epic into stacked PRs. A route-set check
         # cannot see a narrowing inside a route, so it is named here and in
         # contracts/v1/app_http.md.
-        "desktop": {"/humans/ship", "/humans/ship/run"},
+        "desktop": {"/team/ship", "/team/ship/run"},
     },
 }
 

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -120,7 +120,7 @@ CAPABILITIES: dict[str, dict] = {
             "project_set_defaults",
         },
         "tui_mode": Exempt(
-            "a welcome-screen keycap (p) opening the project switcher, not a card — "
+            "a welcome-screen keycap (P) opening the project switcher, not a card — "
             "an eleventh card breaks the 84x40 layout, the ceremonies/niko argument"
         ),
         "cli": {"project"},
@@ -662,8 +662,8 @@ CLI_ONLY_DESTS: dict[str, set[str]] = {
     "project list": set(),
     "project show": set(),
     "project link": set(),
-    # --analysis-profile is one key of the engine's `defaults` dict.
-    "project set-defaults": {"analysis_profile"},
+    # --analysis-profile and --context are each one key of the engine's `defaults` dict.
+    "project set-defaults": {"analysis_profile", "context"},
     # delivery/code/docs are assembled into the engine's `components` dict (component
     # → sub-source map); each flag names a component's sub-sources, not an engine param.
     "analyze": {
@@ -707,7 +707,7 @@ CLI_HIDDEN: dict[str, dict[str, str]] = {
         "driver": "AgentDriver injection seam for tests; every wire surface runs the real Claude Code driver",
     },
     "project set-defaults": {
-        "defaults": "assembled from the per-key flags (--analysis-profile); a raw dict flag invites typos",
+        "defaults": "assembled from the per-key flags (--analysis-profile, --context); a raw dict flag invites typos",
     },
 }
 

--- a/tests/unit/test_tui_parity.py
+++ b/tests/unit/test_tui_parity.py
@@ -119,11 +119,11 @@ class TestSlashCommands:
 
     def test_every_terminal_verb_reaches_the_desktop_or_is_exempt(self, manifest):
         if not manifest["commands"]:
-            # With no chat surface there is no verb registry to mirror; the
-            # constant above is the reason. A half-registered list — some verbs
-            # answered, most not — is still a failure below.
-            assert DESKTOP_CHAT_RETIRED
-            return
+            # With no chat surface there is no verb registry to mirror. Skipped
+            # rather than passed, so the run reports the guard as off instead of
+            # green; it re-arms the moment the manifest carries one command, and
+            # a half-registered list is a failure below.
+            pytest.skip(DESKTOP_CHAT_RETIRED)
         answered = {command["tui"] for command in manifest["commands"]}
         exempt = {name.lstrip("/") for name in TERMINAL_ONLY}
         missing = self._terminal_verbs() - answered - exempt

--- a/tests/unit/test_tui_parity.py
+++ b/tests/unit/test_tui_parity.py
@@ -99,6 +99,17 @@ class TestTerminalOnly:
 # ---------------------------------------------------------------------------
 
 
+# The desktop ships no chat surface at all: the standalone planning chat folded
+# into the project flow (blueprint → one-shot generation), and the interactive
+# conversation returns with the ChatSession-in-project work. An empty commands
+# registry is the honest encoding of that state — reverse this constant when
+# the chat comes back.
+DESKTOP_CHAT_RETIRED = (
+    "the standalone planning chat folded into the project flow; one-shot generation "
+    "replaced the pipeline, and the interactive chat returns with the ChatSession-in-project work"
+)
+
+
 class TestSlashCommands:
     @staticmethod
     def _terminal_verbs() -> set[str]:
@@ -107,6 +118,12 @@ class TestSlashCommands:
         return {command.name for command in COMMANDS}
 
     def test_every_terminal_verb_reaches_the_desktop_or_is_exempt(self, manifest):
+        if not manifest["commands"]:
+            # With no chat surface there is no verb registry to mirror; the
+            # constant above is the reason. A half-registered list — some verbs
+            # answered, most not — is still a failure below.
+            assert DESKTOP_CHAT_RETIRED
+            return
         answered = {command["tui"] for command in manifest["commands"]}
         exempt = {name.lstrip("/") for name in TERMINAL_ONLY}
         missing = self._terminal_verbs() - answered - exempt
@@ -206,8 +223,8 @@ class TestPlanningIsWholeOnTheDesktop:
         desktop had a window for none of them.
         """
         paths = {route["path"] for route in manifest["routes"]}
-        assert "/humans/planning/plan" in paths, (
+        assert "/projects/:id/plan" in paths, (
             "the desktop has no page for a finished plan — plan_get/plan_export/plan_publish/plan_sync "
             f"would have no window to be called from\n{_HOW_TO}"
         )
-        assert "/humans/planning/plan" in CAPABILITIES["planning"]["desktop"]
+        assert "/projects/:id/plan" in CAPABILITIES["planning"]["desktop"]


### PR DESCRIPTION
## Summary

Adds **projects** as a first-class scoping primitive, per-run **context toggles**, and reshapes the landing split from two audiences into three worlds.

**Projects.** A projects store (SQLite, schema v31) with session links and a prune guard, and `ProjectScope` — a pull-based resolver that narrows cross-mode reads to one project's sessions. `project_id` threads through the standup, retro, poker, performance and reporting engines and their feeding edges. The surface lands everywhere: engine, MCP tools (`mcp/tools_projects.py`), a `yeaboi project` CLI subcommand, a TUI switcher on the welcome screen's `P` keycap, a `CAPABILITIES` row and a `FeatureTip`.

**Context toggles.** Per-run `context_deps` with a named incognito preset across every surface. Each cross-mode gather is gated behind them — the retro history browser, the poker perspective, the performance evidence gather, and every analysis-profile read. A switched-off source settles its coverage row saying so, so silence never reads as an idle period.

**Three worlds.** The `humans` audience is renamed `team` across config, UI, niko and contracts, and a new `solo` world joins it: a three-way landing split, a solo menu, a flock mascot, and beta badges on solo + agents. Solo runs are tailored — the retro dep is off by default (Solo has no retro mode) and analysis skips the roster.

## Review fixes in this branch

An independent review found one bug the tests could not see, plus five smaller ones; all are fixed in `531e8d21`:

- **`project_id`/`context_deps` never reached a node.** LangGraph drops state keys the schema does not declare, and neither was a `ScrumState` field — so every scoped planning run silently read unscoped, from the TUI and from headless alike. Both are now declared, with a regression test (`test_scope_keys_reach_a_node`) that drives them through a compiled graph rather than asserting on the input dict.
- **The TUI planning session never linked to the active project**, so the planning→standup/reporting edge never fired from the terminal. It now seeds `project_id` and passes it to `create_session`.
- **The perf `--project`/`--context`/`--incognito` flags and the two MCP tool descriptions claimed to be a no-op** while being fully wired into the evidence gather. Corrected — only the engineer-keyed `PerformanceStore` reads stay unscoped.
- **`get_all_history` limited before filtering** on both the retro and standup stores, so a scoped read's window could fill with other projects' runs and hide the project's own. The filter moved into SQL on both.
- `project set-defaults` gained the missing `--context` flag, and now exits 2 instead of printing a success line when given no flags.
- The Solo world's "All on" message no longer claims every source is on (retro stays off), and two prose sites still naming the old lowercase `p` keycap were corrected.

## Notes for the reviewer

- **Rebased onto `origin/main`** (9 commits behind). Three conflicts, all resolved deliberately:
  - Upstream shipped `p` = privacy and `k` = system check while this branch wanted `p` = projects. **Projects was rekeyed to capital `P`** — dispatch, version-row keycap, tip text and both prose sites. `read_key` returns printable characters verbatim and `F` was already an uppercase binding, so `P` is reachable; the version row was checked at 84–200 columns and still crops rightmost-first.
  - `uv.lock` took `origin/main`'s side verbatim — this branch makes no `pyproject.toml` dependency change, so the lock carries no diff.
  - `_components.py` kept upstream's new `PRIVACY_THEME`/`SYSTEM_CHECK_THEME` alongside this branch's rewritten three-worlds comment.
- **`contracts/v1/routes_manifest.json` is a vendored regeneration from yeaboi-desktop**, and it empties the desktop chat command registry (the standalone planning chat folded into the project flow). That is a real parity guard going quiet, so `test_every_terminal_verb_reaches_the_desktop_or_is_exempt` now **skips with its reason** rather than passing on a tautological assert — the run reports the guard as off, and it re-arms the moment the manifest carries one command. Worth a conscious sign-off.
- One reviewer nit is **left unfixed by choice**: in the Solo world `get_context_deps()` always returns a concrete tuple, which overrides a project's `default_context_deps`. That is the point of the solo default (Solo has no retro mode, so a project default enabling retro would be meaningless there), not an accident.

## Test plan

- `make ship-gate` — green: lint, format-check, the full suite (**15,278 passed, 60 skipped**) on Python 3.11/3.12/3.13/3.14, security, and 3 preflight jobs.
- New tests: `test_scope_keys_reach_a_node` (the blocker, driven through a compiled `StateGraph`), scoped `get_all_history` on both stores (including that an empty tuple means no rows, and that the limit counts scoped rows), and three `project set-defaults` CLI cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
