### PR TITLE
carry the desktop's real route manifest, replacing the hand-written one

### DIFF
--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -32,6 +32,31 @@
       "title": "Usage"
     },
     {
+      "path": "/team/planning",
+      "capability": "planning",
+      "title": "Planning"
+    },
+    {
+      "path": "/team/planning/chat",
+      "capability": "planning",
+      "title": "Planning · Chat"
+    },
+    {
+      "path": "/team/planning/plan",
+      "capability": "planning",
+      "title": "The plan"
+    },
+    {
+      "path": "/team/planning/sessions",
+      "capability": "sessions",
+      "title": "Saved plans"
+    },
+    {
+      "path": "/team/planning/roadmap",
+      "capability": "roadmap",
+      "title": "Planning · Roadmap intake"
+    },
+    {
       "path": "/team/analysis",
       "capability": "team-analysis",
       "title": "Analysis"
@@ -213,12 +238,12 @@
     },
     {
       "path": "/projects",
-      "capability": "projects",
+      "capability": null,
       "title": "Projects"
     },
     {
       "path": "/projects/:id",
-      "capability": "projects",
+      "capability": null,
       "title": "Project"
     },
     {
@@ -228,18 +253,8 @@
     },
     {
       "path": "/projects/:id/blueprint",
-      "capability": "planning",
+      "capability": null,
       "title": "Blueprint"
-    },
-    {
-      "path": "/projects/:id/plan",
-      "capability": "planning",
-      "title": "Project · Plan"
-    },
-    {
-      "path": "/projects/new/from-roadmap",
-      "capability": "roadmap",
-      "title": "New project · From roadmap"
     },
     {
       "path": "/projects/:id/sessions/new",
@@ -339,5 +354,66 @@
       ]
     }
   ],
-  "commands": []
+  "commands": [
+    {
+      "name": "help",
+      "tui": "help",
+      "help": "shortcuts and everything you can type"
+    },
+    {
+      "name": "export",
+      "tui": "export",
+      "help": "save the plan and/or chat transcript"
+    },
+    {
+      "name": "skip",
+      "tui": "skip",
+      "help": "skip the current question"
+    },
+    {
+      "name": "defaults",
+      "tui": "defaults",
+      "help": "accept defaults for all remaining questions"
+    },
+    {
+      "name": "form",
+      "tui": "form",
+      "help": "see every question in one panel and answer them in any order"
+    },
+    {
+      "name": "finish",
+      "tui": "finish",
+      "help": "answer the remaining questions with defaults"
+    },
+    {
+      "name": "summary",
+      "tui": "summary",
+      "help": "show your answers so far"
+    },
+    {
+      "name": "questions",
+      "tui": "questions",
+      "help": "see what I'll ask and what's already answered"
+    },
+    {
+      "name": "edit",
+      "tui": "edit",
+      "help": "browse your answers (/edit 6 re-asks one) or refine the last artifact"
+    },
+    {
+      "name": "small",
+      "tui": "small",
+      "help": "switch to a Small plan"
+    },
+    {
+      "name": "large",
+      "tui": "large",
+      "help": "switch to a Large plan"
+    },
+    {
+      "name": "duck",
+      "tui": "duck",
+      "help": "mute or unmute the duck's speech bubble"
+    }
+  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.38.0"
+version = "3.38.1"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,19 @@
   "schema_version": 2,
   "entries": [
     {
+      "version": "3.38.1",
+      "date": "2026-09-01",
+      "headline": "Desktop route manifest corrected",
+      "summary": "Nothing changes in how yeaboi works — this release is internal corrections to the desktop route manifest and parity checks, ensuring the desktop app builds against reality.",
+      "highlights": [
+        {
+          "text": "Desktop manifest now matches what the app generates",
+          "areas": ["general"],
+          "surfaces": ["desktop"]
+        }
+      ]
+    },
+    {
       "version": "3.38.0",
       "date": "2026-08-31",
       "headline": "Work by project and pick your working world",

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -73,10 +73,13 @@ class FeatureTip:
 # lands on the right card.
 _FEATURE_TIPS: tuple[FeatureTip, ...] = (
     # No mode_key: projects open from the welcome screen's `P` keycap, not a card.
+    # TUI-only, like the capability: the tip names a keycap, and the desktop has
+    # no projects surface to send anyone to (CAPABILITIES marks it exempt there).
     FeatureTip(
         "projects",
         "\U0001f5c2️ Tip: Press P to pick a project — scoped runs feed each other's context",
         is_new=True,
+        surfaces=("tui",),
     ),
     FeatureTip(
         "team-analysis",
@@ -168,12 +171,15 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
     ),
     # Capabilities without a dedicated home-screen card (tui_mode Exempt) — they
     # still rotate to aid discovery, just with no jump target.
-    # TUI-only: on the desktop, saved plans surface through each project's plan
-    # panel (CAPABILITIES marks sessions exempt there), so no desktop tip.
     FeatureTip(
         "sessions",
         "\U0001f5c2️ Tip: every plan is saved — resume any past session with --resume",
         surfaces=("tui",),
+    ),
+    FeatureTip(
+        "sessions",
+        "\U0001f5c2️ Tip: every plan is saved — reopen any past run from Saved plans",
+        surfaces=("desktop",),
     ),
     # No desktop route (CAPABILITIES marks it exempt there), so no desktop tip.
     FeatureTip(

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -100,9 +100,7 @@ CAPABILITIES: dict[str, dict] = {
             "--architecture-spike",
         },
         "skill": "plan-sprint",
-        # Planning folded into the desktop's project flow: the blueprint is
-        # the intake and /projects/:id/plan renders the finished plan.
-        "desktop": {"/projects/:id/blueprint", "/projects/:id/plan"},
+        "desktop": {"/team/planning", "/team/planning/chat", "/team/planning/plan"},
     },
     "projects": {
         "engines": {
@@ -128,7 +126,11 @@ CAPABILITIES: dict[str, dict] = {
             "a scoping primitive, not a guided workflow — modes gain --project/project_id, "
             "and agents call the project_* tools directly"
         ),
-        "desktop": {"/projects", "/projects/:id"},
+        "desktop": Exempt(
+            "no desktop surface yet: `yeaboi app` exposes no /api/projects* routes, so the window "
+            "would have nothing to call. The desktop's own /projects is the planning platform's — "
+            "uuid4 rows on a different backend, not this store's proj-<8hex> ids"
+        ),
     },
     "sessions": {
         "engines": Exempt("thin SessionStore reads — no pipeline to extract"),
@@ -136,10 +138,7 @@ CAPABILITIES: dict[str, dict] = {
         "tui_mode": Exempt("sessions are surfaced inside the planning-mode screens, no dedicated card"),
         "cli": {"--list-sessions", "--resume", "--clear-sessions"},
         "skill": Exempt("agents call the session tools directly — no guided workflow needed"),
-        "desktop": Exempt(
-            "saved plans surface through each project's plan panel (the iteration carries its "
-            "session id) — a raw session browser would be a second door to the same room"
-        ),
+        "desktop": {"/team/planning/sessions"},
     },
     "standup": {
         "engines": {
@@ -272,7 +271,7 @@ CAPABILITIES: dict[str, dict] = {
         # carrying a milestone that has shipped: the intake tile needs a
         # roadmap path that is not TUI-only, and no surface has one yet — the
         # same gap the four rows above already track.
-        "desktop": {"/projects/new/from-roadmap"},
+        "desktop": {"/team/planning/roadmap"},
     },
     "anonymize": {
         # Post-processing action, not a mode of its own: an "Anonymize" button on every

--- a/tests/unit/test_tui_parity.py
+++ b/tests/unit/test_tui_parity.py
@@ -99,17 +99,6 @@ class TestTerminalOnly:
 # ---------------------------------------------------------------------------
 
 
-# The desktop ships no chat surface at all: the standalone planning chat folded
-# into the project flow (blueprint → one-shot generation), and the interactive
-# conversation returns with the ChatSession-in-project work. An empty commands
-# registry is the honest encoding of that state — reverse this constant when
-# the chat comes back.
-DESKTOP_CHAT_RETIRED = (
-    "the standalone planning chat folded into the project flow; one-shot generation "
-    "replaced the pipeline, and the interactive chat returns with the ChatSession-in-project work"
-)
-
-
 class TestSlashCommands:
     @staticmethod
     def _terminal_verbs() -> set[str]:
@@ -118,12 +107,6 @@ class TestSlashCommands:
         return {command.name for command in COMMANDS}
 
     def test_every_terminal_verb_reaches_the_desktop_or_is_exempt(self, manifest):
-        if not manifest["commands"]:
-            # With no chat surface there is no verb registry to mirror. Skipped
-            # rather than passed, so the run reports the guard as off instead of
-            # green; it re-arms the moment the manifest carries one command, and
-            # a half-registered list is a failure below.
-            pytest.skip(DESKTOP_CHAT_RETIRED)
         answered = {command["tui"] for command in manifest["commands"]}
         exempt = {name.lstrip("/") for name in TERMINAL_ONLY}
         missing = self._terminal_verbs() - answered - exempt
@@ -223,8 +206,8 @@ class TestPlanningIsWholeOnTheDesktop:
         desktop had a window for none of them.
         """
         paths = {route["path"] for route in manifest["routes"]}
-        assert "/projects/:id/plan" in paths, (
+        assert "/team/planning/plan" in paths, (
             "the desktop has no page for a finished plan — plan_get/plan_export/plan_publish/plan_sync "
             f"would have no window to be called from\n{_HOW_TO}"
         )
-        assert "/projects/:id/plan" in CAPABILITIES["planning"]["desktop"]
+        assert "/team/planning/plan" in CAPABILITIES["planning"]["desktop"]


### PR DESCRIPTION
## Summary

Replaces the `routes_manifest.json` that landed with #350 with the one **yeaboi-desktop actually generates** ([yeaboi-desktop#33](https://github.com/yeaboi-ai/yeaboi-desktop/pull/33)), and corrects the parity registry to match.

The manifest is meant to be generated in yeaboi-desktop and carried here — "theirs, then a small one here." #350 skipped the first half and wrote it by hand, so this repo's parity guards have been asserting against a desktop that does not exist.

## What was claimed vs. what is there

| | #350's manifest | the real app |
|---|---|---|
| `/humans/*` → `/team/*` | renamed | **correct** — shipping in desktop#33 |
| `/team/planning/*` (5 routes) | deleted | **live**, calling `/api/chat/sessions/*` |
| chat commands | `[]` | **12**, live |
| `/projects/:id/plan`, `/projects/new/from-roadmap` | added | **do not exist** |
| `/projects`, `/projects/:id` capability | `projects` | the **planning platform's** projects |

The rename was the one true part, and it matters: `/api/meta/capabilities` now serves `solo`/`team`/`agents`, so the desktop's home page was looking up a `humans` category that no longer exists. desktop#33 fixes that.

## Why `projects` cannot reach the desktop yet

Two systems share the word. The desktop's `/projects/:id` is a `String(36)` uuid4 row in the planning-platform FastAPI (`owner_id`/`org_id`/`team_id`), reached through `lib/api-base.ts`. This repo's projects are `proj-<8hex>` rows in the local `sessions.db` — `ProjectStore._new_id` says so outright: *"Not the legacy planning-TUI uuid4 project_id."*

And there is nothing for a window to call: **`yeaboi app` exposes no `/api/projects*` routes.** Projects reached the engine, MCP, CLI and TUI in #350, but never the loopback backend. So `/projects/:id/plan` could not have been built as specified — it would be handed a planning-platform uuid while `plan_get` needs a yeaboi session id.

`projects` is therefore `Exempt` on the desktop with that reason, rather than claiming a surface it does not have. Making it real is loopback routes here first, then the page there, then the manifest — in that order.

## Changes

- **`contracts/v1/routes_manifest.json`** — the generated file from desktop#33.
- **`CAPABILITIES`**: `planning` → `/team/planning`, `/team/planning/chat`, `/team/planning/plan`; `sessions` → `/team/planning/sessions` (its `Exempt` described a plan panel that does not exist); `roadmap` → `/team/planning/roadmap`; `projects` → `Exempt` with the reason above.
- **`test_tui_parity.py`**: the plan-window assertion points at `/team/planning/plan`, which is where the desktop really reads, exports, publishes and syncs a plan — the test's intent was right, only its path was wrong. The slash-command guard loses its skip and **enforces again** over all 12 commands.
- **`_tips.py`**: restores the desktop `sessions` tip #350 deleted, and scopes the `projects` tip to the TUI (it names a keycap, and there is no desktop surface to send anyone to).

## Test plan

`make ship-gate` green: lint, format-check, **15,293 passed / 59 skipped** on 3.11–3.14, security, 3 preflight jobs. The skip count is one lower than on main — that is the slash-command guard coming back on.

**Merge after desktop#33**, so the manifest here is one that repo's `check-manifest` already agrees with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
