### PR TITLE
carry the desktop manifest now the project flow has actually landed

### DIFF
--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -32,31 +32,6 @@
       "title": "Usage"
     },
     {
-      "path": "/team/planning",
-      "capability": "planning",
-      "title": "Planning"
-    },
-    {
-      "path": "/team/planning/chat",
-      "capability": "planning",
-      "title": "Planning · Chat"
-    },
-    {
-      "path": "/team/planning/plan",
-      "capability": "planning",
-      "title": "The plan"
-    },
-    {
-      "path": "/team/planning/sessions",
-      "capability": "sessions",
-      "title": "Saved plans"
-    },
-    {
-      "path": "/team/planning/roadmap",
-      "capability": "roadmap",
-      "title": "Planning · Roadmap intake"
-    },
-    {
       "path": "/team/analysis",
       "capability": "team-analysis",
       "title": "Analysis"
@@ -243,12 +218,12 @@
     },
     {
       "path": "/projects",
-      "capability": null,
+      "capability": "projects",
       "title": "Projects"
     },
     {
       "path": "/projects/:id",
-      "capability": null,
+      "capability": "projects",
       "title": "Project"
     },
     {
@@ -258,8 +233,18 @@
     },
     {
       "path": "/projects/:id/blueprint",
-      "capability": null,
+      "capability": "planning",
       "title": "Blueprint"
+    },
+    {
+      "path": "/projects/:id/plan",
+      "capability": "planning",
+      "title": "Project · Plan"
+    },
+    {
+      "path": "/projects/new/from-roadmap",
+      "capability": "roadmap",
+      "title": "New project · From roadmap"
     },
     {
       "path": "/projects/:id/sessions/new",
@@ -367,66 +352,5 @@
       ]
     }
   ],
-  "commands": [
-    {
-      "name": "help",
-      "tui": "help",
-      "help": "shortcuts and everything you can type"
-    },
-    {
-      "name": "export",
-      "tui": "export",
-      "help": "save the plan and/or chat transcript"
-    },
-    {
-      "name": "skip",
-      "tui": "skip",
-      "help": "skip the current question"
-    },
-    {
-      "name": "defaults",
-      "tui": "defaults",
-      "help": "accept defaults for all remaining questions"
-    },
-    {
-      "name": "form",
-      "tui": "form",
-      "help": "see every question in one panel and answer them in any order"
-    },
-    {
-      "name": "finish",
-      "tui": "finish",
-      "help": "answer the remaining questions with defaults"
-    },
-    {
-      "name": "summary",
-      "tui": "summary",
-      "help": "show your answers so far"
-    },
-    {
-      "name": "questions",
-      "tui": "questions",
-      "help": "see what I'll ask and what's already answered"
-    },
-    {
-      "name": "edit",
-      "tui": "edit",
-      "help": "browse your answers (/edit 6 re-asks one) or refine the last artifact"
-    },
-    {
-      "name": "small",
-      "tui": "small",
-      "help": "switch to a Small plan"
-    },
-    {
-      "name": "large",
-      "tui": "large",
-      "help": "switch to a Large plan"
-    },
-    {
-      "name": "duck",
-      "tui": "duck",
-      "help": "mute or unmute the duck's speech bubble"
-    }
-  ]
+  "commands": []
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.39.0"
+version = "3.39.1"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,19 @@
   "schema_version": 2,
   "entries": [
     {
+      "version": "3.39.1",
+      "date": "2026-09-02",
+      "headline": "Desktop projects now expose their planning capabilities",
+      "summary": "The desktop project flow was redesigned to fold planning into project navigation. This release corrects the route manifest to match what the desktop app actually has.",
+      "highlights": [
+        {
+          "text": "Desktop projects now correctly expose planning routes",
+          "areas": ["planning"],
+          "surfaces": ["desktop"]
+        }
+      ]
+    },
+    {
       "version": "3.39.0",
       "date": "2026-09-01",
       "headline": "Connect to 20 vendors and build your own integrations",

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -72,14 +72,20 @@ class FeatureTip:
 # ``mode_key`` (when set) MUST be a _MODE_CARDS key so the jump-into-feature key
 # lands on the right card.
 _FEATURE_TIPS: tuple[FeatureTip, ...] = (
-    # No mode_key: projects open from the welcome screen's `P` keycap, not a card.
-    # TUI-only, like the capability: the tip names a keycap, and the desktop has
-    # no projects surface to send anyone to (CAPABILITIES marks it exempt there).
+    # No mode_key on either: projects open from the welcome screen's `P` keycap,
+    # not a card. Split by surface because only the terminal has that keycap —
+    # the desktop opens a project from the Projects page.
     FeatureTip(
         "projects",
         "\U0001f5c2️ Tip: Press P to pick a project — scoped runs feed each other's context",
         is_new=True,
         surfaces=("tui",),
+    ),
+    FeatureTip(
+        "projects",
+        "\U0001f5c2️ Tip: open a project — its standups, retros and reports feed each other's context",
+        is_new=True,
+        surfaces=("desktop",),
     ),
     FeatureTip(
         "team-analysis",
@@ -171,15 +177,12 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
     ),
     # Capabilities without a dedicated home-screen card (tui_mode Exempt) — they
     # still rotate to aid discovery, just with no jump target.
+    # TUI-only: on the desktop, saved plans surface through each project's plan
+    # panel (CAPABILITIES marks sessions exempt there), so no desktop tip.
     FeatureTip(
         "sessions",
         "\U0001f5c2️ Tip: every plan is saved — resume any past session with --resume",
         surfaces=("tui",),
-    ),
-    FeatureTip(
-        "sessions",
-        "\U0001f5c2️ Tip: every plan is saved — reopen any past run from Saved plans",
-        surfaces=("desktop",),
     ),
     # No desktop route (CAPABILITIES marks it exempt there), so no desktop tip.
     FeatureTip(

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -100,7 +100,9 @@ CAPABILITIES: dict[str, dict] = {
             "--architecture-spike",
         },
         "skill": "plan-sprint",
-        "desktop": {"/team/planning", "/team/planning/chat", "/team/planning/plan"},
+        # Planning folded into the desktop's project flow: the blueprint is
+        # the intake and /projects/:id/plan renders the finished plan.
+        "desktop": {"/projects/:id/blueprint", "/projects/:id/plan"},
     },
     "projects": {
         "engines": {
@@ -126,11 +128,7 @@ CAPABILITIES: dict[str, dict] = {
             "a scoping primitive, not a guided workflow — modes gain --project/project_id, "
             "and agents call the project_* tools directly"
         ),
-        "desktop": Exempt(
-            "no desktop surface yet: `yeaboi app` exposes no /api/projects* routes, so the window "
-            "would have nothing to call. The desktop's own /projects is the planning platform's — "
-            "uuid4 rows on a different backend, not this store's proj-<8hex> ids"
-        ),
+        "desktop": {"/projects", "/projects/:id"},
     },
     "sessions": {
         "engines": Exempt("thin SessionStore reads — no pipeline to extract"),
@@ -138,7 +136,10 @@ CAPABILITIES: dict[str, dict] = {
         "tui_mode": Exempt("sessions are surfaced inside the planning-mode screens, no dedicated card"),
         "cli": {"--list-sessions", "--resume", "--clear-sessions"},
         "skill": Exempt("agents call the session tools directly — no guided workflow needed"),
-        "desktop": {"/team/planning/sessions"},
+        "desktop": Exempt(
+            "saved plans surface through each project's plan panel (the iteration carries its "
+            "session id) — a raw session browser would be a second door to the same room"
+        ),
     },
     "standup": {
         "engines": {
@@ -271,7 +272,7 @@ CAPABILITIES: dict[str, dict] = {
         # carrying a milestone that has shipped: the intake tile needs a
         # roadmap path that is not TUI-only, and no surface has one yet — the
         # same gap the four rows above already track.
-        "desktop": {"/team/planning/roadmap"},
+        "desktop": {"/projects/new/from-roadmap"},
     },
     "anonymize": {
         # Post-processing action, not a mode of its own: an "Anonymize" button on every

--- a/tests/unit/test_tui_parity.py
+++ b/tests/unit/test_tui_parity.py
@@ -99,6 +99,16 @@ class TestTerminalOnly:
 # ---------------------------------------------------------------------------
 
 
+# The desktop ships no chat surface: the standalone planning chat folded into the
+# project flow, and the conversation returns with the ChatSession-in-project work.
+# An empty commands registry is the honest encoding of that — reverse this when
+# the chat comes back.
+DESKTOP_CHAT_RETIRED = (
+    "the standalone planning chat folded into the project flow; the interactive "
+    "chat returns with the ChatSession-in-project work"
+)
+
+
 class TestSlashCommands:
     @staticmethod
     def _terminal_verbs() -> set[str]:
@@ -107,6 +117,13 @@ class TestSlashCommands:
         return {command.name for command in COMMANDS}
 
     def test_every_terminal_verb_reaches_the_desktop_or_is_exempt(self, manifest):
+        if not manifest["commands"]:
+            # The standalone chat retired with the planning pages, so there is no
+            # verb registry to mirror. Skipped rather than passed, so the run
+            # reports the guard as off instead of green; it re-arms the moment the
+            # manifest carries one command, and a half-registered list still fails
+            # below.
+            pytest.skip(DESKTOP_CHAT_RETIRED)
         answered = {command["tui"] for command in manifest["commands"]}
         exempt = {name.lstrip("/") for name in TERMINAL_ONLY}
         missing = self._terminal_verbs() - answered - exempt
@@ -206,8 +223,8 @@ class TestPlanningIsWholeOnTheDesktop:
         desktop had a window for none of them.
         """
         paths = {route["path"] for route in manifest["routes"]}
-        assert "/team/planning/plan" in paths, (
+        assert "/projects/:id/plan" in paths, (
             "the desktop has no page for a finished plan — plan_get/plan_export/plan_publish/plan_sync "
             f"would have no window to be called from\n{_HOW_TO}"
         )
-        assert "/team/planning/plan" in CAPABILITIES["planning"]["desktop"]
+        assert "/projects/:id/plan" in CAPABILITIES["planning"]["desktop"]


### PR DESCRIPTION
## Summary

[yeaboi-desktop#35](https://github.com/yeaboi-ai/yeaboi-desktop/pull/35) merged the desktop half of #350 — planning folded into the project flow, `/projects/:id/plan` and `/projects/new/from-roadmap` built, the two project id spaces bridged, the standalone chat retired. This carries its regenerated manifest, byte-identical to `yeaboi-desktop@main`.

**It undoes #351.** That PR replaced the correct manifest on the premise that the desktop work did not exist. It did exist — unmerged, in a `desktop/planning-mode-mash` worktree paired by name with the one in this repo. I checked `origin/main` in both repos, found nothing, and concluded the manifest had been invented. One `git worktree list` in the desktop repo would have shown otherwise.

#351's stated reason for exempting `projects` — *"`yeaboi app` exposes no `/api/projects*` routes, so the window would have nothing to call"* — was wrong on both counts: the desktop bridges the id spaces with a nullable `yeaboi_project_id` and a lazy `project_create` mint, and generates the plan through the engine.

## Changes

The manifest, and the four registry rows #351 moved, back to what the desktop actually has:

| capability | now |
|---|---|
| `planning` | `/projects/:id/blueprint`, `/projects/:id/plan` |
| `projects` | `/projects`, `/projects/:id` |
| `sessions` | `Exempt` — saved plans surface through each project's plan panel |
| `roadmap` | `/projects/new/from-roadmap` |

Plus: the plan-window assertion in `test_tui_parity.py` points at `/projects/:id/plan` again; the slash-command guard goes back to **skipping with its reason** while the manifest carries no commands (the chat retired with the pages) — skipped rather than passed, so a run reports the guard as off rather than green, and it re-arms the moment a command returns; the desktop `sessions` tip goes again; and the `projects` tip splits by surface, since only the terminal has the `P` keycap.

`/settings/connections` needs no attention here — [yeaboi-desktop#34](https://github.com/yeaboi-ai/yeaboi-desktop/pull/34) landed the catalog UI, so the route #352 registered now genuinely exists. Both manifests agree on it.

## Test plan

`make ship-gate` green: lint, format-check, **16,160 passed / 60 skipped** on 3.11–3.14, security, 3 preflight jobs.

Verified separately: this manifest is byte-identical to `yeaboi-desktop@main`'s, and the two repos' route sets now match exactly.

## Worth a follow-up

The manifest has been hand-edited in this repo three times now (#350, #352, and #351's revert of #350), each time describing a desktop that did not match. Nothing here checks it: `check-manifest` runs in the desktop repo against its own registry, so this copy can drift silently. A CI job here that fetches `yeaboi-desktop@main`'s `routes.json` and diffs it would have caught all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
