### PR TITLE
carry the desktop's sessions and agent-project routes

### DIFF
--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -7,6 +7,11 @@
       "title": "Home"
     },
     {
+      "path": "/sessions",
+      "capability": "sessions",
+      "title": "Sessions"
+    },
+    {
       "path": "/whats-new",
       "capability": null,
       "title": "What's New"
@@ -155,6 +160,16 @@
       "path": "/agents/security",
       "capability": "agent-security",
       "title": "Agent Security"
+    },
+    {
+      "path": "/agents/projects",
+      "capability": "projects",
+      "title": "Agent projects"
+    },
+    {
+      "path": "/agents/projects/:id",
+      "capability": "projects",
+      "title": "Agent project"
     },
     {
       "path": "/ceremonies",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.41.0"
+version = "3.41.1"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,24 @@
   "schema_version": 2,
   "entries": [
     {
+      "version": "3.41.1",
+      "date": "2026-09-05",
+      "headline": "Desktop now fully supports Sessions and Projects",
+      "summary": "The desktop app now supports Sessions and Projects workflows with the same door-based navigation as the terminal. All project and session screens work identically across surfaces.",
+      "highlights": [
+        {
+          "text": "Sessions and Projects doors both available on desktop",
+          "areas": ["general"],
+          "surfaces": ["desktop"]
+        },
+        {
+          "text": "Navigate projects and access project details on desktop",
+          "areas": ["planning"],
+          "surfaces": ["desktop"]
+        }
+      ]
+    },
+    {
       "version": "3.41.0",
       "date": "2026-09-03",
       "headline": "Choose between projects and one-off sessions",

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -202,12 +202,11 @@ _FEATURE_TIPS: tuple[FeatureTip, ...] = (
         "\U0001f5c2️ Tip: every plan is saved — resume any past session with --resume",
         surfaces=("tui",),
     ),
-    # The other door. Terminal-only until the desktop's Sessions page lands.
+    # The other door, on both surfaces: the desktop's Sessions page is the same room.
     FeatureTip(
         "sessions",
         "\U0001f5c2️ Tip: Sessions are one-off runs — a standalone standup or analysis that carries nothing over",
         is_new=True,
-        surfaces=("tui",),
     ),
     # No desktop route (CAPABILITIES marks it exempt there), so no desktop tip.
     FeatureTip(
@@ -366,7 +365,7 @@ _META_TIPS: tuple[FeatureTip, ...] = (
 _DESKTOP_TIPS: tuple[FeatureTip, ...] = (
     FeatureTip(
         "desktop:projects",
-        "\U0001f4c1 Tip: Projects holds every blueprint session, diagram and deliverable you've made",
+        "\U0001f4c1 Tip: Projects is the durable door — every run you start inside one shares its context",
         surfaces=("desktop",),
     ),
     FeatureTip(

--- a/tests/unit/test_surface_parity.py
+++ b/tests/unit/test_surface_parity.py
@@ -129,7 +129,7 @@ CAPABILITIES: dict[str, dict] = {
             "a scoping primitive, not a guided workflow — modes gain --project/project_id, "
             "and agents call the project_* tools directly"
         ),
-        "desktop": {"/projects", "/projects/:id"},
+        "desktop": {"/projects", "/projects/:id", "/agents/projects", "/agents/projects/:id"},
     },
     "sessions": {
         "engines": Exempt("thin SessionStore reads — no pipeline to extract"),
@@ -140,10 +140,7 @@ CAPABILITIES: dict[str, dict] = {
         ),
         "cli": {"--list-sessions", "--resume", "--clear-sessions"},
         "skill": Exempt("agents call the session tools directly — no guided workflow needed"),
-        "desktop": Exempt(
-            "the manifest carries no /sessions yet — the desktop's Sessions page lands with its rail "
-            "redesign, and this column flips in the same commit as the manifest it vendors"
-        ),
+        "desktop": {"/sessions"},
     },
     "standup": {
         "engines": {


### PR DESCRIPTION
## Summary

The third and smallest step of the two-door redesign. yeaboi-ai/yeaboi-desktop#40 adds `/sessions`, `/agents/projects` and `/agents/projects/:id` to its route registry; this PR vendors that regenerated `contracts/v1/routes_manifest.json` and, in the same commit, flips the parity registry to match: `sessions` gains `{"/sessions"}` as its desktop routes (it was an honest exemption) and `projects` gains the two agents pages. The two edits cannot be split because `TestDesktop.test_routes_registered` is two-way set equality over capability-bearing manifest routes.

Also: the Sessions door tip now rotates on the desktop as well as the terminal, and the desktop's Projects tip names the door rather than the planning platform's blueprint sessions.

**Merge order**: after #358 (this branch is stacked on it; retarget to main and rebase over the auto-bump once #358 merges) and after yeaboi-desktop#40, so the manifest never claims a route the released desktop lacks. Rebased on 2026-09-04 over #358's front-page commits; the vendored manifest is now byte-identical to the desktop branch's (`/settings/news` from #358 plus the three rows here).

## Test plan

- CI: all 3 checks green on `baaa8c46` (2026-09-05).
- `make test-scoped`: 16,614 passed, 60 skipped; `make lint` clean.
- Targeted: `test_surface_parity.py`, `test_tui_parity.py`, `test_tips.py`, `test_beta_surfaces.py` — 108 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxptx7NGRrBP7rAQ8ABzn9
