### PR TITLE
note how to reinstall the devkit plugin when /ship goes missing

### DIFF
--- a/.claude/repo-notes.md
+++ b/.claude/repo-notes.md
@@ -4,6 +4,19 @@ The facts the shared `/ship` and `/sync-main` deliberately do not hardcode, beca
 desktop, site and tooling repos answer them differently. The procedures live in the `yeaboi-devkit`
 plugin; this is what they read.
 
+## If `/ship` is missing
+
+The plugin arrives through `.claude/settings.json` alone, and that path is not reliable: Claude
+Code can drop the plugin's install record after the marketplace bumps its version, then orphan the
+cached copy, and every session afterwards starts with no `/ship`, `/sync-main`, `/wt` or `/migrate`
+and no visible error (only a `plugin-cache-miss` line in `claude --debug-file`). The fix:
+
+```
+claude plugin install yeaboi-devkit@yeaboi-tooling --scope user
+```
+
+then restart the session. A user-scope install covers every worktree, so it needs doing once.
+
 ## Commit
 
 Commit with **`SKIP=unit-tests`**. That pre-commit hook is `make test-scoped`, which the Stop hook


### PR DESCRIPTION
## Summary

- Adds an "If `/ship` is missing" section to `.claude/repo-notes.md`.
- The `yeaboi-devkit` plugin is enabled only through `.claude/settings.json`, and Claude Code can drop its install record after the marketplace bumps the plugin version, then orphan the cached copy. Every session afterwards starts without `/ship`, `/sync-main`, `/wt` or `/migrate`, with no visible error (only a `plugin-cache-miss` line in the debug log).
- The note gives the one-time fix, `claude plugin install yeaboi-devkit@yeaboi-tooling --scope user`, which covers every worktree.

## Test plan

- [x] `uv run pytest tests/unit/test_ship_gate.py` (the test that reads repo-notes) passes
- [x] Docs-only change; no source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK1JtYp9mcMddVqpgQnx9t