### PR TITLE
add spotify, apple music and youtube music as sources, with sign-in and a library behind the desktop's music page

### DIFF
--- a/.claude/skills/project-map/SKILL.md
+++ b/.claude/skills/project-map/SKILL.md
@@ -252,6 +252,7 @@ The `src/yeaboi/mcp/` package exposes yeaboi to AI coding agents (Claude Code, C
 - `RETRO_PORT` — optional, base loopback port for the Retro collaboration server, which the tunnel forwards to (default 5173; walks upward if busy)
 - `POKER_PORT` — same for the Poker board (default 5273; clear of retro's 5173..5193 walk range)
 - `SHIP_PORT` — same for the Ship board (default 5473), the live view over a supervised ship run
+- `YEABOI_OAUTH_PORT` — optional, the loopback port the music sign-in's callback listener binds (default 8643). **Fixed, never walked**: Spotify matches the registered Redirect URI exactly, so changing it means updating the URI in your own Spotify app too
 - `YEABOI_SHIP_BOARD` — optional, `1`/`true`/`yes` opts the Ship board in (`config.get_ship_board_enabled()`, default off). Read-only: guests watch; approval stays in the TUI
 - `YEABOI_NO_TUNNEL` — optional, `1`/`true`/`yes` stops the live boards opening a Cloudflare tunnel (`config.tunnels_disabled()`). The board still runs for the host on `127.0.0.1` but has nothing to share. Needed because the tunnel now auto-starts: without it `make run-dry` would download ~40 MB and publish a public URL
 - `CLOUDFLARED_PATH` — optional, path to an existing `cloudflared` binary for Retro remote tunnels (else the app auto-downloads one to `~/.yeaboi/bin/`)

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -91,7 +91,7 @@ over this wire. Writes are allowlisted to the engine's field registry
 | POST | `/api/settings/provider/verify` | body `{provider, credential, model?}` → `{ok, message}` (network, up to ~8s) |
 | POST | `/api/settings/provider/models` | body `{provider, credential}` → `{models, default, hints}` (discovered-first merge) |
 | POST | `/api/settings/connection/verify` | body `{kind, …fields}` → `{ok, message}`. `kind` is any `verify_kind` the `/api/connections` rows report — the legacy literals (`github`, `jira`, `confluence`, `notion`, `elevenlabs`, `tavus`) plus every descriptor-verified connector key (`datadog`, `grafana`, `sentry`, `gitlab`, `custom_*`, …), and the accepted field names are that kind's declared verify fields (e.g. `token`, `app_key`, `base_url`, `email`, `space_key`). Omitted fields fall back to saved values, so a stored credential can be re-checked without echoing it — but a stored secret only travels to the stored host: a caller-supplied `base_url`/`email` requires **every** secret verify field of that kind in the same request (Datadog: `token` and `app_key`), and a supplied `base_url` must be https (400 otherwise; network, up to ~10s) |
-| GET | `/api/connections` | the integration catalog: `{connectors: [{key, label, summary, detail, family, family_label, section, connected, read_only, managed_by, kind, docs_url, glyph, icon, accent, verify_kind, auth_env, auth_methods: [{key, label, summary, recommended, warning, setup_url, envs}], fields: [{env, label, secret, required, is_set, choices, default, placeholder, hint, help_url, help_scope, auth_method}]}], families, connected}`. `?all=1` is the browse view: every connector that could be added, plus the built-in integrations (GitHub, Jira, Azure DevOps Boards, Confluence, Notion, Slack, ElevenLabs, Tavus) as `managed_by: "credentials"` rows; the default lists only connected connector-layer rows — the view a Credentials-side "your integrations" panel renders. `kind` is a custom connection's kind (`api`/`webhook`/`mcp`); built-in and legacy rows send `""`. `icon` is a custom connection's uploaded icon — a server-validated `data:image/(png\|jpeg\|webp);base64,` URI, never SVG, decoded size ≤ 64KB; `""` everywhere else (built-in marks ship with the client). `managed_by` says where configuring happens — `"connections"` rows carry their own add flow (write the fields via `/api/settings/set`, then probe `verify_kind`), `"credentials"` rows deep-link to Settings ▸ Credentials/setup and their `verify_kind` is `""` when no probe exists (Slack, Azure DevOps). **Never carries a field value** — a field reports only whether it is set. `auth_methods` is empty for a connector with one way in, and a field's `auth_method` is empty when every method needs it; a client that ignores both keys renders exactly as it did before they existed. Exactly one method carries `recommended: true`, and every other carries a non-empty `warning` — a method yeaboi cannot bound says so on itself |
+| GET | `/api/connections` | the integration catalog: `{connectors: [{key, label, summary, detail, family, family_label, section, connected, read_only, managed_by, kind, docs_url, glyph, icon, accent, verify_kind, auth_env, signin, auth_methods: [{key, label, summary, recommended, warning, setup_url, envs}], fields: [{env, label, secret, required, is_set, choices, default, placeholder, hint, help_url, help_scope, auth_method, action}]}], families, connected}`. `signin` is `{signed_in, account}` for a connector with an OAuth sign-in (Spotify, YouTube Music) and `null` otherwise; `account` is the display name the sign-in was minted for — the one field value this payload ever carries, and not a credential. A field's `action` is `"signin"` when the sign-in flow writes it (the refresh token, the display name): no surface prompts for it, and the desktop renders it as a status row with Sign in / Sign out (see *Music* below). `?all=1` is the browse view: every connector that could be added, plus the built-in integrations (GitHub, Jira, Azure DevOps Boards, Confluence, Notion, Slack, ElevenLabs, Tavus) as `managed_by: "credentials"` rows; the default lists only connected connector-layer rows — the view a Credentials-side "your integrations" panel renders. `kind` is a custom connection's kind (`api`/`webhook`/`mcp`); built-in and legacy rows send `""`. `icon` is a custom connection's uploaded icon — a server-validated `data:image/(png\|jpeg\|webp);base64,` URI, never SVG, decoded size ≤ 64KB; `""` everywhere else (built-in marks ship with the client). `managed_by` says where configuring happens — `"connections"` rows carry their own add flow (write the fields via `/api/settings/set`, then probe `verify_kind`), `"credentials"` rows deep-link to Settings ▸ Credentials/setup and their `verify_kind` is `""` when no probe exists (Slack, Azure DevOps). **Never carries a field value** — a field reports only whether it is set. `auth_methods` is empty for a connector with one way in, and a field's `auth_method` is empty when every method needs it; a client that ignores both keys renders exactly as it did before they existed. Exactly one method carries `recommended: true`, and every other carries a non-empty `warning` — a method yeaboi cannot bound says so on itself |
 | POST | `/api/connections/custom` | save one user-created connection. Body: descriptor JSON — `{key: "custom_…", label, family, summary, detail?, docs_url?, glyph, accent, kind: api\|webhook\|mcp, auth_scheme: bearer\|basic\|header, header_name?, probe_path, probe_ok_status, webhook_verify?: token\|hmac, events?: {path, items_key, kind, title_path, ref_path?, severity_path?, status_path?, url_path?, started_at_path?, service_path?}, extra_fields?: [{label, env_suffix, secret?, header_name?, hint?}], icon_data?}` — **never a credential** (values are typed afterwards through `/api/settings/set`, exactly like a built-in connector's fields). An `mcp` kind stores a streamable-HTTP MCP server URL and optional bearer token (derived envs, values typed afterwards via `/api/settings/set`), verifies with the MCP initialize + tools/list handshake, and gathers nothing. A `webhook` kind requires the events mapping, ignores the HTTP-shape fields, and mints its delivery secret server-side — returned once as `webhook_secret` on the created row (`/api/webhooks/{key}/url` can show it again). `extra_fields` (`api` kind only, ≤ 4) declares extra credentials/config beyond the auth scheme — a Datadog-style app key beside the api key: `env_suffix` is UPPER_SNAKE and derives the env (`YEABOI_CUSTOM_<KEY>_<SUFFIX>`), `secret` defaults true, and a `header_name` sends the value as that request header on probe and fetch. `icon_data` is an optional icon in the `icon` row key's data-URI shape (png/jpeg/webp only, never SVG, ≤ 64KB decoded — the validator refuses the rest). The runtime validator is the gate: every problem comes back joined in a 400 `{"error": …}`. Success returns the new catalog row in the `/api/connections` row shape (`managed_by: "connections"`) |
 | POST | `/api/connections/custom/draft` | body `{description}` → `{ok, draft, problems}`: one LLM pass from a plain-language service description to a candidate descriptor (same shape as the create body). Never saves — a draft with problems pre-fills the create form. The model proposes identity, look and shape only — any kind, `extra_fields` included; never a credential value, an env name, verify wiring or `icon_data` (network + one LLM call) |
 | POST | `/api/connections/custom/{key}/delete` | remove one user-created connection — the descriptor AND its stored env values in the same act (a definition-less credential is an orphan). `{deleted: key}`; 404 for a key that is not a custom connection |
@@ -663,12 +663,62 @@ not accepted as an index — `bool` is an `int` in Python, and silently selectin
 station 1 is worse than a 400.
 
 `music.services` lists the streaming services the desktop can also play —
-`[{key, label, connected, playback}]` for Spotify, Apple Music and YouTube
-Music. Each is a keyless connector in the integrations catalogue: `connected`
-is whether its one "where it plays" choice has been saved (through
-`POST /api/settings/set`, like every connector field), and `playback` is that
-choice. Playback itself happens in the desktop's embedded player or the
-vendor's own app and never touches this API; the terminal ignores the block.
+`[{key, label, connected, playback, can_sign_in, signed_in, account}]` for
+Spotify, Apple Music and YouTube Music. Each is a connector in the integrations
+catalogue: `connected` is whether its "where it plays" choice has been saved
+(through `POST /api/settings/set`, like every connector field), and `playback`
+is that choice. Signing in is a separate, optional step: `can_sign_in` is false
+for Apple Music (the desktop browses the Music app on the Mac itself),
+`signed_in` says whether a token is held, and `account` is the display name it
+was minted for. A desktop that finds no `signed_in` key is talking to an older
+backend and hides Sign in and Browse. Playback itself happens in the desktop's
+embedded player or the vendor's own app and never touches this API; the
+terminal ignores the block.
+
+## Music
+
+The Browse behind the desktop's Music page: sign in to Spotify or YouTube
+Music, then read the library. Chrome like ambience — no capability, no MCP
+tool — and every route below needs the bearer.
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/connections/{key}/signin` | start a sign-in → `{started, url, message}`. The desktop opens `url` in the system browser. 404 for a connector with no sign-in (`apple_music`). `started: false` carries the reason in `message` — no client configured (paste your own client ID), or the callback port busy |
+| GET | `/api/connections/{key}/signin` | poll → `{active, done?, ok?, saved?, account?, message?}`; `{active: false}` when no sign-in for that key is running. On the poll that first sees the token it is persisted before `saved: true` is reported — the token itself is never in any body |
+| POST | `/api/connections/{key}/signin/cancel` | stop and discard the session → `{ok: true}` |
+| POST | `/api/connections/{key}/signout` | forget the token and the display name → `{ok: true, signed_in: false}` |
+| GET | `/api/music/{key}/library` | `?shelf=&cursor=&limit=` — one shelf of the signed-in library → `{items, next_cursor}`. `shelf` ∈ `playlists`, `liked`, `albums`, `recent` (YouTube: the first two; the rest 400). `next_cursor` is opaque; `""` ends the list. Apple has no library here (404): the desktop browses the Music app itself |
+| GET | `/api/music/{key}/playlist/{playlist_id}/items` | `?cursor=&limit=` — the tracks of one playlist, same shape |
+| GET | `/api/music/{key}/search` | `?q=&limit=` — catalogue search, same shape with an empty `next_cursor`. Spotify caps a page at 10. `apple_music` needs no sign-in: Apple's public iTunes Search API, `?country=` (two letters, default `us`), and each row carries `preview_url` |
+| POST | `/api/music/spotify/play` | body `{uri, device_id?}` → `{ok: true}`: play a Spotify URI on the active device. Premium only — see the codes below |
+| GET | `/api/music/spotify/player` | `{playing, progress_ms, item, device: {id, name}}`; `item`/`device` null when nothing plays |
+| GET | `/api/music/spotify/devices` | `{devices: [{id, name, type, active}]}` |
+
+A row is `{id, kind, title, subtitle, artwork_url, duration_ms, url, uri,
+preview_url, count}` — `kind` ∈ `track`, `album`, `playlist`, `video`, `song`;
+`url` is always a share link the desktop's own link grammar accepts
+(`https://open.spotify.com/<kind>/<id>`, `https://www.youtube.com/watch?v=`
+or `playlist?list=`, `https://music.apple.com/<cc>/album/<slug>/<id>?i=<track>`),
+so a row plays through exactly the path a pasted link does.
+
+A vendor's refusal comes back as `{error, code, retry_after?}` with the status
+the code implies: `signed_out` (**409**, never 401 — the desktop's bearer
+handling must not read it as its own failure; offer Sign in), `premium_required`
+(403) and `no_active_device` (409) — the desktop hands the track to the
+Spotify app instead — `not_allowlisted` (403: an unapproved app allows only a
+few sign-ins; paste your own client ID), `quota_exceeded` (429),
+`rate_limited` (429, `retry_after` seconds), `unsupported_shelf` / `bad_uri`
+(400), `unavailable` (502).
+
+The sign-in is Authorization Code + PKCE. The vendor sends the browser back
+to a loopback listener of the backend's own, never the app wire: it binds
+`127.0.0.1` on a **fixed** port (8643, `YEABOI_OAUTH_PORT` overrides — Spotify
+matches the registered Redirect URI exactly, so a busy port is an error, not a
+walk) and serves `/callback/{key}` for one sign-in. The refresh token is
+written to `~/.yeaboi/.env` as `SPOTIFY_REFRESH_TOKEN` / `YOUTUBE_MUSIC_REFRESH_TOKEN`
+(masked everywhere), the display name beside it. yeaboi's registered apps are
+built in; a `SPOTIFY_CLIENT_ID` or `YOUTUBE_MUSIC_CLIENT_ID` (+ `_CLIENT_SECRET`)
+saved through `/api/settings/set` takes precedence.
 
 `saver` is the same shape for the same reason: `idle_seconds`, the `styles`
 catalogue (key → display name) and the chosen `style`, set with `saver_style`.

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -663,14 +663,16 @@ not accepted as an index — `bool` is an `int` in Python, and silently selectin
 station 1 is worse than a 400.
 
 `music.services` lists the streaming services the desktop can also play —
-`[{key, label, connected, playback, can_sign_in, signed_in, account}]` for
+`[{key, label, connected, playback, can_sign_in, signed_in, account, client}]` for
 Spotify, Apple Music and YouTube Music. Each is a connector in the integrations
 catalogue: `connected` is whether its "where it plays" choice has been saved
 (through `POST /api/settings/set`, like every connector field), and `playback`
 is that choice. Signing in is a separate, optional step: `can_sign_in` is false
 for Apple Music (the desktop browses the Music app on the Mac itself),
-`signed_in` says whether a token is held, and `account` is the display name it
-was minted for. A desktop that finds no `signed_in` key is talking to an older
+`signed_in` says whether a token is held, `account` is the display name it
+was minted for, and `client` says which OAuth app a sign-in would use —
+`own` (the user's `*_CLIENT_ID`), `builtin` (yeaboi's), or `none`, in which
+case the desktop asks for one before offering Sign in. A desktop that finds no `signed_in` key is talking to an older
 backend and hides Sign in and Browse. Playback itself happens in the desktop's
 embedded player or the vendor's own app and never touches this API; the
 terminal ignores the block.

--- a/contracts/v1/app_http.md
+++ b/contracts/v1/app_http.md
@@ -656,9 +656,19 @@ their behalf.
 `/api/ambience` serves music as a **catalogue and a preference only**. The
 terminal hands a station URL to `ffplay`; the desktop hands the same URL to an
 `<audio>` element and needs no binary, so playback state lives in the renderer
-and never round-trips. A bad channel index is refused rather than clamped, and
-`true` is not accepted as an index — `bool` is an `int` in Python, and silently
-selecting station 1 is worse than a 400.
+and never round-trips. The desktop writes `music_enabled` and `music_channel`
+back when the user presses play or picks a station, so both surfaces agree on
+what is on. A bad channel index is refused rather than clamped, and `true` is
+not accepted as an index — `bool` is an `int` in Python, and silently selecting
+station 1 is worse than a 400.
+
+`music.services` lists the streaming services the desktop can also play —
+`[{key, label, connected, playback}]` for Spotify, Apple Music and YouTube
+Music. Each is a keyless connector in the integrations catalogue: `connected`
+is whether its one "where it plays" choice has been saved (through
+`POST /api/settings/set`, like every connector field), and `playback` is that
+choice. Playback itself happens in the desktop's embedded player or the
+vendor's own app and never touches this API; the terminal ignores the block.
 
 `saver` is the same shape for the same reason: `idle_seconds`, the `styles`
 catalogue (key → display name) and the chosen `style`, set with `saver_style`.

--- a/contracts/v1/connectors.json
+++ b/contracts/v1/connectors.json
@@ -156,6 +156,33 @@
       "managed_by": "connections"
     },
     {
+      "key": "apple_music",
+      "label": "Apple Music",
+      "family": "music",
+      "family_label": "Music",
+      "accent": "rgb(250,45,85)",
+      "glyph": "🍎",
+      "managed_by": "connections"
+    },
+    {
+      "key": "spotify",
+      "label": "Spotify",
+      "family": "music",
+      "family_label": "Music",
+      "accent": "rgb(30,215,96)",
+      "glyph": "🎧",
+      "managed_by": "connections"
+    },
+    {
+      "key": "youtube_music",
+      "label": "YouTube Music",
+      "family": "music",
+      "family_label": "Music",
+      "accent": "rgb(255,0,0)",
+      "glyph": "▶️",
+      "managed_by": "connections"
+    },
+    {
       "key": "azdevops",
       "label": "Azure DevOps Boards",
       "family": "delivery",

--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -302,9 +302,19 @@
       "title": "Settings"
     },
     {
+      "path": "/music",
+      "capability": null,
+      "title": "Music"
+    },
+    {
       "path": "/settings/appearance",
       "capability": null,
       "title": "Settings · Appearance"
+    },
+    {
+      "path": "/settings/music",
+      "capability": null,
+      "title": "Settings · Player"
     },
     {
       "path": "/settings/duck",

--- a/contracts/web/fixtures/poker.boot.json
+++ b/contracts/web/fixtures/poker.boot.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "Classical",
-      "url": "https://stream.srg-ssr.ch/m/rsc_de/mp3_128"
+      "url": "https://icecast.radiofrance.fr/francemusique-midfi.mp3"
     },
     {
       "name": "Ambient",

--- a/contracts/web/fixtures/retro.boot.json
+++ b/contracts/web/fixtures/retro.boot.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "Classical",
-      "url": "https://stream.srg-ssr.ch/m/rsc_de/mp3_128"
+      "url": "https://icecast.radiofrance.fr/francemusique-midfi.mp3"
     },
     {
       "name": "Ambient",

--- a/contracts/web/ui.json
+++ b/contracts/web/ui.json
@@ -11,6 +11,7 @@
     "standup"
   ],
   "connector_accents": [
+    "apple_music",
     "aws",
     "azdevops",
     "azure_cloud",
@@ -33,9 +34,11 @@
     "pagerduty",
     "sentry",
     "slack",
+    "spotify",
     "statuspage",
     "tavus",
-    "trello"
+    "trello",
+    "youtube_music"
   ],
   "timing": {
     "refused_hold_sleep_ms": 1500

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yeaboi"
-version = "3.42.0"
+version = "3.43.0"
 description = "yeaboi — an AI Scrum Master for your terminal: sprint planning, standups, retros, planning poker, 1:1s and delivery reports, plus cost and security posture for your AI coding agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/yeaboi/ambience.py
+++ b/src/yeaboi/ambience.py
@@ -78,9 +78,10 @@ MUSIC_SERVICE_KEYS: tuple[str, ...] = ("spotify", "apple_music", "youtube_music"
 def music_services() -> list[dict]:
     """The streaming services, and whether each is switched on in the catalogue.
 
-    A service is on when its connector is connected, which for these keyless
-    connectors means its one "where it plays" choice has been saved. The choice
-    travels too: it is the only field, and it is never a secret.
+    A service is on when its connector is connected, which means its "where it
+    plays" choice has been saved; signing in is a separate, optional step, and
+    ``signed_in``/``account`` say where it stands. The choice travels too: it
+    is the first field, and it is never a secret.
     """
     import os
 
@@ -99,6 +100,9 @@ def music_services() -> list[dict]:
                 "label": connector.label,
                 "connected": registry.is_connected(connector),
                 "playback": playback if playback in field.choices else field.default,
+                "can_sign_in": connector.can_sign_in,
+                "signed_in": bool(os.environ.get(connector.signin_env, "").strip()) if connector.can_sign_in else False,
+                "account": os.environ.get(connector.account_env, "").strip() if connector.account_env else "",
             }
         )
     return services

--- a/src/yeaboi/ambience.py
+++ b/src/yeaboi/ambience.py
@@ -75,6 +75,13 @@ def music_channels() -> list[dict[str, str]]:
 MUSIC_SERVICE_KEYS: tuple[str, ...] = ("spotify", "apple_music", "youtube_music")
 
 
+def _client_kind(key: str) -> str:
+    from yeaboi.connectors import oauth_clients
+
+    client = oauth_clients.resolve(key)
+    return "none" if client is None else ("own" if client.own else "builtin")
+
+
 def music_services() -> list[dict]:
     """The streaming services, and whether each is switched on in the catalogue.
 
@@ -103,6 +110,9 @@ def music_services() -> list[dict]:
                 "can_sign_in": connector.can_sign_in,
                 "signed_in": bool(os.environ.get(connector.signin_env, "").strip()) if connector.can_sign_in else False,
                 "account": os.environ.get(connector.account_env, "").strip() if connector.account_env else "",
+                # Which OAuth app a sign-in would use: the user's own, yeaboi's
+                # built-in, or none — so the page can ask for one before a click.
+                "client": _client_kind(key) if connector.can_sign_in else "none",
             }
         )
     return services

--- a/src/yeaboi/ambience.py
+++ b/src/yeaboi/ambience.py
@@ -70,6 +70,40 @@ def music_channels() -> list[dict[str, str]]:
     return [dict(channel) for channel in CHANNELS]
 
 
+#: The catalogue connectors that are music sources on the desktop, in the order
+#: the Music page lists them after the built-in radio.
+MUSIC_SERVICE_KEYS: tuple[str, ...] = ("spotify", "apple_music", "youtube_music")
+
+
+def music_services() -> list[dict]:
+    """The streaming services, and whether each is switched on in the catalogue.
+
+    A service is on when its connector is connected, which for these keyless
+    connectors means its one "where it plays" choice has been saved. The choice
+    travels too: it is the only field, and it is never a secret.
+    """
+    import os
+
+    from yeaboi.connectors import registry
+
+    services = []
+    for key in MUSIC_SERVICE_KEYS:
+        connector = registry.by_key(key)
+        if connector is None:
+            continue
+        field = connector.fields[0]
+        playback = os.environ.get(field.env, "").strip() or field.default
+        services.append(
+            {
+                "key": key,
+                "label": connector.label,
+                "connected": registry.is_connected(connector),
+                "playback": playback if playback in field.choices else field.default,
+            }
+        )
+    return services
+
+
 def state() -> dict:
     """Every ambience preference and catalogue, in one read."""
     from yeaboi import config
@@ -83,6 +117,7 @@ def state() -> dict:
             "channels": channels,
             "channel": channel if 0 <= channel < len(channels) else 0,
             "enabled": config.is_music_enabled(),
+            "services": music_services(),
         },
         "saver": {
             "idle_seconds": IDLE_SECONDS,

--- a/src/yeaboi/app/registry.py
+++ b/src/yeaboi/app/registry.py
@@ -27,6 +27,7 @@ from yeaboi.app import (
     routes_consent,
     routes_feedback,
     routes_meta,
+    routes_music,
     routes_news,
     routes_niko,
     routes_performance,
@@ -236,6 +237,19 @@ ROUTES: tuple[AppRoute, ...] = (
     AppRoute("POST", "/api/feedback", routes_feedback.submit),
     AppRoute("POST", "/api/feedback/polish", routes_feedback.polish),
     AppRoute("POST", "/api/feedback/attachments", routes_feedback.attach),
+    # The music services' sign-in and library: the Browse behind the desktop's
+    # Music page. Chrome like ambience — playback is the desktop's, and a
+    # library read is a UI affordance, not work an agent would be asked to do.
+    AppRoute("POST", "/api/connections/{key}/signin", routes_music.signin_start),
+    AppRoute("GET", "/api/connections/{key}/signin", routes_music.signin_status),
+    AppRoute("POST", "/api/connections/{key}/signin/cancel", routes_music.signin_cancel),
+    AppRoute("POST", "/api/connections/{key}/signout", routes_music.signout),
+    AppRoute("GET", "/api/music/{key}/library", routes_music.library),
+    AppRoute("GET", "/api/music/{key}/playlist/{playlist_id}/items", routes_music.playlist),
+    AppRoute("GET", "/api/music/{key}/search", routes_music.search),
+    AppRoute("POST", "/api/music/spotify/play", routes_music.spotify_play),
+    AppRoute("GET", "/api/music/spotify/player", routes_music.spotify_player),
+    AppRoute("GET", "/api/music/spotify/devices", routes_music.spotify_devices),
     AppRoute("GET", "/api/consent", routes_consent.pending),
     AppRoute("POST", "/api/consent/{req_id}", routes_consent.resolve),
     # -- dictation (the M11 surface) ------------------------------------------

--- a/src/yeaboi/app/routes_music.py
+++ b/src/yeaboi/app/routes_music.py
@@ -1,0 +1,190 @@
+"""The music services' sign-in and library — the desktop's Browse behind the Music page.
+
+Chrome, not a capability: nothing here is work anyone would ask an agent to
+do. The sign-in is a session the app holds (``app.oauth_signin``), driven a
+poll at a time exactly like the subscription sign-in in ``routes_settings``;
+the credential it mints is persisted server-side and never appears in a body.
+A vendor's refusal comes back as a typed ``{error, code}`` with the status the
+code implies — and ``signed_out`` is a 409 on purpose, so the desktop never
+reads it as a failure of its own bearer.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from yeaboi.app.router import HTTPError, Request, Response, json_response
+
+logger = logging.getLogger(__name__)
+
+
+def _connector(key: str):
+    from yeaboi.connectors import registry
+
+    connector = registry.by_key(key)
+    if connector is None or not connector.can_sign_in:
+        raise HTTPError(404, f"{key} has no sign-in")
+    return connector
+
+
+# -- sign-in ----------------------------------------------------------------------
+
+
+def signin_start(app, request: Request) -> Response:
+    """``POST /api/connections/{key}/signin`` — open the listener and hand back the URL to open."""
+    from yeaboi.connectors.oauth import OAuthSignIn
+
+    key = request.params["key"]
+    _connector(key)
+    with app.oauth_signin_lock:
+        if app.oauth_signin is not None:
+            app.oauth_signin.cancel()
+            app.oauth_signin = None
+        session = OAuthSignIn(key)
+        if not session.start():
+            logger.warning("music: %s sign-in could not start", key)
+            return json_response({"started": False, "url": "", "message": session.message})
+        app.oauth_signin = session
+    return json_response({"started": True, "url": session.url, "message": ""})
+
+
+def signin_status(app, request: Request) -> Response:
+    """``GET /api/connections/{key}/signin`` — poll; persisted before ``saved`` is reported."""
+    key = request.params["key"]
+    with app.oauth_signin_lock:
+        session = app.oauth_signin
+        if session is None or session.key != key:
+            return json_response({"active": False})
+        session.poll()
+        return json_response(
+            {
+                "active": True,
+                "done": session.done,
+                "ok": session.ok,
+                "saved": session.persisted,
+                "account": session.account if session.persisted else "",
+                "message": session.message if session.done else "",
+            }
+        )
+
+
+def signin_cancel(app, request: Request) -> Response:
+    """``POST /api/connections/{key}/signin/cancel`` — stop and discard the session."""
+    key = request.params["key"]
+    with app.oauth_signin_lock:
+        session, keep = (
+            (app.oauth_signin, None) if app.oauth_signin and app.oauth_signin.key == key else (None, app.oauth_signin)
+        )
+        app.oauth_signin = keep
+    if session is not None:
+        session.cancel()
+        logger.info("music: %s sign-in cancelled", key)
+    return json_response({"ok": True})
+
+
+def signout(app, request: Request) -> Response:
+    """``POST /api/connections/{key}/signout`` — forget the token and the name."""
+    from yeaboi.connectors import library, oauth
+
+    key = request.params["key"]
+    _connector(key)
+    oauth.sign_out(key)
+    library.forget(key)
+    return json_response({"ok": True, "signed_in": False})
+
+
+# -- the library --------------------------------------------------------------------
+
+
+def _answer(call) -> Response:
+    from yeaboi.connectors.library import LibraryError
+
+    try:
+        result = call()
+    except LibraryError as exc:
+        logger.info("music: %s (%d)", exc.code, exc.status)
+        return json_response(exc.as_dict(), exc.status)
+    return json_response(result.as_dict() if hasattr(result, "as_dict") else result)
+
+
+def _vendor(key: str):
+    from yeaboi.connectors import library_spotify, library_youtube
+
+    if key == "spotify":
+        return library_spotify
+    if key == "youtube_music":
+        return library_youtube
+    raise HTTPError(404, f"{key} has no library here")
+
+
+def library(app, request: Request) -> Response:
+    """``GET /api/music/{key}/library?shelf=&cursor=&limit=`` → ``{items, next_cursor}``."""
+    from yeaboi.connectors.library import SHELVES
+
+    key = request.params["key"]
+    vendor = _vendor(key)
+    shelf = request.query.get("shelf", "playlists")
+    if shelf not in SHELVES:
+        raise ValueError(f"shelf must be one of {', '.join(SHELVES)}")
+    return _answer(lambda: vendor.library(shelf, request.query.get("cursor", ""), request.query.get("limit", "")))
+
+
+def playlist(app, request: Request) -> Response:
+    """``GET /api/music/{key}/playlist/{playlist_id}/items?cursor=`` → ``{items, next_cursor}``."""
+    key = request.params["key"]
+    vendor = _vendor(key)
+    playlist_id = request.params["playlist_id"]
+    if not playlist_id.replace("-", "").replace("_", "").isalnum():
+        raise ValueError("playlist id is not well-formed")
+    return _answer(
+        lambda: vendor.playlist_items(playlist_id, request.query.get("cursor", ""), request.query.get("limit", ""))
+    )
+
+
+def search(app, request: Request) -> Response:
+    """``GET /api/music/{key}/search?q=&limit=`` → ``{items, next_cursor}``; Apple needs no sign-in."""
+    from yeaboi.connectors import library_apple
+
+    key = request.params["key"]
+    query = request.query.get("q", "").strip()
+    if not query:
+        raise ValueError("q must not be empty")
+    limit = request.query.get("limit", "")
+    if key == "apple_music":
+        return _answer(lambda: library_apple.search(query, limit, request.query.get("country", "us")))
+    vendor = _vendor(key)
+    return _answer(lambda: vendor.search(query, limit))
+
+
+def spotify_play(app, request: Request) -> Response:
+    """``POST /api/music/spotify/play`` body ``{uri, device_id?}`` → ``{ok}``; Premium only."""
+    from yeaboi.connectors import library_spotify
+
+    payload = request.json()
+    uri = payload.get("uri")
+    if not isinstance(uri, str) or not uri:
+        raise ValueError("uri must be a non-empty string")
+    device = payload.get("device_id", "")
+    if not isinstance(device, str):
+        raise ValueError("device_id must be a string")
+
+    def run():
+        library_spotify.play(uri, device)
+        logger.info("music: spotify play sent")
+        return {"ok": True}
+
+    return _answer(run)
+
+
+def spotify_player(app, request: Request) -> Response:
+    """``GET /api/music/spotify/player`` → ``{playing, progress_ms, item, device}``."""
+    from yeaboi.connectors import library_spotify
+
+    return _answer(library_spotify.player)
+
+
+def spotify_devices(app, request: Request) -> Response:
+    """``GET /api/music/spotify/devices`` → ``{devices: [{id, name, type, active}]}``."""
+    from yeaboi.connectors import library_spotify
+
+    return _answer(library_spotify.devices)

--- a/src/yeaboi/app/routes_music.py
+++ b/src/yeaboi/app/routes_music.py
@@ -84,12 +84,11 @@ def signin_cancel(app, request: Request) -> Response:
 
 def signout(app, request: Request) -> Response:
     """``POST /api/connections/{key}/signout`` — forget the token and the name."""
-    from yeaboi.connectors import library, oauth
+    from yeaboi.connectors import oauth
 
     key = request.params["key"]
     _connector(key)
     oauth.sign_out(key)
-    library.forget(key)
     return json_response({"ok": True, "signed_in": False})
 
 

--- a/src/yeaboi/app/server.py
+++ b/src/yeaboi/app/server.py
@@ -188,6 +188,9 @@ class AppServer:
         # `claude setup-token` child, driven a poll at a time over the API.
         self.signin = None
         self.signin_lock = threading.Lock()
+        # The music services' OAuth sign-in: one at a time, any service.
+        self.oauth_signin = None
+        self.oauth_signin_lock = threading.Lock()
         # The open planning conversations (routes_chat) — sessions live here
         # so a reloaded window rejoins the one it left.
         self.chats = chats if chats is not None else ChatSupervisor()

--- a/src/yeaboi/changelog_data.json
+++ b/src/yeaboi/changelog_data.json
@@ -2,6 +2,29 @@
   "schema_version": 2,
   "entries": [
     {
+      "version": "3.43.0",
+      "date": "2026-09-05",
+      "headline": "Spotify, Apple Music and YouTube Music join the library",
+      "summary": "Spotify, Apple Music and YouTube Music are now available as music sources on the desktop. Sign in to Spotify or YouTube Music to browse their libraries; Apple Music uses the system's Music app with keyless search.",
+      "highlights": [
+        {
+          "text": "Sign in to browse Spotify and YouTube Music libraries on desktop",
+          "areas": ["general"],
+          "surfaces": ["desktop"]
+        },
+        {
+          "text": "Search Apple Music without signing in or installing apps",
+          "areas": ["general"],
+          "surfaces": ["desktop"]
+        },
+        {
+          "text": "Music page and player settings tabs on the desktop",
+          "areas": ["settings"],
+          "surfaces": ["desktop"]
+        }
+      ]
+    },
+    {
       "version": "3.42.0",
       "date": "2026-09-05",
       "headline": "The front page comes to the terminal",

--- a/src/yeaboi/cli.py
+++ b/src/yeaboi/cli.py
@@ -2986,6 +2986,11 @@ def _cmd_connections(args: argparse.Namespace, console: Console) -> int:
         for field in connector.fields_for(method.key) if method else connector.fields:
             if connector.auth_env and field.env == connector.auth_env:
                 continue
+            # A sign-in's fields are minted by the flow, never typed.
+            if field.action == "signin":
+                if field.secret:
+                    console.print(f"[dim]{field.label}: sign in from the desktop's Music page[/dim]")
+                continue
             # An external ID is yeaboi's to mint, not the user's to invent: it
             # is what stops a confused deputy assuming the role, so it has to be
             # unguessable. Shown once, for pasting into the trust policy.

--- a/src/yeaboi/connectors/apple_music.py
+++ b/src/yeaboi/connectors/apple_music.py
@@ -1,0 +1,41 @@
+"""Apple Music — an album or playlist as a source on the desktop's Music page.
+
+No credential: the desktop browses through Apple's public embed player and
+hands a link to the Music app for full tracks. The one field is where playback
+happens, and choosing it is what switches the service on.
+"""
+
+from __future__ import annotations
+
+from yeaboi.connectors.spec import Connector, ConnectorField
+
+#: Where an Apple Music link plays once it is picked on the Music page.
+PLAYBACK_ENV = "APPLE_MUSIC_PLAYBACK"
+PLAYBACK_CHOICES = ("desktop", "embed")
+
+CONNECTOR = Connector(
+    key="apple_music",
+    label="Apple Music",
+    family="music",
+    section="connections",
+    summary="Your albums and playlists as a focus-music source in the desktop app",
+    detail=(
+        "yeaboi shows an album or playlist you paste through Apple Music's own embedded "
+        "player, which plays previews, and hands it to the Music app for full tracks. It never "
+        "signs in with your Apple ID, never reads your library or listening history, and never "
+        "writes anything to Apple Music."
+    ),
+    verify="_verify_apple_music",
+    docs_url="https://support.apple.com/music",
+    glyph="\U0001f34e",  # 🍎 — the apple
+    accent="rgb(250,45,85)",
+    fields=(
+        ConnectorField(
+            env=PLAYBACK_ENV,
+            label="Where it plays",
+            choices=PLAYBACK_CHOICES,
+            default="desktop",
+            hint="In the Music app for full tracks, or inside yeaboi for previews",
+        ),
+    ),
+)

--- a/src/yeaboi/connectors/apple_music.py
+++ b/src/yeaboi/connectors/apple_music.py
@@ -1,8 +1,10 @@
 """Apple Music — an album or playlist as a source on the desktop's Music page.
 
-No credential: the desktop browses through Apple's public embed player and
-hands a link to the Music app for full tracks. The one field is where playback
-happens, and choosing it is what switches the service on.
+No credential, ever: the desktop browses the Music app's own library on this
+Mac, plays previews through Apple's public embed player, searches the catalogue
+through Apple's public iTunes Search API, and hands a link to the Music app
+for full tracks. The one field is where playback happens, and choosing it is
+what switches the service on.
 """
 
 from __future__ import annotations
@@ -21,9 +23,11 @@ CONNECTOR = Connector(
     summary="Your albums and playlists as a focus-music source in the desktop app",
     detail=(
         "yeaboi shows an album or playlist you paste through Apple Music's own embedded "
-        "player, which plays previews, and hands it to the Music app for full tracks. It never "
-        "signs in with your Apple ID, never reads your library or listening history, and never "
-        "writes anything to Apple Music."
+        "player, which plays previews, and hands it to the Music app for full tracks. On a Mac "
+        "the desktop browses the Music app's own library — the playlists already on this "
+        "machine — and searches the catalogue through Apple's public iTunes Search API, with "
+        "30-second previews. It never signs in with your Apple ID, never reads your listening "
+        "history, and never writes anything to Apple Music."
     ),
     verify="_verify_apple_music",
     docs_url="https://support.apple.com/music",

--- a/src/yeaboi/connectors/engine.py
+++ b/src/yeaboi/connectors/engine.py
@@ -26,6 +26,16 @@ from yeaboi.connectors.spec import FAMILY_LABELS, FAMILY_ORDER
 logger = logging.getLogger(__name__)
 
 
+def _signin_state(connector) -> dict | None:
+    """``{signed_in, account}`` for a connector with a sign-in, else ``None``."""
+    if not connector.can_sign_in:
+        return None
+    return {
+        "signed_in": bool(os.environ.get(connector.signin_env, "").strip()),
+        "account": os.environ.get(connector.account_env, "").strip() if connector.account_env else "",
+    }
+
+
 def list_connections(*, family: str = "", connected_only: bool = True, include_legacy: bool = False) -> dict:
     """The connector catalog: what exists, what is connected, and what it needs.
 
@@ -84,6 +94,10 @@ def list_connections(*, family: str = "", connected_only: bool = True, include_l
                 # way sends an empty list and no selector, so a surface that
                 # ignores these keys renders exactly as it did before.
                 "auth_env": connector.auth_env,
+                # The sign-in, when the connector has one: whether a token is
+                # held, and the display name it was minted for — the one field
+                # value this payload ever carries, and it is not a credential.
+                "signin": _signin_state(connector),
                 "auth_methods": [
                     {
                         "key": m.key,
@@ -110,6 +124,7 @@ def list_connections(*, family: str = "", connected_only: bool = True, include_l
                         "help_url": f.help_url,
                         "help_scope": f.help_scope,
                         "auth_method": f.auth_method,
+                        "action": f.action,
                     }
                     for f in connector.fields
                 ],

--- a/src/yeaboi/connectors/http.py
+++ b/src/yeaboi/connectors/http.py
@@ -106,6 +106,17 @@ def post_form(url: str, *, data: dict[str, str], timeout: int = DEFAULT_TIMEOUT)
     return httpx.post(assert_safe_url(url), data=data, timeout=timeout)
 
 
+def put_json(url: str, *, headers: dict[str, str], payload: dict, timeout: int = DEFAULT_TIMEOUT):
+    """``PUT`` a JSON body to a guarded URL. Returns the raw httpx response.
+
+    The one write the music layer makes — Spotify's "play this" — through the
+    same guard as every read.
+    """
+    import httpx
+
+    return httpx.put(assert_safe_url(url), json=payload, headers=headers, timeout=timeout)
+
+
 def post_json(url: str, *, headers: dict[str, str], payload: dict, timeout: int = DEFAULT_TIMEOUT):
     """``POST`` a JSON body to a guarded URL. Returns the raw httpx response.
 

--- a/src/yeaboi/connectors/library.py
+++ b/src/yeaboi/connectors/library.py
@@ -1,0 +1,239 @@
+"""One shape for what a music service holds, and one door to ask it.
+
+Every vendor answers with its own nouns; the desktop wants one row: a title, a
+line under it, some art, a length, and a URL its own link grammar already
+accepts. The vendor modules beside this one map their payloads onto
+:class:`Item`; this module owns the shape, the bearer, the status translation
+and a small cache.
+
+Errors are a vocabulary rather than a message: ``signed_out`` (the desktop
+offers Sign in), ``premium_required`` and ``no_active_device`` (it hands the
+track to the Spotify app instead), ``quota_exceeded`` and ``rate_limited``
+(wait), ``not_allowlisted`` (paste your own client), ``unavailable`` (later).
+A ``signed_out`` is a 409, never a 401: the desktop's bearer handling must not
+mistake a vendor's refusal for a failure of its own wire.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+
+from yeaboi.connectors import http, oauth
+
+logger = logging.getLogger(__name__)
+
+#: Cache lifetimes: a library page changes rarely; a search costs real quota.
+LIBRARY_TTL_SECONDS = 60
+SEARCH_TTL_SECONDS = 600
+CACHE_ENTRIES = 64
+
+SHELVES: tuple[str, ...] = ("playlists", "liked", "albums", "recent")
+MAX_LIMIT = 50
+
+
+@dataclass(frozen=True)
+class Item:
+    id: str
+    #: track | album | playlist | video | song
+    kind: str
+    title: str
+    subtitle: str = ""
+    artwork_url: str = ""
+    duration_ms: int = 0
+    #: A share link the desktop's link grammar parses (open.spotify.com,
+    #: youtube.com/watch, music.apple.com).
+    url: str = ""
+    #: The vendor's own handle, when it has one (a Spotify URI).
+    uri: str = ""
+    #: A 30-second preview, when the vendor offers one without a sign-in.
+    preview_url: str = ""
+    #: How many tracks a playlist or album holds, when known.
+    count: int = 0
+
+
+@dataclass(frozen=True)
+class Page:
+    items: tuple[Item, ...] = ()
+    next_cursor: str = ""
+
+    def as_dict(self) -> dict:
+        return {"items": [asdict(item) for item in self.items], "next_cursor": self.next_cursor}
+
+
+@dataclass(frozen=True)
+class LibraryError(Exception):
+    code: str
+    message: str
+    status: int = 502
+    retry_after: int = 0
+    extra: dict = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        return self.message
+
+    def as_dict(self) -> dict:
+        body = {"error": self.message, "code": self.code, **self.extra}
+        if self.retry_after:
+            body["retry_after"] = self.retry_after
+        return body
+
+
+def _retry_after(resp) -> int:
+    try:
+        return max(0, int(resp.headers.get("Retry-After", "0")))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _error_reason(resp) -> str:
+    """The vendor's own reason code, when the body carries one."""
+    try:
+        body = resp.json()
+    except Exception:  # noqa: BLE001 — a non-JSON error body is just a status
+        return ""
+    if not isinstance(body, dict):
+        return ""
+    error = body.get("error")
+    if isinstance(error, dict):
+        reason = error.get("reason") or ""
+        if not reason:
+            errors = error.get("errors") or []
+            if errors and isinstance(errors[0], dict):
+                reason = errors[0].get("reason") or ""
+        return str(reason)
+    return str(body.get("error_description") or error or "")
+
+
+def translate(key: str, resp) -> LibraryError:
+    """The :class:`LibraryError` a non-200 vendor answer means."""
+    status = resp.status_code
+    reason = _error_reason(resp)
+    if status == 401:
+        return LibraryError("signed_out", "Sign in again to keep browsing", 409)
+    if status == 403:
+        if reason == "PREMIUM_REQUIRED":
+            return LibraryError(
+                "premium_required", "Playing from here needs Spotify Premium — opening in the app instead", 403
+            )
+        if reason in ("quotaExceeded", "dailyLimitExceeded", "rateLimitExceeded"):
+            return LibraryError(
+                "quota_exceeded", "YouTube's daily quota is used up — paste your own client in Settings", 429
+            )
+        return LibraryError(
+            "not_allowlisted",
+            "The service refused this account — an unapproved app allows only a few sign-ins; "
+            "paste your own client ID in Settings",
+            403,
+        )
+    if status == 404 and reason == "NO_ACTIVE_DEVICE":
+        return LibraryError(
+            "no_active_device", "Nothing is playing Spotify right now — opening in the app instead", 409
+        )
+    if status == 429:
+        return LibraryError(
+            "rate_limited", "The service is rate-limiting yeaboi — try again in a moment", 429, _retry_after(resp)
+        )
+    return LibraryError("unavailable", f"The service answered {status}", 502)
+
+
+def _bearer(key: str) -> str:
+    try:
+        return oauth.bearer_for(key)
+    except oauth.SignedOutError as exc:
+        raise LibraryError("signed_out", str(exc), 409) from None
+
+
+def vendor_get(key: str, url: str, params: dict | None = None) -> dict:
+    """``GET`` a vendor URL as the signed-in user. Translates every failure."""
+    from urllib.parse import urlencode
+
+    full = f"{url}?{urlencode({k: v for k, v in (params or {}).items() if v not in (None, '')})}" if params else url
+    resp = _request("GET", key, full)
+    return _body(key, resp)
+
+
+def vendor_put(key: str, url: str, payload: dict) -> None:
+    """``PUT`` a JSON body as the signed-in user; 2xx is success."""
+    _request("PUT", key, url, payload)
+
+
+def _request(method: str, key: str, url: str, payload: dict | None = None):
+    token = _bearer(key)
+    resp = _send(method, url, token, payload)
+    if resp.status_code == 401:
+        # One forced refresh: an access token can be revoked under a valid refresh token.
+        oauth.reset_cache_for(key)
+        resp = _send(method, url, _bearer(key), payload)
+    logger.info("music: %s %s → %d (%d bytes)", key, method, resp.status_code, len(resp.content or b""))
+    if resp.status_code >= 400:
+        raise translate(key, resp)
+    return resp
+
+
+def _send(method: str, url: str, token: str, payload: dict | None):
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        if method == "PUT":
+            return http.put_json(url, headers=headers, payload=payload or {})
+        return http.get_json(url, headers=headers)
+    except http.UnsafeUrlError as exc:
+        raise LibraryError("unavailable", str(exc), 502) from None
+    except Exception as exc:  # noqa: BLE001 — transport failures are one message
+        raise LibraryError("unavailable", f"Could not reach the service: {type(exc).__name__}", 502) from None
+
+
+def _body(key: str, resp) -> dict:
+    if resp.status_code == 204 or not resp.content:
+        return {}
+    try:
+        body = resp.json()
+    except Exception:  # noqa: BLE001
+        raise LibraryError("unavailable", "The service did not answer with JSON", 502) from None
+    return body if isinstance(body, dict) else {"items": body}
+
+
+# -- a small cache -------------------------------------------------------------
+
+_cache: dict[tuple, tuple[float, Page]] = {}
+_cache_lock = threading.Lock()
+
+
+def cached(cache_key: tuple, ttl: int, load) -> Page:
+    """The page under ``cache_key`` while it is fresh, else ``load()`` and keep it."""
+    now = time.monotonic()
+    with _cache_lock:
+        hit = _cache.get(cache_key)
+        if hit and hit[0] > now:
+            return hit[1]
+    page = load()
+    with _cache_lock:
+        if len(_cache) >= CACHE_ENTRIES:
+            oldest = min(_cache, key=lambda k: _cache[k][0])
+            _cache.pop(oldest, None)
+        _cache[cache_key] = (now + ttl, page)
+    return page
+
+
+def forget(key: str) -> None:
+    """Drop every cached page for one service — on sign-out."""
+    with _cache_lock:
+        for cache_key in [k for k in _cache if k and k[0] == key]:
+            _cache.pop(cache_key, None)
+
+
+def clamp_limit(raw: str | int | None, default: int = 20) -> int:
+    try:
+        value = int(raw) if raw not in (None, "") else default
+    except (TypeError, ValueError):
+        value = default
+    return max(1, min(MAX_LIMIT, value))
+
+
+def ms(seconds: float | int | None) -> int:
+    try:
+        return max(0, int(float(seconds or 0) * 1000))
+    except (TypeError, ValueError):
+        return 0

--- a/src/yeaboi/connectors/library_apple.py
+++ b/src/yeaboi/connectors/library_apple.py
@@ -1,0 +1,92 @@
+"""Apple's catalogue, through the public iTunes Search API — no sign-in.
+
+The library itself lives in the Music app on the user's Mac, and the desktop
+browses that directly; this only searches the catalogue and hands back rows
+whose URL the desktop's link grammar accepts (``music.apple.com/<cc>/album/
+<slug>/<collectionId>?i=<trackId>``), with the 30-second preview Apple offers.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlencode
+
+from yeaboi.connectors import http
+from yeaboi.connectors.library import SEARCH_TTL_SECONDS, Item, LibraryError, Page, cached, clamp_limit
+
+KEY = "apple_music"
+SEARCH_URL = "https://itunes.apple.com/search"
+_NOT_SLUG = re.compile(r"[^a-z0-9]+")
+
+
+def slug(name: str) -> str:
+    """Apple's own path word for a name — lower, dashed, never empty."""
+    cleaned = _NOT_SLUG.sub("-", (name or "").lower()).strip("-")
+    return cleaned or "album"
+
+
+def _country(value: str) -> str:
+    value = (value or "").strip().lower()
+    return value if len(value) == 2 and value.isalpha() else "us"
+
+
+def _artwork(row: dict) -> str:
+    art = str(row.get("artworkUrl100") or "")
+    return art.replace("100x100bb", "300x300bb") if art else ""
+
+
+def result_item(row: dict, country: str) -> Item | None:
+    if not isinstance(row, dict):
+        return None
+    collection = row.get("collectionId")
+    if not collection:
+        return None
+    base = f"https://music.apple.com/{country}/album/{slug(str(row.get('collectionName', '')))}/{collection}"
+    if row.get("wrapperType") == "track" and row.get("trackId"):
+        return Item(
+            id=str(row["trackId"]),
+            kind="song",
+            title=str(row.get("trackName", "")),
+            subtitle=" · ".join(p for p in (str(row.get("artistName", "")), str(row.get("collectionName", ""))) if p),
+            artwork_url=_artwork(row),
+            duration_ms=int(row.get("trackTimeMillis") or 0),
+            url=f"{base}?i={row['trackId']}",
+            preview_url=str(row.get("previewUrl") or ""),
+        )
+    if row.get("wrapperType") == "collection":
+        return Item(
+            id=str(collection),
+            kind="album",
+            title=str(row.get("collectionName", "")),
+            subtitle=str(row.get("artistName", "")),
+            artwork_url=_artwork(row),
+            url=base,
+            count=int(row.get("trackCount") or 0),
+        )
+    return None
+
+
+def search(query: str, limit: int = 20, country: str = "us") -> Page:
+    limit = clamp_limit(limit)
+    country = _country(country)
+
+    def load() -> Page:
+        params = urlencode(
+            {"term": query, "media": "music", "entity": "song,album", "limit": limit, "country": country}
+        )
+        try:
+            resp = http.get_json(f"{SEARCH_URL}?{params}", headers={})
+        except Exception as exc:  # noqa: BLE001
+            raise LibraryError("unavailable", f"Could not reach Apple: {type(exc).__name__}", 502) from None
+        if resp.status_code == 429:
+            raise LibraryError("rate_limited", "Apple is rate-limiting yeaboi — try again in a moment", 429, 20)
+        if resp.status_code != 200:
+            raise LibraryError("unavailable", f"Apple answered {resp.status_code}", 502)
+        try:
+            body = resp.json()
+        except Exception:  # noqa: BLE001
+            raise LibraryError("unavailable", "Apple did not answer with JSON", 502) from None
+        items = tuple(i for i in (result_item(row, country) for row in body.get("results") or []) if i)
+        return Page(items, "")
+
+    return cached((KEY, "search", query.strip().lower(), limit, country), SEARCH_TTL_SECONDS, load)

--- a/src/yeaboi/connectors/library_spotify.py
+++ b/src/yeaboi/connectors/library_spotify.py
@@ -173,8 +173,10 @@ def play(uri: str, device_id: str = "") -> None:
     parts = uri.split(":")
     if len(parts) != 3 or parts[0] != "spotify" or parts[1] not in _URI_KINDS or not parts[2].isalnum():
         raise LibraryError("bad_uri", "That is not a Spotify URI", 400)
+    if device_id and not device_id.isalnum():
+        raise LibraryError("bad_uri", "That is not a Spotify device id", 400)
     payload = {"uris": [uri]} if parts[1] == "track" else {"context_uri": uri}
-    url = f"{API}/me/player/play" + (f"?device_id={device_id}" if device_id.isalnum() else "")
+    url = f"{API}/me/player/play" + (f"?device_id={device_id}" if device_id else "")
     vendor_put(KEY, url, payload)
 
 

--- a/src/yeaboi/connectors/library_spotify.py
+++ b/src/yeaboi/connectors/library_spotify.py
@@ -1,0 +1,209 @@
+"""Spotify's library, as the desktop's rows.
+
+Read-only but for one verb: ``play`` sends a play command to whatever device
+is running Spotify — Premium only, and the desktop falls back to the app when
+Spotify says so. Every URL built here is a share link the desktop's own link
+grammar accepts: ``https://open.spotify.com/<kind>/<id>``.
+"""
+
+from __future__ import annotations
+
+from yeaboi.connectors.library import (
+    LIBRARY_TTL_SECONDS,
+    SEARCH_TTL_SECONDS,
+    Item,
+    LibraryError,
+    Page,
+    cached,
+    clamp_limit,
+    vendor_get,
+    vendor_put,
+)
+
+KEY = "spotify"
+API = "https://api.spotify.com/v1"
+#: Spotify caps a search page at ten since the 2026 migration.
+SEARCH_LIMIT = 10
+
+_SHELF_URLS = {
+    "playlists": f"{API}/me/playlists",
+    "liked": f"{API}/me/tracks",
+    "albums": f"{API}/me/albums",
+    "recent": f"{API}/me/player/recently-played",
+}
+
+
+def _art(images) -> str:
+    if not isinstance(images, list) or not images:
+        return ""
+    # Spotify lists the largest first; the middle one is plenty for a row.
+    pick = images[min(1, len(images) - 1)]
+    return str(pick.get("url", "")) if isinstance(pick, dict) else ""
+
+
+def _names(people) -> str:
+    return ", ".join(str(p.get("name", "")) for p in (people or []) if isinstance(p, dict) and p.get("name"))
+
+
+def track_item(track: dict) -> Item | None:
+    if not isinstance(track, dict) or not track.get("id"):
+        return None
+    album = track.get("album") or {}
+    return Item(
+        id=str(track["id"]),
+        kind="track",
+        title=str(track.get("name", "")),
+        subtitle=" · ".join(p for p in (_names(track.get("artists")), str(album.get("name", ""))) if p),
+        artwork_url=_art(album.get("images")),
+        duration_ms=int(track.get("duration_ms") or 0),
+        url=f"https://open.spotify.com/track/{track['id']}",
+        uri=str(track.get("uri") or f"spotify:track:{track['id']}"),
+        preview_url=str(track.get("preview_url") or ""),
+    )
+
+
+def album_item(album: dict) -> Item | None:
+    if not isinstance(album, dict) or not album.get("id"):
+        return None
+    return Item(
+        id=str(album["id"]),
+        kind="album",
+        title=str(album.get("name", "")),
+        subtitle=_names(album.get("artists")),
+        artwork_url=_art(album.get("images")),
+        url=f"https://open.spotify.com/album/{album['id']}",
+        uri=str(album.get("uri") or f"spotify:album:{album['id']}"),
+        count=int(album.get("total_tracks") or 0),
+    )
+
+
+def playlist_item(playlist: dict) -> Item | None:
+    if not isinstance(playlist, dict) or not playlist.get("id"):
+        return None
+    owner = playlist.get("owner") or {}
+    tracks = playlist.get("tracks") or {}
+    return Item(
+        id=str(playlist["id"]),
+        kind="playlist",
+        title=str(playlist.get("name", "")),
+        subtitle=str(owner.get("display_name") or ""),
+        artwork_url=_art(playlist.get("images")),
+        url=f"https://open.spotify.com/playlist/{playlist['id']}",
+        uri=str(playlist.get("uri") or f"spotify:playlist:{playlist['id']}"),
+        count=int(tracks.get("total") or 0) if isinstance(tracks, dict) else 0,
+    )
+
+
+def _offset(cursor: str) -> int:
+    try:
+        return max(0, int(cursor)) if cursor else 0
+    except ValueError:
+        return 0
+
+
+def _next_offset(body: dict, offset: int, limit: int) -> str:
+    total = int(body.get("total") or 0)
+    return str(offset + limit) if body.get("next") or (total and offset + limit < total) else ""
+
+
+def library(shelf: str, cursor: str = "", limit: int = 20) -> Page:
+    url = _SHELF_URLS.get(shelf)
+    if url is None:
+        raise LibraryError("unsupported_shelf", f"Spotify has no '{shelf}' shelf", 400)
+    limit = clamp_limit(limit)
+
+    def load() -> Page:
+        if shelf == "recent":
+            params = {"limit": limit, "before": cursor} if cursor else {"limit": limit}
+            body = vendor_get(KEY, url, params)
+            items = tuple(i for i in (track_item((row or {}).get("track")) for row in body.get("items") or []) if i)
+            cursors = body.get("cursors") or {}
+            return Page(items, str(cursors.get("before") or "") if body.get("next") else "")
+        offset = _offset(cursor)
+        body = vendor_get(KEY, url, {"limit": limit, "offset": offset})
+        rows = body.get("items") or []
+        if shelf == "playlists":
+            items = tuple(i for i in (playlist_item(row) for row in rows) if i)
+        elif shelf == "albums":
+            items = tuple(i for i in (album_item((row or {}).get("album")) for row in rows) if i)
+        else:
+            items = tuple(i for i in (track_item((row or {}).get("track")) for row in rows) if i)
+        return Page(items, _next_offset(body, offset, limit))
+
+    return cached((KEY, "library", shelf, cursor, limit), LIBRARY_TTL_SECONDS, load)
+
+
+def playlist_items(playlist_id: str, cursor: str = "", limit: int = 50) -> Page:
+    limit = clamp_limit(limit, 50)
+    offset = _offset(cursor)
+
+    def load() -> Page:
+        body = vendor_get(KEY, f"{API}/playlists/{playlist_id}/tracks", {"limit": limit, "offset": offset})
+        items = tuple(i for i in (track_item((row or {}).get("track")) for row in body.get("items") or []) if i)
+        return Page(items, _next_offset(body, offset, limit))
+
+    return cached((KEY, "playlist", playlist_id, cursor, limit), LIBRARY_TTL_SECONDS, load)
+
+
+def search(query: str, limit: int = 10) -> Page:
+    limit = min(clamp_limit(limit, SEARCH_LIMIT), SEARCH_LIMIT)
+
+    def load() -> Page:
+        body = vendor_get(KEY, f"{API}/search", {"q": query, "type": "track,album,playlist", "limit": limit})
+        items: list[Item] = []
+        for row in (body.get("tracks") or {}).get("items") or []:
+            if (item := track_item(row)) is not None:
+                items.append(item)
+        for row in (body.get("albums") or {}).get("items") or []:
+            if (item := album_item(row)) is not None:
+                items.append(item)
+        for row in (body.get("playlists") or {}).get("items") or []:
+            if (item := playlist_item(row)) is not None:
+                items.append(item)
+        return Page(tuple(items), "")
+
+    return cached((KEY, "search", query.strip().lower(), limit), SEARCH_TTL_SECONDS, load)
+
+
+_URI_KINDS = ("track", "album", "playlist", "artist")
+
+
+def play(uri: str, device_id: str = "") -> None:
+    """Start ``uri`` on the active Spotify device (Premium). Raises the fallback codes."""
+    parts = uri.split(":")
+    if len(parts) != 3 or parts[0] != "spotify" or parts[1] not in _URI_KINDS or not parts[2].isalnum():
+        raise LibraryError("bad_uri", "That is not a Spotify URI", 400)
+    payload = {"uris": [uri]} if parts[1] == "track" else {"context_uri": uri}
+    url = f"{API}/me/player/play" + (f"?device_id={device_id}" if device_id.isalnum() else "")
+    vendor_put(KEY, url, payload)
+
+
+def player() -> dict:
+    """What Spotify is playing now, for the desktop's Now Playing."""
+    body = vendor_get(KEY, f"{API}/me/player")
+    if not body:
+        return {"playing": False, "progress_ms": 0, "item": None, "device": None}
+    item = track_item(body.get("item") or {})
+    device = body.get("device") or {}
+    return {
+        "playing": bool(body.get("is_playing")),
+        "progress_ms": int(body.get("progress_ms") or 0),
+        "item": item.__dict__ if item else None,
+        "device": {"id": str(device.get("id", "")), "name": str(device.get("name", ""))} if device else None,
+    }
+
+
+def devices() -> dict:
+    body = vendor_get(KEY, f"{API}/me/player/devices")
+    return {
+        "devices": [
+            {
+                "id": str(d.get("id", "")),
+                "name": str(d.get("name", "")),
+                "type": str(d.get("type", "")),
+                "active": bool(d.get("is_active")),
+            }
+            for d in body.get("devices") or []
+            if isinstance(d, dict)
+        ]
+    }

--- a/src/yeaboi/connectors/library_youtube.py
+++ b/src/yeaboi/connectors/library_youtube.py
@@ -1,0 +1,150 @@
+"""YouTube's library, as the desktop's rows — playlists and liked videos.
+
+Read-only (``youtube.readonly``). A search costs a hundred units of the
+project's daily ten thousand, shared by everyone on the built-in client, so
+search pages are cached the longest. Every URL built here is a watch or
+playlist link the desktop's own grammar accepts.
+"""
+
+from __future__ import annotations
+
+from yeaboi.connectors.library import (
+    LIBRARY_TTL_SECONDS,
+    SEARCH_TTL_SECONDS,
+    Item,
+    LibraryError,
+    Page,
+    cached,
+    clamp_limit,
+    vendor_get,
+)
+
+KEY = "youtube_music"
+API = "https://www.googleapis.com/youtube/v3"
+#: The liked-videos playlist every account has.
+LIKED_PLAYLIST = "LL"
+#: YouTube's music category, so a search does not return lectures.
+MUSIC_CATEGORY = "10"
+
+
+def _thumb(snippet: dict) -> str:
+    thumbs = snippet.get("thumbnails") or {}
+    for size in ("medium", "high", "default"):
+        entry = thumbs.get(size)
+        if isinstance(entry, dict) and entry.get("url"):
+            return str(entry["url"])
+    return ""
+
+
+def _video_id(row: dict) -> str:
+    rid = row.get("id")
+    if isinstance(rid, dict):
+        return str(rid.get("videoId") or "")
+    snippet = row.get("snippet") or {}
+    resource = snippet.get("resourceId") or {}
+    content = row.get("contentDetails") or {}
+    return str(resource.get("videoId") or content.get("videoId") or "")
+
+
+def _playlist_id(row: dict) -> str:
+    rid = row.get("id")
+    if isinstance(rid, dict):
+        return str(rid.get("playlistId") or "")
+    return str(rid or "")
+
+
+def video_item(row: dict) -> Item | None:
+    vid = _video_id(row)
+    snippet = row.get("snippet") or {}
+    if not vid or snippet.get("title") in ("Private video", "Deleted video"):
+        return None
+    return Item(
+        id=vid,
+        kind="video",
+        title=str(snippet.get("title", "")),
+        subtitle=str(snippet.get("videoOwnerChannelTitle") or snippet.get("channelTitle") or ""),
+        artwork_url=_thumb(snippet),
+        url=f"https://www.youtube.com/watch?v={vid}",
+    )
+
+
+def playlist_item(row: dict) -> Item | None:
+    pid = _playlist_id(row)
+    snippet = row.get("snippet") or {}
+    if not pid:
+        return None
+    content = row.get("contentDetails") or {}
+    return Item(
+        id=pid,
+        kind="playlist",
+        title=str(snippet.get("title", "")),
+        subtitle=str(snippet.get("channelTitle") or ""),
+        artwork_url=_thumb(snippet),
+        url=f"https://www.youtube.com/playlist?list={pid}",
+        count=int(content.get("itemCount") or 0),
+    )
+
+
+def _page(body: dict, mapper) -> Page:
+    items = tuple(i for i in (mapper(row) for row in body.get("items") or [] if isinstance(row, dict)) if i)
+    return Page(items, str(body.get("nextPageToken") or ""))
+
+
+def library(shelf: str, cursor: str = "", limit: int = 20) -> Page:
+    limit = clamp_limit(limit)
+    if shelf == "playlists":
+
+        def load() -> Page:
+            body = vendor_get(
+                KEY,
+                f"{API}/playlists",
+                {"part": "snippet,contentDetails", "mine": "true", "maxResults": limit, "pageToken": cursor},
+            )
+            return _page(body, playlist_item)
+
+        return cached((KEY, "library", shelf, cursor, limit), LIBRARY_TTL_SECONDS, load)
+    if shelf == "liked":
+        return playlist_items(LIKED_PLAYLIST, cursor, limit)
+    raise LibraryError("unsupported_shelf", f"YouTube has no '{shelf}' shelf", 400)
+
+
+def playlist_items(playlist_id: str, cursor: str = "", limit: int = 50) -> Page:
+    limit = clamp_limit(limit, 50)
+
+    def load() -> Page:
+        body = vendor_get(
+            KEY,
+            f"{API}/playlistItems",
+            {"part": "snippet,contentDetails", "playlistId": playlist_id, "maxResults": limit, "pageToken": cursor},
+        )
+        return _page(body, video_item)
+
+    return cached((KEY, "playlist", playlist_id, cursor, limit), LIBRARY_TTL_SECONDS, load)
+
+
+def search(query: str, limit: int = 10) -> Page:
+    limit = clamp_limit(limit, 10)
+
+    def load() -> Page:
+        body = vendor_get(
+            KEY,
+            f"{API}/search",
+            {
+                "part": "snippet",
+                "q": query,
+                "type": "video,playlist",
+                "videoCategoryId": MUSIC_CATEGORY,
+                "maxResults": limit,
+            },
+        )
+        items: list[Item] = []
+        for row in body.get("items") or []:
+            if not isinstance(row, dict):
+                continue
+            rid = row.get("id") or {}
+            item = playlist_item(row) if isinstance(rid, dict) and rid.get("playlistId") else video_item(row)
+            if item is not None:
+                items.append(item)
+        return Page(tuple(items), "")
+
+    return cached((KEY, "search", query.strip().lower(), limit), SEARCH_TTL_SECONDS, load)

--- a/src/yeaboi/connectors/library_youtube.py
+++ b/src/yeaboi/connectors/library_youtube.py
@@ -126,13 +126,15 @@ def search(query: str, limit: int = 10) -> Page:
     limit = clamp_limit(limit, 10)
 
     def load() -> Page:
+        # The category filter is only valid on a video-only search, so a
+        # search returns videos; playlists come from the library shelves.
         body = vendor_get(
             KEY,
             f"{API}/search",
             {
                 "part": "snippet",
                 "q": query,
-                "type": "video,playlist",
+                "type": "video",
                 "videoCategoryId": MUSIC_CATEGORY,
                 "maxResults": limit,
             },

--- a/src/yeaboi/connectors/oauth.py
+++ b/src/yeaboi/connectors/oauth.py
@@ -324,7 +324,9 @@ class OAuthSignIn:
                 f"port {port} is busy — set YEABOI_OAUTH_PORT and update the Redirect URI "
                 f"in your own {connector.label} app"
             )
-            logger.warning("oauth: %s sign-in could not bind port %d", self.key, port)
+            # The number is in the message the person sees; a scanner reads a
+            # value named after "oauth" as a credential, so the log names none.
+            logger.warning("oauth: %s sign-in could not bind its callback port", self.key)
             return False
         self.url = authorize_url(provider, client.client_id, self._redirect, self._state, challenge)
         # Which app, without touching the client object: a field of it is a

--- a/src/yeaboi/connectors/oauth.py
+++ b/src/yeaboi/connectors/oauth.py
@@ -209,13 +209,16 @@ class _CallbackServer:
                 if urlparse(self.path).path != wanted:
                     self._page(404, _FAILED_PAGE)
                     return
+                # Settle the result before answering: a client that has read the
+                # page must find the session done, not a moment from it.
                 try:
                     outer.code = parse_callback(self.path, outer.expected_state)
-                    self._page(200, _DONE_PAGE)
+                    status, page = 200, _DONE_PAGE
                 except CallbackError as exc:
                     outer.error = str(exc)
-                    self._page(400, _FAILED_PAGE)
+                    status, page = 400, _FAILED_PAGE
                 outer._event.set()
+                self._page(status, page)
 
             def _page(self, status: int, body: str) -> None:
                 raw = body.encode("utf-8")

--- a/src/yeaboi/connectors/oauth.py
+++ b/src/yeaboi/connectors/oauth.py
@@ -1,0 +1,497 @@
+"""Sign in to a music service: Authorization Code + PKCE, driven a poll at a time.
+
+The shape is :class:`yeaboi.claude_auth.SubscriptionSignIn`'s — a session the
+app server holds, the renderer polls, and a credential that is persisted on
+the poll that first sees it and never echoed. What differs is the transport:
+the vendor sends the user's browser back to a loopback listener of our own.
+
+That listener is its own tiny HTTP server, never the app wire: the app server
+answers only to its bearer token, and an OAuth redirect carries none. It binds
+``127.0.0.1`` on a FIXED port (8643, ``YEABOI_OAUTH_PORT`` overrides) because
+Spotify matches the registered redirect URI exactly, port included — so a busy
+port is a hard error naming the fix, never a port walk. It serves exactly one
+path per sign-in and answers with a page that says "you can close this tab";
+nothing from the query is echoed or logged.
+
+Access tokens are cached in memory and refreshed with a minute's skew; a
+refresh the vendor refuses (``invalid_grant`` — Spotify's six-month consent
+expiry included) signs the user out cleanly rather than failing every read.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+import secrets
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from yeaboi.connectors import http, oauth_clients, registry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PORT = 8643
+CALLBACK_PATH = "/callback"
+#: How long the browser has to come back before the sign-in gives up.
+SIGNIN_TIMEOUT_SECONDS = 300
+#: Refresh an access token this long before the vendor says it expires.
+REFRESH_SKEW_SECONDS = 60
+
+
+class SignedOutError(Exception):
+    """The vendor no longer honours the stored refresh token."""
+
+
+@dataclass(frozen=True)
+class OAuthProvider:
+    authorize_url: str
+    token_url: str
+    scopes: tuple[str, ...]
+    #: Extra query on the authorize URL (Google's offline access, for one).
+    extra_authorize_params: tuple[tuple[str, str], ...] = ()
+    #: Fetch the account's display name with a fresh access token.
+    identity: Callable[[str], str] = lambda token: ""
+    #: Whether a refresh hands back a new refresh token to persist.
+    refresh_rotates: bool = False
+    #: Whether the token exchange sends the (non-confidential) client secret.
+    sends_secret: bool = False
+
+
+def _spotify_identity(token: str) -> str:
+    resp = http.get_json("https://api.spotify.com/v1/me", headers={"Authorization": f"Bearer {token}"})
+    if resp.status_code != 200:
+        return ""
+    data = resp.json()
+    return str(data.get("display_name") or data.get("id") or "")
+
+
+def _youtube_identity(token: str) -> str:
+    resp = http.get_json(
+        "https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    if resp.status_code != 200:
+        return ""
+    items = resp.json().get("items") or []
+    return str(items[0].get("snippet", {}).get("title", "")) if items else ""
+
+
+PROVIDERS: dict[str, OAuthProvider] = {
+    "spotify": OAuthProvider(
+        authorize_url="https://accounts.spotify.com/authorize",
+        token_url="https://accounts.spotify.com/api/token",  # noqa: S106 — an endpoint, not a credential
+        scopes=(
+            "playlist-read-private",
+            "playlist-read-collaborative",
+            "user-library-read",
+            "user-read-recently-played",
+            "user-read-playback-state",
+            "user-modify-playback-state",
+        ),
+        identity=_spotify_identity,
+        refresh_rotates=True,
+    ),
+    "youtube_music": OAuthProvider(
+        authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+        token_url="https://oauth2.googleapis.com/token",  # noqa: S106 — an endpoint, not a credential
+        scopes=("https://www.googleapis.com/auth/youtube.readonly",),
+        extra_authorize_params=(("access_type", "offline"), ("prompt", "consent")),
+        identity=_youtube_identity,
+        sends_secret=True,
+    ),
+}
+
+
+# -- pure helpers --------------------------------------------------------------
+
+
+def oauth_port() -> int:
+    """The port the callback listener binds — fixed, because the registered redirect URI names it."""
+    raw = os.environ.get("YEABOI_OAUTH_PORT", "").strip()
+    try:
+        return int(raw) if raw else DEFAULT_PORT
+    except ValueError:
+        return DEFAULT_PORT
+
+
+def redirect_uri(key: str, port: int | None = None) -> str:
+    """The literal loopback IP, which Spotify requires in place of ``localhost``."""
+    return f"http://127.0.0.1:{port or oauth_port()}{CALLBACK_PATH}/{key}"
+
+
+def pkce_pair() -> tuple[str, str]:
+    """``(verifier, challenge)`` per RFC 7636: S256, base64url, no padding."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def new_state() -> str:
+    return secrets.token_urlsafe(24)
+
+
+def authorize_url(provider: OAuthProvider, client_id: str, redirect: str, state: str, challenge: str) -> str:
+    params = [
+        ("client_id", client_id),
+        ("response_type", "code"),
+        ("redirect_uri", redirect),
+        ("scope", " ".join(provider.scopes)),
+        ("state", state),
+        ("code_challenge_method", "S256"),
+        ("code_challenge", challenge),
+        *provider.extra_authorize_params,
+    ]
+    return f"{provider.authorize_url}?{urlencode(params)}"
+
+
+class CallbackError(ValueError):
+    """The redirect did not carry a usable code."""
+
+
+def parse_callback(path: str, expected_state: str) -> str:
+    """The authorization code in a callback path, or :class:`CallbackError`.
+
+    Nothing from the query is ever put in a message: the vendor's ``error``
+    is named by its code alone, and a wrong state says only that it was wrong.
+    """
+    query = parse_qs(urlparse(path).query)
+    error = (query.get("error") or [""])[0]
+    if error:
+        raise CallbackError("Sign-in was refused" if error == "access_denied" else "Sign-in did not complete")
+    state = (query.get("state") or [""])[0]
+    if not state or not secrets.compare_digest(state, expected_state):
+        raise CallbackError("Sign-in did not match the one that was started")
+    code = (query.get("code") or [""])[0]
+    if not code:
+        raise CallbackError("Sign-in came back without a code")
+    return code
+
+
+# -- the listener -------------------------------------------------------------
+
+_DONE_PAGE = (
+    "<!doctype html><meta charset='utf-8'><title>yeaboi</title>"
+    "<body style='font-family:system-ui;padding:3rem'><h1>Signed in</h1>"
+    "<p>You can close this tab and go back to yeaboi.</p></body>"
+)
+_FAILED_PAGE = (
+    "<!doctype html><meta charset='utf-8'><title>yeaboi</title>"
+    "<body style='font-family:system-ui;padding:3rem'><h1>Sign-in did not complete</h1>"
+    "<p>Go back to yeaboi and try again.</p></body>"
+)
+
+
+class _CallbackServer:
+    """One loopback HTTP server, alive for one sign-in, that catches one redirect."""
+
+    def __init__(self, key: str, expected_state: str, port: int) -> None:
+        self.key = key
+        self.expected_state = expected_state
+        self.code = ""
+        self.error = ""
+        self._event = threading.Event()
+        wanted = f"{CALLBACK_PATH}/{key}"
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, format, *args):  # noqa: A002 — BaseHTTPRequestHandler's name
+                # The path carries the code; only its route is worth a line.
+                logger.debug("oauth: callback %s", urlparse(self.path).path)
+
+            def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler's convention
+                if urlparse(self.path).path != wanted:
+                    self._page(404, _FAILED_PAGE)
+                    return
+                try:
+                    outer.code = parse_callback(self.path, outer.expected_state)
+                    self._page(200, _DONE_PAGE)
+                except CallbackError as exc:
+                    outer.error = str(exc)
+                    self._page(400, _FAILED_PAGE)
+                outer._event.set()
+
+            def _page(self, status: int, body: str) -> None:
+                raw = body.encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(raw)))
+                self.send_header("Cache-Control", "no-store")
+                self.end_headers()
+                self.wfile.write(raw)
+
+        # Raises OSError on a busy port: the caller turns that into a message.
+        self._server = HTTPServer(("127.0.0.1", port), Handler)
+        self._server.timeout = 1
+        self._thread = threading.Thread(target=self._serve, name="oauth-callback", daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        deadline = time.monotonic() + SIGNIN_TIMEOUT_SECONDS
+        while not self._event.is_set() and time.monotonic() < deadline:
+            self._server.handle_request()
+        self._server.server_close()
+
+    @property
+    def done(self) -> bool:
+        return self._event.is_set()
+
+    def close(self) -> None:
+        self._event.set()
+
+
+# -- the session ---------------------------------------------------------------
+
+
+class OAuthSignIn:
+    """A running sign-in for one connector, driven a poll at a time.
+
+    Lifecycle: :meth:`start`, then :meth:`poll` until :attr:`done`; :meth:`cancel`
+    at any point. Every method is safe to call in any state.
+    """
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+        self.url = ""
+        self.account = ""
+        self.error = ""
+        self.persisted = False
+        self._verifier = ""
+        self._state = ""
+        self._redirect = ""
+        self._client: oauth_clients.OAuthClient | None = None
+        self._listener: _CallbackServer | None = None
+        self._worker: threading.Thread | None = None
+        self._refresh_token = ""
+
+    @property
+    def done(self) -> bool:
+        return bool(self.persisted or self.error)
+
+    @property
+    def ok(self) -> bool:
+        return self.persisted
+
+    @property
+    def message(self) -> str:
+        if self.persisted:
+            return f"Signed in as {self.account}" if self.account else "Signed in"
+        return self.error or "Sign-in cancelled"
+
+    def start(self) -> bool:
+        """Bind the listener and build the URL. False (with :attr:`error`) if it could not."""
+        provider = PROVIDERS.get(self.key)
+        connector = registry.by_key(self.key)
+        if provider is None or connector is None or not connector.can_sign_in:
+            self.error = "This service has no sign-in"
+            return False
+        client = oauth_clients.resolve(self.key)
+        if client is None:
+            field = oauth_clients.CLIENT_ID_ENVS.get(self.key, "")
+            self.error = (
+                f"yeaboi's {connector.label} app is not configured in this build — "
+                f"paste your own client ID ({field}) in Settings"
+            )
+            logger.warning("oauth: %s sign-in has no client id", self.key)
+            return False
+        self._client = client
+        self._verifier, challenge = pkce_pair()
+        self._state = new_state()
+        port = oauth_port()
+        self._redirect = redirect_uri(self.key, port)
+        try:
+            self._listener = _CallbackServer(self.key, self._state, port)
+        except OSError:
+            self.error = (
+                f"port {port} is busy — set YEABOI_OAUTH_PORT and update the Redirect URI "
+                f"in your own {connector.label} app"
+            )
+            logger.warning("oauth: %s sign-in could not bind port %d", self.key, port)
+            return False
+        self.url = authorize_url(provider, client.client_id, self._redirect, self._state, challenge)
+        logger.info("oauth: %s sign-in started (%s client)", self.key, "own" if client.own else "built-in")
+        return True
+
+    def poll(self) -> None:
+        """Advance: once the redirect landed, exchange the code off this thread; persist when done."""
+        listener = self._listener
+        if listener is None or self.done:
+            return
+        if listener.error and not self.error:
+            self.error = listener.error
+            logger.warning("oauth: %s callback failed: %s", self.key, self.error)
+            return
+        if listener.code and self._worker is None:
+            self._worker = threading.Thread(
+                target=self._exchange, args=(listener.code,), name="oauth-exchange", daemon=True
+            )
+            self._worker.start()
+            return
+        if not listener.done and not listener._thread.is_alive() and not self.error:
+            self.error = "Sign-in timed out — try again"
+            logger.warning("oauth: %s sign-in timed out", self.key)
+            return
+        if self._refresh_token and not self.persisted:
+            self._persist()
+
+    def _exchange(self, code: str) -> None:
+        provider = PROVIDERS[self.key]
+        client = self._client
+        assert client is not None
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self._redirect,
+            "client_id": client.client_id,
+            "code_verifier": self._verifier,
+        }
+        if provider.sends_secret and client.client_secret:
+            data["client_secret"] = client.client_secret
+        try:
+            resp = http.post_form(provider.token_url, data=data)
+        except Exception as exc:  # noqa: BLE001 — any transport failure is one message
+            self.error = f"Could not reach {self.key}'s sign-in service: {type(exc).__name__}"
+            logger.warning("oauth: %s token exchange failed: %s", self.key, type(exc).__name__)
+            return
+        if resp.status_code != 200:
+            self.error = _exchange_message(self.key, resp.status_code)
+            logger.warning("oauth: %s token exchange returned %d", self.key, resp.status_code)
+            return
+        payload = resp.json()
+        refresh = str(payload.get("refresh_token") or "")
+        access = str(payload.get("access_token") or "")
+        if not refresh:
+            self.error = "Sign-in finished but no token was returned"
+            logger.warning("oauth: %s exchange carried no refresh token", self.key)
+            return
+        _cache_put(self.key, access, int(payload.get("expires_in") or 3600))
+        try:
+            self.account = provider.identity(access) if access else ""
+        except Exception:  # noqa: BLE001 — a name is a nicety, not the credential
+            self.account = ""
+        self._refresh_token = refresh
+
+    def _persist(self) -> None:
+        from yeaboi.config import apply_config_value
+
+        connector = registry.by_key(self.key)
+        assert connector is not None
+        apply_config_value(connector.signin_env, self._refresh_token)
+        if connector.account_env:
+            apply_config_value(connector.account_env, self.account)
+        self.persisted = True
+        self._refresh_token = ""
+        logger.info("oauth: %s signed in as %s", self.key, self.account or "(unnamed)")
+
+    def cancel(self) -> None:
+        listener, self._listener = self._listener, None
+        if listener is not None:
+            listener.close()
+        if not self.done:
+            self.error = "Sign-in cancelled"
+        self._refresh_token = ""
+
+
+def _exchange_message(key: str, status: int) -> str:
+    if key == "spotify" and status in (400, 401, 403):
+        return (
+            "Spotify refused the sign-in — if you are not allowlisted on yeaboi's app, "
+            "paste your own client ID in Settings"
+        )
+    if status in (400, 401, 403):
+        return "The sign-in was refused — check the client ID in Settings"
+    return f"The sign-in service answered {status}"
+
+
+# -- the access-token cache ------------------------------------------------------
+
+_cache: dict[str, tuple[str, float]] = {}
+_cache_lock = threading.Lock()
+
+
+def _cache_put(key: str, access: str, expires_in: int) -> None:
+    with _cache_lock:
+        _cache[key] = (access, time.monotonic() + max(0, expires_in - REFRESH_SKEW_SECONDS))
+
+
+def sign_out(key: str) -> None:
+    """Forget the token and the name; the vendor keeps its own consent record."""
+    from yeaboi.config import apply_config_value
+
+    connector = registry.by_key(key)
+    if connector is None or not connector.can_sign_in:
+        return
+    apply_config_value(connector.signin_env, "")
+    if connector.account_env:
+        apply_config_value(connector.account_env, "")
+    with _cache_lock:
+        _cache.pop(key, None)
+    logger.info("oauth: %s signed out", key)
+
+
+def bearer_for(key: str) -> str:
+    """A live access token for ``key``, refreshed when stale. Raises :class:`SignedOutError`."""
+    with _cache_lock:
+        cached = _cache.get(key)
+    if cached and cached[1] > time.monotonic():
+        return cached[0]
+    return _refresh(key)
+
+
+def _refresh(key: str) -> str:
+    provider = PROVIDERS.get(key)
+    connector = registry.by_key(key)
+    if provider is None or connector is None or not connector.can_sign_in:
+        raise SignedOutError("This service has no sign-in")
+    refresh = os.environ.get(connector.signin_env, "").strip()
+    if not refresh:
+        raise SignedOutError(f"Sign in to {connector.label} to browse your library")
+    client = oauth_clients.resolve(key)
+    if client is None:
+        raise SignedOutError(f"{connector.label}'s sign-in is not configured")
+    data = {"grant_type": "refresh_token", "refresh_token": refresh, "client_id": client.client_id}
+    if provider.sends_secret and client.client_secret:
+        data["client_secret"] = client.client_secret
+    try:
+        resp = http.post_form(provider.token_url, data=data)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("oauth: %s refresh failed: %s", key, type(exc).__name__)
+        raise SignedOutError(f"Could not reach {connector.label} — try again") from None
+    if resp.status_code in (400, 401):
+        # invalid_grant: revoked, or past the consent's lifetime. A stored token
+        # the vendor refuses is worse than none, so it goes.
+        logger.warning("oauth: %s refresh refused (%d); signing out", key, resp.status_code)
+        sign_out(key)
+        raise SignedOutError(f"{connector.label} signed you out — sign in again")
+    if resp.status_code != 200:
+        logger.warning("oauth: %s refresh returned %d", key, resp.status_code)
+        raise SignedOutError(f"{connector.label} answered {resp.status_code} — try again")
+    payload = resp.json()
+    access = str(payload.get("access_token") or "")
+    if not access:
+        raise SignedOutError(f"{connector.label} returned no token — sign in again")
+    _cache_put(key, access, int(payload.get("expires_in") or 3600))
+    rotated = str(payload.get("refresh_token") or "")
+    if provider.refresh_rotates and rotated and rotated != refresh:
+        from yeaboi.config import apply_config_value
+
+        apply_config_value(connector.signin_env, rotated)
+    return access
+
+
+def reset_cache_for(key: str) -> None:
+    """Forget one cached access token so the next read refreshes it."""
+    with _cache_lock:
+        _cache.pop(key, None)
+
+
+def reset_cache() -> None:
+    """Test seam."""
+    with _cache_lock:
+        _cache.clear()

--- a/src/yeaboi/connectors/oauth.py
+++ b/src/yeaboi/connectors/oauth.py
@@ -115,9 +115,10 @@ def oauth_port() -> int:
     """The port the callback listener binds — fixed, because the registered redirect URI names it."""
     raw = os.environ.get("YEABOI_OAUTH_PORT", "").strip()
     try:
-        return int(raw) if raw else DEFAULT_PORT
+        port = int(raw) if raw else DEFAULT_PORT
     except ValueError:
         return DEFAULT_PORT
+    return port if 1 <= port <= 65535 else DEFAULT_PORT
 
 
 def redirect_uri(key: str, port: int | None = None) -> str:
@@ -166,7 +167,7 @@ def parse_callback(path: str, expected_state: str) -> str:
     if error:
         raise CallbackError("Sign-in was refused" if error == "access_denied" else "Sign-in did not complete")
     state = (query.get("state") or [""])[0]
-    if not state or not secrets.compare_digest(state, expected_state):
+    if not state or not secrets.compare_digest(state.encode("utf-8"), expected_state.encode("utf-8")):
         raise CallbackError("Sign-in did not match the one that was started")
     code = (query.get("code") or [""])[0]
     if not code:
@@ -231,7 +232,7 @@ class _CallbackServer:
 
         # Raises OSError on a busy port: the caller turns that into a message.
         self._server = HTTPServer(("127.0.0.1", port), Handler)
-        self._server.timeout = 1
+        self._server.timeout = 0.2
         self._thread = threading.Thread(target=self._serve, name="oauth-callback", daemon=True)
         self._thread.start()
 
@@ -246,7 +247,15 @@ class _CallbackServer:
         return self._event.is_set()
 
     def close(self) -> None:
+        """Stop listening and release the port before returning.
+
+        The next sign-in binds the same fixed port straight away; a socket the
+        serve thread is still holding would refuse it with a misleading
+        "port busy".
+        """
         self._event.set()
+        if self._thread.is_alive() and threading.current_thread() is not self._thread:
+            self._thread.join(timeout=3)
 
 
 # -- the session ---------------------------------------------------------------
@@ -366,14 +375,18 @@ class OAuthSignIn:
             self.error = _exchange_message(self.key, resp.status_code)
             logger.warning("oauth: %s token exchange returned %d", self.key, resp.status_code)
             return
-        payload = resp.json()
+        payload = _token_payload(resp)
+        if payload is None:
+            self.error = "The sign-in service answered with something other than a token"
+            logger.warning("oauth: %s token exchange body was not a token", self.key)
+            return
         refresh = str(payload.get("refresh_token") or "")
         access = str(payload.get("access_token") or "")
         if not refresh:
             self.error = "Sign-in finished but no token was returned"
             logger.warning("oauth: %s exchange carried no refresh token", self.key)
             return
-        _cache_put(self.key, access, int(payload.get("expires_in") or 3600))
+        _cache_put(self.key, access, _expires_in(payload))
         try:
             self.account = provider.identity(access) if access else ""
         except Exception:  # noqa: BLE001 — a name is a nicety, not the credential
@@ -399,6 +412,22 @@ class OAuthSignIn:
         if not self.done:
             self.error = "Sign-in cancelled"
         self._refresh_token = ""
+
+
+def _token_payload(resp) -> dict | None:
+    """The token endpoint's JSON object, or None for anything else."""
+    try:
+        body = resp.json()
+    except Exception:  # noqa: BLE001 — a non-JSON 200 is just not a token
+        return None
+    return body if isinstance(body, dict) else None
+
+
+def _expires_in(payload: dict) -> int:
+    try:
+        return max(1, int(payload.get("expires_in") or 3600))
+    except (TypeError, ValueError):
+        return 3600
 
 
 def _exchange_message(key: str, status: int) -> str:
@@ -435,6 +464,10 @@ def sign_out(key: str) -> None:
         apply_config_value(connector.account_env, "")
     with _cache_lock:
         _cache.pop(key, None)
+    # Pages read as the old account must not be served to the next one.
+    from yeaboi.connectors import library
+
+    library.forget(key)
     logger.info("oauth: %s signed out", key)
 
 
@@ -475,11 +508,11 @@ def _refresh(key: str) -> str:
     if resp.status_code != 200:
         logger.warning("oauth: %s refresh returned %d", key, resp.status_code)
         raise SignedOutError(f"{connector.label} answered {resp.status_code} — try again")
-    payload = resp.json()
-    access = str(payload.get("access_token") or "")
+    payload = _token_payload(resp)
+    access = str(payload.get("access_token") or "") if payload else ""
     if not access:
         raise SignedOutError(f"{connector.label} returned no token — sign in again")
-    _cache_put(key, access, int(payload.get("expires_in") or 3600))
+    _cache_put(key, access, _expires_in(payload or {}))
     rotated = str(payload.get("refresh_token") or "")
     if provider.refresh_rotates and rotated and rotated != refresh:
         from yeaboi.config import apply_config_value

--- a/src/yeaboi/connectors/oauth.py
+++ b/src/yeaboi/connectors/oauth.py
@@ -203,8 +203,8 @@ class _CallbackServer:
 
         class Handler(BaseHTTPRequestHandler):
             def log_message(self, format, *args):  # noqa: A002 — BaseHTTPRequestHandler's name
-                # The path carries the code; only its route is worth a line.
-                logger.debug("oauth: callback %s", urlparse(self.path).path)
+                # The path carries the code, so nothing of the request is logged.
+                logger.debug("oauth: callback request received")
 
             def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler's convention
                 if urlparse(self.path).path != wanted:
@@ -327,7 +327,11 @@ class OAuthSignIn:
             logger.warning("oauth: %s sign-in could not bind port %d", self.key, port)
             return False
         self.url = authorize_url(provider, client.client_id, self._redirect, self._state, challenge)
-        logger.info("oauth: %s sign-in started (%s client)", self.key, "own" if client.own else "built-in")
+        # Which app, without touching the client object: a field of it is a
+        # secret, and a log line must not be derived from one.
+        own_field = oauth_clients.CLIENT_ID_ENVS.get(self.key, "")
+        kind = "own" if own_field and os.environ.get(own_field, "").strip() else "built-in"
+        logger.info("oauth: %s sign-in started (%s client)", self.key, kind)
         return True
 
     def poll(self) -> None:

--- a/src/yeaboi/connectors/oauth.py
+++ b/src/yeaboi/connectors/oauth.py
@@ -153,7 +153,16 @@ def authorize_url(provider: OAuthProvider, client_id: str, redirect: str, state:
 
 
 class CallbackError(ValueError):
-    """The redirect did not carry a usable code."""
+    """The redirect did not carry a usable code.
+
+    ``settles`` says whether the sign-in is over: the vendor refusing it is;
+    a request that merely does not match (a stale tab, a reload, any page
+    poking the port) is not, and the listener keeps waiting for the real one.
+    """
+
+    def __init__(self, message: str, settles: bool = False) -> None:
+        super().__init__(message)
+        self.settles = settles
 
 
 def parse_callback(path: str, expected_state: str) -> str:
@@ -165,7 +174,9 @@ def parse_callback(path: str, expected_state: str) -> str:
     query = parse_qs(urlparse(path).query)
     error = (query.get("error") or [""])[0]
     if error:
-        raise CallbackError("Sign-in was refused" if error == "access_denied" else "Sign-in did not complete")
+        raise CallbackError(
+            "Sign-in was refused" if error == "access_denied" else "Sign-in did not complete", settles=True
+        )
     state = (query.get("state") or [""])[0]
     if not state or not secrets.compare_digest(state.encode("utf-8"), expected_state.encode("utf-8")):
         raise CallbackError("Sign-in did not match the one that was started")
@@ -214,12 +225,15 @@ class _CallbackServer:
                 # page must find the session done, not a moment from it.
                 try:
                     outer.code = parse_callback(self.path, outer.expected_state)
-                    status, page = 200, _DONE_PAGE
+                    outer._event.set()
+                    self._page(200, _DONE_PAGE)
                 except CallbackError as exc:
-                    outer.error = str(exc)
-                    status, page = 400, _FAILED_PAGE
-                outer._event.set()
-                self._page(status, page)
+                    # A mismatch is answered and forgotten: ending the sign-in on
+                    # it would let a stale tab, or any page, abort a real one.
+                    if exc.settles:
+                        outer.error = str(exc)
+                        outer._event.set()
+                    self._page(400, _FAILED_PAGE)
 
             def _page(self, status: int, body: str) -> None:
                 raw = body.encode("utf-8")
@@ -409,6 +423,10 @@ class OAuthSignIn:
             apply_config_value(connector.account_env, self.account)
         self.persisted = True
         self._refresh_token = ""
+        # Pages read as whoever was signed in before must not be served now.
+        from yeaboi.connectors import library
+
+        library.forget(self.key)
         logger.info("oauth: %s signed in as %s", self.key, self.account or "(unnamed)")
 
     def cancel(self) -> None:

--- a/src/yeaboi/connectors/oauth_clients.py
+++ b/src/yeaboi/connectors/oauth_clients.py
@@ -1,0 +1,57 @@
+"""The OAuth apps yeaboi is registered as, and the user's own in their place.
+
+Spotify and Google each know yeaboi by a client ID. Both are public clients:
+the code exchange is bound by PKCE, and a client secret grants nothing on its
+own. Google still issues its "Desktop app" clients a ``client_secret`` and says
+in its own docs that an installed app cannot keep it confidential — so it is a
+shipped constant here, never a user secret, and never logged.
+
+The built-in apps have limits a user may hit — Spotify's development mode
+allows five sign-ins; Google caps an unverified app at a hundred testers and
+shares one daily quota across everyone — so each connector carries a
+bring-your-own client field that takes precedence when set. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+#: yeaboi's registered apps. Blank until the registrations exist; a blank
+#: built-in makes sign-in fail with a message that names the BYO field.
+SPOTIFY_CLIENT_ID = ""
+GOOGLE_CLIENT_ID = ""
+GOOGLE_CLIENT_SECRET = ""
+
+#: The bring-your-own override fields, by connector key.
+CLIENT_ID_ENVS: dict[str, str] = {"spotify": "SPOTIFY_CLIENT_ID", "youtube_music": "YOUTUBE_MUSIC_CLIENT_ID"}
+CLIENT_SECRET_ENVS: dict[str, str] = {"youtube_music": "YOUTUBE_MUSIC_CLIENT_SECRET"}
+
+_BUILTIN: dict[str, tuple[str, str]] = {
+    "spotify": (SPOTIFY_CLIENT_ID, ""),
+    "youtube_music": (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET),
+}
+
+
+@dataclass(frozen=True)
+class OAuthClient:
+    client_id: str
+    client_secret: str
+    #: True when the user's own app is in force rather than yeaboi's.
+    own: bool
+
+
+def resolve(key: str) -> OAuthClient | None:
+    """The client to sign in with: the user's own when set, else yeaboi's.
+
+    ``None`` when neither exists — the caller turns that into the message
+    that names the field to fill in.
+    """
+    own_id = os.environ.get(CLIENT_ID_ENVS.get(key, ""), "").strip()
+    if own_id:
+        own_secret = os.environ.get(CLIENT_SECRET_ENVS.get(key, ""), "").strip()
+        return OAuthClient(own_id, own_secret, own=True)
+    builtin_id, builtin_secret = _BUILTIN.get(key, ("", ""))
+    if not builtin_id:
+        return None
+    return OAuthClient(builtin_id, builtin_secret, own=False)

--- a/src/yeaboi/connectors/registry.py
+++ b/src/yeaboi/connectors/registry.py
@@ -15,6 +15,7 @@ import os
 from collections.abc import Mapping
 
 from yeaboi.connectors import (
+    apple_music,
     aws,
     azure_cloud,
     bitbucket,
@@ -30,8 +31,10 @@ from yeaboi.connectors import (
     linear,
     pagerduty,
     sentry,
+    spotify,
     statuspage,
     trello,
+    youtube_music,
 )
 from yeaboi.connectors.spec import FAMILY_ORDER, Connector
 
@@ -58,6 +61,9 @@ _CONNECTORS: tuple[Connector, ...] = (
     launchdarkly.CONNECTOR,
     linear.CONNECTOR,
     trello.CONNECTOR,
+    spotify.CONNECTOR,
+    apple_music.CONNECTOR,
+    youtube_music.CONNECTOR,
 )
 
 

--- a/src/yeaboi/connectors/spec.py
+++ b/src/yeaboi/connectors/spec.py
@@ -31,6 +31,7 @@ FAMILIES: dict[str, str] = {
     "code": "\U0001f500",  # 🔀
     "chat": "\U0001f4ac",  # 💬
     "media": "\U0001f3a4",  # 🎤
+    "music": "\U0001f3b5",  # 🎵
 }
 
 #: Render order for the catalog. Families the user is most likely to be adding
@@ -45,6 +46,7 @@ FAMILY_ORDER: tuple[str, ...] = (
     "docs",
     "chat",
     "media",
+    "music",
 )
 
 FAMILY_LABELS: dict[str, str] = {
@@ -57,6 +59,7 @@ FAMILY_LABELS: dict[str, str] = {
     "docs": "Docs",
     "chat": "Chat",
     "media": "Voice & video",
+    "music": "Music",
 }
 
 

--- a/src/yeaboi/connectors/spec.py
+++ b/src/yeaboi/connectors/spec.py
@@ -116,6 +116,11 @@ class ConnectorField:
     auth_method: str = ""
     choices: tuple[str, ...] = ()
     default: str = ""
+    # A non-empty action names the flow that mints this value instead of a
+    # typed write — the same vocabulary as ``SettingField.action``. ``signin``
+    # means an OAuth sign-in writes it: no surface ever prompts for it, and
+    # the desktop renders it as a status row with Sign in / Sign out.
+    action: str = ""
 
 
 @dataclass(frozen=True)
@@ -166,6 +171,15 @@ class Connector:
     auth_env: str = ""
     #: Read-only connectors gather data and never write to the vendor.
     read_only: bool = True
+    #: The refresh-token field an OAuth sign-in writes, and the field holding
+    #: the account's display name — the one value the catalogue may show.
+    #: Empty means the connector has no sign-in.
+    signin_env: str = ""
+    account_env: str = ""
+
+    @property
+    def can_sign_in(self) -> bool:
+        return bool(self.signin_env)
 
     @property
     def mark(self) -> str:

--- a/src/yeaboi/connectors/spotify.py
+++ b/src/yeaboi/connectors/spotify.py
@@ -1,0 +1,41 @@
+"""Spotify — a playlist as a source on the desktop's Music page.
+
+No credential: the desktop browses through Spotify's public embed player and
+hands a playlist to the Spotify app for full tracks. The one field is where
+playback happens, and choosing it is what switches the service on.
+"""
+
+from __future__ import annotations
+
+from yeaboi.connectors.spec import Connector, ConnectorField
+
+#: Where a Spotify link plays once it is picked on the Music page.
+PLAYBACK_ENV = "SPOTIFY_PLAYBACK"
+PLAYBACK_CHOICES = ("desktop", "embed")
+
+CONNECTOR = Connector(
+    key="spotify",
+    label="Spotify",
+    family="music",
+    section="connections",
+    summary="Your playlists as a focus-music source in the desktop app",
+    detail=(
+        "yeaboi shows a playlist you paste through Spotify's own embedded player, which "
+        "plays previews, and hands it to the Spotify app for full tracks. It never signs in "
+        "to your account, never reads your library or listening history, and never writes "
+        "anything to Spotify."
+    ),
+    verify="_verify_spotify",
+    docs_url="https://support.spotify.com/",
+    glyph="\U0001f3a7",  # 🎧 — headphones
+    accent="rgb(30,215,96)",
+    fields=(
+        ConnectorField(
+            env=PLAYBACK_ENV,
+            label="Where it plays",
+            choices=PLAYBACK_CHOICES,
+            default="desktop",
+            hint="In the Spotify app for full tracks, or inside yeaboi for previews",
+        ),
+    ),
+)

--- a/src/yeaboi/connectors/spotify.py
+++ b/src/yeaboi/connectors/spotify.py
@@ -1,8 +1,12 @@
 """Spotify — a playlist as a source on the desktop's Music page.
 
-No credential: the desktop browses through Spotify's public embed player and
-hands a playlist to the Spotify app for full tracks. The one field is where
-playback happens, and choosing it is what switches the service on.
+Two ways in, both optional beyond the one choice that switches it on: paste a
+link and it plays through Spotify's public embed player (previews) or the
+Spotify app (full tracks), with no credential at all; or sign in, and the
+desktop can browse your playlists, liked songs, albums and recently played.
+The sign-in is Authorization Code + PKCE against yeaboi's registered app or
+one of your own, and what it writes here is a refresh token and a display
+name — never a password.
 """
 
 from __future__ import annotations
@@ -13,6 +17,11 @@ from yeaboi.connectors.spec import Connector, ConnectorField
 PLAYBACK_ENV = "SPOTIFY_PLAYBACK"
 PLAYBACK_CHOICES = ("desktop", "embed")
 
+#: The bring-your-own app, and what the sign-in writes.
+CLIENT_ID_ENV = "SPOTIFY_CLIENT_ID"
+REFRESH_TOKEN_ENV = "SPOTIFY_REFRESH_TOKEN"  # noqa: S105 — an env NAME, not a credential
+ACCOUNT_ENV = "SPOTIFY_ACCOUNT"
+
 CONNECTOR = Connector(
     key="spotify",
     label="Spotify",
@@ -21,14 +30,19 @@ CONNECTOR = Connector(
     summary="Your playlists as a focus-music source in the desktop app",
     detail=(
         "yeaboi shows a playlist you paste through Spotify's own embedded player, which "
-        "plays previews, and hands it to the Spotify app for full tracks. It never signs in "
-        "to your account, never reads your library or listening history, and never writes "
-        "anything to Spotify."
+        "plays previews, and hands it to the Spotify app for full tracks — with no sign-in at "
+        "all. Signing in is optional: it lets the desktop browse your playlists, liked songs, "
+        "albums and recently played, read-only. yeaboi never creates, follows, likes or edits "
+        "anything; pressing Play sends a play command to your Spotify app (Premium only), and "
+        "that is the only thing it ever changes. Spotify's developer terms cap an unapproved "
+        "app at five sign-ins, so a 'not allowlisted' message means paste your own client ID."
     ),
     verify="_verify_spotify",
     docs_url="https://support.spotify.com/",
     glyph="\U0001f3a7",  # 🎧 — headphones
     accent="rgb(30,215,96)",
+    signin_env=REFRESH_TOKEN_ENV,
+    account_env=ACCOUNT_ENV,
     fields=(
         ConnectorField(
             env=PLAYBACK_ENV,
@@ -36,6 +50,32 @@ CONNECTOR = Connector(
             choices=PLAYBACK_CHOICES,
             default="desktop",
             hint="In the Spotify app for full tracks, or inside yeaboi for previews",
+        ),
+        ConnectorField(
+            env=CLIENT_ID_ENV,
+            label="Your own Spotify app",
+            required=False,
+            placeholder="yeaboi's registered app",
+            hint="Optional — a client ID from your own Spotify developer app",
+            help_url="https://developer.spotify.com/dashboard",
+            help_scope=(
+                "Create an app and add http://127.0.0.1:8643/callback/spotify as its Redirect URI. "
+                "Needed only past the five sign-ins yeaboi's own app allows."
+            ),
+        ),
+        ConnectorField(
+            env=REFRESH_TOKEN_ENV,
+            label="Account",
+            secret=True,
+            required=False,
+            action="signin",
+            hint="Written by Sign in on the desktop's Music page; never typed",
+        ),
+        ConnectorField(
+            env=ACCOUNT_ENV,
+            label="Signed in as",
+            required=False,
+            action="signin",
         ),
     ),
 )

--- a/src/yeaboi/connectors/youtube_music.py
+++ b/src/yeaboi/connectors/youtube_music.py
@@ -1,0 +1,40 @@
+"""YouTube Music — a playlist or video as a source on the desktop's Music page.
+
+No credential: YouTube's public embed plays in full inside the desktop app.
+The one field is where playback happens, and choosing it is what switches the
+service on.
+"""
+
+from __future__ import annotations
+
+from yeaboi.connectors.spec import Connector, ConnectorField
+
+#: Where a YouTube link plays once it is picked on the Music page.
+PLAYBACK_ENV = "YOUTUBE_MUSIC_PLAYBACK"
+PLAYBACK_CHOICES = ("embed", "browser")
+
+CONNECTOR = Connector(
+    key="youtube_music",
+    label="YouTube Music",
+    family="music",
+    section="connections",
+    summary="Playlists and videos as a focus-music source in the desktop app",
+    detail=(
+        "yeaboi plays a playlist or video you paste through YouTube's own embedded player, "
+        "in full, inside the desktop app. It never signs in to your Google account, never reads "
+        "your subscriptions or watch history, and never writes anything to YouTube."
+    ),
+    verify="_verify_youtube_music",
+    docs_url="https://support.google.com/youtubemusic/",
+    glyph="▶️",  # ▶️ — the play mark
+    accent="rgb(255,0,0)",
+    fields=(
+        ConnectorField(
+            env=PLAYBACK_ENV,
+            label="Where it plays",
+            choices=PLAYBACK_CHOICES,
+            default="embed",
+            hint="Inside yeaboi in full, or in the browser",
+        ),
+    ),
+)

--- a/src/yeaboi/connectors/youtube_music.py
+++ b/src/yeaboi/connectors/youtube_music.py
@@ -1,8 +1,10 @@
 """YouTube Music — a playlist or video as a source on the desktop's Music page.
 
-No credential: YouTube's public embed plays in full inside the desktop app.
-The one field is where playback happens, and choosing it is what switches the
-service on.
+Paste a link and YouTube's public embed plays it in full inside the desktop,
+with no credential. Signing in is optional: a read-only Google sign-in
+(``youtube.readonly``) lets the desktop browse your playlists and liked
+videos. Google's "Desktop app" clients carry a non-confidential secret; see
+``oauth_clients``.
 """
 
 from __future__ import annotations
@@ -13,6 +15,12 @@ from yeaboi.connectors.spec import Connector, ConnectorField
 PLAYBACK_ENV = "YOUTUBE_MUSIC_PLAYBACK"
 PLAYBACK_CHOICES = ("embed", "browser")
 
+#: The bring-your-own Google client, and what the sign-in writes.
+CLIENT_ID_ENV = "YOUTUBE_MUSIC_CLIENT_ID"
+CLIENT_SECRET_ENV = "YOUTUBE_MUSIC_CLIENT_SECRET"  # noqa: S105 — an env NAME, not a credential
+REFRESH_TOKEN_ENV = "YOUTUBE_MUSIC_REFRESH_TOKEN"  # noqa: S105
+ACCOUNT_ENV = "YOUTUBE_MUSIC_ACCOUNT"
+
 CONNECTOR = Connector(
     key="youtube_music",
     label="YouTube Music",
@@ -21,13 +29,18 @@ CONNECTOR = Connector(
     summary="Playlists and videos as a focus-music source in the desktop app",
     detail=(
         "yeaboi plays a playlist or video you paste through YouTube's own embedded player, "
-        "in full, inside the desktop app. It never signs in to your Google account, never reads "
-        "your subscriptions or watch history, and never writes anything to YouTube."
+        "in full, inside the desktop app — with no sign-in at all. Signing in is optional and "
+        "read-only: it lets the desktop browse your playlists and liked videos. yeaboi never "
+        "reads your watch history and never writes anything to YouTube. Until Google verifies "
+        "yeaboi's app, its shared client is limited to a hundred testers and one daily quota, so "
+        "paste your own client for reliable search."
     ),
     verify="_verify_youtube_music",
     docs_url="https://support.google.com/youtubemusic/",
     glyph="▶️",  # ▶️ — the play mark
     accent="rgb(255,0,0)",
+    signin_env=REFRESH_TOKEN_ENV,
+    account_env=ACCOUNT_ENV,
     fields=(
         ConnectorField(
             env=PLAYBACK_ENV,
@@ -35,6 +48,39 @@ CONNECTOR = Connector(
             choices=PLAYBACK_CHOICES,
             default="embed",
             hint="Inside yeaboi in full, or in the browser",
+        ),
+        ConnectorField(
+            env=CLIENT_ID_ENV,
+            label="Your own Google client",
+            required=False,
+            placeholder="yeaboi's registered app",
+            hint="Optional — a Desktop app OAuth client ID from your own Google Cloud project",
+            help_url="https://console.cloud.google.com/apis/credentials",
+            help_scope=(
+                "Create a Desktop app OAuth client with the YouTube Data API enabled. "
+                "Needed only when yeaboi's shared client is full or over quota."
+            ),
+        ),
+        ConnectorField(
+            env=CLIENT_SECRET_ENV,
+            label="Its client secret",
+            secret=True,
+            required=False,
+            hint="Google issues Desktop app clients one; it is not confidential, but it is still yours",
+        ),
+        ConnectorField(
+            env=REFRESH_TOKEN_ENV,
+            label="Account",
+            secret=True,
+            required=False,
+            action="signin",
+            hint="Written by Sign in on the desktop's Music page; never typed",
+        ),
+        ConnectorField(
+            env=ACCOUNT_ENV,
+            label="Signed in as",
+            required=False,
+            action="signin",
         ),
     ),
 )

--- a/src/yeaboi/music.py
+++ b/src/yeaboi/music.py
@@ -69,7 +69,9 @@ _CAN_SUSPEND = hasattr(signal, "SIGSTOP") and hasattr(signal, "SIGCONT")
 CHANNELS: tuple[dict[str, str], ...] = (
     {"name": "Lofi", "url": "https://ice1.somafm.com/groovesalad-128-mp3"},
     {"name": "Jazz", "url": "https://ice1.somafm.com/sonicuniverse-128-mp3"},
-    {"name": "Classical", "url": "https://stream.srg-ssr.ch/m/rsc_de/mp3_128"},
+    # Radio France serves this one over https end to end; the Swiss stream
+    # redirected to plain http, which a window refuses and a terminal does not.
+    {"name": "Classical", "url": "https://icecast.radiofrance.fr/francemusique-midfi.mp3"},
     {"name": "Ambient", "url": "https://ice1.somafm.com/dronezone-128-mp3"},
 )
 

--- a/src/yeaboi/provider_verification.py
+++ b/src/yeaboi/provider_verification.py
@@ -1173,6 +1173,43 @@ def _verify_launchdarkly(token: str) -> tuple[bool, str]:
     return True, "LaunchDarkly verified"
 
 
+def _verify_music_player(url: str, verified: str) -> tuple[bool, str]:
+    """One unauthenticated GET against a music vendor's public catalogue.
+
+    The music connectors hold no credential, so the probe answers the only
+    question there is: whether the vendor's player is reachable from here.
+    """
+    from yeaboi.connectors.http import probe_status
+
+    status, message = probe_status(url, headers={})
+    if status == 0:
+        return False, message
+    if status != 200:
+        return False, f"Unexpected response: {status}"
+    return True, verified
+
+
+def _verify_spotify() -> tuple[bool, str]:
+    from urllib.parse import quote
+
+    playlist = quote("https://open.spotify.com/playlist/37i9dQZF1DX8Uebhn9wzrS", safe="")
+    return _verify_music_player(f"https://open.spotify.com/oembed?url={playlist}", "Spotify's player is reachable")
+
+
+def _verify_apple_music() -> tuple[bool, str]:
+    # Apple has no oEmbed; the iTunes lookup is the public, keyless catalogue read.
+    return _verify_music_player("https://itunes.apple.com/lookup?id=1440935467", "Apple Music's catalogue is reachable")
+
+
+def _verify_youtube_music() -> tuple[bool, str]:
+    from urllib.parse import quote
+
+    video = quote("https://www.youtube.com/watch?v=jfKfPfyJRdk", safe="")
+    return _verify_music_player(
+        f"https://www.youtube.com/oembed?url={video}&format=json", "YouTube's player is reachable"
+    )
+
+
 def _verify_jsm_ops(token: str, cloud_id: str) -> tuple[bool, str]:
     """Verify a JSM Ops API key can list one site's alerts.
 

--- a/src/yeaboi/settings/engine.py
+++ b/src/yeaboi/settings/engine.py
@@ -265,6 +265,7 @@ def _connector_fields() -> tuple[SettingField, ...]:
             secret=f.secret,
             choices=f.choices,
             default=f.default,
+            action=f.action,
         )
         for c in registry.all_connectors()
         for f in c.fields

--- a/src/yeaboi/system_check.py
+++ b/src/yeaboi/system_check.py
@@ -198,10 +198,18 @@ def _check_music() -> CheckResult:
     from yeaboi.music import is_music_available
 
     ok, reason = is_music_available()
+    # The terminal's player only: the desktop app plays the same stations
+    # through an <audio> element and never needs the binary.
+    feature = "Background music in the terminal"
     if ok:
-        return CheckResult("music", "Music (ffplay)", "ok", detail="ffplay on PATH", feature="Background music")
+        return CheckResult("music", "Music (ffplay)", "ok", detail="ffplay on PATH", feature=feature)
     return CheckResult(
-        "music", "Music (ffplay)", "missing", detail="ffplay not on PATH", hint=reason, feature="Background music"
+        "music",
+        "Music (ffplay)",
+        "missing",
+        detail="ffplay not on PATH",
+        hint=f"{reason} — the desktop app plays radio without it",
+        feature=feature,
     )
 
 

--- a/src/yeaboi/ui/catalog/__init__.py
+++ b/src/yeaboi/ui/catalog/__init__.py
@@ -361,10 +361,11 @@ def run_catalog_browser(console: Console, live, read_key, frame_time: float, sup
                     logger.info("catalog: %s connects via %s", connector.key, method.key)
                     break
 
+        # A sign-in's fields are minted by the flow, never typed here.
         fields = [
             f
             for f in (connector.fields_for(method.key) if method else connector.fields)
-            if not (connector.auth_env and f.env == connector.auth_env)
+            if not (connector.auth_env and f.env == connector.auth_env) and f.action != "signin"
         ]
         entry.update({"stage": "field", "fields": fields})
         set_text_entry(True)

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -427,8 +427,8 @@ def get_tips() -> tuple[FeatureTip, ...]:
     }[state]
     desktop_voice_tip = FeatureTip("voice", desktop_voice_text, surfaces=("desktop",))
     music_available, _music_reason = is_music_available()
-    # Terminal-only: focus music is a pair of keybindings there, and the desktop
-    # app ships no control for it.
+    # Terminal-only because the text names the terminal's keys; the desktop has
+    # its own Music page, menu chords and a `desktop:music` tip.
     music_tip = FeatureTip(
         "music",
         "\U0001f3b5 Tip: press Ctrl+P for focus music · Ctrl+O to switch channel"

--- a/src/yeaboi/ui/shared/_tips.py
+++ b/src/yeaboi/ui/shared/_tips.py
@@ -364,6 +364,12 @@ _META_TIPS: tuple[FeatureTip, ...] = (
 # what TestDesktopOnlyTips checks against the desktop's own route manifest.
 _DESKTOP_TIPS: tuple[FeatureTip, ...] = (
     FeatureTip(
+        "desktop:music",
+        "\U0001f3b5 Tip: Music lives in the rail's pocket — radio shared with the terminal, "
+        "or Spotify, Apple Music and YouTube Music once they are on in the catalog",
+        surfaces=("desktop",),
+    ),
+    FeatureTip(
         "desktop:projects",
         "\U0001f4c1 Tip: Projects is the durable door — every run you start inside one shares its context",
         surfaces=("desktop",),

--- a/tests/unit/test_ambience.py
+++ b/tests/unit/test_ambience.py
@@ -15,6 +15,8 @@ def env(monkeypatch):
     monkeypatch.setattr(config, "set_config_value", lambda _k, _v: Path("/tmp/.env"))
     for key in ("DUCK_ENABLED", "MUSIC_ENABLED", "MUSIC_CHANNEL", "PET_ENABLED", "SAVER_STYLE"):
         monkeypatch.delenv(key, raising=False)
+    for key in ("SPOTIFY_PLAYBACK", "APPLE_MUSIC_PLAYBACK", "YOUTUBE_MUSIC_PLAYBACK"):
+        monkeypatch.delenv(key, raising=False)
     return monkeypatch
 
 
@@ -62,6 +64,27 @@ class TestState:
 
     def test_the_style_catalogue_travels_with_the_state(self, env):
         assert ambience.state()["saver"]["styles"] == ambience.SAVER_STYLES
+
+    def test_the_streaming_services_travel_with_the_state_and_start_off(self, env):
+        # The catalogue decides what is on; with nothing saved, nothing is.
+        services = ambience.state()["music"]["services"]
+        assert [s["key"] for s in services] == list(ambience.MUSIC_SERVICE_KEYS)
+        assert all(set(s) == {"key", "label", "connected", "playback"} for s in services)
+        assert not any(s["connected"] for s in services)
+        assert [s["playback"] for s in services] == ["desktop", "desktop", "embed"]
+
+    def test_a_saved_playback_choice_switches_the_service_on(self, env):
+        env.setenv("SPOTIFY_PLAYBACK", "embed")
+        by_key = {s["key"]: s for s in ambience.state()["music"]["services"]}
+        assert by_key["spotify"] == {"key": "spotify", "label": "Spotify", "connected": True, "playback": "embed"}
+        assert by_key["apple_music"]["connected"] is False
+
+    def test_an_unknown_playback_choice_reads_as_the_default(self, env):
+        # A value written by a newer desktop must not hand the older one a word it cannot act on.
+        env.setenv("YOUTUBE_MUSIC_PLAYBACK", "hologram")
+        by_key = {s["key"]: s for s in ambience.state()["music"]["services"]}
+        assert by_key["youtube_music"]["playback"] == "embed"
+        assert by_key["youtube_music"]["connected"] is True
 
     def test_the_state_is_a_copy_a_caller_cannot_corrupt(self, env):
         ambience.state()["duck"]["quips"]["standup_done"] = "nope"

--- a/tests/unit/test_ambience.py
+++ b/tests/unit/test_ambience.py
@@ -70,7 +70,8 @@ class TestState:
         services = ambience.state()["music"]["services"]
         assert [s["key"] for s in services] == list(ambience.MUSIC_SERVICE_KEYS)
         assert all(
-            set(s) == {"key", "label", "connected", "playback", "can_sign_in", "signed_in", "account"} for s in services
+            set(s) == {"key", "label", "connected", "playback", "can_sign_in", "signed_in", "account", "client"}
+            for s in services
         )
         assert not any(s["connected"] for s in services)
         assert not any(s["signed_in"] for s in services)
@@ -89,8 +90,16 @@ class TestState:
             "can_sign_in": True,
             "signed_in": False,
             "account": "",
+            "client": "none",
         }
         assert by_key["apple_music"]["connected"] is False
+
+    def test_the_client_a_sign_in_would_use_is_named(self, env):
+        env.setenv("SPOTIFY_CLIENT_ID", "own-app")
+        by_key = {s["key"]: s for s in ambience.state()["music"]["services"]}
+        assert by_key["spotify"]["client"] == "own"
+        assert by_key["youtube_music"]["client"] == "none"
+        assert by_key["apple_music"]["client"] == "none"
 
     def test_a_held_token_reads_as_signed_in_with_its_name_and_never_its_value(self, env):
         env.setenv("SPOTIFY_REFRESH_TOKEN", "AQD-refresh-token-value")

--- a/tests/unit/test_ambience.py
+++ b/tests/unit/test_ambience.py
@@ -69,15 +69,38 @@ class TestState:
         # The catalogue decides what is on; with nothing saved, nothing is.
         services = ambience.state()["music"]["services"]
         assert [s["key"] for s in services] == list(ambience.MUSIC_SERVICE_KEYS)
-        assert all(set(s) == {"key", "label", "connected", "playback"} for s in services)
+        assert all(
+            set(s) == {"key", "label", "connected", "playback", "can_sign_in", "signed_in", "account"} for s in services
+        )
         assert not any(s["connected"] for s in services)
+        assert not any(s["signed_in"] for s in services)
         assert [s["playback"] for s in services] == ["desktop", "desktop", "embed"]
+        # Apple never signs in: the desktop browses the Music app itself.
+        assert [s["can_sign_in"] for s in services] == [True, False, True]
 
     def test_a_saved_playback_choice_switches_the_service_on(self, env):
         env.setenv("SPOTIFY_PLAYBACK", "embed")
         by_key = {s["key"]: s for s in ambience.state()["music"]["services"]}
-        assert by_key["spotify"] == {"key": "spotify", "label": "Spotify", "connected": True, "playback": "embed"}
+        assert by_key["spotify"] == {
+            "key": "spotify",
+            "label": "Spotify",
+            "connected": True,
+            "playback": "embed",
+            "can_sign_in": True,
+            "signed_in": False,
+            "account": "",
+        }
         assert by_key["apple_music"]["connected"] is False
+
+    def test_a_held_token_reads_as_signed_in_with_its_name_and_never_its_value(self, env):
+        env.setenv("SPOTIFY_REFRESH_TOKEN", "AQD-refresh-token-value")
+        env.setenv("SPOTIFY_ACCOUNT", "dinho")
+        by_key = {s["key"]: s for s in ambience.state()["music"]["services"]}
+        assert by_key["spotify"]["signed_in"] is True
+        assert by_key["spotify"]["account"] == "dinho"
+        # Signing in does not switch the service on; the playback choice does.
+        assert by_key["spotify"]["connected"] is False
+        assert "AQD-refresh-token-value" not in repr(ambience.state())
 
     def test_an_unknown_playback_choice_reads_as_the_default(self, env):
         # A value written by a newer desktop must not hand the older one a word it cannot act on.

--- a/tests/unit/test_app_music_routes.py
+++ b/tests/unit/test_app_music_routes.py
@@ -1,0 +1,221 @@
+"""The music sign-in and library routes — socketless, over AppServer.handle()."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from yeaboi.app.router import parse_request
+from yeaboi.app.server import AppServer
+from yeaboi.connectors import library, oauth
+from yeaboi.connectors.library import Item, LibraryError, Page
+
+TOKEN = "test-token"
+
+
+def request(app: AppServer, method: str, path: str, payload: dict | None = None, *, authed: bool = True):
+    headers = {"Authorization": f"Bearer {TOKEN}"} if authed else {}
+    body = json.dumps(payload).encode() if payload is not None else b""
+    return app.handle(parse_request(method, path, headers, body))
+
+
+@pytest.fixture
+def app():
+    return AppServer(token=TOKEN)
+
+
+class FakeSignIn:
+    def __init__(self, key: str, *, can_start: bool = True):
+        self.key = key
+        self.url = f"https://vendor.example/authorize?for={key}"
+        self.account = ""
+        self.error = (
+            "" if can_start else "yeaboi's app is not configured — paste your own client ID (SPOTIFY_CLIENT_ID)"
+        )
+        self.persisted = False
+        self.cancelled = False
+        self._can_start = can_start
+        self.polls = 0
+
+    def start(self) -> bool:
+        return self._can_start
+
+    def poll(self) -> None:
+        self.polls += 1
+        if self.polls >= 2:
+            self.persisted = True
+            self.account = "dinho"
+
+    @property
+    def done(self) -> bool:
+        return bool(self.persisted or self.error)
+
+    @property
+    def ok(self) -> bool:
+        return self.persisted
+
+    @property
+    def message(self) -> str:
+        return f"Signed in as {self.account}" if self.persisted else self.error
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+class TestAuth:
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("POST", "/api/connections/spotify/signin"),
+            ("GET", "/api/connections/spotify/signin"),
+            ("POST", "/api/connections/spotify/signin/cancel"),
+            ("POST", "/api/connections/spotify/signout"),
+            ("GET", "/api/music/spotify/library"),
+            ("GET", "/api/music/spotify/playlist/abc/items"),
+            ("GET", "/api/music/spotify/search?q=x"),
+            ("POST", "/api/music/spotify/play"),
+            ("GET", "/api/music/spotify/player"),
+            ("GET", "/api/music/spotify/devices"),
+        ],
+    )
+    def test_every_route_needs_the_bearer(self, app, method, path):
+        assert request(app, method, path, authed=False).code == 401
+
+
+class TestSignIn:
+    def test_apple_has_no_sign_in(self, app):
+        assert request(app, "POST", "/api/connections/apple_music/signin").code == 404
+        assert request(app, "POST", "/api/connections/apple_music/signout").code == 404
+        assert request(app, "POST", "/api/connections/nope/signin").code == 404
+
+    def test_the_lifecycle_never_carries_a_token(self, app, monkeypatch):
+        monkeypatch.setattr("yeaboi.connectors.oauth.OAuthSignIn", FakeSignIn)
+        assert json.loads(request(app, "GET", "/api/connections/spotify/signin").body) == {"active": False}
+        started = json.loads(request(app, "POST", "/api/connections/spotify/signin").body)
+        assert started == {"started": True, "url": "https://vendor.example/authorize?for=spotify", "message": ""}
+        first = json.loads(request(app, "GET", "/api/connections/spotify/signin").body)
+        assert first == {"active": True, "done": False, "ok": False, "saved": False, "account": "", "message": ""}
+        second = json.loads(request(app, "GET", "/api/connections/spotify/signin").body)
+        assert second == {
+            "active": True,
+            "done": True,
+            "ok": True,
+            "saved": True,
+            "account": "dinho",
+            "message": "Signed in as dinho",
+        }
+        # Another service's poll does not see this session.
+        assert json.loads(request(app, "GET", "/api/connections/youtube_music/signin").body) == {"active": False}
+
+    def test_a_start_that_cannot_names_the_field(self, app, monkeypatch):
+        monkeypatch.setattr("yeaboi.connectors.oauth.OAuthSignIn", lambda key: FakeSignIn(key, can_start=False))
+        body = json.loads(request(app, "POST", "/api/connections/spotify/signin").body)
+        assert body["started"] is False and "SPOTIFY_CLIENT_ID" in body["message"] and body["url"] == ""
+
+    def test_starting_again_cancels_the_old_session(self, app, monkeypatch):
+        monkeypatch.setattr("yeaboi.connectors.oauth.OAuthSignIn", FakeSignIn)
+        request(app, "POST", "/api/connections/spotify/signin")
+        old = app.oauth_signin
+        request(app, "POST", "/api/connections/youtube_music/signin")
+        assert old.cancelled and app.oauth_signin.key == "youtube_music"
+
+    def test_cancel_only_touches_its_own_service(self, app, monkeypatch):
+        monkeypatch.setattr("yeaboi.connectors.oauth.OAuthSignIn", FakeSignIn)
+        request(app, "POST", "/api/connections/spotify/signin")
+        assert json.loads(request(app, "POST", "/api/connections/youtube_music/signin/cancel").body) == {"ok": True}
+        assert app.oauth_signin is not None
+        request(app, "POST", "/api/connections/spotify/signin/cancel")
+        assert app.oauth_signin is None
+
+    def test_signout_forgets_the_token_and_the_pages(self, app, monkeypatch):
+        applied: dict[str, str] = {}
+        monkeypatch.setattr("yeaboi.config.apply_config_value", lambda k, v: applied.__setitem__(k, v))
+        library.cached(("spotify", "library", "x"), 60, lambda: Page())
+        body = json.loads(request(app, "POST", "/api/connections/spotify/signout").body)
+        assert body == {"ok": True, "signed_in": False}
+        assert applied == {"SPOTIFY_REFRESH_TOKEN": "", "SPOTIFY_ACCOUNT": ""}
+        assert not [k for k in library._cache if k[0] == "spotify"]
+
+
+ROW = Item(
+    id="4uLU6hMCjMI75M1A2tKUQC", kind="track", title="Song", url="https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC"
+)
+
+
+class TestLibrary:
+    def test_a_page_is_the_row_shape(self, app, monkeypatch):
+        seen: list[tuple] = []
+        monkeypatch.setattr(
+            "yeaboi.connectors.library_spotify.library",
+            lambda shelf, cursor, limit: seen.append((shelf, cursor, limit)) or Page((ROW,), "20"),
+        )
+        resp = request(app, "GET", "/api/music/spotify/library?shelf=liked&cursor=0&limit=20")
+        assert resp.code == 200
+        body = json.loads(resp.body)
+        assert body["next_cursor"] == "20" and body["items"][0]["url"] == ROW.url
+        assert set(body["items"][0]) == {
+            "id",
+            "kind",
+            "title",
+            "subtitle",
+            "artwork_url",
+            "duration_ms",
+            "url",
+            "uri",
+            "preview_url",
+            "count",
+        }
+        assert seen == [("liked", "0", "20")]
+
+    def test_a_bad_shelf_is_a_400_and_apple_has_no_library_here(self, app):
+        assert request(app, "GET", "/api/music/spotify/library?shelf=moods").code == 400
+        assert request(app, "GET", "/api/music/apple_music/library").code == 404
+        assert request(app, "GET", "/api/music/nope/library").code == 404
+
+    def test_a_refusal_is_its_code_with_its_status(self, app, monkeypatch):
+        monkeypatch.setattr(
+            "yeaboi.connectors.library_spotify.library",
+            lambda shelf, cursor, limit: (_ for _ in ()).throw(LibraryError("signed_out", "Sign in to Spotify", 409)),
+        )
+        resp = request(app, "GET", "/api/music/spotify/library")
+        assert resp.code == 409
+        assert json.loads(resp.body) == {"error": "Sign in to Spotify", "code": "signed_out"}
+
+    def test_a_playlist_id_is_checked_before_any_call(self, app):
+        assert request(app, "GET", "/api/music/spotify/playlist/../items").code in (400, 404)
+        assert request(app, "GET", "/api/music/spotify/playlist/a%20b/items").code == 400
+
+    def test_search_needs_a_query_and_apple_needs_no_sign_in(self, app, monkeypatch):
+        assert request(app, "GET", "/api/music/spotify/search").code == 400
+        monkeypatch.setattr("yeaboi.connectors.library_apple.search", lambda q, limit, country: Page((ROW,), ""))
+        resp = request(app, "GET", "/api/music/apple_music/search?q=daft")
+        assert resp.code == 200 and json.loads(resp.body)["items"][0]["id"] == ROW.id
+
+    def test_play_validates_and_hands_back_the_fallback_codes(self, app, monkeypatch):
+        assert request(app, "POST", "/api/music/spotify/play", {}).code == 400
+        assert request(app, "POST", "/api/music/spotify/play", {"uri": "x", "device_id": 3}).code == 400
+        monkeypatch.setattr("yeaboi.connectors.library_spotify.play", lambda uri, device: None)
+        assert json.loads(request(app, "POST", "/api/music/spotify/play", {"uri": "spotify:track:x"}).body) == {
+            "ok": True
+        }
+        monkeypatch.setattr(
+            "yeaboi.connectors.library_spotify.play",
+            lambda uri, device: (_ for _ in ()).throw(LibraryError("premium_required", "Needs Premium", 403)),
+        )
+        resp = request(app, "POST", "/api/music/spotify/play", {"uri": "spotify:track:x"})
+        assert resp.code == 403 and json.loads(resp.body)["code"] == "premium_required"
+
+    def test_player_and_devices_pass_through(self, app, monkeypatch):
+        monkeypatch.setattr("yeaboi.connectors.library_spotify.player", lambda: {"playing": False, "item": None})
+        monkeypatch.setattr("yeaboi.connectors.library_spotify.devices", lambda: {"devices": []})
+        assert json.loads(request(app, "GET", "/api/music/spotify/player").body) == {"playing": False, "item": None}
+        assert json.loads(request(app, "GET", "/api/music/spotify/devices").body) == {"devices": []}
+
+
+def test_no_music_route_is_open(app):
+    from yeaboi.app.registry import ROUTES, UNAUTHENTICATED
+
+    music = [r.path for r in ROUTES if r.path.startswith("/api/music") or "/signin" in r.path or "/signout" in r.path]
+    assert music and not set(music) & UNAUTHENTICATED
+    assert oauth.CALLBACK_PATH not in {r.path for r in ROUTES}

--- a/tests/unit/test_app_settings_routes.py
+++ b/tests/unit/test_app_settings_routes.py
@@ -50,6 +50,28 @@ class TestSettingsRead:
         assert {"providers", "anthropic_auth_modes", "token_help"} == set(payload)
 
 
+class TestConnectionsSignInRow:
+    def test_the_catalog_reports_a_signin_without_its_token(self, app, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_REFRESH_TOKEN", "AQD-refresh-token-value")
+        monkeypatch.setenv("SPOTIFY_ACCOUNT", "dinho")
+        resp = request(app, "GET", "/api/connections?all=1")
+        assert resp.code == 200
+        assert "AQD-refresh-token-value" not in resp.body.decode()
+        spotify = next(c for c in json.loads(resp.body)["connectors"] if c["key"] == "spotify")
+        assert spotify["signin"] == {"signed_in": True, "account": "dinho"}
+        token = next(f for f in spotify["fields"] if f["env"] == "SPOTIFY_REFRESH_TOKEN")
+        assert token["action"] == "signin" and token["secret"] and token["is_set"]
+        apple = next(c for c in json.loads(resp.body)["connectors"] if c["key"] == "apple_music")
+        assert apple["signin"] is None
+
+    def test_the_settings_snapshot_masks_the_token(self, app, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_REFRESH_TOKEN", "AQD-refresh-token-value-long-enough")
+        resp = request(app, "GET", "/api/settings")
+        assert "AQD-refresh-token-value-long-enough" not in resp.body.decode()
+        row = next(f for f in json.loads(resp.body)["fields"] if f["env"] == "SPOTIFY_REFRESH_TOKEN")
+        assert row["secret"] and row["is_set"] and row["action"] == "signin"
+
+
 class TestSettingsWrites:
     @pytest.fixture(autouse=True)
     def _no_disk(self, monkeypatch):

--- a/tests/unit/test_app_shell_routes.py
+++ b/tests/unit/test_app_shell_routes.py
@@ -51,6 +51,7 @@ class TestAmbience:
         assert payload["duck"]["enabled"] is True
         assert payload["duck"]["quips"]["standup_done"]
         assert payload["music"]["channels"]
+        assert [s["key"] for s in payload["music"]["services"]] == ["spotify", "apple_music", "youtube_music"]
         assert payload["saver"]["idle_seconds"] > 0
         assert payload["pet"]["enabled"] is False
 

--- a/tests/unit/test_catalog_tui.py
+++ b/tests/unit/test_catalog_tui.py
@@ -46,6 +46,14 @@ class TestBrowse:
         for label in labels:
             assert label in seen, f"{label} never renders in the catalog"
 
+    def test_the_music_shelf_names_its_three_services(self, payload):
+        # Keyless services are still catalogue entries: the shelf is where a
+        # user finds out they exist, on this surface as on the desktop.
+        out = _render(build_catalog_screen(payload, 0, filter_text="music", width=120, height=44))
+        assert "Music" in out
+        for label in ("Spotify", "Apple Music", "YouTube Music"):
+            assert label in out, f"{label} missing from the music shelf"
+
     def test_the_filter_narrows_by_label_summary_and_family(self, payload):
         assert [r["key"] for r in visible_rows(payload, "gitla")] == ["gitlab"]
         assert "sentry" in [r["key"] for r in visible_rows(payload, "error")]  # family label

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -118,7 +118,7 @@ class TestCopyContract:
 
     # CamelCase-shaped names that are products, not internals.
     PRODUCT_NAMES = frozenset(
-        {"GitHub", "DevOps", "PyPI", "JetBrains", "OpenAI", "JavaScript", "TypeScript", "DeepSeek"}
+        {"GitHub", "DevOps", "PyPI", "JetBrains", "OpenAI", "JavaScript", "TypeScript", "DeepSeek", "YouTube"}
     )
 
     BANNED = (

--- a/tests/unit/test_connectors_oauth.py
+++ b/tests/unit/test_connectors_oauth.py
@@ -1,0 +1,278 @@
+"""The music sign-in: PKCE, the authorize URL, the callback, the exchange, the cache."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import threading
+import urllib.request
+
+import pytest
+
+from yeaboi.connectors import oauth, oauth_clients
+
+
+class FakeResponse:
+    def __init__(self, status: int, body: dict | None = None):
+        self.status_code = status
+        self._body = body or {}
+        self.content = b"{}"
+        self.headers: dict[str, str] = {}
+
+    def json(self):
+        return self._body
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    oauth.reset_cache()
+    for env in ("SPOTIFY_CLIENT_ID", "SPOTIFY_REFRESH_TOKEN", "SPOTIFY_ACCOUNT", "YEABOI_OAUTH_PORT"):
+        monkeypatch.delenv(env, raising=False)
+    yield
+    oauth.reset_cache()
+
+
+class TestPkce:
+    def test_the_challenge_is_the_s256_of_the_verifier(self):
+        verifier, challenge = oauth.pkce_pair()
+        assert 43 <= len(verifier) <= 128
+        assert set(verifier) <= set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+        assert challenge == expected
+        assert "=" not in challenge
+
+    def test_pairs_and_states_are_fresh(self):
+        assert oauth.pkce_pair()[0] != oauth.pkce_pair()[0]
+        assert oauth.new_state() != oauth.new_state()
+
+
+class TestAuthorizeUrl:
+    def test_spotify_names_the_loopback_ip_and_pkce(self):
+        from urllib.parse import parse_qs, urlparse
+
+        url = oauth.authorize_url(oauth.PROVIDERS["spotify"], "cid", oauth.redirect_uri("spotify", 8643), "st", "ch")
+        parsed = urlparse(url)
+        assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://accounts.spotify.com/authorize"
+        query = parse_qs(parsed.query)
+        assert query["redirect_uri"] == ["http://127.0.0.1:8643/callback/spotify"]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["code_challenge"] == ["ch"] and query["state"] == ["st"] and query["client_id"] == ["cid"]
+        assert "user-library-read" in query["scope"][0]
+        assert "access_type" not in query
+
+    def test_google_asks_for_offline_consent_and_only_reads(self):
+        from urllib.parse import parse_qs, urlparse
+
+        url = oauth.authorize_url(
+            oauth.PROVIDERS["youtube_music"], "cid", oauth.redirect_uri("youtube_music"), "s", "c"
+        )
+        query = parse_qs(urlparse(url).query)
+        assert query["access_type"] == ["offline"] and query["prompt"] == ["consent"]
+        assert query["scope"] == ["https://www.googleapis.com/auth/youtube.readonly"]
+
+    def test_the_port_is_fixed_and_overridable(self, monkeypatch):
+        assert oauth.oauth_port() == 8643
+        monkeypatch.setenv("YEABOI_OAUTH_PORT", "9911")
+        assert oauth.redirect_uri("spotify") == "http://127.0.0.1:9911/callback/spotify"
+        monkeypatch.setenv("YEABOI_OAUTH_PORT", "not-a-port")
+        assert oauth.oauth_port() == 8643
+
+
+class TestCallback:
+    def test_a_matching_state_yields_the_code(self):
+        assert oauth.parse_callback("/callback/spotify?code=abc&state=st", "st") == "abc"
+
+    def test_anything_else_is_a_named_refusal_that_echoes_nothing(self):
+        with pytest.raises(oauth.CallbackError, match="did not match"):
+            oauth.parse_callback("/callback/spotify?code=abc&state=other", "st")
+        with pytest.raises(oauth.CallbackError, match="refused"):
+            oauth.parse_callback("/callback/spotify?error=access_denied&state=st", "st")
+        with pytest.raises(oauth.CallbackError, match="without a code"):
+            oauth.parse_callback("/callback/spotify?state=st", "st")
+        with pytest.raises(oauth.CallbackError) as info:
+            oauth.parse_callback("/callback/spotify?error=server_error&error_description=SECRET-DETAIL&state=st", "st")
+        assert "SECRET-DETAIL" not in str(info.value)
+
+
+class TestListener:
+    def test_it_catches_one_redirect_and_answers_a_page_without_the_query(self):
+        listener = oauth._CallbackServer("spotify", "st", 0)
+        port = listener._server.server_address[1]
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?code=the-code&state=st") as resp:
+                body = resp.read().decode()
+                assert resp.status == 200
+            assert "close this tab" in body and "the-code" not in body
+            assert listener.code == "the-code" and listener.done
+            listener._thread.join(timeout=3)
+            assert not listener._thread.is_alive()
+        finally:
+            listener.close()
+
+    def test_a_wrong_state_is_a_400_and_a_message(self):
+        listener = oauth._CallbackServer("spotify", "st", 0)
+        port = listener._server.server_address[1]
+        try:
+            with pytest.raises(urllib.error.HTTPError) as info:
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?code=x&state=nope")
+            assert info.value.code == 400
+            assert "x" not in info.value.read().decode().split("<h1>")[1]
+            assert listener.error and not listener.code
+        finally:
+            listener.close()
+
+    def test_a_busy_port_is_a_hard_error_never_a_walk(self):
+        first = oauth._CallbackServer("spotify", "st", 0)
+        port = first._server.server_address[1]
+        try:
+            with pytest.raises(OSError):
+                oauth._CallbackServer("spotify", "st", port)
+        finally:
+            first.close()
+
+
+class TestSession:
+    def test_no_client_fails_cleanly_and_names_the_field(self):
+        session = oauth.OAuthSignIn("spotify")
+        assert session.start() is False
+        assert "SPOTIFY_CLIENT_ID" in session.error and session.done and not session.ok
+
+    def test_apple_has_no_sign_in(self):
+        session = oauth.OAuthSignIn("apple_music")
+        assert session.start() is False and "no sign-in" in session.error
+
+    def test_a_busy_port_names_the_override(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_CLIENT_ID", "own-client")
+        holder = oauth._CallbackServer("spotify", "st", 0)
+        monkeypatch.setenv("YEABOI_OAUTH_PORT", str(holder._server.server_address[1]))
+        try:
+            session = oauth.OAuthSignIn("spotify")
+            assert session.start() is False
+            assert "YEABOI_OAUTH_PORT" in session.error
+        finally:
+            holder.close()
+
+    def test_the_whole_flow_persists_the_token_and_the_name_and_never_echoes(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_CLIENT_ID", "own-client")
+        monkeypatch.setenv("YEABOI_OAUTH_PORT", "0")
+        applied: dict[str, str] = {}
+        monkeypatch.setattr("yeaboi.config.apply_config_value", lambda k, v: applied.__setitem__(k, v))
+        posted: list[dict] = []
+
+        def fake_post(url, *, data, timeout=10):
+            posted.append({"url": url, **data})
+            return FakeResponse(200, {"access_token": "AT", "refresh_token": "RT", "expires_in": 3600})
+
+        monkeypatch.setattr(oauth.http, "post_form", fake_post)
+        monkeypatch.setattr(oauth.http, "get_json", lambda url, headers: FakeResponse(200, {"display_name": "dinho"}))
+
+        session = oauth.OAuthSignIn("spotify")
+        assert session.start() is True
+        assert session.url.startswith("https://accounts.spotify.com/authorize?")
+        port = session._listener._server.server_address[1]
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?code=the-code&state={session._state}").read()
+        for _ in range(100):
+            session.poll()
+            if session.done:
+                break
+            session._worker and session._worker.join(timeout=0.1)
+        assert session.ok and session.persisted
+        assert applied == {"SPOTIFY_REFRESH_TOKEN": "RT", "SPOTIFY_ACCOUNT": "dinho"}
+        assert posted[0]["grant_type"] == "authorization_code" and posted[0]["code"] == "the-code"
+        assert posted[0]["code_verifier"] == session._verifier and "client_secret" not in posted[0]
+        assert session.message == "Signed in as dinho"
+        assert "RT" not in session.message and "AT" not in session.url
+
+    def test_a_refused_exchange_is_a_message(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_CLIENT_ID", "own-client")
+        monkeypatch.setenv("YEABOI_OAUTH_PORT", "0")
+        monkeypatch.setattr(
+            oauth.http, "post_form", lambda url, *, data, timeout=10: FakeResponse(400, {"error": "invalid_grant"})
+        )
+        session = oauth.OAuthSignIn("spotify")
+        assert session.start()
+        port = session._listener._server.server_address[1]
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?code=c&state={session._state}").read()
+        for _ in range(100):
+            session.poll()
+            if session.done:
+                break
+            session._worker and session._worker.join(timeout=0.1)
+        assert not session.ok and "client ID" in session.error
+
+    def test_cancel_is_safe_in_any_state(self):
+        session = oauth.OAuthSignIn("spotify")
+        session.cancel()
+        session.cancel()
+        assert session.message == "Sign-in cancelled"
+
+
+class TestBearer:
+    def test_a_missing_token_is_signed_out(self):
+        with pytest.raises(oauth.SignedOutError, match="Sign in"):
+            oauth.bearer_for("spotify")
+
+    def test_a_refresh_is_cached_and_a_rotated_token_persisted(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_CLIENT_ID", "own-client")
+        monkeypatch.setenv("SPOTIFY_REFRESH_TOKEN", "RT1")
+        applied: dict[str, str] = {}
+        monkeypatch.setattr("yeaboi.config.apply_config_value", lambda k, v: applied.__setitem__(k, v))
+        calls: list[dict] = []
+
+        def fake_post(url, *, data, timeout=10):
+            calls.append(data)
+            return FakeResponse(200, {"access_token": "AT1", "refresh_token": "RT2", "expires_in": 3600})
+
+        monkeypatch.setattr(oauth.http, "post_form", fake_post)
+        assert oauth.bearer_for("spotify") == "AT1"
+        assert oauth.bearer_for("spotify") == "AT1"
+        assert len(calls) == 1 and calls[0]["grant_type"] == "refresh_token"
+        assert applied == {"SPOTIFY_REFRESH_TOKEN": "RT2"}
+
+    def test_a_refused_refresh_signs_out(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_CLIENT_ID", "own-client")
+        monkeypatch.setenv("SPOTIFY_REFRESH_TOKEN", "RT-expired")
+        monkeypatch.setenv("SPOTIFY_ACCOUNT", "dinho")
+        applied: dict[str, str] = {}
+        monkeypatch.setattr("yeaboi.config.apply_config_value", lambda k, v: applied.__setitem__(k, v))
+        monkeypatch.setattr(
+            oauth.http, "post_form", lambda url, *, data, timeout=10: FakeResponse(400, {"error": "invalid_grant"})
+        )
+        with pytest.raises(oauth.SignedOutError, match="sign in again"):
+            oauth.bearer_for("spotify")
+        assert applied == {"SPOTIFY_REFRESH_TOKEN": "", "SPOTIFY_ACCOUNT": ""}
+
+    def test_sign_out_clears_both_and_the_cache(self, monkeypatch):
+        applied: dict[str, str] = {}
+        monkeypatch.setattr("yeaboi.config.apply_config_value", lambda k, v: applied.__setitem__(k, v))
+        oauth._cache_put("spotify", "AT", 3600)
+        oauth.sign_out("spotify")
+        assert applied == {"SPOTIFY_REFRESH_TOKEN": "", "SPOTIFY_ACCOUNT": ""}
+        assert "spotify" not in oauth._cache
+        oauth.sign_out("apple_music")  # nothing to do, nothing raised
+
+
+class TestClients:
+    def test_the_users_own_client_wins(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_CLIENT_ID", "own")
+        assert oauth_clients.resolve("spotify") == oauth_clients.OAuthClient("own", "", own=True)
+
+    def test_a_blank_builtin_is_none(self, monkeypatch):
+        monkeypatch.delenv("SPOTIFY_CLIENT_ID", raising=False)
+        monkeypatch.setattr(oauth_clients, "_BUILTIN", {"spotify": ("", "")})
+        assert oauth_clients.resolve("spotify") is None
+        monkeypatch.setattr(oauth_clients, "_BUILTIN", {"spotify": ("builtin", "")})
+        assert oauth_clients.resolve("spotify") == oauth_clients.OAuthClient("builtin", "", own=False)
+
+    def test_google_carries_its_non_confidential_secret(self, monkeypatch):
+        monkeypatch.setenv("YOUTUBE_MUSIC_CLIENT_ID", "gid")
+        monkeypatch.setenv("YOUTUBE_MUSIC_CLIENT_SECRET", "gsecret")
+        assert oauth_clients.resolve("youtube_music") == oauth_clients.OAuthClient("gid", "gsecret", own=True)
+
+
+def test_the_listener_thread_is_a_daemon():
+    listener = oauth._CallbackServer("spotify", "st", 0)
+    try:
+        assert isinstance(listener._thread, threading.Thread) and listener._thread.daemon
+    finally:
+        listener.close()

--- a/tests/unit/test_connectors_oauth.py
+++ b/tests/unit/test_connectors_oauth.py
@@ -20,6 +20,8 @@ class FakeResponse:
         self.headers: dict[str, str] = {}
 
     def json(self):
+        if self._body is None:
+            raise ValueError("not json")
         return self._body
 
 
@@ -76,6 +78,8 @@ class TestAuthorizeUrl:
         assert oauth.redirect_uri("spotify") == "http://127.0.0.1:9911/callback/spotify"
         monkeypatch.setenv("YEABOI_OAUTH_PORT", "not-a-port")
         assert oauth.oauth_port() == 8643
+        monkeypatch.setenv("YEABOI_OAUTH_PORT", "70000")
+        assert oauth.oauth_port() == 8643
 
 
 class TestCallback:
@@ -118,6 +122,23 @@ class TestListener:
             assert info.value.code == 400
             assert "x" not in info.value.read().decode().split("<h1>")[1]
             assert listener.error and not listener.code
+        finally:
+            listener.close()
+
+    def test_close_releases_the_port_for_the_next_sign_in(self):
+        first = oauth._CallbackServer("spotify", "st", 0)
+        port = first._server.server_address[1]
+        first.close()
+        second = oauth._CallbackServer("spotify", "st", port)
+        second.close()
+
+    def test_a_non_ascii_state_is_a_400_page_not_a_traceback(self):
+        listener = oauth._CallbackServer("spotify", "st", 0)
+        port = listener._server.server_address[1]
+        try:
+            with pytest.raises(urllib.error.HTTPError) as info:
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?code=x&state=%C3%A9")
+            assert info.value.code == 400
         finally:
             listener.close()
 
@@ -200,6 +221,21 @@ class TestSession:
             session._worker and session._worker.join(timeout=0.1)
         assert not session.ok and "client ID" in session.error
 
+    def test_a_token_body_that_is_not_one_ends_the_sign_in(self, monkeypatch):
+        monkeypatch.setenv("SPOTIFY_CLIENT_ID", "own-client")
+        monkeypatch.setenv("YEABOI_OAUTH_PORT", "0")
+        monkeypatch.setattr(oauth.http, "post_form", lambda url, *, data, timeout=10: FakeResponse(200, None))
+        session = oauth.OAuthSignIn("spotify")
+        assert session.start()
+        port = session._listener._server.server_address[1]
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?code=c&state={session._state}").read()
+        for _ in range(100):
+            session.poll()
+            if session.done:
+                break
+            session._worker and session._worker.join(timeout=0.1)
+        assert session.done and not session.ok and "token" in session.error
+
     def test_cancel_is_safe_in_any_state(self):
         session = oauth.OAuthSignIn("spotify")
         session.cancel()
@@ -242,13 +278,17 @@ class TestBearer:
             oauth.bearer_for("spotify")
         assert applied == {"SPOTIFY_REFRESH_TOKEN": "", "SPOTIFY_ACCOUNT": ""}
 
-    def test_sign_out_clears_both_and_the_cache(self, monkeypatch):
+    def test_sign_out_clears_both_the_cache_and_the_pages(self, monkeypatch):
+        from yeaboi.connectors import library
+
         applied: dict[str, str] = {}
         monkeypatch.setattr("yeaboi.config.apply_config_value", lambda k, v: applied.__setitem__(k, v))
         oauth._cache_put("spotify", "AT", 3600)
+        library.cached(("spotify", "library", "x"), 60, lambda: library.Page())
         oauth.sign_out("spotify")
         assert applied == {"SPOTIFY_REFRESH_TOKEN": "", "SPOTIFY_ACCOUNT": ""}
         assert "spotify" not in oauth._cache
+        assert not [k for k in library._cache if k[0] == "spotify"]
         oauth.sign_out("apple_music")  # nothing to do, nothing raised
 
 

--- a/tests/unit/test_connectors_oauth.py
+++ b/tests/unit/test_connectors_oauth.py
@@ -113,7 +113,9 @@ class TestListener:
         finally:
             listener.close()
 
-    def test_a_wrong_state_is_a_400_and_a_message(self):
+    def test_a_wrong_state_is_a_400_and_the_listener_keeps_waiting(self):
+        # A stale tab, a reload, or any page poking the port must not abort the
+        # real sign-in that is still on its way.
         listener = oauth._CallbackServer("spotify", "st", 0)
         port = listener._server.server_address[1]
         try:
@@ -121,7 +123,19 @@ class TestListener:
                 urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?code=x&state=nope")
             assert info.value.code == 400
             assert "x" not in info.value.read().decode().split("<h1>")[1]
-            assert listener.error and not listener.code
+            assert not listener.error and not listener.code and not listener.done
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?code=real&state=st").read()
+            assert listener.code == "real" and listener.done
+        finally:
+            listener.close()
+
+    def test_the_vendor_refusing_it_settles_the_sign_in(self):
+        listener = oauth._CallbackServer("spotify", "st", 0)
+        port = listener._server.server_address[1]
+        try:
+            with pytest.raises(urllib.error.HTTPError):
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/callback/spotify?error=access_denied&state=st")
+            assert listener.error == "Sign-in was refused" and listener.done
         finally:
             listener.close()
 
@@ -182,11 +196,17 @@ class TestSession:
 
         def fake_post(url, *, data, timeout=10):
             posted.append({"url": url, **data})
-            return FakeResponse(200, {"access_token": "AT", "refresh_token": "RT", "expires_in": 3600})
+            return FakeResponse(
+                200,
+                {"access_token": "ACCESS-TOKEN-VALUE-1", "refresh_token": "REFRESH-TOKEN-VALUE-1", "expires_in": 3600},
+            )
 
         monkeypatch.setattr(oauth.http, "post_form", fake_post)
         monkeypatch.setattr(oauth.http, "get_json", lambda url, headers: FakeResponse(200, {"display_name": "dinho"}))
 
+        from yeaboi.connectors import library
+
+        library.cached(("spotify", "library", "old-account"), 60, lambda: library.Page())
         session = oauth.OAuthSignIn("spotify")
         assert session.start() is True
         assert session.url.startswith("https://accounts.spotify.com/authorize?")
@@ -198,11 +218,13 @@ class TestSession:
                 break
             session._worker and session._worker.join(timeout=0.1)
         assert session.ok and session.persisted
-        assert applied == {"SPOTIFY_REFRESH_TOKEN": "RT", "SPOTIFY_ACCOUNT": "dinho"}
+        assert applied == {"SPOTIFY_REFRESH_TOKEN": "REFRESH-TOKEN-VALUE-1", "SPOTIFY_ACCOUNT": "dinho"}
+        # Whoever was signed in before: their cached pages are gone.
+        assert not [k for k in library._cache if k[0] == "spotify"]
         assert posted[0]["grant_type"] == "authorization_code" and posted[0]["code"] == "the-code"
         assert posted[0]["code_verifier"] == session._verifier and "client_secret" not in posted[0]
         assert session.message == "Signed in as dinho"
-        assert "RT" not in session.message and "AT" not in session.url
+        assert "TOKEN-VALUE" not in session.message and "TOKEN-VALUE" not in session.url
 
     def test_a_refused_exchange_is_a_message(self, monkeypatch):
         monkeypatch.setenv("SPOTIFY_CLIENT_ID", "own-client")

--- a/tests/unit/test_connectors_spec.py
+++ b/tests/unit/test_connectors_spec.py
@@ -142,6 +142,43 @@ class TestSecrets:
                 assert not (f.choices and f.secret), f"{c.key}.{f.env} is both a choice and a secret"
 
 
+class TestSignIn:
+    """A sign-in's fields are minted by a flow: never typed, never a choice, always masked."""
+
+    def test_a_signin_field_is_optional_and_named_by_its_connector(self):
+        for c in ALL:
+            for f in c.fields:
+                if f.action != "signin":
+                    continue
+                assert not f.required, f"{c.key}.{f.env} is minted by a sign-in and cannot be required"
+                assert not f.choices and not f.verify_arg, f"{c.key}.{f.env} is a sign-in field with typed semantics"
+                assert f.env in (c.signin_env, c.account_env), (
+                    f"{c.key}.{f.env} is a sign-in field the descriptor does not name"
+                )
+
+    def test_the_token_is_secret_and_the_name_is_not(self):
+        for c in ALL:
+            if not c.can_sign_in:
+                continue
+            by_env = {f.env: f for f in c.fields}
+            assert by_env[c.signin_env].secret, f"{c.key}'s refresh token would be shown"
+            assert by_env[c.signin_env].action == "signin"
+            if c.account_env:
+                assert not by_env[c.account_env].secret, f"{c.key}'s display name is not a credential"
+                assert by_env[c.account_env].action == "signin"
+
+    def test_a_signin_never_makes_a_connector_connected(self):
+        # Signing in is optional; the playback choice is what switches a service on.
+        for c in ALL:
+            if c.can_sign_in:
+                assert c.signin_env not in c.required_envs, f"{c.key} would count a token as its switch"
+
+    def test_every_signin_has_a_provider(self):
+        from yeaboi.connectors.oauth import PROVIDERS
+
+        assert {c.key for c in ALL if c.can_sign_in} == set(PROVIDERS)
+
+
 class TestVerification:
     def test_every_named_probe_exists(self):
         from yeaboi import provider_verification

--- a/tests/unit/test_connectors_spec.py
+++ b/tests/unit/test_connectors_spec.py
@@ -247,8 +247,10 @@ class TestTheFetchSeam:
     # Delivery trackers verify a credential and feed the catalog, but the
     # ops-event vocabulary has no delivery kind — their read/write path is the
     # tracker integration, not a gather. Verify stays: a credential the user
-    # just typed must be probeable.
-    _CATALOG_ONLY = {"linear", "trello"}
+    # just typed must be probeable. The music services are the same shape for
+    # a different reason: playback is the desktop's job, and nothing about a
+    # playlist is an ops event.
+    _CATALOG_ONLY = {"linear", "trello", "spotify", "apple_music", "youtube_music"}
 
     def test_a_connector_that_can_be_verified_can_be_gathered_from(self):
         # An entry in the catalog that verifies but returns nothing is a settings

--- a/tests/unit/test_music_library.py
+++ b/tests/unit/test_music_library.py
@@ -1,0 +1,310 @@
+"""The music library layer: vendor payloads onto one row, refusals onto one vocabulary."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from yeaboi.connectors import library, library_apple, library_spotify, library_youtube, oauth
+
+
+class FakeResponse:
+    def __init__(self, status: int, body=None, headers: dict | None = None, content: bytes = b"{}"):
+        self.status_code = status
+        self._body = body
+        self.headers = headers or {}
+        self.content = content if body is not None or status == 204 else b""
+
+    def json(self):
+        if self._body is None:
+            raise ValueError("no json")
+        return self._body
+
+
+# The desktop's link grammar, ported: every URL a row carries must pass it.
+SPOTIFY_URL = re.compile(r"^https://open\.spotify\.com/(track|album|playlist|artist)/[A-Za-z0-9]{22}$")
+YOUTUBE_URL = re.compile(r"^https://www\.youtube\.com/(watch\?v=[A-Za-z0-9_-]{11}|playlist\?list=[A-Za-z0-9_-]+)$")
+APPLE_URL = re.compile(r"^https://music\.apple\.com/[a-z]{2}/album/[a-z0-9-]+/\d+(\?i=\d{4,})?$")
+
+SPOTIFY_ID = "4uLU6hMCjMI75M1A2tKUQC"
+SPOTIFY_TRACK = {
+    "id": SPOTIFY_ID,
+    "name": "Never Gonna Give You Up",
+    "uri": f"spotify:track:{SPOTIFY_ID}",
+    "duration_ms": 213573,
+    "preview_url": "https://p.scdn.co/mp3-preview/x",
+    "artists": [{"name": "Rick Astley"}],
+    "album": {"name": "Whenever You Need Somebody", "images": [{"url": "big"}, {"url": "mid"}, {"url": "small"}]},
+}
+SPOTIFY_PLAYLIST = {
+    "id": "37i9dQZF1DX8Uebhn9wzrS",
+    "name": "Deep Focus",
+    "uri": "spotify:playlist:37i9dQZF1DX8Uebhn9wzrS",
+    "owner": {"display_name": "Spotify"},
+    "images": [{"url": "cover"}],
+    "tracks": {"total": 120},
+}
+
+
+@pytest.fixture(autouse=True)
+def _signed_in(monkeypatch):
+    library._cache.clear()
+    oauth.reset_cache()
+    monkeypatch.setattr(oauth, "bearer_for", lambda key: "AT")
+    yield
+    library._cache.clear()
+
+
+def serve(monkeypatch, status=200, body=None, headers=None, calls=None):
+    def fake_get(url, *, headers=None, timeout=10):
+        if calls is not None:
+            calls.append(url)
+        return FakeResponse(status, body, headers)
+
+    monkeypatch.setattr(library.http, "get_json", fake_get)
+
+
+class TestSpotifyRows:
+    def test_a_track_row_carries_a_share_link_the_desktop_parses(self):
+        item = library_spotify.track_item(SPOTIFY_TRACK)
+        assert item.kind == "track" and item.title == "Never Gonna Give You Up"
+        assert item.subtitle == "Rick Astley · Whenever You Need Somebody"
+        assert item.artwork_url == "mid" and item.duration_ms == 213573
+        assert SPOTIFY_URL.match(item.url) and item.uri == f"spotify:track:{SPOTIFY_ID}"
+        assert item.preview_url
+
+    def test_a_playlist_row(self):
+        item = library_spotify.playlist_item(SPOTIFY_PLAYLIST)
+        assert item.kind == "playlist" and item.subtitle == "Spotify" and item.count == 120
+        assert SPOTIFY_URL.match(item.url)
+
+    def test_junk_rows_are_dropped(self):
+        assert library_spotify.track_item({}) is None
+        assert library_spotify.track_item(None) is None
+        assert library_spotify.album_item({"name": "no id"}) is None
+
+    def test_the_liked_shelf_pages_by_offset(self, monkeypatch):
+        calls: list[str] = []
+        serve(monkeypatch, 200, {"items": [{"track": SPOTIFY_TRACK}], "total": 45, "next": "…"}, calls=calls)
+        page = library_spotify.library("liked", "", 20)
+        assert [i.id for i in page.items] == [SPOTIFY_ID] and page.next_cursor == "20"
+        assert calls[0].startswith("https://api.spotify.com/v1/me/tracks?") and "offset=0" in calls[0]
+        last = library_spotify.library("liked", "40", 20)
+        assert last.next_cursor == "" or calls[-1].endswith("offset=40")
+
+    def test_recently_played_pages_by_cursor(self, monkeypatch):
+        serve(monkeypatch, 200, {"items": [{"track": SPOTIFY_TRACK}], "cursors": {"before": "1700"}, "next": "…"})
+        page = library_spotify.library("recent", "", 20)
+        assert page.next_cursor == "1700"
+
+    def test_an_unknown_shelf_is_a_400(self):
+        with pytest.raises(library.LibraryError) as info:
+            library_spotify.library("moods")
+        assert info.value.code == "unsupported_shelf" and info.value.status == 400
+
+    def test_search_merges_the_three_kinds_and_caps_at_ten(self, monkeypatch):
+        calls: list[str] = []
+        serve(
+            monkeypatch,
+            200,
+            {"tracks": {"items": [SPOTIFY_TRACK]}, "albums": {"items": []}, "playlists": {"items": [SPOTIFY_PLAYLIST]}},
+            calls=calls,
+        )
+        page = library_spotify.search("rick", 50)
+        assert [i.kind for i in page.items] == ["track", "playlist"]
+        assert "limit=10" in calls[0]
+
+    def test_play_builds_the_right_body_and_refuses_a_bad_uri(self, monkeypatch):
+        sent: list[tuple[str, dict]] = []
+        monkeypatch.setattr(
+            library.http,
+            "put_json",
+            lambda url, *, headers, payload, timeout=10: sent.append((url, payload)) or FakeResponse(204),
+        )
+        library_spotify.play(f"spotify:track:{SPOTIFY_ID}")
+        library_spotify.play("spotify:playlist:37i9dQZF1DX8Uebhn9wzrS", "dev1")
+        assert sent[0] == ("https://api.spotify.com/v1/me/player/play", {"uris": [f"spotify:track:{SPOTIFY_ID}"]})
+        assert sent[1][0].endswith("?device_id=dev1") and sent[1][1] == {
+            "context_uri": "spotify:playlist:37i9dQZF1DX8Uebhn9wzrS"
+        }
+        with pytest.raises(library.LibraryError, match="not a Spotify URI"):
+            library_spotify.play("spotify:track:../evil")
+
+    def test_player_reads_nothing_playing_as_quiet(self, monkeypatch):
+        serve(monkeypatch, 204, None)
+        assert library_spotify.player() == {"playing": False, "progress_ms": 0, "item": None, "device": None}
+        serve(
+            monkeypatch,
+            200,
+            {"is_playing": True, "progress_ms": 12000, "item": SPOTIFY_TRACK, "device": {"id": "d", "name": "Mac"}},
+        )
+        now = library_spotify.player()
+        assert now["playing"] and now["item"]["id"] == SPOTIFY_ID and now["device"] == {"id": "d", "name": "Mac"}
+
+
+class TestYouTubeRows:
+    def test_a_playlist_item_row_is_a_watch_link(self):
+        row = {
+            "snippet": {
+                "title": "Song",
+                "videoOwnerChannelTitle": "Artist",
+                "resourceId": {"videoId": "dQw4w9WgXcQ"},
+                "thumbnails": {"medium": {"url": "thumb"}},
+            }
+        }
+        item = library_youtube.video_item(row)
+        assert item.kind == "video" and item.subtitle == "Artist" and item.artwork_url == "thumb"
+        assert YOUTUBE_URL.match(item.url)
+
+    def test_private_and_deleted_videos_are_dropped(self):
+        row = {"snippet": {"title": "Private video", "resourceId": {"videoId": "dQw4w9WgXcQ"}}}
+        assert library_youtube.video_item(row) is None
+
+    def test_a_playlist_row_and_page_tokens(self, monkeypatch):
+        calls: list[str] = []
+        body = {
+            "items": [
+                {"id": "PLx", "snippet": {"title": "Focus", "channelTitle": "Me"}, "contentDetails": {"itemCount": 9}}
+            ],
+            "nextPageToken": "CAUQAA",
+        }
+        serve(monkeypatch, 200, body, calls=calls)
+        page = library_youtube.library("playlists", "", 20)
+        assert page.items[0].count == 9 and YOUTUBE_URL.match(page.items[0].url)
+        assert page.next_cursor == "CAUQAA" and "mine=true" in calls[0]
+
+    def test_liked_is_the_ll_playlist_and_albums_are_unsupported(self, monkeypatch):
+        calls: list[str] = []
+        serve(monkeypatch, 200, {"items": []}, calls=calls)
+        library_youtube.library("liked")
+        assert "playlistId=LL" in calls[0]
+        with pytest.raises(library.LibraryError) as info:
+            library_youtube.library("albums")
+        assert info.value.status == 400
+
+    def test_search_stays_in_the_music_category_and_is_cached(self, monkeypatch):
+        calls: list[str] = []
+        serve(monkeypatch, 200, {"items": [{"id": {"videoId": "dQw4w9WgXcQ"}, "snippet": {"title": "S"}}]}, calls=calls)
+        first = library_youtube.search("rick")
+        second = library_youtube.search("Rick ")
+        assert first is second and len(calls) == 1 and "videoCategoryId=10" in calls[0]
+
+
+class TestAppleRows:
+    def test_a_song_result_is_an_album_link_with_the_track_and_a_preview(self, monkeypatch):
+        body = {
+            "results": [
+                {
+                    "wrapperType": "track",
+                    "trackId": 1440935467,
+                    "collectionId": 1440935400,
+                    "trackName": "Get Lucky",
+                    "artistName": "Daft Punk",
+                    "collectionName": "Random Access Memories (Deluxe)",
+                    "artworkUrl100": "https://a/100x100bb.jpg",
+                    "trackTimeMillis": 369000,
+                    "previewUrl": "https://p/preview.m4a",
+                },
+                {
+                    "wrapperType": "collection",
+                    "collectionId": 5,
+                    "collectionName": "RAM",
+                    "artistName": "Daft Punk",
+                    "trackCount": 13,
+                },
+                {"wrapperType": "artist", "artistId": 1},
+            ]
+        }
+        monkeypatch.setattr(library_apple.http, "get_json", lambda url, headers, timeout=10: FakeResponse(200, body))
+        page = library_apple.search("daft punk", 20, "GB")
+        song, album = page.items
+        assert (
+            song.kind == "song"
+            and APPLE_URL.match(song.url)
+            and song.url.startswith("https://music.apple.com/gb/album/")
+        )
+        assert (
+            song.url.endswith("/1440935400?i=1440935467")
+            and song.preview_url
+            and song.artwork_url.endswith("300x300bb.jpg")
+        )
+        assert album.kind == "album" and album.count == 13 and APPLE_URL.match(album.url)
+
+    def test_a_bad_country_is_us_and_a_slug_is_never_empty(self):
+        assert library_apple._country("zzz") == "us"
+        assert library_apple.slug("!!!") == "album"
+        assert library_apple.slug("Random Access Memories (Deluxe)") == "random-access-memories-deluxe"
+
+
+class TestRefusals:
+    @pytest.mark.parametrize(
+        ("status", "body", "code", "http_status"),
+        [
+            (401, {}, "signed_out", 409),
+            (403, {"error": {"status": 403, "reason": "PREMIUM_REQUIRED"}}, "premium_required", 403),
+            (403, {"error": {"errors": [{"reason": "quotaExceeded"}]}}, "quota_exceeded", 429),
+            (403, {"error": "forbidden"}, "not_allowlisted", 403),
+            (404, {"error": {"reason": "NO_ACTIVE_DEVICE"}}, "no_active_device", 409),
+            (429, {}, "rate_limited", 429),
+            (503, None, "unavailable", 502),
+        ],
+    )
+    def test_every_vendor_refusal_has_one_name(self, status, body, code, http_status):
+        error = library.translate("spotify", FakeResponse(status, body, {"Retry-After": "7"}))
+        assert error.code == code and error.status == http_status
+        if code == "rate_limited":
+            assert error.retry_after == 7 and error.as_dict()["retry_after"] == 7
+        assert set(error.as_dict()) >= {"error", "code"}
+
+    def test_a_401_gets_one_forced_refresh_then_signs_out(self, monkeypatch):
+        tokens = iter(["AT-old", "AT-new"])
+        monkeypatch.setattr(oauth, "bearer_for", lambda key: next(tokens))
+        seen: list[str] = []
+
+        def fake_get(url, *, headers, timeout=10):
+            seen.append(headers["Authorization"])
+            return FakeResponse(401, {})
+
+        monkeypatch.setattr(library.http, "get_json", fake_get)
+        with pytest.raises(library.LibraryError) as info:
+            library.vendor_get("spotify", "https://api.spotify.com/v1/me")
+        assert seen == ["Bearer AT-old", "Bearer AT-new"] and info.value.code == "signed_out"
+
+    def test_a_missing_token_is_signed_out_before_any_request(self, monkeypatch):
+        monkeypatch.setattr(
+            oauth, "bearer_for", lambda key: (_ for _ in ()).throw(oauth.SignedOutError("Sign in to Spotify"))
+        )
+        with pytest.raises(library.LibraryError) as info:
+            library_spotify.library("playlists")
+        assert info.value.code == "signed_out" and info.value.status == 409
+
+    def test_a_transport_failure_is_unavailable_and_names_no_url(self, monkeypatch):
+        def boom(url, *, headers, timeout=10):
+            raise ConnectionError("https://api.spotify.com/v1/me?token=SECRET")
+
+        monkeypatch.setattr(library.http, "get_json", boom)
+        with pytest.raises(library.LibraryError) as info:
+            library.vendor_get("spotify", "https://api.spotify.com/v1/me")
+        assert info.value.code == "unavailable" and "SECRET" not in info.value.message
+
+
+class TestCache:
+    def test_pages_are_kept_and_forgotten_per_service(self, monkeypatch):
+        calls: list[str] = []
+        serve(monkeypatch, 200, {"items": [], "total": 0}, calls=calls)
+        library_spotify.library("playlists")
+        library_spotify.library("playlists")
+        assert len(calls) == 1
+        library.forget("spotify")
+        library_spotify.library("playlists")
+        assert len(calls) == 2
+
+    def test_the_cache_is_bounded(self):
+        for i in range(library.CACHE_ENTRIES + 10):
+            library.cached(("k", i), 60, lambda: library.Page())
+        assert len(library._cache) <= library.CACHE_ENTRIES
+
+    def test_limits_clamp(self):
+        assert library.clamp_limit("") == 20 and library.clamp_limit("abc") == 20
+        assert library.clamp_limit("999") == library.MAX_LIMIT and library.clamp_limit(0) == 1

--- a/tests/unit/test_music_library.py
+++ b/tests/unit/test_music_library.py
@@ -130,6 +130,8 @@ class TestSpotifyRows:
         }
         with pytest.raises(library.LibraryError, match="not a Spotify URI"):
             library_spotify.play("spotify:track:../evil")
+        with pytest.raises(library.LibraryError, match="device id"):
+            library_spotify.play(f"spotify:track:{SPOTIFY_ID}", "dev 1")
 
     def test_player_reads_nothing_playing_as_quiet(self, monkeypatch):
         serve(monkeypatch, 204, None)
@@ -189,6 +191,8 @@ class TestYouTubeRows:
         first = library_youtube.search("rick")
         second = library_youtube.search("Rick ")
         assert first is second and len(calls) == 1 and "videoCategoryId=10" in calls[0]
+        # The category filter is only valid on a video-only search.
+        assert "type=video&" in calls[0] or calls[0].endswith("type=video")
 
 
 class TestAppleRows:

--- a/tests/unit/test_provider_verify_music.py
+++ b/tests/unit/test_provider_verify_music.py
@@ -1,0 +1,65 @@
+"""The music connectors' probes — keyless, so they ask only whether the vendor answers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from yeaboi.provider_verification import _verify_apple_music, _verify_spotify, _verify_youtube_music
+
+
+def _resp(status_code: int) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.content = b"{}"
+    r.json.return_value = {}
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    monkeypatch.setattr("socket.getaddrinfo", lambda *a, **k: [(2, 1, 6, "", ("93.184.216.34", 443))])
+
+
+PROBES = [
+    (_verify_spotify, "https://open.spotify.com/oembed?url=", "Spotify's player is reachable"),
+    (_verify_apple_music, "https://itunes.apple.com/lookup?id=", "Apple Music's catalogue is reachable"),
+    (_verify_youtube_music, "https://www.youtube.com/oembed?url=", "YouTube's player is reachable"),
+]
+
+
+@pytest.mark.parametrize(("probe", "prefix", "verified"), PROBES, ids=lambda p: getattr(p, "__name__", str(p)))
+class TestMusicProbes:
+    def test_a_200_from_the_public_endpoint_verifies(self, monkeypatch, probe, prefix, verified):
+        capture = MagicMock(return_value=_resp(200))
+        monkeypatch.setattr("httpx.get", capture)
+        assert probe() == (True, verified)
+        assert capture.call_args.args[0].startswith(prefix)
+        # No credential exists, so none may ride the request.
+        assert capture.call_args.kwargs["headers"] == {}
+
+    def test_anything_else_is_named_by_status(self, monkeypatch, probe, prefix, verified):
+        monkeypatch.setattr("httpx.get", MagicMock(return_value=_resp(503)))
+        assert probe() == (False, "Unexpected response: 503")
+
+    def test_a_transport_failure_is_reported_not_raised(self, monkeypatch, probe, prefix, verified):
+        monkeypatch.setattr("httpx.get", MagicMock(side_effect=ConnectionError("boom")))
+        ok, message = probe()
+        assert ok is False
+        assert message
+
+
+class TestTheProbeUrls:
+    def test_the_share_link_rides_the_query_encoded(self, monkeypatch):
+        capture = MagicMock(return_value=_resp(200))
+        monkeypatch.setattr("httpx.get", capture)
+        _verify_spotify()
+        url = capture.call_args.args[0]
+        assert "url=https%3A%2F%2Fopen.spotify.com%2Fplaylist%2F" in url
+
+    def test_youtube_asks_for_json(self, monkeypatch):
+        capture = MagicMock(return_value=_resp(200))
+        monkeypatch.setattr("httpx.get", capture)
+        _verify_youtube_music()
+        assert capture.call_args.args[0].endswith("&format=json")


### PR DESCRIPTION
## Summary

Spotify, Apple Music and YouTube Music join the integrations catalogue as music sources for the desktop's Music page, and the desktop can now sign in and browse a library instead of only pasting links.

- **Keyless first.** Three `music`-family connectors with one "where it plays" choice field; saving the choice is what switches a service on. `music.services` rides `/api/ambience`. The Classical station moves to Radio France over https. The desktop's `/music` and `/settings/music` routes are carried in the manifest, with a `desktop:music` tip.
- **Optional, read-only sign-in** for Spotify and YouTube Music: Authorization Code + PKCE against yeaboi's registered app or the user's own (`SPOTIFY_CLIENT_ID`, `YOUTUBE_MUSIC_CLIENT_ID` + `_CLIENT_SECRET`), driven a poll at a time like the subscription sign-in. The callback lands on a loopback listener of the backend's own on a fixed port (8643, `YEABOI_OAUTH_PORT`), never on the bearer-gated app wire. The refresh token and display name are connector fields with `action="signin"`: never typed, masked everywhere, the name the one value the catalogue shows. Each service row says which OAuth app a sign-in would use (`own` / `builtin` / `none`); the built-in client IDs are blank until the vendor apps are registered.
- **Library routes** read the signed-in library's shelves, a playlist's tracks and catalogue search into one row shape whose `url` the desktop's link grammar already accepts. Spotify's play/player/devices carry the Premium and no-device refusals the desktop falls back on. Apple's search is keyless through the iTunes Search API, since the desktop browses the Music app itself.
- **One error vocabulary** for a vendor's refusal, with the status the code implies; `signed_out` is a 409 so it is never mistaken for the wire's own auth.

The CLI and the TUI catalogue skip sign-in fields with a pointer to the desktop; the TUI keeps radio only, so a terminal sign-in unlocks nothing there.

Follow-ups, deliberately out of scope: registering yeaboi's own Spotify app and Google client and filling `connectors/oauth_clients.py`; a live Spotify sign-in against a real client (the not-configured path, Apple search and the sign-in offers were verified live from the desktop).

The desktop half is a separate PR in yeaboi-desktop on the same branch name and lands after this wheel is released.

## Test plan

- `make ship-gate`: lint, format-check, the full unit + integration + contract suite, security, and preflight (compat lane on 3.11–3.14) — green.
- New unit suites: `test_connectors_oauth.py` (PKCE vector, authorize URLs, callback parsing and the listener's lifecycle, exchange and refresh with mocked httpx, the port release on close), `test_music_library.py` (vendor payloads onto the row shape, every URL through a port of the desktop grammar, the refusal vocabulary, the forced-refresh-then-sign-out path, the cache), `test_app_music_routes.py` (bearer on every route, the sign-in lifecycle over `AppServer.handle`, error envelopes, no token in any body).
- Extended: `test_ambience.py`, `test_connectors_spec.py` (sign-in field rules), `test_app_settings_routes.py` (token masked, `signin` on the catalogue row), `test_provider_verify_music.py`.
- Independent fresh-context review of `git diff origin/main...HEAD`; its three should-fix findings (port release on close, unguarded token parse, YouTube's category filter) and four nits are fixed in the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSCq1h6KvRjqmtWyTpdpAb
