### PR TITLE
land the version bump even when Claude cannot

### DIFF
--- a/.github/codeql/triage-policy.yml
+++ b/.github/codeql/triage-policy.yml
@@ -48,6 +48,8 @@ propose:
       dismissed as accepted risk once that decision was recorded here.
       auto-version.yml:60 checks out the PR head on purpose, and the file already
       carries the reasoning plus the fine-grained-PAT requirement that bounds it.
+      Its fallback bump step (alert #77) runs the same two PR-head scripts the
+      Claude step already runs, under the same same-repo guard: no new exposure.
       Removing the checkout breaks the workflow_run chain that Claude Review and
       Dependabot verify both depend on. publish.yml's `test` job checks out
       `needs.check.outputs.sha` rather than main for the guarantee the whole file

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -74,7 +74,8 @@ jobs:
           # repository with `Contents: read and write` and nothing else. Do not
           # substitute a classic `repo`-scoped token on rotation: the steps below
           # run `claude-code-action` with unrestricted `Bash` against code checked
-          # out FROM THE PR BRANCH (including `scripts/bump_version.py`), and
+          # out FROM THE PR BRANCH (including `scripts/bump_version.py` and
+          # `scripts/changelog_stub.py`, which the fallback step runs too), and
           # checkout persists this credential into `.git/config`. A fine-grained
           # token bounds a leak to this repo's contents; a classic one would
           # expose the whole account, and the job's `permissions:` block does not

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -125,7 +125,13 @@ jobs:
           #    pushed after the bump+entry land won't refresh the entry — same
           #    acceptance class as the dual-PR version race documented below.
           if [ "$HEAD_V" != "$BASE_V" ]; then
-            if grep -q "\"version\": \"$HEAD_V\"" src/yeaboi/changelog_data.json; then
+            if python scripts/changelog_stub.py is-stub "$HEAD_V"; then
+              # The fallback below wrote a placeholder while Claude was down: run
+              # changelog-only so a working Claude rewrites it in place.
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              echo "changelog_only=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::version already bumped ($BASE_V -> $HEAD_V) with a placeholder changelog entry; running changelog-only to write the real one."
+            elif grep -q "\"version\": \"$HEAD_V\"" src/yeaboi/changelog_data.json; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "::notice::version already changed in this PR ($BASE_V -> $HEAD_V) and changelog entry exists; skipping."
             else
@@ -250,9 +256,14 @@ jobs:
           # which is otherwise indistinguishable from the outside.
           echo "::notice::Claude credential present and well-formed (oauth=$([ -n "$OAUTH" ] && echo yes || echo no) len=${#OAUTH}, api_key=$([ -n "$APIKEY" ] && echo yes || echo no) len=${#APIKEY}). If the step after this one still fails with 401, the stored value is intact and the token was revoked or minted against the wrong account — re-mint it rather than re-pasting."
 
+      # A failure here no longer fails the bump: the fallback step below lands a
+      # deterministic bump when Claude cannot, and the explainer still names the
+      # cause. `outcome` (not `conclusion`) is what carries the real result once
+      # continue-on-error is set.
       - name: Classify & bump with Claude
         id: claude
         if: steps.guard.outputs.skip == 'false'
+        continue-on-error: true
         uses: anthropics/claude-code-action@e2a4b761cd77a1138a5b41410eda9b28581f9bcd # v1.0.196
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -370,18 +381,16 @@ jobs:
       # the last investigation after the model instead of the token. Restate it
       # as an annotation with the remediation attached.
       #
-      # `failure()` is required, not decorative: a step-level `if:` that names no
-      # status function is implicitly ANDed with success(), which would stop this
-      # from ever running. `failure()` rather than `always()` so it stays quiet
-      # on cancellation — this workflow sets cancel-in-progress, so cancels are
-      # routine on any PR that gets a follow-up push.
+      # The Claude step carries continue-on-error, so the job is not failing when
+      # this runs and no status function is needed: `outcome` is the step's real
+      # result, and `conclusion` would read success.
       #
       # The log path is the action's internal temp file, so it can move under the
       # floating @v1 tag. If it does, say so rather than going quietly no-op —
       # a diagnostic that silently stops diagnosing is the exact failure class
       # this whole branch exists to remove.
       - name: Explain an auth failure
-        if: failure() && steps.claude.conclusion == 'failure'
+        if: steps.guard.outputs.skip == 'false' && steps.claude.outcome == 'failure'
         run: |
           set -uo pipefail
           LOG="${RUNNER_TEMP}/claude-execution-output.json"
@@ -390,3 +399,67 @@ jobs:
           elif grep -q '"api_error_status": *401' "$LOG"; then
             echo "::error::Claude rejected this repository's credential with HTTP 401. The secret exists and is well-formed, so it has expired or been revoked. Fix: run 'claude setup-token' on a machine logged into the Claude subscription, then 'gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo ${{ github.repository }}'. This same secret backs claude-review, ci-sentinel, dependabot-auto, flaky-test-hunter, feedback-remediation and claude — they are all down until it is replaced."
           fi
+
+      # When the Claude step fails the bump still lands. The level is mechanical
+      # (labels win; otherwise a new module under src/yeaboi/ reads as a feature,
+      # anything else as a fix) and the release notes are a placeholder the copy
+      # contract accepts. The guard above recognises that placeholder on the next
+      # push and runs Claude in changelog-only mode, so the real notes arrive on
+      # their own once the credential is back — nothing to redo by hand. In
+      # changelog-only mode there is nothing for this step to do: the version is
+      # already bumped and the placeholder is already there. A preflight failure
+      # (no credential, a mangled paste) still reds the job: that is a setting a
+      # human has to fix, and hiding it behind a bump would keep it broken.
+      - name: Fall back to a deterministic bump
+        if: steps.guard.outputs.skip == 'false' && steps.claude.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          CHANGELOG_ONLY: ${{ steps.guard.outputs.changelog_only || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "$CHANGELOG_ONLY" = "true" ]; then
+            echo "::warning::Claude is unavailable, so the placeholder release notes stay for now; the next push will try again."
+            exit 0
+          fi
+          # Claude may have failed AFTER editing or pushing (turns ran out, a push
+          # was rejected). Bump only from the untouched PR head: if the branch has
+          # moved since this run started, leave it to the run that push triggers.
+          git fetch --no-tags origin "$HEAD_REF"
+          if [ "$(git rev-parse FETCH_HEAD)" != "$HEAD_SHA" ]; then
+            echo "::notice::the branch moved during this run; leaving the bump to the run that follows."
+            exit 0
+          fi
+          git reset -q --hard "$HEAD_SHA"
+          case ",$LABELS," in
+            *,release:skip,*|*,semver:none,*)
+              gh pr comment "$PR" --body "🏷️ auto-version: no release-worthy change — skipping bump."
+              exit 0 ;;
+            *,semver:major,*) LEVEL="major" ;;
+            *,semver:minor,*) LEVEL="minor" ;;
+            *,semver:patch,*) LEVEL="patch" ;;
+            *)
+              # Into a variable first, as the guard does: `grep -q` closing the
+              # pipe early reads as a failure under pipefail and would bump patch.
+              git fetch --no-tags origin "$BASE_REF"
+              ADDED=$(git diff --name-only --diff-filter=A FETCH_HEAD...HEAD)
+              if printf '%s\n' "$ADDED" | grep -qE '^src/yeaboi/.*\.py$'; then
+                LEVEL="minor"
+              else
+                LEVEL="patch"
+              fi ;;
+          esac
+          NEW=$(python scripts/bump_version.py "$LEVEL")
+          python scripts/changelog_stub.py write "$NEW" --pr "$PR"
+          python -c "import json; json.load(open('src/yeaboi/changelog_data.json'))"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml src/yeaboi/changelog_data.json
+          git commit -q -m "chore: bump version to $NEW [auto]" -m "Fallback bump: Claude was unavailable, so the level came from the labels or the diff and the release notes are a placeholder for the next run to rewrite."
+          git push origin "HEAD:$HEAD_REF"
+          gh pr comment "$PR" --body "🏷️ auto-version (fallback): Claude was unavailable, so this bumped **$LEVEL** to **$NEW** by rule — labels win, else a new module means minor, else patch — and wrote placeholder release notes. The next push rewrites them once the credential works; edit pyproject.toml by hand if the level is wrong."
+          echo "::warning::Claude was unavailable; bumped $LEVEL to $NEW by rule with placeholder release notes."

--- a/scripts/changelog_stub.py
+++ b/scripts/changelog_stub.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""The changelog entry auto-version writes when Claude is not there to write one.
+
+``auto-version.yml`` asks Claude to choose the semver level and write the
+release notes. When that call fails (a dead credential, an outage) the workflow
+still has to land a bump, or every release-worthy PR reds until someone fixes the
+secret by hand. This writes a placeholder entry the copy contract accepts, and
+``is-stub`` lets the workflow recognise it later so the next run with a working
+Claude rewrites it in place (its changelog-only mode).
+
+    python scripts/changelog_stub.py write 3.42.0 --pr 362
+    python scripts/changelog_stub.py is-stub 3.42.0      # exit 0 when the entry is the stub
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+
+STUB_HEADLINE = "Release notes to follow"
+STUB_SUMMARY = (
+    "This release went out while the release-notes writer was away. The pull request that made it says what changed."
+)
+STUB_HIGHLIGHT = "Read the pull request for this release to see what changed"
+
+_DEFAULT_DATA = Path(__file__).resolve().parent.parent / "src" / "yeaboi" / "changelog_data.json"
+
+
+def stub_entry(version: str, date: str) -> dict:
+    return {
+        "version": version,
+        "date": date,
+        "headline": STUB_HEADLINE,
+        "summary": STUB_SUMMARY,
+        "highlights": [{"text": STUB_HIGHLIGHT, "areas": ["general"]}],
+    }
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# The bundled file is hand- and bot-written over many releases and no one
+# serializer reproduces it, so a stub is spliced into the text at the top of the
+# array and every other byte stays put. Short string lists fold onto one line,
+# the way the recent entries have them.
+_INLINE_LIST = re.compile(r'\[\s+("[^"]*"(?:,\s+"[^"]*")*)\s+\]')
+_ENTRIES = '"entries": ['
+
+
+def render_entry(entry: dict, *, indent: int = 4) -> str:
+    text = json.dumps(entry, indent=2, ensure_ascii=False)
+    text = _INLINE_LIST.sub(lambda m: "[" + ", ".join(part.strip() for part in m.group(1).split(",")) + "]", text)
+    pad = " " * indent
+    return "\n".join(pad + line for line in text.splitlines())
+
+
+def _entry(data: dict, version: str) -> dict | None:
+    return next((entry for entry in data.get("entries", []) if entry.get("version") == version), None)
+
+
+def write(version: str, *, date: str | None = None, path: Path | None = None) -> bool:
+    """Prepend the stub for ``version`` unless the version already has an entry. True when written."""
+    path = path or _DEFAULT_DATA
+    text = path.read_text(encoding="utf-8")
+    if _entry(json.loads(text), version) is not None:
+        return False
+    today = date or dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    at = text.index(_ENTRIES) + len(_ENTRIES)
+    out = text[:at] + "\n" + render_entry(stub_entry(version, today)) + "," + text[at:]
+    json.loads(out)  # a splice that does not parse must never reach the disk
+    path.write_text(out, encoding="utf-8")
+    return True
+
+
+def is_stub(version: str, *, path: Path | None = None) -> bool:
+    entry = _entry(_load(path or _DEFAULT_DATA), version)
+    return entry is not None and entry.get("headline") == STUB_HEADLINE
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--data", type=Path, default=None, help="the changelog file; the bundled one when omitted")
+    sub = parser.add_subparsers(dest="command", required=True)
+    writer = sub.add_parser("write", help="prepend the stub entry for a version")
+    writer.add_argument("version")
+    writer.add_argument("--pr", type=int, default=0, help="the pull request, for the log line")
+    writer.add_argument("--date", default=None, help="YYYY-MM-DD; today (UTC) when omitted")
+    checker = sub.add_parser("is-stub", help="exit 0 when the version's entry is the stub")
+    checker.add_argument("version")
+    args = parser.parse_args(argv)
+    if args.command == "write":
+        written = write(args.version, date=args.date, path=args.data)
+        print(f"{'wrote' if written else 'kept'} the changelog entry for {args.version} (PR #{args.pr})")
+        return 0
+    return 0 if is_stub(args.version, path=args.data) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_scope.py
+++ b/scripts/test_scope.py
@@ -570,6 +570,7 @@ ALWAYS: tuple[str, ...] = (
     # repo + CI metadata
     "tests/unit/test_workflow_schema.py",
     "tests/unit/test_workflow_concurrency.py",
+    "tests/unit/test_auto_version_fallback.py",
     "tests/unit/test_publish_workflows.py",
     "tests/unit/test_codeql_triage.py",
     "tests/unit/test_claude_workflow.py",

--- a/tests/unit/test_auto_version_fallback.py
+++ b/tests/unit/test_auto_version_fallback.py
@@ -1,0 +1,110 @@
+"""auto-version.yml lands a bump even when Claude cannot (scripts/changelog_stub.py and the fallback step)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.unit import test_changelog as changelog_rules
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "auto-version.yml"
+
+
+@pytest.fixture(scope="module")
+def stub():
+    spec = importlib.util.spec_from_file_location("changelog_stub", ROOT / "scripts" / "changelog_stub.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def data(tmp_path: Path) -> Path:
+    path = tmp_path / "changelog_data.json"
+    real = json.loads((ROOT / "src" / "yeaboi" / "changelog_data.json").read_text(encoding="utf-8"))
+    path.write_text(json.dumps({"schema_version": real.get("schema_version", 2), "entries": real["entries"][:2]}))
+    return path
+
+
+class TestStub:
+    def test_the_placeholder_passes_the_copy_contract(self, stub):
+        rules = changelog_rules.TestCopyContract()
+        entry = stub.stub_entry("9.9.9", "2026-09-05")
+        assert len(entry["headline"]) <= rules.HEADLINE_MAX and not entry["headline"].endswith(".")
+        assert len(entry["summary"]) <= rules.SUMMARY_MAX
+        assert len(re.split(r"(?<=[.!?])\s+", entry["summary"].strip())) <= rules.SENTENCE_MAX
+        for highlight in entry["highlights"]:
+            assert len(highlight["text"]) <= rules.HIGHLIGHT_MAX and not highlight["text"].endswith(".")
+            assert highlight["areas"] == ["general"]
+        for _field, text in rules._strings(entry):
+            for label, pattern in rules.BANNED:
+                assert re.search(pattern, text) is None, (label, text)
+
+    def test_write_prepends_once_and_is_stub_recognises_it(self, stub, data):
+        assert stub.write("9.9.9", date="2026-09-05", path=data)
+        assert not stub.write("9.9.9", date="2026-09-05", path=data)  # already there
+        entries = json.loads(data.read_text())["entries"]
+        assert entries[0]["version"] == "9.9.9" and entries[0]["date"] == "2026-09-05"
+        assert stub.is_stub("9.9.9", path=data)
+        assert not stub.is_stub(entries[1]["version"], path=data)  # a real entry
+        assert not stub.is_stub("0.0.1", path=data)  # no entry at all
+
+    def test_the_command_line(self, stub, data):
+        # Always through --data: a test that touched the bundled file would ship a fake release.
+        assert stub.main(["--data", str(data), "is-stub", "9.9.9"]) == 1
+        assert stub.main(["--data", str(data), "write", "9.9.9", "--pr", "362", "--date", "2026-09-05"]) == 0
+        assert stub.main(["--data", str(data), "is-stub", "9.9.9"]) == 0
+
+    def test_writing_only_adds_lines(self, stub, tmp_path):
+        import difflib
+
+        real = ROOT / "src" / "yeaboi" / "changelog_data.json"
+        copy = tmp_path / "changelog_data.json"
+        copy.write_text(real.read_text(encoding="utf-8"), encoding="utf-8")
+        assert stub.write("9.9.9", date="2026-09-05", path=copy)
+        before, after = real.read_text(encoding="utf-8").splitlines(), copy.read_text(encoding="utf-8").splitlines()
+        changes = [line for line in difflib.unified_diff(before, after, lineterm="", n=0) if line[:1] in "+-"]
+        removed = [line for line in changes if line.startswith("-") and not line.startswith("---")]
+        added = [line for line in changes if line.startswith("+") and not line.startswith("+++")]
+        assert removed == [] and 5 <= len(added) <= 12  # the stub entry, and nothing re-flowed
+        assert json.loads(copy.read_text())["entries"][0]["version"] == "9.9.9"
+
+
+@pytest.fixture(scope="module")
+def steps() -> dict[str, dict]:
+    job = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["bump"]
+    return {step["name"]: step for step in job["steps"]}
+
+
+class TestWorkflow:
+    def test_claude_no_longer_fails_the_job(self, steps):
+        assert steps["Classify & bump with Claude"].get("continue-on-error") is True
+
+    def test_the_fallback_runs_exactly_when_claude_failed(self, steps):
+        fallback = steps["Fall back to a deterministic bump"]
+        assert "steps.claude.outcome == 'failure'" in fallback["if"]
+        assert "steps.guard.outputs.skip == 'false'" in fallback["if"]
+        assert "steps.claude.outcome == 'failure'" in steps["Explain an auth failure"]["if"]
+        # continue-on-error makes `conclusion` read success; only `outcome` tells the truth.
+        assert "conclusion" not in fallback["if"] and "conclusion" not in steps["Explain an auth failure"]["if"]
+
+    def test_the_fallback_bumps_by_rule_and_writes_the_placeholder(self, steps):
+        run = steps["Fall back to a deterministic bump"]["run"]
+        assert "scripts/bump_version.py" in run and "scripts/changelog_stub.py write" in run
+        for label in ("semver:major", "semver:minor", "semver:patch", "release:skip", "semver:none"):
+            assert label in run
+        assert "ADDED=$(git diff --name-only --diff-filter=A" in run  # a new module reads as a feature, via a variable
+        assert "git push origin" in run and "gh pr comment" in run
+        assert 'if [ "$CHANGELOG_ONLY" = "true" ]' in run  # never bumps twice
+        assert 'git reset -q --hard "$HEAD_SHA"' in run and '!= "$HEAD_SHA"' in run  # only from the untouched head
+
+    def test_the_guard_heals_the_placeholder_on_the_next_run(self, steps):
+        run = steps["Deterministic guards"]["run"]
+        assert "changelog_stub.py is-stub" in run
+        assert run.index("is-stub") < run.index("changelog entry exists; skipping")


### PR DESCRIPTION
## Summary

Every Claude workflow in the org has been failing with `401 Invalid bearer token` since the credential moved to the org level this morning, and `auto-version.yml` had no path to a bump that did not go through Claude: a dead token meant no version bump on any release-worthy PR (#361, #362) until someone fixed the secret by hand.

This makes the bump land whatever Claude does:

- The Claude step carries `continue-on-error`, so its failure no longer fails the job; the auth explainer keys off `steps.claude.outcome` accordingly.
- A fallback step runs only when the Claude step failed. It bumps by rule (semver labels win; otherwise a new module under `src/yeaboi/` reads as minor, anything else as patch), writes a placeholder changelog entry with the new `scripts/changelog_stub.py` (spliced into the file's text so the bump is one hunk), commits and pushes on the PR branch with the checkout's persisted credentials, and says what it did in a PR comment. It only bumps from the untouched PR head: if the branch moved during the run it leaves the bump to the next one.
- The deterministic guard recognises the placeholder on a later run and runs Claude in changelog-only mode, so the real release notes replace it on their own once the credential works again. In changelog-only mode the fallback does nothing, so nothing bumps twice.
- A preflight failure (no credential at all, a mangled paste) still reds the job: that is a setting a human must fix.

Not in this PR: the credential itself. The org-level `CLAUDE_CODE_OAUTH_TOKEN` (set 2026-09-05 04:38 UTC) is well-formed but rejected; it needs re-minting with `claude setup-token` and re-setting as the org admin. Until then every fallback-bumped PR ships placeholder notes and Claude Review does not run.

## Test plan

- `make ship-gate` green: lint, format-check, the full suite on 3.11–3.14, security, preflight including actionlint over the new bash.
- `tests/unit/test_auto_version_fallback.py` (always-run) pins: the placeholder passes the changelog copy contract; the writer only adds lines and is idempotent; the command line never touches the bundled file without `--data`; the Claude step has `continue-on-error`; the fallback and explainer key off `outcome`; the fallback bumps by rule, resets to the PR head, never bumps in changelog-only mode; the guard heals the placeholder.
- An independent review pass: both blockers (a definition-time path default that let a test write a fake release into the bundled file; a test that would have failed CI on every fallback-bumped PR) and both should-fix items (`grep -q` under pipefail, bumping after Claude had already edited) are fixed.
- Cannot be exercised on this PR: the Claude action skips itself when the workflow file differs from `main`, so the fallback first runs for real on the next release-worthy PR after this merges. A green auto-version check here proves only the guard and the YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bur3QzMeuQSUFCxCBkX7LN
