### PR TITLE
carry the desktop's studio and workspace-settings routes

### DIFF
--- a/contracts/v1/routes_manifest.json
+++ b/contracts/v1/routes_manifest.json
@@ -292,6 +292,16 @@
       "title": "Ticket"
     },
     {
+      "path": "/studio",
+      "capability": null,
+      "title": "Studio"
+    },
+    {
+      "path": "/studio/:area",
+      "capability": null,
+      "title": "Studio · Section"
+    },
+    {
       "path": "/settings",
       "capability": null,
       "title": "Settings"
@@ -320,6 +330,26 @@
       "path": "/settings/news",
       "capability": null,
       "title": "Settings · Front page"
+    },
+    {
+      "path": "/settings/profile",
+      "capability": null,
+      "title": "Settings · Profile"
+    },
+    {
+      "path": "/settings/models",
+      "capability": null,
+      "title": "Settings · Models"
+    },
+    {
+      "path": "/settings/voice",
+      "capability": null,
+      "title": "Settings · Voice"
+    },
+    {
+      "path": "/settings/brand",
+      "capability": null,
+      "title": "Settings · Brand"
     },
     {
       "path": "/settings/themes",


### PR DESCRIPTION
The manifest half of yeaboi-desktop#49.

`contracts/v1/routes_manifest.json` is generated in yeaboi-desktop and committed
in both repos; `test_surface_parity.py` and `test_tui_parity.py` read this copy
to decide what reached the window. Six new routes:

- `/studio` and `/studio/:area` — the planning Studio (blueprint sections and
  templates, personas, the agent harness, ticket templates, generation presets)
- `/settings/profile`, `/settings/models`, `/settings/voice`, `/settings/brand`
  — a third settings group for the planning workspace

All six are `capability: null`, so **no `CAPABILITIES` row moves**. They are
planning-workspace configuration, which the terminal does not have and is not
expected to grow — the same reason `/settings/appearance`, `/settings/themes`
and `/settings/duck` are ordinary routes rather than `settings_tabs` entries.
That block stays byte-equal to `_SETTINGS_TAB_SECTIONS`.

Merge after yeaboi-desktop#49; `gen-routes-manifest --check` is red over there
until this lands, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzJBPEbJsgWB4u2JLPZu61